### PR TITLE
Parse bounds declarations for variable declarations.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1623,7 +1623,8 @@ bool Parser::MightBeDeclarator(unsigned Context) {
       // and in block scope it's probably a label. Inside a class definition,
       // this is a bit-field.
       return Context == Declarator::MemberContext ||
-             (getLangOpts().CPlusPlus && Context == Declarator::FileContext);
+             (getLangOpts().CPlusPlus && Context == Declarator::FileContext) ||
+             getLangOpts().CheckedC;
 
     case tok::identifier: // Possible virt-specifier.
       return getLangOpts().CPlusPlus11 && isCXX11VirtSpecifier(NextToken());
@@ -1936,6 +1937,8 @@ bool Parser::ParseAsmAttributesAfterDeclarator(Declarator &D) {
 /// [GNU]   declarator simple-asm-expr[opt] attributes[opt]
 /// [GNU]   declarator simple-asm-expr[opt] attributes[opt] '=' initializer
 /// [C++]   declarator initializer[opt]
+/// [Checked C] declarator ':' bounds-expression
+/// [Checked C] declarator ':' bounds-expression '=' initializer
 ///
 /// [C++] initializer:
 /// [C++]   '=' initializer-clause
@@ -2017,6 +2020,23 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
   }
 
   bool TypeContainsAuto = D.getDeclSpec().containsPlaceholderType();
+
+  // Parse the optional Checked C bounds expression.
+  if (getLangOpts().CheckedC && Tok.is(tok::colon)) {
+    ConsumeToken();
+    ExprResult Bounds = ParseBoundsExpression();
+    if (Bounds.isInvalid())
+      SkipUntil(tok::comma, tok::equal, StopAtSemi | StopBeforeMatch);
+
+    VarDecl *ThisVarDecl = dyn_cast<VarDecl>(ThisDecl);
+    if (ThisVarDecl) {
+      if (Bounds.isInvalid())
+        Actions.ActOnInvalidBoundsExpr(ThisVarDecl);
+      else
+        Actions.ActOnBoundsExpr(ThisVarDecl, cast<BoundsExpr>(Bounds.get()));
+    } else
+      llvm_unreachable("Unexpected decl type");
+  }
 
   // Parse declarator '=' initializer.
   // If a '==' or '+=' is found, suggest a fixit to '='.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1622,6 +1622,10 @@ bool Parser::MightBeDeclarator(unsigned Context) {
       // At namespace scope, 'identifier:' is probably a typo for 'identifier::'
       // and in block scope it's probably a label. Inside a class definition,
       // this is a bit-field.
+      //
+      // For Checked C 'identifier:' is a valid start to a declarator because
+      // it may be followed by a bounds expression declaring the bounds of
+      // identifier.
       return Context == Declarator::MemberContext ||
              (getLangOpts().CPlusPlus && Context == Declarator::FileContext) ||
              getLangOpts().CheckedC;


### PR DESCRIPTION
This change adds  parsing of variable declarations with bounds declarations (issue #13).
For each declarator in a declaration, the declarator is parsed and then the
optional Checked C bounds declaration  is parsed.  The bounds declaration is
parsed before the optional initializing expression for the declarator.  Because 
the declarator has already been parsed and added to the current scope, the 
bounds expression can be eagerly parsed.

One surprise with clang was that placing declarators for a declaration
on multiple lines caused a parsing error in the initial implementation,
while having all the declarators on one line did not.   I traced this back to
special case code that looks for typographical mistakes 
at line endings by calling MightBeDeclarator and generating an
error if MightBeDeclarator is false.   MightBeDeclarator returns true
for syntactic items that might start a declarator.  It has special
case checks to make sure that an identifier is followed by something
that might also be part of a declarator.  For Checked C, an identifier 
that starts a declarator may be followed by ':' and a bounds expression,
so allow ':' when the  language options include Checked C.

This change also improves error handling during the parsing of bounds
expressions.
- When an error occurs after having parsed an identifier and a left parenthesis,
  always scan for the matching right parenthesis.  The scan for the matching
  right parenthesis was only happening in one specific case, leading to
  hard-to-understand spurious parsing errors.
- Make a best effort to continue if an error occurs while parsing a
  bounds expression of the form bounds '(' e1 ',' e2, ')'.  clang does not
  differentiate during parsing of expressions between semantic errors and
  parsing failures.  It is important to continue parsing so that a semantic
  error does not cause a cascade of parsing errors.

These problems were uncovered during testing of parsing of variable declarations
with bounds expressions.  Specifically, using an incorrect bounds expression
in a variable declaration with an initializer caused a spurious parsing
errors.

Testing:
- Created a new feature test for parsing of declarations with bounds
  (parsing_bounds_var_declarations.c).  This will be committed separately to the
  checkedc repo.
- Passes existing Checked C tests.
- Passes existing clang base line tests.