### PR TITLE
Parse and represent bounds-safe interface type annotations

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4695,22 +4695,21 @@ public:
 ///  such as `int **y', where y could have a bounds-safe interface that
 /// is `ptr<ptr<int>>` or `array_ptr<ptr<int>>`.
 ///
-/// This is not a bounds expression.  Because we typically need bounds-safe
-/// interface information at the same points where we would need bounds
-/// information, so it is convenient to store the information as a bounds
-/// expression.  
-class InteropTypeBoundsExpr : public BoundsExpr {
+/// We typically need bounds-safe interface information at the same points
+/// where we need bounds information, so it is convenient to store the
+/// information as a bounds expression.
+class InteropTypeBoundsAnnot : public BoundsExpr {
 private:
   TypeSourceInfo *TIInfo;
 public:
-  InteropTypeBoundsExpr(QualType Ty, SourceLocation StartLoc,
+  InteropTypeBoundsAnnot(QualType Ty, SourceLocation StartLoc,
                         SourceLocation EndLoc, TypeSourceInfo *tyAsWritten)
-    : BoundsExpr(InteropTypeBoundsExprClass, Ty, InteropTypeAnnotation,
+    : BoundsExpr(InteropTypeBoundsAnnotClass, Ty, InteropTypeAnnotation,
                  StartLoc, EndLoc), TIInfo(tyAsWritten) {
   }
 
-  explicit InteropTypeBoundsExpr(EmptyShell Empty)
-    : BoundsExpr(InteropTypeBoundsExprClass, Empty) {}
+  explicit InteropTypeBoundsAnnot(EmptyShell Empty)
+    : BoundsExpr(InteropTypeBoundsAnnotClass, Empty) {}
 
   /// getTypeInfoAsWritten - Returns the type source info for the type
   /// in the interop annotaiton
@@ -4722,7 +4721,7 @@ public:
   QualType getTypeAsWritten() const { return TIInfo->getType(); }
 
   static bool classof(const Stmt *T) {
-    return T->getStmtClass() == InteropTypeBoundsExprClass;
+    return T->getStmtClass() == InteropTypeBoundsAnnotClass;
   }
 
   // Iterators

--- a/include/clang/AST/RecursiveASTVisitor.h
+++ b/include/clang/AST/RecursiveASTVisitor.h
@@ -2425,7 +2425,7 @@ DEF_TRAVERSE_STMT(AtomicExpr, {})
 DEF_TRAVERSE_STMT(CountBoundsExpr, {})
 DEF_TRAVERSE_STMT(NullaryBoundsExpr, {})
 DEF_TRAVERSE_STMT(RangeBoundsExpr, {})
-DEF_TRAVERSE_STMT(InteropTypeBoundsAnnot, {})
+DEF_TRAVERSE_STMT(InteropTypeBoundsAnnotation, {})
 
 // For coroutines expressions, traverse either the operand
 // as written or the implied calls, depending on what the

--- a/include/clang/AST/RecursiveASTVisitor.h
+++ b/include/clang/AST/RecursiveASTVisitor.h
@@ -2425,7 +2425,7 @@ DEF_TRAVERSE_STMT(AtomicExpr, {})
 DEF_TRAVERSE_STMT(CountBoundsExpr, {})
 DEF_TRAVERSE_STMT(NullaryBoundsExpr, {})
 DEF_TRAVERSE_STMT(RangeBoundsExpr, {})
-DEF_TRAVERSE_STMT(InteropTypeBoundsExpr, {})
+DEF_TRAVERSE_STMT(InteropTypeBoundsAnnot, {})
 
 // For coroutines expressions, traverse either the operand
 // as written or the implied calls, depending on what the

--- a/include/clang/AST/RecursiveASTVisitor.h
+++ b/include/clang/AST/RecursiveASTVisitor.h
@@ -2425,6 +2425,7 @@ DEF_TRAVERSE_STMT(AtomicExpr, {})
 DEF_TRAVERSE_STMT(CountBoundsExpr, {})
 DEF_TRAVERSE_STMT(NullaryBoundsExpr, {})
 DEF_TRAVERSE_STMT(RangeBoundsExpr, {})
+DEF_TRAVERSE_STMT(InteropTypeBoundsExpr, {})
 
 // For coroutines expressions, traverse either the operand
 // as written or the implied calls, depending on what the

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1066,4 +1066,10 @@ def err_for_co_await_not_range_for : Error<
 def err_expected_bounds_expr : Error<
   "expected bounds expression">;
 
+def err_expected_bounds_interop_type : Error<
+  "expected bounds-safe interface type">;
+
+def err_expected_bounds_expr_or_interop_type : Error<
+  "expected bounds expression or bounds-safe interface type">;
+
 } // end of Parser diagnostics

--- a/include/clang/Basic/StmtNodes.td
+++ b/include/clang/Basic/StmtNodes.td
@@ -175,7 +175,7 @@ def BoundsExpr : DStmt<Expr, 1>;
 def NullaryBoundsExpr : DStmt<BoundsExpr>;
 def CountBoundsExpr : DStmt<BoundsExpr>;
 def RangeBoundsExpr : DStmt<BoundsExpr>;
-def InteropTypeBoundsAnnot : DStmt<BoundsExpr>;
+def InteropTypeBoundsAnnotation : DStmt<BoundsExpr>;
 
 // CUDA Expressions.
 def CUDAKernelCallExpr : DStmt<CallExpr>;

--- a/include/clang/Basic/StmtNodes.td
+++ b/include/clang/Basic/StmtNodes.td
@@ -175,6 +175,7 @@ def BoundsExpr : DStmt<Expr, 1>;
 def NullaryBoundsExpr : DStmt<BoundsExpr>;
 def CountBoundsExpr : DStmt<BoundsExpr>;
 def RangeBoundsExpr : DStmt<BoundsExpr>;
+def InteropTypeBoundsExpr : DStmt<BoundsExpr>;
 
 // CUDA Expressions.
 def CUDAKernelCallExpr : DStmt<CallExpr>;

--- a/include/clang/Basic/StmtNodes.td
+++ b/include/clang/Basic/StmtNodes.td
@@ -175,7 +175,7 @@ def BoundsExpr : DStmt<Expr, 1>;
 def NullaryBoundsExpr : DStmt<BoundsExpr>;
 def CountBoundsExpr : DStmt<BoundsExpr>;
 def RangeBoundsExpr : DStmt<BoundsExpr>;
-def InteropTypeBoundsExpr : DStmt<BoundsExpr>;
+def InteropTypeBoundsAnnot : DStmt<BoundsExpr>;
 
 // CUDA Expressions.
 def CUDAKernelCallExpr : DStmt<CallExpr>;

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -165,6 +165,9 @@ class Parser : public CodeCompletionHandler {
   /// \brief Identifier for "none".
   IdentifierInfo *Ident_none;
 
+  /// \brief Identifier for "type"
+  IdentifierInfo *Ident_type;
+
   // C++ type trait keywords that can be reverted to identifiers and still be
   // used as type traits.
   llvm::SmallDenseMap<IdentifierInfo *, tok::TokenKind> RevertibleTypeTraits;

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1657,6 +1657,9 @@ private:
 
   /// \brief Return true if this token can start a bounds expression.
   bool StartsBoundsExpression(Token &Tok);
+  /// \brief Return true if this token can start a interop type bounds
+  /// annotation.
+  bool StartsInteropTypeBoundsAnnotation(Token &tok);
   ExprResult ParseBoundsExpression();
   bool ConsumeAndStoreBoundsExpression(CachedTokens &Toks);
   ExprResult DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks);
@@ -1921,7 +1924,7 @@ private:
 
   void ParseStructDeclaration(
       ParsingDeclSpec &DS,
-      llvm::function_ref<void(ParsingFieldDeclarator &, std::unique_ptr<CachedTokens>)> FieldsCallback);
+      llvm::function_ref<void(ParsingFieldDeclarator &)> FieldsCallback);
 
   bool isDeclarationSpecifier(bool DisambiguatingWithExpression = false);
   bool isTypeSpecifierQualifier();

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1657,13 +1657,15 @@ private:
 
   /// \brief Return true if this token can start a bounds expression.
   bool StartsBoundsExpression(Token &Tok);
-  /// \brief Return true if this token can start a interop type bounds
-  /// annotation.
-  bool StartsInteropTypeBoundsAnnotation(Token &tok);
+  /// \brief Return true if this token can start a bounds-safe interface
+  /// type annotation.
+  bool StartsInteropTypeAnnotation(Token &tok);
+
   ExprResult ParseBoundsExpression();
+  ExprResult ParseInteropTypeAnnotation();
+  ExprResult ParseBoundsExpressionOrInteropType();
   bool ConsumeAndStoreBoundsExpression(CachedTokens &Toks);
   ExprResult DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks);
-
 
   //===--------------------------------------------------------------------===//
   // clang Expressions

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -2417,7 +2417,7 @@ struct FieldDeclarator {
   Declarator D;
   Expr *BitfieldSize;
   std::unique_ptr<CachedTokens> BoundsExprTokens;
-  InteropTypeBoundsAnnot *BoundsAnnotation;
+  InteropTypeBoundsAnnotation *BoundsAnnotation;
 
   explicit FieldDeclarator(const DeclSpec &DS)
     : D(DS, Declarator::MemberContext), BitfieldSize(nullptr), BoundsExprTokens(nullptr),

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -2417,7 +2417,7 @@ struct FieldDeclarator {
   Declarator D;
   Expr *BitfieldSize;
   std::unique_ptr<CachedTokens> BoundsExprTokens;
-  InteropTypeBoundsExpr *BoundsAnnotation;
+  InteropTypeBoundsAnnot *BoundsAnnotation;
 
   explicit FieldDeclarator(const DeclSpec &DS)
     : D(DS, Declarator::MemberContext), BitfieldSize(nullptr), BoundsExprTokens(nullptr),

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -2408,12 +2408,20 @@ public:
 };
 
 /// \brief This little struct is used to capture information about
-/// structure field declarators, which is basically just a bitfield size.
+/// structure field declarators. This is just a bitfield size, except
+/// for Checked C.  
+///
+/// For Checked C, it could be a bounds expression to be parsed later
+// or an interop type bounds annotation.
 struct FieldDeclarator {
   Declarator D;
   Expr *BitfieldSize;
+  std::unique_ptr<CachedTokens> BoundsExprTokens;
+  InteropTypeBoundsExpr *BoundsAnnotation;
+
   explicit FieldDeclarator(const DeclSpec &DS)
-    : D(DS, Declarator::MemberContext), BitfieldSize(nullptr) { }
+    : D(DS, Declarator::MemberContext), BitfieldSize(nullptr), BoundsExprTokens(nullptr),
+      BoundsAnnotation(nullptr) { }
 };
 
 /// \brief Represents a C++11 virt-specifier-seq.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4224,7 +4224,10 @@ public:
                                   SourceLocation RParenLoc);
   ExprResult ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc, Expr *LowerBound,
                                   Expr *UpperBound, SourceLocation RParenLoc);
-  ExprResult ActOnBoundsInteropType(ParsedType ty);
+  ExprResult ActOnBoundsInteropType(SourceLocation TypeKWLoc, ParsedType Ty,
+                                    SourceLocation RParenLoc);
+  ExprResult CreateBoundsInteropType(SourceLocation TypeKWLoc, TypeSourceInfo *TInfo,
+                                    SourceLocation RParenLoc);
   void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr, bool isReturnDecl=false);
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4224,6 +4224,7 @@ public:
                                   SourceLocation RParenLoc);
   ExprResult ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc, Expr *LowerBound,
                                   Expr *UpperBound, SourceLocation RParenLoc);
+  ExprResult ActOnBoundsInteropType(ParsedType ty);
   void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr, bool isReturnDecl=false);
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();

--- a/include/clang/Serialization/ASTBitCodes.h
+++ b/include/clang/Serialization/ASTBitCodes.h
@@ -1443,7 +1443,7 @@ namespace clang {
       EXPR_COUNT_BOUNDS_EXPR,      // CountBoundsExpr
       EXPR_NULLARY_BOUNDS_EXPR,    // NullaryBoundsExpr
       EXPR_RANGE_BOUNDS_EXPR,      // RangeBoundsExpr
-      EXPR_INTEROPTYPE_BOUNDS_ANNOT,// InteropTypeBoundsAnnot
+      EXPR_INTEROPTYPE_BOUNDS_ANNOTATION,// InteropTypeBoundsAnnotation
 
       // OpenCL
       EXPR_ASTYPE,                 // AsTypeExpr

--- a/include/clang/Serialization/ASTBitCodes.h
+++ b/include/clang/Serialization/ASTBitCodes.h
@@ -1443,6 +1443,7 @@ namespace clang {
       EXPR_COUNT_BOUNDS_EXPR,      // CountBoundsExpr
       EXPR_NULLARY_BOUNDS_EXPR,    // NullaryBoundsExpr
       EXPR_RANGE_BOUNDS_EXPR,      // RangeBoundsExpr
+      EXPR_INTEROPTYPE_BOUNDS_EXPR,// InteropTypeBoundsExpr
 
       // OpenCL
       EXPR_ASTYPE,                 // AsTypeExpr

--- a/include/clang/Serialization/ASTBitCodes.h
+++ b/include/clang/Serialization/ASTBitCodes.h
@@ -1443,7 +1443,7 @@ namespace clang {
       EXPR_COUNT_BOUNDS_EXPR,      // CountBoundsExpr
       EXPR_NULLARY_BOUNDS_EXPR,    // NullaryBoundsExpr
       EXPR_RANGE_BOUNDS_EXPR,      // RangeBoundsExpr
-      EXPR_INTEROPTYPE_BOUNDS_EXPR,// InteropTypeBoundsExpr
+      EXPR_INTEROPTYPE_BOUNDS_ANNOT,// InteropTypeBoundsAnnot
 
       // OpenCL
       EXPR_ASTYPE,                 // AsTypeExpr

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3825,7 +3825,7 @@ bool BoundsExpr::validateKind(Kind K) {
       return K == ElementCount || K == ByteCount;
     case RangeBoundsExprClass:
       return K == Range;
-    case InteropTypeBoundsAnnotClass:
+    case InteropTypeBoundsAnnotationClass:
       return K == InteropTypeAnnotation;
     default:
       return false;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3825,7 +3825,7 @@ bool BoundsExpr::validateKind(Kind K) {
       return K == ElementCount || K == ByteCount;
     case RangeBoundsExprClass:
       return K == Range;
-    case InteropTypeBoundsExprClass:
+    case InteropTypeBoundsAnnotClass:
       return K == InteropTypeAnnotation;
     default:
       return false;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3820,11 +3820,13 @@ bool BoundsExpr::validateKind(Kind K) {
 
   switch (getStmtClass()) {
     case NullaryBoundsExprClass:
-      return K == None || K == PtrInteropAnnotation;
+      return K == None;
     case CountBoundsExprClass:
       return K == ElementCount || K == ByteCount;
     case RangeBoundsExprClass:
       return K == Range;
+    case InteropTypeBoundsExprClass:
+      return K == InteropTypeAnnotation;
     default:
       return false;
   }

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1845,7 +1845,7 @@ void StmtPrinter::VisitNullaryBoundsExpr(NullaryBoundsExpr *Node) {
       break;
     case BoundsExpr::None:
       OS << "bounds(none)";
-      break;;
+      break;
     default:
       llvm_unreachable("unexpected bounds kind for nullary bounds expr");
   }
@@ -1872,7 +1872,8 @@ void StmtPrinter::VisitRangeBoundsExpr(RangeBoundsExpr *Node) {
   OS << ")";
 }
 
-void StmtPrinter::VisitInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *Node) {
+void StmtPrinter::VisitInteropTypeBoundsAnnotation(
+  InteropTypeBoundsAnnotation *Node) {
   switch (Node->getKind()) {
   case BoundsExpr::Invalid:
     OS << "invalid_interoptype";

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1872,7 +1872,7 @@ void StmtPrinter::VisitRangeBoundsExpr(RangeBoundsExpr *Node) {
   OS << ")";
 }
 
-void StmtPrinter::VisitInteropTypeBoundsExpr(InteropTypeBoundsExpr *Node) {
+void StmtPrinter::VisitInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *Node) {
   switch (Node->getKind()) {
   case BoundsExpr::Invalid:
     OS << "invalid_interoptype";

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1845,10 +1845,7 @@ void StmtPrinter::VisitNullaryBoundsExpr(NullaryBoundsExpr *Node) {
       break;
     case BoundsExpr::None:
       OS << "bounds(none)";
-      break;
-    case BoundsExpr::PtrInteropAnnotation:
-      OS << "ptr";
-      break;
+      break;;
     default:
       llvm_unreachable("unexpected bounds kind for nullary bounds expr");
   }
@@ -1873,6 +1870,19 @@ void StmtPrinter::VisitRangeBoundsExpr(RangeBoundsExpr *Node) {
   OS << ", ";
   PrintExpr(Node->getUpperExpr());
   OS << ")";
+}
+
+void StmtPrinter::VisitInteropTypeBoundsExpr(InteropTypeBoundsExpr *Node) {
+  switch (Node->getKind()) {
+  case BoundsExpr::Invalid:
+    OS << "invalid_interoptype";
+    break;
+  case BoundsExpr::InteropTypeAnnotation:
+    Node->getTypeAsWritten().print(OS, Policy);
+    break;
+  default:
+    llvm_unreachable("unexpected bounds kind for interop type bounds expr");
+  }
 }
 
 // C++

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1011,7 +1011,8 @@ void StmtProfiler::VisitRangeBoundsExpr(const RangeBoundsExpr *S) {
   ID.AddInteger(S->getKind());
 }
 
-void StmtProfiler::VisitInteropTypeBoundsAnnot(const InteropTypeBoundsAnnot *S) {
+void StmtProfiler::VisitInteropTypeBoundsAnnotation(
+  const InteropTypeBoundsAnnotation *S) {
   VisitExpr(S);
   ID.AddInteger(S->getKind());
 }

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1008,6 +1008,12 @@ void StmtProfiler::VisitNullaryBoundsExpr(const NullaryBoundsExpr *S) {
 
 void StmtProfiler::VisitRangeBoundsExpr(const RangeBoundsExpr *S) {
   VisitExpr(S);
+  ID.AddInteger(S->getKind());
+}
+
+void StmtProfiler::VisitInteropTypeBoundsExpr(const InteropTypeBoundsExpr *S) {
+  VisitExpr(S);
+  ID.AddInteger(S->getKind());
 }
 
 void StmtProfiler::VisitAtomicExpr(const AtomicExpr *S) {

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1011,7 +1011,7 @@ void StmtProfiler::VisitRangeBoundsExpr(const RangeBoundsExpr *S) {
   ID.AddInteger(S->getKind());
 }
 
-void StmtProfiler::VisitInteropTypeBoundsExpr(const InteropTypeBoundsExpr *S) {
+void StmtProfiler::VisitInteropTypeBoundsAnnot(const InteropTypeBoundsAnnot *S) {
   VisitExpr(S);
   ID.AddInteger(S->getKind());
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3688,8 +3688,8 @@ void Parser::ParseStructDeclaration(
         if (BoundsResult.isInvalid())
           SkipUntil(tok::semi, StopBeforeMatch);
         else {
-          InteropTypeBoundsAnnot *BoundsAnnotation =
-            dyn_cast<InteropTypeBoundsAnnot>(BoundsResult.get());
+          InteropTypeBoundsAnnotation *BoundsAnnotation =
+            dyn_cast<InteropTypeBoundsAnnotation>(BoundsResult.get());
           assert(BoundsAnnotation && "dyn_cast failed");
           if (BoundsAnnotation)
             DeclaratorInfo.BoundsAnnotation = BoundsAnnotation;
@@ -3802,9 +3802,11 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
         // One or both of FD.BoundsExprTokens and FD.BoundsAnnotation must be
         // null. They cannot both be non-null at the same time, or we'll end
         // up losing/overwriting information.
-        assert(FD.BoundsExprTokens == nullptr || FD.BoundsAnnotation == nullptr);
+        assert(FD.BoundsExprTokens == nullptr ||
+               FD.BoundsAnnotation == nullptr);
         if (FD.BoundsExprTokens != nullptr)
-          deferredBoundsExpressions.emplace_back(Field, std::move(FD.BoundsExprTokens));
+          deferredBoundsExpressions.emplace_back(Field,
+            std::move(FD.BoundsExprTokens));
         if (FD.BoundsAnnotation != nullptr)
           Field->setBoundsExpr(FD.BoundsAnnotation);
       };
@@ -6183,13 +6185,13 @@ void Parser::ParseParameterDeclarationClause(
         else {
            // fall back to general code that eagerly parses a bounds expression
            // bounds-safe interface type annotation
-          ExprResult BoundsAnnot = ParseBoundsExpressionOrInteropType();
-          if (BoundsAnnot.isInvalid()) {
+          ExprResult BoundsAnnotation = ParseBoundsExpressionOrInteropType();
+          if (BoundsAnnotation.isInvalid()) {
             SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
             Actions.ActOnInvalidBoundsDecl(Param);
           }
           else
-            Actions.ActOnBoundsDecl(Param, cast<BoundsExpr>(BoundsAnnot.get()));
+            Actions.ActOnBoundsDecl(Param, cast<BoundsExpr>(BoundsAnnotation.get()));
         }
       }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3688,8 +3688,8 @@ void Parser::ParseStructDeclaration(
         if (BoundsResult.isInvalid())
           SkipUntil(tok::semi, StopBeforeMatch);
         else {
-          InteropTypeBoundsExpr *BoundsAnnotation =
-            dyn_cast<InteropTypeBoundsExpr>(BoundsResult.get());
+          InteropTypeBoundsAnnot *BoundsAnnotation =
+            dyn_cast<InteropTypeBoundsAnnot>(BoundsResult.get());
           assert(BoundsAnnotation && "dyn_cast failed");
           if (BoundsAnnotation)
             DeclaratorInfo.BoundsAnnotation = BoundsAnnotation;

--- a/lib/Parse/ParseObjc.cpp
+++ b/lib/Parse/ParseObjc.cpp
@@ -1985,7 +1985,7 @@ void Parser::ParseObjCClassInstanceVariables(Decl *interfaceDecl,
       // BoundsExprTokens and BoundsAnnotations are used only for Checked C.  
       // They should be null here.
       assert(FD.BoundsExprTokens == nullptr);
-      assert(FD.BitfieldSize == nullptr);
+      assert(FD.BoundsAnnotation == nullptr);
       Actions.ActOnObjCContainerStartDefinition(interfaceDecl);
       // Install the declarator into the interface decl.
       FD.D.setObjCIvar(true);

--- a/lib/Parse/ParseObjc.cpp
+++ b/lib/Parse/ParseObjc.cpp
@@ -742,10 +742,11 @@ void Parser::ParseObjCInterfaceDeclList(tok::ObjCKeywordKind contextKey,
       }
 
       bool addedToDeclSpec = false;
-      auto ObjCPropertyCallback = [&](ParsingFieldDeclarator &FD,
-                                      std::unique_ptr<CachedTokens> BoundsExprTokens) {
-        // BoundsExprTokens are used only for Checked C.  They should be null here.
-        assert(BoundsExprTokens == nullptr);
+      auto ObjCPropertyCallback = [&](ParsingFieldDeclarator &FD) {
+        // BoundsExprTokens and BoundsAnnotations are used only for Checked C.
+        // They should be null here.
+        assert(FD.BoundsExprTokens == nullptr);
+        assert(FD.BoundsAnnotation == nullptr);
         if (FD.D.getIdentifier() == nullptr) {
           Diag(AtLoc, diag::err_objc_property_requires_field_name)
               << FD.D.getSourceRange();
@@ -1980,10 +1981,11 @@ void Parser::ParseObjCClassInstanceVariables(Decl *interfaceDecl,
       return cutOffParsing();
     }
 
-    auto ObjCIvarCallback = [&](ParsingFieldDeclarator &FD,
-                                std::unique_ptr<CachedTokens> BoundsExprTokens) {
-      // BoundsExprTokens are used only for Checked C.  They should be null here.
-      assert(BoundsExprTokens == nullptr);
+    auto ObjCIvarCallback = [&](ParsingFieldDeclarator &FD) {
+      // BoundsExprTokens and BoundsAnnotations are used only for Checked C.  
+      // They should be null here.
+      assert(FD.BoundsExprTokens == nullptr);
+      assert(FD.BitfieldSize == nullptr);
       Actions.ActOnObjCContainerStartDefinition(interfaceDecl);
       // Install the declarator into the interface decl.
       FD.D.setObjCIvar(true);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -499,11 +499,13 @@ void Parser::Initialize() {
     Ident_byte_count = &PP.getIdentifierTable().get("byte_count");
     Ident_count = &PP.getIdentifierTable().get("count");
     Ident_none = &PP.getIdentifierTable().get("none");
+    Ident_type = &PP.getIdentifierTable().get("type");
   } else {
     Ident_bounds = nullptr;
     Ident_byte_count = nullptr;
     Ident_count = nullptr;
     Ident_none = nullptr;
+    Ident_type = nullptr;
   }
 
   Ident__except = nullptr;

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12292,16 +12292,20 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
                                        RParenLoc);
 }
 
-ExprResult Sema::ActOnBoundsInteropType(ParsedType ParsedTy) {
-  TypeSourceInfo *TypeInfo;
-  (void) GetTypeFromParser(ParsedTy, &TypeInfo);
-  QualType QT = TypeInfo->getType();
-  assert(QT->isCheckedPointerType());
-  TypeLoc Loc = TypeInfo->getTypeLoc();
-  return new (Context) InteropTypeBoundsAnnot(QT, Loc.getBeginLoc(),
-                                             Loc.getEndLoc(), TypeInfo);
+ExprResult Sema::ActOnBoundsInteropType(SourceLocation TypeKWLoc, ParsedType Ty,
+                                        SourceLocation RParenLoc) {
+  TypeSourceInfo *TInfo = nullptr;
+  GetTypeFromParser(Ty, &TInfo);
+  return CreateBoundsInteropType(TypeKWLoc, TInfo, RParenLoc);
 }
 
+ExprResult Sema::CreateBoundsInteropType(SourceLocation TypeKWLoc, TypeSourceInfo *TInfo,
+                                         SourceLocation RParenLoc) {
+  QualType QT = TInfo->getType();
+  assert(QT->isCheckedPointerType());
+  return new (Context) InteropTypeBoundsAnnotation(QT, TypeKWLoc, RParenLoc,
+                                                   TInfo);
+}
 
 //===----------------------------------------------------------------------===//
 // Clang Extensions.

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12292,6 +12292,17 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
                                        RParenLoc);
 }
 
+ExprResult Sema::ActOnBoundsInteropType(ParsedType ParsedTy) {
+  TypeSourceInfo *TypeInfo;
+  (void) GetTypeFromParser(ParsedTy, &TypeInfo);
+  QualType QT = TypeInfo->getType();
+  assert(QT->isCheckedPointerType());
+  TypeLoc Loc = TypeInfo->getTypeLoc();
+  return new (Context) InteropTypeBoundsExpr(QT, Loc.getBeginLoc(),
+                                             Loc.getEndLoc(), TypeInfo);
+}
+
+
 //===----------------------------------------------------------------------===//
 // Clang Extensions.
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12298,7 +12298,7 @@ ExprResult Sema::ActOnBoundsInteropType(ParsedType ParsedTy) {
   QualType QT = TypeInfo->getType();
   assert(QT->isCheckedPointerType());
   TypeLoc Loc = TypeInfo->getTypeLoc();
-  return new (Context) InteropTypeBoundsExpr(QT, Loc.getBeginLoc(),
+  return new (Context) InteropTypeBoundsAnnot(QT, Loc.getBeginLoc(),
                                              Loc.getEndLoc(), TypeInfo);
 }
 

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -2361,8 +2361,10 @@ public:
     return getSema().ActOnRangeBoundsExpr(StartLoc, Lower, Upper, RParenLoc);
   }
 
-  ExprResult RebuildInteropTypeBoundsAnnot(ParsedType ParsedTy) {
-    return getSema().ActOnBoundsInteropType(ParsedTy);
+  ExprResult RebuildInteropTypeBoundsAnnotation(SourceLocation StartLoc,
+                                                TypeSourceInfo *Ty,
+                                                SourceLocation RParenLoc) {
+    return getSema().CreateBoundsInteropType(StartLoc, Ty, RParenLoc);
   }
 
   /// \brief Build a new overloaded operator call expression.
@@ -11541,8 +11543,13 @@ TreeTransform<Derived>::TransformRangeBoundsExpr(RangeBoundsExpr *E) {
 
 template<typename Derived>
 ExprResult
-TreeTransform<Derived>::TransformInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *E) {
-  return E;
+TreeTransform<Derived>::TransformInteropTypeBoundsAnnotation(
+  InteropTypeBoundsAnnotation *E) {
+  TypeSourceInfo *TInfo =
+    getDerived().TransformType(E->getTypeInfoAsWritten());
+  return getDerived().
+    RebuildInteropTypeBoundsAnnotation(E->getStartLoc(), TInfo,
+                                       E->getRParenLoc());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -2361,6 +2361,10 @@ public:
     return getSema().ActOnRangeBoundsExpr(StartLoc, Lower, Upper, RParenLoc);
   }
 
+  ExprResult RebuildInteropTypeBoundsExpr(ParsedType ParsedTy) {
+    return getSema().ActOnBoundsInteropType(ParsedTy);
+  }
+
   /// \brief Build a new overloaded operator call expression.
   ///
   /// By default, performs semantic analysis to build the new expression.
@@ -11533,6 +11537,12 @@ TreeTransform<Derived>::TransformRangeBoundsExpr(RangeBoundsExpr *E) {
                                              LowerExpr.get(),
                                              UpperExpr.get(),
                                              E->getRParenLoc());
+}
+
+template<typename Derived>
+ExprResult
+TreeTransform<Derived>::TransformInteropTypeBoundsExpr(InteropTypeBoundsExpr *E) {
+  return E;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -2361,7 +2361,7 @@ public:
     return getSema().ActOnRangeBoundsExpr(StartLoc, Lower, Upper, RParenLoc);
   }
 
-  ExprResult RebuildInteropTypeBoundsExpr(ParsedType ParsedTy) {
+  ExprResult RebuildInteropTypeBoundsAnnot(ParsedType ParsedTy) {
     return getSema().ActOnBoundsInteropType(ParsedTy);
   }
 
@@ -11541,7 +11541,7 @@ TreeTransform<Derived>::TransformRangeBoundsExpr(RangeBoundsExpr *E) {
 
 template<typename Derived>
 ExprResult
-TreeTransform<Derived>::TransformInteropTypeBoundsExpr(InteropTypeBoundsExpr *E) {
+TreeTransform<Derived>::TransformInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *E) {
   return E;
 }
 

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -980,7 +980,8 @@ void ASTStmtReader::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   E->EndLoc = ReadSourceLocation(Record, Idx);
 }
 
-void ASTStmtReader::VisitInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *E) {
+void ASTStmtReader::VisitInteropTypeBoundsAnnotation(
+  InteropTypeBoundsAnnotation *E) {
   VisitExpr(E);
   E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->StartLoc = ReadSourceLocation(Record, Idx);
@@ -3857,8 +3858,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       S = new (Context) RangeBoundsExpr(Empty);
       break;
 
-    case EXPR_INTEROPTYPE_BOUNDS_ANNOT:
-      S = new (Context) InteropTypeBoundsAnnot(Empty);
+    case EXPR_INTEROPTYPE_BOUNDS_ANNOTATION:
+      S = new (Context) InteropTypeBoundsAnnotation(Empty);
       break;
         
     case EXPR_LAMBDA: {

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -960,23 +960,31 @@ void ASTStmtReader::VisitCountBoundsExpr(CountBoundsExpr *E) {
   VisitExpr(E);
   E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->setCountExpr(Reader.ReadSubExpr());
-  E->setStartLoc(ReadSourceLocation(Record, Idx));
-  E->setRParenLoc(ReadSourceLocation(Record, Idx));
+  E->StartLoc = ReadSourceLocation(Record, Idx);
+  E->EndLoc = ReadSourceLocation(Record, Idx);
 }
 
 void ASTStmtReader::VisitNullaryBoundsExpr(NullaryBoundsExpr *E) {
   VisitExpr(E);
   E->setKind((BoundsExpr::Kind)Record[Idx++]);
-  E->setStartLoc(ReadSourceLocation(Record, Idx));
-  E->setRParenLoc(ReadSourceLocation(Record, Idx));
+  E->StartLoc = ReadSourceLocation(Record, Idx);
+  E->EndLoc = ReadSourceLocation(Record, Idx);
 }
 
 void ASTStmtReader::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   VisitExpr(E);
+  E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->setLowerExpr(Reader.ReadSubExpr());
   E->setUpperExpr(Reader.ReadSubExpr());
-  E->setStartLoc(ReadSourceLocation(Record, Idx));
-  E->setRParenLoc(ReadSourceLocation(Record, Idx));
+  E->StartLoc = ReadSourceLocation(Record, Idx);
+  E->EndLoc = ReadSourceLocation(Record, Idx);
+}
+
+void ASTStmtReader::VisitInteropTypeBoundsExpr(InteropTypeBoundsExpr *E) {
+  VisitExpr(E);
+  E->setKind((BoundsExpr::Kind)Record[Idx++]);
+  E->StartLoc = ReadSourceLocation(Record, Idx);
+  E->EndLoc = ReadSourceLocation(Record, Idx);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3847,6 +3855,10 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
     case EXPR_RANGE_BOUNDS_EXPR:
       S = new (Context) RangeBoundsExpr(Empty);
+      break;
+
+    case EXPR_INTEROPTYPE_BOUNDS_EXPR:
+      S = new (Context) InteropTypeBoundsExpr(Empty);
       break;
         
     case EXPR_LAMBDA: {

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -980,7 +980,7 @@ void ASTStmtReader::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   E->EndLoc = ReadSourceLocation(Record, Idx);
 }
 
-void ASTStmtReader::VisitInteropTypeBoundsExpr(InteropTypeBoundsExpr *E) {
+void ASTStmtReader::VisitInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *E) {
   VisitExpr(E);
   E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->StartLoc = ReadSourceLocation(Record, Idx);
@@ -3857,8 +3857,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       S = new (Context) RangeBoundsExpr(Empty);
       break;
 
-    case EXPR_INTEROPTYPE_BOUNDS_EXPR:
-      S = new (Context) InteropTypeBoundsExpr(Empty);
+    case EXPR_INTEROPTYPE_BOUNDS_ANNOT:
+      S = new (Context) InteropTypeBoundsAnnot(Empty);
       break;
         
     case EXPR_LAMBDA: {

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -937,12 +937,13 @@ void ASTStmtWriter::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   Code = serialization::EXPR_RANGE_BOUNDS_EXPR;
 }
 
-void ASTStmtWriter::VisitInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *E) {
+void ASTStmtWriter::VisitInteropTypeBoundsAnnotation(
+  InteropTypeBoundsAnnotation *E) {
   VisitExpr(E);
   Record.push_back(E->getKind());
   Record.AddSourceLocation(E->getStartLoc());
   Record.AddSourceLocation(E->getLocEnd());
-  Code = serialization::EXPR_INTEROPTYPE_BOUNDS_ANNOT;
+  Code = serialization::EXPR_INTEROPTYPE_BOUNDS_ANNOTATION;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -937,12 +937,12 @@ void ASTStmtWriter::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   Code = serialization::EXPR_RANGE_BOUNDS_EXPR;
 }
 
-void ASTStmtWriter::VisitInteropTypeBoundsExpr(InteropTypeBoundsExpr *E) {
+void ASTStmtWriter::VisitInteropTypeBoundsAnnot(InteropTypeBoundsAnnot *E) {
   VisitExpr(E);
   Record.push_back(E->getKind());
   Record.AddSourceLocation(E->getStartLoc());
   Record.AddSourceLocation(E->getLocEnd());
-  Code = serialization::EXPR_INTEROPTYPE_BOUNDS_EXPR;
+  Code = serialization::EXPR_INTEROPTYPE_BOUNDS_ANNOT;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -929,11 +929,20 @@ void ASTStmtWriter::VisitNullaryBoundsExpr(NullaryBoundsExpr *E) {
 
 void ASTStmtWriter::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   VisitExpr(E);
+  Record.push_back(E->getKind());
   VisitExpr(E->getLowerExpr());
   VisitExpr(E->getUpperExpr());
   Record.AddSourceLocation(E->getStartLoc());
   Record.AddSourceLocation(E->getRParenLoc());
   Code = serialization::EXPR_RANGE_BOUNDS_EXPR;
+}
+
+void ASTStmtWriter::VisitInteropTypeBoundsExpr(InteropTypeBoundsExpr *E) {
+  VisitExpr(E);
+  Record.push_back(E->getKind());
+  Record.AddSourceLocation(E->getStartLoc());
+  Record.AddSourceLocation(E->getLocEnd());
+  Code = serialization::EXPR_INTEROPTYPE_BOUNDS_EXPR;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This change implements parsing of bounds-safe interface type annotations.  The type annotations are a generalization of the `int * x : ptr` annotation described in the specification.    That annotation does not provide a way to represent information for pointers with multiple levels of indirection (`int **x` for example).   Instead of just using `ptr`, we will allow a checked pointer type be specified.   The annotation for something like `int **` could be `_Ptr<_Ptr<int>>`.   This richer form is needed so that we can represent bounds-safe interfaces where pointers are passed by reference, for example.'

A bounds-safe type annotation has the syntax `type` `(` _type name_ `)` where _type name_
is a C type name.   _type name_ can include typedef'ed names and type modifies.  The type annotation
can be used in place of a bounds expression (following a `:`).   For example:
```
void f(int *p : type(ptr<int>)) {
}
```
We create a subclass of `BoundsExpr` to represent the new annotation, even though this annotation is not really a bounds expression.   It will be needed in the same places in the compiler where bounds expressions are needed.

The bounds-safe interface type annotations do not need to be delay parsed for parameters or structure/union members.   They don't refer to other parameters or members.  We special case this in the parser.   This simplifies the code because we don't have to implement delay parsing for types.

For structure/union members, we now store the bounds annotation or the tokens to be delayed parsed in the FieldDeclarator structure (which already stores the bitsize expression for a member).   This uet us revent changes to the callback method that passed the tokens as extra arguments.

This change also fixes a bug that I noticed in stmt serialization.  We weren't writing out the kind field for RangeBoundsExpr.   It is possible to have an invalid kind field (this could happen if someone serializes IR with invalid bounds expressions.  I also cleaned up serialization code that needs to access some private members.  We had setter methods - I noticed the rest of the serialization code is using friend classes instead.

Testing:
- Passes existing clang and Checked C tests.
- A new test for parsing these annotations will be added to the Checked C repo by a separate commit.