### PR TITLE
Only allow the Checked C extension flag for C.

### DIFF
--- a/docs/checkedc/Test-Baselines.md
+++ b/docs/checkedc/Test-Baselines.md
@@ -1,42 +1,5 @@
 # Test base lines
 
-## Current baseline for the master branch
-
-Here is the current baseline for testing just clang with the x86 target (using the check-clang project)
-
-```
-         Failing Tests (3):
-             Clang :: Index/index-templates.cpp
-             Clang :: Index/usrs.m
-             Clang :: Lexer/eof-conflict-marker.c
-```
-```
-           Expected Passes    : 8945
-           Expected Failures  : 21
-           Unsupported Tests  : 206
-           Unexpected Failures: 3
-```
-
-Here is the current base line for testing LLVM + clang on x86 (check-all):
-```
-         Failing Tests (5):
-             Clang :: Index/index-templates.cpp
-             Clang :: Index/usrs.m
-             Clang :: Lexer/eof-conflict-marker.c
-             LLVM :: MC/AsmParser/macros-gas.s
-             LLVM :: tools/llvm-objdump/malformed-archives.test
-```
-```
-           Expected Passes    : 18787
-           Expected Failures  : 97
-           Unsupported Tests  : 6647
-           Unexpected Failures: 5
-```
-
-
-The current base line for testing LLVM + clang on all targets (check-all) in the master
-branch needs to be updated.
-
 ## Testing baseline for the base line branch
 
 
@@ -89,17 +52,14 @@ Here is the current base line for testing LLVM + clang on all targets (check-all
            Unexpected Failures: 6
 ```
 
-## Delta between the master branch and baseline branch
+## Differences in test results between branches
 
-We have added tests for Checked C to the master branch.  These tests are specific to clang, such as tests of
-compiler internals or the driver.  We currently expect the master branch to pass the following additional tests
-in these configurations.
-
-- For just clang with the x86 target (using the check-clang project), 3 additional `Expected Passes` tests.
-- For testing LLVM + clang on x86 (check-all), 8 additional `Expected Passes` tests
-
+The  master branch in the checkedc-clang repo has additional tests for
+Checked C.  It is expected that the master branch will have more
+`Expected Passes` than the baseline branch.
 
 ## In-progress baseline updates
 
-This section records the test results for an in-progress update to latest sources in the baseline branch.  It is currently empty because
-no update is in-progress.
+This section records the test results for an in-progress update to latest
+sources in the baseline branch.  It is currently empty because no update
+is in-progress.

--- a/docs/checkedc/Test-Baselines.md
+++ b/docs/checkedc/Test-Baselines.md
@@ -1,6 +1,43 @@
 # Test base lines
 
-## Current baseline
+## Current baseline for the master branch
+
+Here is the current baseline for testing just clang with the x86 target (using the check-clang project)
+
+```
+         Failing Tests (3):
+             Clang :: Index/index-templates.cpp
+             Clang :: Index/usrs.m
+             Clang :: Lexer/eof-conflict-marker.c
+```
+```
+           Expected Passes    : 8945
+           Expected Failures  : 21
+           Unsupported Tests  : 206
+           Unexpected Failures: 3
+```
+
+Here is the current base line for testing LLVM + clang on x86 (check-all):
+```
+         Failing Tests (5):
+             Clang :: Index/index-templates.cpp
+             Clang :: Index/usrs.m
+             Clang :: Lexer/eof-conflict-marker.c
+             LLVM :: MC/AsmParser/macros-gas.s
+             LLVM :: tools/llvm-objdump/malformed-archives.test
+```
+```
+           Expected Passes    : 18787
+           Expected Failures  : 97
+           Unsupported Tests  : 6647
+           Unexpected Failures: 5
+```
+
+
+The current base line for testing LLVM + clang on all targets (check-all) in the master
+branch needs to be updated.
+
+## Testing baseline for the base line branch
 
 
 Here is the current baseline for testing just clang with the x86 target (using the check-clang project)
@@ -51,6 +88,16 @@ Here is the current base line for testing LLVM + clang on all targets (check-all
            Unsupported Tests  : 871
            Unexpected Failures: 6
 ```
+
+## Delta between the master branch and baseline branch
+
+We have added tests for Checked C to the master branch.  These tests are specific to clang, such as tests of
+compiler internals or the driver.  We currently expect the master branch to pass the following additional tests
+in these configurations.
+
+- For just clang with the x86 target (using the check-clang project), 3 additional `Expected Passes` tests.
+- For testing LLVM + clang on x86 (check-all), 8 additional `Expected Passes` tests
+
 
 ## In-progress baseline updates
 

--- a/docs/checkedc/Testing.md
+++ b/docs/checkedc/Testing.md
@@ -5,7 +5,9 @@ target to the build system for running the test suite: check-checkedc.
 
 The Checked C version of clang/LLVM should pass the same tests as the baseline version
 of clang/LLVM (in the baseline branch) and the Checked C specific tests.   The testing
-results for the baseline branch are recorded in [testing baselines](Test-Baselines.md)
+results for the baseline branch are recorded in [testing baselines](Test-Baselines.md).
+A developer should confirm that no new unexpected failures occur as a result of a change
+before committing a change.
 
 When testing a change, the testing should be sufficient for the type of change.  For changes
 to parsing and typechecking, it is usually sufficient to pass the Checked C and clang tests.
@@ -49,8 +51,9 @@ The clang-specific documentation on running tests appears to be out-of-date, so 
 		llvm-lit d:\autobahn1\llvm\tools\clang\test
 
 ## Test baselines
-We have observed a few tests fail on Windows on a clean LLVM/clang enlistment that don't seem to fail on the buildbots.  
-We have not tracked down the source of the failures.  For now, we are using [testing baselines](Test-Baselines.md) to exclude these
-tests.  LLVM/clang have an optimistic check-in policy, so it is possible that a few tests may fail in the 
-main-line repos when we update to the latest sources.
-
+We have observed a few tests fail unexpectedly on Windows on a clean LLVM/clang
+enlistment.  These tests don't seem to fail on the buildbots. We have not 
+tracked down the source of the failures.  For now, we are using
+[testing baselines](Test-Baselines.md) to exclude these tests.  LLVM/clang has
+an optimistic check-in policy, so it is possible that a few tests may fail in
+the main-line repos when we update to the latest sources.

--- a/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -64,8 +64,6 @@ Then run tests.  We have added tests for Checked C to the clang master branch, s
 into account during testing.  Make sure the code passes the following tests:
 
 - The same tests as the baseline branch, _plus_ the Checked C specific tests for clang in the master branch.
-  See the delta on the [testing baselines](Test-Baselines.md) page.
 - The Checked C languages tests for the Checked C project.
 
-After the tests are passing, update the markdown for the testing baselines in clang/docs/CheckedC/Test-Baselines.md.
-Then push the changes up to a personal Github fork and issue a pull request.
+Once the tests are passing, push the changes up to a personal Github fork and issue a pull request.

--- a/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -44,12 +44,12 @@ Then do
 
 ## Update the baseline branch on Github
 
-You will then need to build and run tests to establish test baselines.   Assuming that the tests  results are good, you can push them to your personal 
-Github forks:
+You will then need to build and run tests to establish test baselines.   Assuming that the tests  results are good, 
+you can push them to your personal Github forks:
 
 	git push origin baseline
 
-You can then issue a pull request to pull the changes into the mainline change.
+You can then issue pull requests to pull the changes into the Microsift Github repos.
 
 ## Update the master branch.
 
@@ -58,6 +58,14 @@ After you have updated the baseline branch, you can update the master branch. Ch
 	git checkout master
 	git merge baseline
 
-Then set up the build system and compile.  Fix any issues that you encounter.  Then run tests.  Once you are passing the same
-testing as the baseline branch, push this up to personal Github fork and issue a pull request.
+Set up the build system and compile.  Fix any issues that you encounter.  
 
+Then run tests.  We have added tests for Checked C to the clang master branch, so these additional tests need to be taken
+into account during testing.  Make sure the code passes the following tests:
+
+- The same tests as the baseline branch, _plus_ the Checked C specific tests for clang in the master branch.
+  See the delta on the [testing baselines](Test-Baselines.md) page.
+- The Checked C languages tests for the Checked C project.
+
+After the tests are passing, update the markdown for the testing baselines in clang/docs/CheckedC/Test-Baselines.md.
+Then push the changes up to a personal Github fork and issue a pull request.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1701,7 +1701,25 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.PascalStrings = Args.hasArg(OPT_fpascal_strings);
   Opts.VtorDispMode = getLastArgIntValue(Args, OPT_vtordisp_mode_EQ, 1, Diags);
   Opts.Borland = Args.hasArg(OPT_fborland_extensions);
-  Opts.CheckedC = Args.hasArg(OPT_fcheckedc_extension);
+  if (Args.hasArg(OPT_fcheckedc_extension)) {
+    const char *disallowed = nullptr;
+    if (Opts.CUDA)
+      disallowed = "CUDA";
+    else if (Opts.OpenCL)
+      disallowed = "OpenCL";
+    else if (Opts.CPlusPlus)
+      disallowed = "C++";
+    else if (Opts.ObjC1 || Opts.ObjC2)
+      disallowed = "Objective C";
+    if (disallowed) {
+      Diags.Report(diag::err_drv_argument_not_allowed_with) <<
+        "-fcheckedc-extension" << disallowed;
+    } else if (!(Opts.C99 || Opts.C11)) {
+      Diags.Report(diag::err_drv_argument_only_allowed_with) <<
+        "-fcheckedc-extension" << "C";
+    } else
+      Opts.CheckedC = true;
+  }
   Opts.WritableStrings = Args.hasArg(OPT_fwritable_strings);
   Opts.ConstStrings = Args.hasFlag(OPT_fconst_strings, OPT_fno_const_strings,
                                    Opts.ConstStrings);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1702,21 +1702,24 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.VtorDispMode = getLastArgIntValue(Args, OPT_vtordisp_mode_EQ, 1, Diags);
   Opts.Borland = Args.hasArg(OPT_fborland_extensions);
   if (Args.hasArg(OPT_fcheckedc_extension)) {
-    const char *disallowed = nullptr;
+    std::string disallowed;
     if (Opts.CUDA)
       disallowed = "CUDA";
     else if (Opts.OpenCL)
       disallowed = "OpenCL";
-    else if (Opts.CPlusPlus)
+    else if (Opts.ObjC1 || Opts.ObjC2) {
+      if (Opts.CPlusPlus)
+        disallowed = "Objective C/C++";
+      else
+        disallowed = "Objective C";
+    }
+    else if (Opts.CPlusPlus) {
       disallowed = "C++";
-    else if (Opts.ObjC1 || Opts.ObjC2)
-      disallowed = "Objective C";
-    if (disallowed) {
+    }
+
+    if (disallowed.size() > 0) {
       Diags.Report(diag::err_drv_argument_not_allowed_with) <<
         "-fcheckedc-extension" << disallowed;
-    } else if (!(Opts.C99 || Opts.C11)) {
-      Diags.Report(diag::err_drv_argument_only_allowed_with) <<
-        "-fcheckedc-extension" << "C";
     } else
       Opts.CheckedC = true;
   }

--- a/test/Driver/checkedc-notsupported.cl
+++ b/test/Driver/checkedc-notsupported.cl
@@ -1,0 +1,9 @@
+// Checked C extension is not supported for OpenCL.   Make sure driver
+// rejects the flag.
+//
+// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'OpenCL'
+
+extern void f() {}
+
+

--- a/test/Driver/checkedc-notsupported.cl
+++ b/test/Driver/checkedc-notsupported.cl
@@ -4,10 +4,10 @@
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'OpenCL'
 //
-// Have clang compile this file as a C file
+// Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
-// Have clang-cl to to compile this file as a C file
+// Have clang-cl compile this file as a C file.
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}

--- a/test/Driver/checkedc-notsupported.cl
+++ b/test/Driver/checkedc-notsupported.cl
@@ -3,7 +3,12 @@
 //
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'OpenCL'
+//
+// Have clang compile this file as a C file
+// RUN: %clang -c -fcheckedc-extension -x c %s
+//
+// Have clang-cl to to compile this file as a C file
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}
-
 

--- a/test/Driver/checkedc-notsupported.cpp
+++ b/test/Driver/checkedc-notsupported.cpp
@@ -3,6 +3,12 @@
 //
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+//
+// Have clang compile this file as a C file
+// RUN: %clang -c -fcheckedc-extension -x c %s
+//
+// Have clang-cl to to compile this file as a C file
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}
 

--- a/test/Driver/checkedc-notsupported.cpp
+++ b/test/Driver/checkedc-notsupported.cpp
@@ -1,0 +1,9 @@
+// Checked C extension is not supported for C++.   Make sure driver
+// rejects the flag.
+//
+// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+
+extern void f() {}
+
+

--- a/test/Driver/checkedc-notsupported.cpp
+++ b/test/Driver/checkedc-notsupported.cpp
@@ -4,10 +4,10 @@
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
 //
-// Have clang compile this file as a C file
+// Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
-// Have clang-cl to to compile this file as a C file
+// Have clang-cl compile this file as a C file.
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}

--- a/test/Driver/checkedc-notsupported.cu
+++ b/test/Driver/checkedc-notsupported.cu
@@ -4,10 +4,10 @@
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'CUDA'
 //
-// Have clang compile this file as a C file
+// Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
-// Have clang-cl to to compile this file as a C file
+// Have clang-cl compile this file as a C file.
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}

--- a/test/Driver/checkedc-notsupported.cu
+++ b/test/Driver/checkedc-notsupported.cu
@@ -3,6 +3,12 @@
 //
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'CUDA'
+//
+// Have clang compile this file as a C file
+// RUN: %clang -c -fcheckedc-extension -x c %s
+//
+// Have clang-cl to to compile this file as a C file
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}
 

--- a/test/Driver/checkedc-notsupported.cu
+++ b/test/Driver/checkedc-notsupported.cu
@@ -1,0 +1,9 @@
+// Checked C extension is not supported for CUDA.   Make sure driver
+// rejects the flag.
+//
+// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'CUDA'
+
+extern void f() {}
+
+

--- a/test/Driver/checkedc-notsupported.m
+++ b/test/Driver/checkedc-notsupported.m
@@ -3,6 +3,12 @@
 //
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C'
+//
+// Have clang compile this file as a C file
+// RUN: %clang -c -fcheckedc-extension -x c %s
+//
+// Have clang-cl to to compile this file as a C file
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}
 

--- a/test/Driver/checkedc-notsupported.m
+++ b/test/Driver/checkedc-notsupported.m
@@ -1,0 +1,9 @@
+// Checked C extension is not supported for Objective C.   Make sure driver
+// rejects the flag.
+//
+// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C'
+
+extern void f() {}
+
+

--- a/test/Driver/checkedc-notsupported.m
+++ b/test/Driver/checkedc-notsupported.m
@@ -4,10 +4,10 @@
 // RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
 // CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C'
 //
-// Have clang compile this file as a C file
+// Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
-// Have clang-cl to to compile this file as a C file
+// Have clang-cl compile this file as a C file.
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
 extern void f() {}

--- a/test/Driver/checkedc-supported.c
+++ b/test/Driver/checkedc-supported.c
@@ -1,0 +1,34 @@
+// Checked C extension is supported for C.   Make sure driver
+// accepts the flag for C and rejects it when the file is
+// compiled as another language.
+//
+// RUN: %clang -c -fcheckedc-extension %s 2>&1
+//
+// Have clang compile this file as C++ file
+// RUN: not %clang -c -fcheckedc-extension -x c++ %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=check-cpp
+// check-cpp: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+//
+// Have clang-cl to to compile this file as a C++ file
+// RUN: not %clang_cl -c -Xclang -fcheckedc-extension /TP %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=clcheck-cpp
+// clcheck-cpp: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+//
+// RUN: not %clang -c -fcheckedc-extension -x cuda %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=check-cuda
+// check-cuda: error: invalid argument '-fcheckedc-extension' not allowed with 'CUDA'
+//
+// RUN: not %clang -c -fcheckedc-extension -x cl %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=check-opencl
+// check-opencl: error: invalid argument '-fcheckedc-extension' not allowed with 'OpenCL'
+//
+// RUN: not %clang -c -fcheckedc-extension -x objective-c %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=check-objc
+// check-objc: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C'
+//
+// RUN: not %clang -c -fcheckedc-extension -x objective-c++ %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=check-objcpp
+// check-objcpp: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C/C++'
+
+
+extern void f() {}

--- a/test/Driver/checkedc-supported.c
+++ b/test/Driver/checkedc-supported.c
@@ -5,12 +5,12 @@
 // RUN: %clang -c -fcheckedc-extension %s
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension %s
 //
-// Have clang compile this file as C++ file
+// Have clang compile this file as C++ file.
 // RUN: not %clang -c -fcheckedc-extension -x c++ %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-cpp
 // check-cpp: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
 //
-// Have clang-cl to to compile this file as a C++ file
+// Have clang-cl compile this file as a C++ file.
 // RUN: not %clang_cl -c -Xclang -fcheckedc-extension /TP %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=clcheck-cpp
 // clcheck-cpp: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'

--- a/test/Driver/checkedc-supported.c
+++ b/test/Driver/checkedc-supported.c
@@ -2,7 +2,8 @@
 // accepts the flag for C and rejects it when the file is
 // compiled as another language.
 //
-// RUN: %clang -c -fcheckedc-extension %s 2>&1
+// RUN: %clang -c -fcheckedc-extension %s
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension %s
 //
 // Have clang compile this file as C++ file
 // RUN: not %clang -c -fcheckedc-extension -x c++ %s 2>&1 \
@@ -31,4 +32,4 @@
 // check-objcpp: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C/C++'
 
 
-extern void f() {}
+extern void f(ptr<int> p) {}


### PR DESCRIPTION
This change only allows the -fcheckedc-extension flag to be used for C programs
in clang.  The clang driver will reject the use of -fcheckedc-extension for
other C family languages supported by clang, including C++, Objective
C, OpenCL, and CUDA. This addresses issue #9 in the checked-clang Github repo.

We are currently not modifying clang to support these other languages, which
is why need to disallow using the extension with them.

Testing:
-  Add 4 new tests to clang.  They test that use of the extension flag is
rejected for C++, Objective C, CUDA, and OpenCL.
- As recommended by the clang documentation, I placed the tests in with
  other similar tests in the test tree.
- I updated the testing baselines to reflect the new tests.  I also updated
the documentation to reflect the fact that we have Checked C specific tests
in clang. We need to take the new tests into account when updating to new
versions of the clang/LLVM sources.