### PR TITLE
Type check bounds expression arguments

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8416,9 +8416,6 @@ def warn_objc_redundant_qualified_class_type : Warning<
 
 // Checked C diagnostic messages
 
- def err_typecheck_pointer_type_expected : Error<
-   "expected expression with pointer type (it has type %0)">;
-
 def err_checked_vla : Error<
   "checked variable-length array not allowed">;
 
@@ -8459,6 +8456,15 @@ def err_typecheck_count_bounds_expr : Error<
 
 def err_typecheck_byte_count_bounds_expr : Error<
   "invalid argument type %0 to byte_count expression">;
+
+def err_typecheck_bounds_expr : Error<
+  "invalid argument type %0 to bounds expression">;
+
+def err_typecheck_bounds_expr_incompatible_pointers : Error<
+  "pointer type mismatch%diff{ ($ and $)|}0,1">;
+
+ def err_typecheck_pointer_type_expected : Error<
+   "expected expression with pointer type (it has type %0)">;
 
 def err_typecheck_ptr_decl_with_bounds : Error<
   "bounds declaration not allowed because %0 has a ptr type">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8416,6 +8416,9 @@ def warn_objc_redundant_qualified_class_type : Warning<
 
 // Checked C diagnostic messages
 
+ def err_typecheck_pointer_type_expected : Error<
+   "expected expression with pointer type (it has type %0)">;
+
 def err_checked_vla : Error<
   "checked variable-length array not allowed">;
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4110,6 +4110,10 @@ public:
 
   //===---------------------------- Checked C Extension ----------------------===//
 
+private:
+  const Type *ValidateBoundsExprArgument(Expr *Arg);
+
+public:
   ExprResult ActOnNullaryBoundsExpr(SourceLocation BoundKWLoc,
                                     NullaryBoundsExpr::Kind Kind,
                                     SourceLocation RParenLoc);

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -11954,9 +11954,28 @@ ExprResult Sema::ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
 }
 
 ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
-                                            Expr *LowerBound,
-                                            Expr *UpperBound,
-                                            SourceLocation RParenLoc) {
+                                      Expr *LowerBound,
+                                      Expr *UpperBound,
+                                      SourceLocation RParenLoc) {
+  ExprResult Result = UsualUnaryConversions(LowerBound);
+  if (Result.isInvalid())
+     return ExprError();
+  LowerBound = Result.get();
+
+  Result = UsualUnaryConversions(UpperBound);
+  if (Result.isInvalid())
+    return ExprError();
+  UpperBound = Result.get();
+
+  QualType LowerBoundType = LowerBound->getType();
+  QualType UpperBoundType = UpperBound->getType();
+  if (!LowerBoundType->isPointerType())
+    Diag(LowerBound->getLocStart(),
+         diag::err_typecheck_pointer_type_expected) << LowerBoundType;
+  if (!UpperBoundType->isPointerType())
+    Diag(UpperBound->getLocStart(),
+         diag::err_typecheck_pointer_type_expected) << UpperBoundType;
+
   return new (Context) RangeBoundsExpr(LowerBound, UpperBound, BoundsKWLoc,
                                        RParenLoc);
 }


### PR DESCRIPTION
This change adds type checking for bounds expressions of the form (bounds(e1, e2).  The type checking rules are:
- The types of e1 and e2 must both be pointer types.
- The types e1 and e2 must both be pointers to objects or incomplete types, and
- The types of e1 and e2 must both be pointers to the same type or one of them must be a pointer to void.

Testing: 
- New tests will be added to typechecking\bounds.c in the Checked C GitHub repo.  These will be committed separately.
- Passes existing clang tests.