### PR TITLE
Check type requirements for bounds declarations.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4535,6 +4535,11 @@ public:
 
   SourceLocation getLocStart() const LLVM_READONLY { return StartLoc; }
   SourceLocation getLocEnd() const LLVM_READONLY { return RParenLoc; }
+
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() >= firstBoundsExprConstant &&
+           T->getStmtClass() <= lastBoundsExprConstant;
+  }
 };
 
 /// \brief Represents a Checked C nullary bounds expression.
@@ -4560,6 +4565,10 @@ public:
 
   Kind getKind() const { return (Kind) NullaryBoundsExprBits.Kind; }
   void setKind(Kind Kind) { NullaryBoundsExprBits.Kind = Kind; }
+
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() == NullaryBoundsExprClass;
+  }
 
   // Iterators
   child_range children() {
@@ -4594,6 +4603,9 @@ public:
   Expr *getCountExpr() const { return cast<Expr>(CountExpr); }
   void setCountExpr(Expr *E) { CountExpr = E; }
 
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() == CountBoundsExprClass;
+  }
   // Iterators
   child_range children() {
     return child_range(&CountExpr, &CountExpr + 1);
@@ -4621,6 +4633,10 @@ public:
   void setLowerExpr(Expr *E) { SubExprs[LOWER] = E; }
   Expr *getUpperExpr() const { return cast<Expr>(SubExprs[UPPER]); }
   void setUpperExpr(Expr *E) { SubExprs[UPPER] = E; }
+
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() == RangeBoundsExprClass;
+  }
 
   // Iterators
   child_range children() {

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -244,11 +244,15 @@ protected:
 
   class CountBoundsExprBitFields {
     friend class CountBoundsExpr;
+
+    unsigned : NumExprBits;
     unsigned Kind : 1;
   };
 
   class NullaryBoundsExprBitFields {
     friend class NullaryBoundsExpr;
+
+    unsigned : NumExprBits;
     unsigned Kind : 1;
   };
 

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1683,6 +1683,8 @@ public:
   bool isIncompleteArrayType() const;
   bool isVariableArrayType() const;
   bool isDependentSizedArrayType() const;
+  /// \brief whether this is a Checked C checked array type.
+  bool isCheckedArrayType() const;
   bool isRecordType() const;
   bool isClassType() const;
   bool isStructureType() const;
@@ -1737,6 +1739,8 @@ public:
   bool isTemplateTypeParmType() const;          // C++ template type parameter
   bool isNullPtrType() const;                   // C++0x nullptr_t
   bool isAtomicType() const;                    // C11 _Atomic()
+
+
 
 #define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
   bool is##Id##Type() const;
@@ -5554,6 +5558,12 @@ inline bool Type::isVariableArrayType() const {
 }
 inline bool Type::isDependentSizedArrayType() const {
   return isa<DependentSizedArrayType>(CanonicalType);
+}
+inline bool Type::isCheckedArrayType() const {
+  if (const ArrayType *T = dyn_cast<ArrayType>(CanonicalType))
+    return T->isChecked();
+  else
+    return false;
 }
 inline bool Type::isBuiltinType() const {
   return isa<BuiltinType>(CanonicalType);

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8449,4 +8449,34 @@ def err_typecheck_count_bounds_expr : Error<
 
 def err_typecheck_byte_count_bounds_expr : Error<
   "invalid argument type %0 to byte_count expression">;
+
+def err_typecheck_ptr_decl_with_bounds : Error<
+  "bounds declaration not allowed because %0 has ptr type">;
+
+def err_typecheck_ptr_return_with_bounds : Error<
+  "bounds declaration not allowed because %0 has ptr return type">;
+
+def err_typecheck_function_pointer_decl_with_bounds : Error<
+  "bounds declaration not allowed because %0 has a function pointer type">;
+
+def err_typecheck_function_pointer_return_with_bounds : Error<
+  "bounds declaration not allowed because %0 returns a function pointer type">;
+
+def err_typecheck_count_bounds_decl : Error<
+  "expected %0 to have pointer or array type">;
+
+def err_typecheck_count_return_bounds : Error<
+  "expected %0 to have pointer or array return type">;
+
+def err_typecheck_void_pointer_count_bounds_decl : Error<
+  "expected %0 to have non-void pointer type">;
+
+def err_typecheck_void_pointer_count_return_bounds : Error<
+  "expected %0 to have return type that is a non-void pointer type">;
+
+def err_typecheck_non_count_bounds_decl : Error<
+  "expected %0 to have pointer, array, or integer type">;
+
+def err_typecheck_non_count_return_bounds : Error<
+  "expected %0 to have a return type that is a pointer, array, or integer type">;
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8458,32 +8458,32 @@ def err_typecheck_byte_count_bounds_expr : Error<
   "invalid argument type %0 to byte_count expression">;
 
 def err_typecheck_ptr_decl_with_bounds : Error<
-  "bounds declaration not allowed because %0 has ptr type">;
+  "bounds declaration not allowed because %0 has a ptr type">;
 
 def err_typecheck_ptr_return_with_bounds : Error<
-  "bounds declaration not allowed because %0 has ptr return type">;
+  "bounds declaration not allowed because %0 has a ptr return type">;
 
 def err_typecheck_function_pointer_decl_with_bounds : Error<
   "bounds declaration not allowed because %0 has a function pointer type">;
 
 def err_typecheck_function_pointer_return_with_bounds : Error<
-  "bounds declaration not allowed because %0 returns a function pointer type">;
+  "bounds declaration not allowed because %0 has a function pointer return type">;
 
 def err_typecheck_count_bounds_decl : Error<
-  "expected %0 to have pointer or array type">;
+  "expected %0 to have a pointer or array type">;
 
 def err_typecheck_count_return_bounds : Error<
-  "expected %0 to have pointer or array return type">;
+  "expected %0 to have a pointer or array return type">;
 
 def err_typecheck_void_pointer_count_bounds_decl : Error<
-  "expected %0 to have non-void pointer type">;
+  "expected %0 to have a non-void pointer type">;
 
 def err_typecheck_void_pointer_count_return_bounds : Error<
-  "expected %0 to have return type that is a non-void pointer type">;
+  "expected %0 to have a non-void pointer return type">;
 
 def err_typecheck_non_count_bounds_decl : Error<
-  "expected %0 to have pointer, array, or integer type">;
+  "expected %0 to have a pointer, array, or integer type">;
 
 def err_typecheck_non_count_return_bounds : Error<
-  "expected %0 to have a return type that is a pointer, array, or integer type">;
+  "expected %0 to have a pointer, array, or integer return type">;
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8415,14 +8415,6 @@ def warn_objc_redundant_qualified_class_type : Warning<
   "forget a '*'?">, InGroup<ObjCProtocolQualifiers>;
 
 // Checked C diagnostic messages
-def err_typecheck_ptr_subscript : Error<
-  "subscript of %0">;
-
-def err_typecheck_cond_incompatible_checked_pointer : Error<
-  "pointer type mismatch%diff{ ($ and $)|}0,1">;
-
-def err_typecheck_ptr_arithmetic : Error<
-  "arithmetic on ptr type">;
 
 def err_checked_vla : Error<
   "checked variable-length array not allowed">;
@@ -8443,6 +8435,21 @@ def err_unchecked_array_of_typedef_checked_array : Error<
 
 def err_unchecked_array_of_checked_array : Error<
   "unchecked array of checked array not allowed">;
+
+def err_bounds_safe_interface_unchecked_local_pointer : Error<
+  "expected local variable %0 to have array_ptr type">;
+
+def err_bounds_safe_interface_unchecked_local_array : Error<
+  "expected local variable %0 to have checked array type">;
+
+def err_typecheck_ptr_subscript : Error<
+  "subscript of %0">;
+
+def err_typecheck_cond_incompatible_checked_pointer : Error<
+  "pointer type mismatch%diff{ ($ and $)|}0,1">;
+
+def err_typecheck_ptr_arithmetic : Error<
+  "arithmetic on ptr type">;
 
 def err_typecheck_count_bounds_expr : Error<
   "invalid argument type %0 to count expression">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4119,8 +4119,8 @@ public:
   ExprResult ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc, Expr *LowerBound,
                                   Expr *UpperBound, SourceLocation RParenLoc);
 
-  void ActOnBoundsExpr(DeclaratorDecl *D, BoundsExpr *Expr);
-  void ActOnInvalidBoundsExpr(DeclaratorDecl *D);
+  void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr, bool isReturnDecl=false);
+  void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
 
   //===---------------------------- Clang Extensions ----------------------===//

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2034,9 +2034,9 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
     VarDecl *ThisVarDecl = dyn_cast<VarDecl>(ThisDecl);
     if (ThisVarDecl) {
       if (Bounds.isInvalid())
-        Actions.ActOnInvalidBoundsExpr(ThisVarDecl);
+        Actions.ActOnInvalidBoundsDecl(ThisVarDecl);
       else
-        Actions.ActOnBoundsExpr(ThisVarDecl, cast<BoundsExpr>(Bounds.get()));
+        Actions.ActOnBoundsDecl(ThisVarDecl, cast<BoundsExpr>(Bounds.get()));
     } else
       llvm_unreachable("Unexpected decl type");
   }
@@ -3790,9 +3790,9 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
     std::unique_ptr<CachedTokens> Tokens = std::move(Pair.second);
     ExprResult Bounds = DeferredParseBoundsExpression(std::move(Tokens));
     if (Bounds.isInvalid())
-      Actions.ActOnInvalidBoundsExpr(FieldDecl);
+      Actions.ActOnInvalidBoundsDecl(FieldDecl);
     else
-      Actions.ActOnBoundsExpr(FieldDecl, cast<BoundsExpr>(Bounds.get()));
+      Actions.ActOnBoundsDecl(FieldDecl, cast<BoundsExpr>(Bounds.get()));
   }
   StructScope.Exit();
   Actions.ActOnTagFinishDefinition(getCurScope(), TagDecl,
@@ -6143,9 +6143,9 @@ void Parser::ParseParameterDeclarationClause(
     std::unique_ptr<CachedTokens> Tokens = std::move(Pair.second);
     ExprResult Bounds = DeferredParseBoundsExpression(std::move(Tokens));
     if (Bounds.isInvalid())
-      Actions.ActOnInvalidBoundsExpr(Param);
+      Actions.ActOnInvalidBoundsDecl(Param);
     else
-      Actions.ActOnBoundsExpr(Param, cast<BoundsExpr>(Bounds.get()));
+      Actions.ActOnBoundsDecl(Param, cast<BoundsExpr>(Bounds.get()));
   }
 }
 

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -10882,7 +10882,7 @@ void Sema::ActOnFinishKNRParamDeclarations(Scope *S, Declarator &D,
 //
 // If checkReturnBounds is true, check the return bounds declaration
 // for a function declarator.  The typechecking logic is the same, but
-// the error messages need are slightly different.
+// the error messages are slightly different.
 void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr,
                            bool checkReturnBounds) {
   if (!D || !Expr)
@@ -10902,8 +10902,7 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr,
   // If the type for the declaration wasn't a function type, bail out.
   if (checkReturnBounds) {
     assert(Ty->isFunctionType());
-    const FunctionType *FuncTy = Ty->getAs<FunctionType>();
-    if (FuncTy)
+    if (const FunctionType *FuncTy = Ty->getAs<FunctionType>())
       Ty = FuncTy->getReturnType();
     else
       return;

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -11941,12 +11941,14 @@ ExprResult Sema::ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
     return ExprError();
   Expr *PromotedCountExpr = Result.get();
   QualType ResultType = PromotedCountExpr->getType();
-  if (!ResultType->isIntegerType())
-    return ExprError(Diag(CountExpr->getLocStart(),
-                          Kind == CountBoundsExpr::Kind::ElementCount ?
-                             diag::err_typecheck_count_bounds_expr
-                           : diag::err_typecheck_byte_count_bounds_expr)
-                       << ResultType);
+  if (!ResultType->isIntegerType()) {
+    Diag(CountExpr->getLocStart(),
+         Kind == CountBoundsExpr::Kind::ElementCount ?
+         diag::err_typecheck_count_bounds_expr
+         : diag::err_typecheck_byte_count_bounds_expr)
+      << ResultType;
+    return ExprError();
+  }
   return new (Context) CountBoundsExpr(Kind, PromotedCountExpr, BoundsKWLoc,
                                        RParenLoc);
 }


### PR DESCRIPTION
This change implements checking of type requirements for bounds declarations for variables, members, and function return values.  It implements the checking described in Chapter 3 and Chapter 5 (interoperation) of the Checked C specification.   This addresses Github issue #41.

The requirements in Chapter 3 include:
- Bounds declaration are not allowed for variables, members, and return values with ptr type.
- They are also not allowed for function types and function pointer types.
-  Count bounds expressions are allowed for  variables or members that have pointer type or array type.  They are also allowed for pointer-typed function return values.   The pointer type must be a non-void pointer type.
- `byte_count `and `bounds` bounds expressions are allowed for variables  and members with pointer or array types.  They are also allowed for pointer-typed function return values..

The interoperation requirements include:
- Local variables with unchecked pointer or array types cannot have bounds declared for them.    Other declarations (global variables, members, and function return values) with unchecked pointer or array types can have bounds declared for them.  This is how bounds-safe interfaces are described.
- Integer-typed variables, members, and return values can have bounds declared for them using `byte_count` or `bounds` expressions

This change also:
- Fixes the implementation of clang type tests for BoundsExpr and its subclasses.  The static classof methods were not implemented.  In addition, the kind information for CountBoundsExpr and NullaryBoundsExpr was not properly padded, so it was overwriting the superclass kind information.
- Renames ActOnBoundsExpr to ActOnBoundsDecl, to more accurately describe what the function is doing.

Testing:
- New tests have been added to typechecking\bounds.c.   This will be committed separately to the GitHub CheckedC repo.   The new tests systematically test the cross product of variable/member/function return bounds declarations, the different kinds of bounds expressions, and the different types of variables.
- Passes existing clang tests.
