### PR TITLE
Fix crash during typo correction in C mode.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -451,6 +451,10 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
                                          LHS.get(), TernaryMiddle.get(),
                                          RHS.get());
       }
+      // In this case, ActOnBinOp or ActOnConditionalOp performed the
+      // CorrectDelayedTyposInExpr check.
+      if (!getLangOpts().CPlusPlus)
+        continue;
     }
     // Ensure potential typos aren't left undiagnosed.
     if (LHS.isInvalid()) {

--- a/test/Sema/typo-correction.c
+++ b/test/Sema/typo-correction.c
@@ -57,3 +57,26 @@ void fn2() {
 }
 
 int d = X ? d : L; // expected-error 2 {{use of undeclared identifier}}
+
+int fn_with_ids() { ID = ID == ID >= ID ; } // expected-error 4 {{use of undeclared identifier}}
+
+int fn_with_rs(int r) { r = TYPO + r * TYPO; } // expected-error 2 {{use of undeclared identifier}}
+
+void fn_with_unknown(int a, int b) {
+  fn_with_unknown(unknown, unknown | unknown); // expected-error 3 {{use of undeclared identifier}}
+}
+
+// Two typos in a parenthesized expression or argument list with a conditional
+// expression caused a crash in C mode.
+//
+// r272587 fixed a similar bug for binary operations. The same fix was needed for
+// conditional expressions.
+
+int g(int x, int y) {
+  return x + y;
+}
+
+int h() {
+  g(x, 5 ? z : 0); // expected-error 2 {{use of undeclared identifier}}
+  (x, 5 ? z : 0);  // expected-error 2 {{use of undeclared identifier}}
+}


### PR DESCRIPTION
This fixes a crash in clang that can occur during typo correction in C mode.
I hit this crash while testing out parsing of incorrect bounds declarations on
structure members.

The crashes were fixed in the mainline clang sources for binary operators
with SVN r272587.  I've modified the fix to cover conditional operators as well.
The modification is out for code review for the mainline clang sources.  I'm
checking in the modified fix ported to the Checked C clang branch now.