### PR TITLE
Revamp kinds for bounds expressions.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4509,13 +4509,34 @@ private:
   SourceLocation StartLoc, RParenLoc;
 
 public:
-  BoundsExpr(StmtClass StmtClass, SourceLocation StartLoc, SourceLocation RParenLoc)
+  enum Kind {
+    // Invalid bounds expressions are used to flag invalid bounds
+    // expressions and prevent spurious downstream error messages
+    // in bounds declaration checking.
+    Invalid = 0,
+    // bounds(none)
+    None = 1,
+    // count(e)
+    ElementCount = 2,
+    // byte_count(e)
+    ByteCount = 3,
+    // bounds(e1, e2)
+    Range = 4,
+    // ptr interop annotation
+    PtrInteropAnnotation
+  };
+
+  BoundsExpr(StmtClass StmtClass, Kind BoundsKind, SourceLocation StartLoc,
+             SourceLocation RParenLoc)
     : Expr(StmtClass, QualType(),  VK_RValue, OK_Ordinary, false,
            false, false, false), StartLoc(StartLoc), RParenLoc(RParenLoc) {
+    setKind(BoundsKind);
   }
 
   explicit BoundsExpr(StmtClass StmtClass, EmptyShell Empty) :
-    Expr(StmtClass, Empty) {}
+    Expr(StmtClass, Empty) {
+    setKind(Invalid);
+  }
 
   SourceLocation getStartLoc() { return StartLoc; }
   void setStartLoc(SourceLocation Loc) { StartLoc = Loc; }
@@ -4525,35 +4546,56 @@ public:
   SourceLocation getLocStart() const LLVM_READONLY { return StartLoc; }
   SourceLocation getLocEnd() const LLVM_READONLY { return RParenLoc; }
 
+  Kind getKind() const { return (Kind)BoundsExprBits.Kind; }
+  void setKind(Kind Kind) {
+    BoundsExprBits.Kind = Kind;
+    assert(validateKind());
+  }
+
+  bool isInvalid() {
+    return getKind() == Invalid;
+  }
+
+  bool isNone() {
+    return getKind() == None;
+  }
+
+  bool isElementCount() {
+    return getKind() == ElementCount;
+  }
+
+  bool isByteCount() {
+    return getKind() == ByteCount;
+  }
+
+  bool isRange() {
+    return getKind() == Range;
+  }
+
+  bool isPtrInteropAnnotation() {
+    return getKind() == PtrInteropAnnotation;
+  }
+
   static bool classof(const Stmt *T) {
     return T->getStmtClass() >= firstBoundsExprConstant &&
            T->getStmtClass() <= lastBoundsExprConstant;
   }
+
+private:
+  /// \brief: check that the kind is valid for the type
+  /// of bounds expression.
+  bool validateKind();
 };
 
 /// \brief Represents a Checked C nullary bounds expression.
 class NullaryBoundsExpr : public BoundsExpr {
 public:
-  enum Kind {
-    // Invalid bounds expressions are used to flag invalid bounds
-    // expressions and prevent spurious downstream error messages
-    // in bounds declaration checking.
-    Invalid = 0,
-    // bounds(none)
-    None = 1
-  };
-
-public:
   NullaryBoundsExpr(Kind Kind, SourceLocation StartLoc, SourceLocation RParenLoc)
-    : BoundsExpr(NullaryBoundsExprClass, StartLoc, RParenLoc)  {
-    NullaryBoundsExprBits.Kind = Kind;
+    : BoundsExpr(NullaryBoundsExprClass, Kind, StartLoc, RParenLoc)  {
   }
 
   explicit NullaryBoundsExpr(EmptyShell Empty)
     : BoundsExpr(NullaryBoundsExprClass, Empty) {}
-
-  Kind getKind() const { return (Kind) NullaryBoundsExprBits.Kind; }
-  void setKind(Kind Kind) { NullaryBoundsExprBits.Kind = Kind; }
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == NullaryBoundsExprClass;
@@ -4567,27 +4609,18 @@ public:
 
 /// \brief Represents a Checked C count bounds expression.
 class CountBoundsExpr : public BoundsExpr {
-public:
-  enum Kind {
-    ElementCount = 0,
-    ByteCount = 1,
-  };
 private:
   Stmt *CountExpr;
 
 public:
   CountBoundsExpr(Kind Kind, Expr *Count, SourceLocation StartLoc,
     SourceLocation RParenLoc)
-    : BoundsExpr(CountBoundsExprClass, StartLoc, RParenLoc),
+    : BoundsExpr(CountBoundsExprClass, Kind, StartLoc, RParenLoc),
       CountExpr(Count) {
-    CountBoundsExprBits.Kind = Kind;
   }
 
   explicit CountBoundsExpr(EmptyShell Empty)
     : BoundsExpr(CountBoundsExprClass, Empty) {}
-
-  Kind getKind() const { return (Kind)CountBoundsExprBits.Kind; }
-  void setKind(Kind Kind) { CountBoundsExprBits.Kind = Kind; }
 
   Expr *getCountExpr() const { return cast<Expr>(CountExpr); }
   void setCountExpr(Expr *E) { CountExpr = E; }
@@ -4610,7 +4643,7 @@ private:
 public:
   RangeBoundsExpr(Expr *Lower, Expr *Upper, SourceLocation StartLoc,
                   SourceLocation RParenLoc)
-    : BoundsExpr(RangeBoundsExprClass, StartLoc, RParenLoc) {
+    : BoundsExpr(RangeBoundsExprClass, Range, StartLoc, RParenLoc) {
     SubExprs[LOWER] = Lower;
     SubExprs[UPPER] = Upper;
   }

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -252,18 +252,11 @@ protected:
     unsigned NumArgs : 32 - 8 - 1 - NumExprBits;
   };
 
-  class CountBoundsExprBitFields {
-    friend class CountBoundsExpr;
+  class BoundsExprBitFields {
+    friend class BoundsExpr;
 
     unsigned : NumExprBits;
-    unsigned Kind : 1;
-  };
-
-  class NullaryBoundsExprBitFields {
-    friend class NullaryBoundsExpr;
-
-    unsigned : NumExprBits;
-    unsigned Kind : 1;
+    unsigned Kind : 3;
   };
 
   union {
@@ -282,8 +275,7 @@ protected:
     ObjCIndirectCopyRestoreExprBitfields ObjCIndirectCopyRestoreExprBits;
     InitListExprBitfields InitListExprBits;
     TypeTraitExprBitfields TypeTraitExprBits;
-    CountBoundsExprBitFields CountBoundsExprBits;
-    NullaryBoundsExprBitFields NullaryBoundsExprBits;
+    BoundsExprBitFields BoundsExprBits;
   };
 
   friend class ASTStmtReader;

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -252,11 +252,13 @@ protected:
     unsigned NumArgs : 32 - 8 - 1 - NumExprBits;
   };
 
+  enum { NumBoundsExprKindBits = 3 };
+
   class BoundsExprBitFields {
     friend class BoundsExpr;
 
     unsigned : NumExprBits;
-    unsigned Kind : 3;
+    unsigned Kind : NumBoundsExprKindBits;
   };
 
   union {

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4217,14 +4217,13 @@ private:
 
 public:
   ExprResult ActOnNullaryBoundsExpr(SourceLocation BoundKWLoc,
-                                    NullaryBoundsExpr::Kind Kind,
+                                    BoundsExpr::Kind Kind,
                                     SourceLocation RParenLoc);
   ExprResult ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
-                                  CountBoundsExpr::Kind Kind, Expr *CountExpr,
+                                  BoundsExpr::Kind Kind, Expr *CountExpr,
                                   SourceLocation RParenLoc);
   ExprResult ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc, Expr *LowerBound,
                                   Expr *UpperBound, SourceLocation RParenLoc);
-
   void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr, bool isReturnDecl=false);
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3814,18 +3814,20 @@ PseudoObjectExpr::PseudoObjectExpr(QualType type, ExprValueKind VK,
   }
 }
 
-bool BoundsExpr::validateKind() {
-  Kind K = getKind();
+bool BoundsExpr::validateKind(Kind K) {
   if (K == Invalid)
     return true;
-  else if (isa<NullaryBoundsExpr>(this))
-    return K == None || K == PtrInteropAnnotation;
-  else if (isa<CountBoundsExpr>(this))
-    return K == ElementCount || K == ByteCount;
-  else if (isa<RangeBoundsExpr>(this))
-    return K == Range;
 
-  return false;
+  switch (getStmtClass()) {
+    case NullaryBoundsExprClass:
+      return K == None || K == PtrInteropAnnotation;
+    case CountBoundsExprClass:
+      return K == ElementCount || K == ByteCount;
+    case RangeBoundsExprClass:
+      return K == Range;
+    default:
+      return false;
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3814,6 +3814,20 @@ PseudoObjectExpr::PseudoObjectExpr(QualType type, ExprValueKind VK,
   }
 }
 
+bool BoundsExpr::validateKind() {
+  Kind K = getKind();
+  if (K == Invalid)
+    return true;
+  else if (isa<NullaryBoundsExpr>(this))
+    return K == None || K == PtrInteropAnnotation;
+  else if (isa<CountBoundsExpr>(this))
+    return K == ElementCount || K == ByteCount;
+  else if (isa<RangeBoundsExpr>(this))
+    return K == Range;
+
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 //  Child Iterators for iterating over subexpressions/substatements
 //===----------------------------------------------------------------------===//

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2762,7 +2762,8 @@ bool Parser::StartsBoundsExpression(Token &tok) {
 }
 
 ExprResult Parser::ParseBoundsExpression() {
-  if (Tok.getKind() != tok::identifier) {
+  tok::TokenKind TokKind = Tok.getKind();
+  if (TokKind != tok::identifier) {
     // This can't be a contextual keyword that begins a bounds expression,
     // so stop now.
     Diag(Tok, diag::err_expected_bounds_expr);
@@ -2783,8 +2784,8 @@ ExprResult Parser::ParseBoundsExpression() {
   if (Ident == Ident_byte_count || Ident == Ident_count) {
     // Parse byte_count(e1) or count(e1)
     Result = Actions.CorrectDelayedTyposInExpr(ParseAssignmentExpression());
-    CountBoundsExpr::Kind CountKind = Ident == Ident_count ?
-      CountBoundsExpr::Kind::ElementCount : CountBoundsExpr::Kind::ByteCount;
+    BoundsExpr::Kind CountKind = Ident == Ident_count ?
+      BoundsExpr::Kind::ElementCount : BoundsExpr::Kind::ByteCount;
     if (Result.isInvalid())
       Result = ExprError();
     else
@@ -2802,7 +2803,7 @@ ExprResult Parser::ParseBoundsExpression() {
         FoundNullaryOperator = true;
         ConsumeToken();
         Result = Actions.ActOnNullaryBoundsExpr(BoundsKWLoc, 
-                                                NullaryBoundsExpr::Kind::None,
+                                                BoundsExpr::Kind::None,
                                                 Tok.getLocation());
       }
     }

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12194,13 +12194,13 @@ ExprResult Sema::ActOnChooseExpr(SourceLocation BuiltinLoc,
 //===----------------------------------------------------------------------===//
 
 ExprResult Sema::ActOnNullaryBoundsExpr(SourceLocation BoundsKWLoc,
-                                        NullaryBoundsExpr::Kind Kind,
+                                        BoundsExpr::Kind Kind,
                                         SourceLocation RParenLoc) {
   return new (Context) NullaryBoundsExpr(Kind, BoundsKWLoc, RParenLoc);
 }
 
 ExprResult Sema::ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
-                                      CountBoundsExpr::Kind Kind,
+                                      BoundsExpr::Kind Kind,
                                       Expr *CountExpr,
                                       SourceLocation RParenLoc) {
   // Do the usual C integer promotions if necessary. 
@@ -12211,7 +12211,7 @@ ExprResult Sema::ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
   QualType ResultType = CountExpr->getType();
   if (!ResultType->isIntegerType()) {
     Diag(CountExpr->getLocStart(),
-         Kind == CountBoundsExpr::Kind::ElementCount ?
+         Kind == BoundsExpr::Kind::ElementCount ?
          diag::err_typecheck_count_bounds_expr
          : diag::err_typecheck_byte_count_bounds_expr)
       << ResultType;

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -2343,14 +2343,14 @@ public:
   }
 
   ExprResult RebuildCountBoundsExpr(SourceLocation StartLoc,
-                                    CountBoundsExpr::Kind Kind,
+                                    BoundsExpr::Kind Kind,
                                     Expr * CountExpr,
                                     SourceLocation RParenLoc) {
     return getSema().ActOnCountBoundsExpr(StartLoc, Kind, CountExpr, RParenLoc);
   }
 
   ExprResult RebuildNullaryBoundsExpr(SourceLocation StartLoc,
-                                      NullaryBoundsExpr::Kind Kind,
+                                      BoundsExpr::Kind Kind,
                                       SourceLocation RParenLoc) {
     return getSema().ActOnNullaryBoundsExpr(StartLoc, Kind, RParenLoc);
   }

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -958,7 +958,7 @@ void ASTStmtReader::VisitAtomicExpr(AtomicExpr *E) {
 
 void ASTStmtReader::VisitCountBoundsExpr(CountBoundsExpr *E) {
   VisitExpr(E);
-  E->setKind((CountBoundsExpr::Kind)Record[Idx++]);
+  E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->setCountExpr(Reader.ReadSubExpr());
   E->setStartLoc(ReadSourceLocation(Record, Idx));
   E->setRParenLoc(ReadSourceLocation(Record, Idx));
@@ -966,7 +966,7 @@ void ASTStmtReader::VisitCountBoundsExpr(CountBoundsExpr *E) {
 
 void ASTStmtReader::VisitNullaryBoundsExpr(NullaryBoundsExpr *E) {
   VisitExpr(E);
-  E->setKind((NullaryBoundsExpr::Kind)Record[Idx++]);
+  E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->setStartLoc(ReadSourceLocation(Record, Idx));
   E->setRParenLoc(ReadSourceLocation(Record, Idx));
 }


### PR DESCRIPTION
Instead of having separate kind enumerations for different bounds expression
classes, have just one kind enumeration for all bounds expression classes.
This makes it easier to write predicates that check for a specific kind of
bounds expression, without having to do a dynamic type test and cast to the
specific bounds expression type.  This addresses Github issue #50.

The downside of the unified kind enumeration is that a developer can use a
kind that is invalid for a specific bounds expression class.  Add code to
validate the kind information.

Add predicates for testing for specific kinds of bounds expressions and
clean up code for type checking bounds expressions by using the predicates.

This also adds a kind for the `: ptr` interop bounds annotation to the
kind enumeration for bounds expressions.

Testing:
- Passes existing clang and Checked C tests.