### PR TITLE
Implement implicit type conversions for bounds-safe interfaces

### DIFF
--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1692,6 +1692,7 @@ public:
   bool isFunctionProtoType() const { return getAs<FunctionProtoType>(); }
   bool isPointerType() const;
   bool isCheckedPointerType() const;
+  bool isUncheckedPointerType() const;
   // Checked C ptr type
   bool isCheckedPointerPtrType() const;
   bool isAnyPointerType() const;   // Any C pointer or ObjC object pointer
@@ -5546,6 +5547,12 @@ inline bool Type::isCheckedPointerType() const {
       return T->getKind() != CheckedPointerKind::Unchecked;
     }
     return false;
+}
+inline bool Type::isUncheckedPointerType() const {
+  if (const PointerType *T = getAs<PointerType>()) {
+    return T->getKind() == CheckedPointerKind::Unchecked;
+  }
+  return false;
 }
 inline bool Type::isCheckedPointerPtrType() const {
     if (const PointerType *T = getAs<PointerType>()) {

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8839,8 +8839,17 @@ public:
 private:
   QualType GetInteropType(const ValueDecl *Decl);
 public:
+  /// \brief Get the bounds-safe interface type for Entity.
+  /// Returns a null QualType if there isn't one.
   QualType GetCheckedCInteropType(const InitializedEntity &Entity);
+
+  /// \brief Get the bounds-safe interface type for LHS.
+  // Returns a null QualType if there isn't one.
   QualType GetCheckedCInteropType(ExprResult LHS);
+
+  /// \brief Chose between using LHSType or LHSInteropType for the type
+  /// of the left-hand side of a single assignment from the RHS. Try using
+  /// LHSType and if that doesn't work, try uisng LHSInteropType.
   QualType ResolveSingleAssignmentType(QualType LHSType, QualType LHSInteropType, 
                                        ExprResult &RHS);
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8836,8 +8836,13 @@ public:
                                                      bool DiagnoseCFAudited = false,
                                                      bool ConvertRHS = true);
 
-  bool CheckedCInteropConversion(const InitializedEntity &Entity, ExprResult &RHS);
-  bool CheckedCInteropConversion(ExprResult LHS, ExprResult &RHS);  
+private:
+  QualType GetInteropType(const ValueDecl *Decl);
+public:
+  QualType GetCheckedCInteropType(const InitializedEntity &Entity);
+  QualType GetCheckedCInteropType(ExprResult LHS);
+  QualType ResolveSingleAssignmentType(QualType LHSType, QualType LHSInteropType, 
+                                       ExprResult &RHS);
 
   // \brief If the lhs type is a transparent union, check whether we
   // can initialize the transparent union with the given expression.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8844,13 +8844,19 @@ public:
   QualType GetCheckedCInteropType(const InitializedEntity &Entity);
 
   /// \brief Get the bounds-safe interface type for LHS.
-  // Returns a null QualType if there isn't one.
+  /// Returns a null QualType if there isn't one.
   QualType GetCheckedCInteropType(ExprResult LHS);
 
-  /// \brief Chose between using LHSType or LHSInteropType for the type
-  /// of the left-hand side of a single assignment from the RHS. Try using
-  /// LHSType and if that doesn't work, try uisng LHSInteropType.
-  QualType ResolveSingleAssignmentType(QualType LHSType, QualType LHSInteropType, 
+  /// This function is part of the implementation of Checked C interoperation
+  /// support.  It chooses between using the LHSType or LHSInteropType for the
+  /// type of the left-hand side of a single assignment from the RHS.  It tries
+  /// type checking the assignment using LHSType. If that does not work, it
+  /// tries the LHSInteropType.  It returns the first type that works.  If 
+  /// neither type works, it returns the LHSType (this will cause any
+  /// diagnostic messages for the type checking failure to refer to the
+  /// LHSType).
+  QualType ResolveSingleAssignmentType(QualType LHSType, 
+                                       QualType LHSInteropType, 
                                        ExprResult &RHS);
 
   // \brief If the lhs type is a transparent union, check whether we

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8836,6 +8836,9 @@ public:
                                                      bool DiagnoseCFAudited = false,
                                                      bool ConvertRHS = true);
 
+  bool CheckedCInteropConversion(const InitializedEntity &Entity, ExprResult &RHS);
+  bool CheckedCInteropConversion(ExprResult LHS, ExprResult &RHS);  
+
   // \brief If the lhs type is a transparent union, check whether we
   // can initialize the transparent union with the given expression.
   AssignConvertType CheckTransparentUnionArgumentConstraints(QualType ArgType,

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8847,14 +8847,9 @@ public:
   /// Returns a null QualType if there isn't one.
   QualType GetCheckedCInteropType(ExprResult LHS);
 
-  /// This function is part of the implementation of Checked C interoperation
-  /// support.  It chooses between using the LHSType or LHSInteropType for the
-  /// type of the left-hand side of a single assignment from the RHS.  It tries
-  /// type checking the assignment using LHSType. If that does not work, it
-  /// tries the LHSInteropType.  It returns the first type that works.  If 
-  /// neither type works, it returns the LHSType (this will cause any
-  /// diagnostic messages for the type checking failure to refer to the
-  /// LHSType).
+  /// \brief Helper function for type checking an assignment whose LHS has a
+  /// Checked C bounds-safe interface.  This function chooses which type to
+  /// use for the LHS of the assignment.
   QualType ResolveSingleAssignmentType(QualType LHSType, 
                                        QualType LHSInteropType, 
                                        ExprResult &RHS);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8837,7 +8837,7 @@ public:
                                                      bool ConvertRHS = true);
 
 private:
-  QualType GetInteropType(const ValueDecl *Decl);
+  QualType GetCheckedCInteropType(const ValueDecl *Decl);
 public:
   /// \brief Get the bounds-safe interface type for Entity.
   /// Returns a null QualType if there isn't one.
@@ -8846,6 +8846,13 @@ public:
   /// \brief Get the bounds-safe interface type for LHS.
   /// Returns a null QualType if there isn't one.
   QualType GetCheckedCInteropType(ExprResult LHS);
+
+  /// \brief If T is an array type, create a checked array type version of T.
+  /// This includes propagating the checked property to nested array types. If
+  /// a valid checked array type cannot be constructed and Diagnose is true,
+  /// print a diagnostic message for the problem.
+  QualType MakeCheckedArrayType(QualType T, bool Diagnose = false,
+                                SourceLocation Loc = SourceLocation());
 
   /// \brief Helper function for type checking an assignment whose LHS has a
   /// Checked C bounds-safe interface.  This function chooses which type to

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8120,10 +8120,10 @@ QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
   return QualType();
 }
 
-/// Get the bounds-safe interface type for the left-hand of an assignment.
-/// Return a null QualType otherwise.  For the left-hand sides of
-/// assignments, only global variables, parameters, and members of
-/// structures/unions have bounds-safe interfaces.
+/// Get the bounds-safe interface type for the left-hand side of an assignment,
+/// if the left-hand side has a bounds-safe interface. Return a null QualType
+/// otherwise.  For the left-hand sides of assignments, only global variables,
+/// parameters, and members of structures/unions have bounds-safe interfaces.
 QualType Sema::GetCheckedCInteropType(ExprResult LHS) {
   if (!LHS.isInvalid()) {
     Expr *LHSExpr = LHS.get();
@@ -8139,11 +8139,11 @@ QualType Sema::GetCheckedCInteropType(ExprResult LHS) {
   return QualType();
 }
 
-/// Helper function for type checking an assignment whose LHS has a Checked C
-/// bounds-safe interface.  This function chooses which type to use for the LHS
-/// of the assignment: the type computed via normal C type checking (LHSType)
-/// or the Checked C interoperation type for the LHS.  It tries type checking
-/// the assignment using LHSType. If that does not work, it tries
+/// Helper function for type checking an assignment whose left-hande side has a
+/// Checked C bounds-safe interface.  This function chooses which type to use
+/// for the LHS of the assignment: the type computed via normal C type checking
+/// (LHSType) or the Checked C interoperation type for the LHS.  It tries type
+/// checking the assignment using LHSType. If that does not work, it tries
 /// LHSInteropType.  It returns the first type that works.  If neither type
 /// works, it returns the LHSType (this will cause any diagnostic messages for
 /// the type checking failure to refer to the LHSType).

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8058,48 +8058,82 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
   return result;
 }
 
-static QualType ExtractInteropType(const ValueDecl *Decl) {
+QualType Sema::GetInteropType(const ValueDecl *Decl) {
   const DeclaratorDecl *TargetDecl = nullptr;
   if (const FieldDecl *Field = dyn_cast<FieldDecl>(Decl))
-     TargetDecl = Field;
-  else if (const VarDecl *Var = dyn_cast<VarDecl>(Decl)) {
-    if (Var->hasExternalStorage() || Var->getKind() == Decl::ParmVar)
-      TargetDecl = Var;
-  }
+    TargetDecl = Field;
+  else if (const VarDecl *Var = dyn_cast<VarDecl>(Decl))
+    TargetDecl = Var;
+
   if (TargetDecl) {
-    const BoundsExpr *Bounds = TargetDecl->getBoundsExpr();
-    if (Bounds && Bounds->getKind() == BoundsExpr::Kind::InteropTypeAnnotation) {
-        const InteropTypeBoundsAnnotation *Annot = dyn_cast<InteropTypeBoundsAnnotation>(Bounds);
-        return Annot->getType();
+    if (const BoundsExpr *Bounds = TargetDecl->getBoundsExpr()) {
+      switch (Bounds->getKind()) {
+        case BoundsExpr::Kind::InteropTypeAnnotation: {
+          const InteropTypeBoundsAnnotation *Annot =
+            dyn_cast<InteropTypeBoundsAnnotation>(Bounds);
+          return Annot->getType();
+        }
+        case BoundsExpr::Kind::ByteCount:
+        case BoundsExpr::Kind::ElementCount:
+        case BoundsExpr::Kind::Range: {
+          QualType Ty = Decl->getType();
+          if (const PointerType *PtrType = Ty->getAs<PointerType>()) {
+            if (PtrType->isUnchecked()) {
+              QualType ResultTy = Context.getPointerType(PtrType->getPointeeType(),
+                                                         CheckedPointerKind::Array);
+              ResultTy.setLocalFastQualifiers(Ty.getCVRQualifiers());
+              return ResultTy;
+            }
+          }
+        }
+        default:
+          break;
+      }
     }
   }
   return QualType();;
 }
 
-QualType Sema::CheckedCInteropType(const InitializedEntity &Entity) {
+QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
   switch (Entity.getKind()) {
     case InitializedEntity::EntityKind::EK_Variable:
     case InitializedEntity::EntityKind::EK_Parameter:
     case InitializedEntity::EntityKind::EK_Member:
-      return ExtractInteropType(Entity.getDecl());
+      return GetInteropType(Entity.getDecl());
   }
-  return QualType();;
+  return QualType();
 }
 
-QualType Sema::CheckedCInteropType(ExprResult LHS) {
+QualType Sema::GetCheckedCInteropType(ExprResult LHS) {
   if (!LHS.isInvalid()) {
     Expr *LHSExpr = LHS.get();
     if (const MemberExpr *Member = dyn_cast<MemberExpr>(LHSExpr)) {
       if (const FieldDecl *Field = dyn_cast<FieldDecl>(Member->getMemberDecl()))
-        return ExtractInteropType(Field);
+        return GetInteropType(Field);
     }
     else if (const DeclRefExpr *DeclRef = dyn_cast<DeclRefExpr>(LHSExpr)) {
       if (const VarDecl *Var = dyn_cast<VarDecl>(DeclRef->getDecl()))
-        if (Var->hasExternalStorage())
-          return ExtractInteropType(Var);
+        return GetInteropType(Var);
     }
   }
   return QualType();
+}
+
+QualType Sema::ResolveSingleAssignmentType(QualType LHSType,
+                                           QualType LHSInteropType,
+                                           ExprResult &RHS) {
+  assert(getLangOpts().CheckedC && !LHSInteropType.isNull());
+  QualType Result = LHSType;
+  Sema::AssignConvertType TrialConvTy =
+    CheckSingleAssignmentConstraints(LHSType, RHS, false, false, false);
+  if (TrialConvTy == Sema::AssignConvertType::Incompatible) {
+    TrialConvTy = 
+      CheckSingleAssignmentConstraints(LHSInteropType, RHS,
+                                         false, false, false);
+    if (TrialConvTy != Sema::AssignConvertType::Incompatible)
+      Result = LHSInteropType;
+  }
+  return Result;
 }
 
 QualType Sema::InvalidOperands(SourceLocation Loc, ExprResult &LHS,
@@ -10303,6 +10337,13 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
         LHSType->isObjCObjectType())
         Diag(Loc, diag::err_objc_object_assignment)
           << LHSType;
+
+    if (getLangOpts().CheckedC && ConvTy == Incompatible &&
+        LHSType->isUncheckedPointerType()) {
+      QualType LHSInteropType = GetCheckedCInteropType(LHSExpr);
+      if (!LHSInteropType.isNull())
+        ConvTy = CheckSingleAssignmentConstraints(LHSInteropType, RHS);
+    }
 
     // If the RHS is a unary plus or minus, check to see if they = and + are
     // right next to each other.  If so, the user may have typo'd "x =+ 4"

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8058,6 +8058,16 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
   return result;
 }
 
+/// If a declaration has a Checked C bounds-safe interface
+/// attached to it, return the checked pointer type for the interface.
+/// Otherwise return an empty QualType.
+///
+/// This falls into two cases:
+/// 1. The interface is a type annotation: return the type in the
+///    annotation.
+/// 2. The interface is a bounds expression.  This implies the checked
+/// type should be _Array_ptr type.  Construct an _Array_ptr version
+/// of the unchecked ponter type for the declaration and return it.
 QualType Sema::GetInteropType(const ValueDecl *Decl) {
   const DeclaratorDecl *TargetDecl = nullptr;
   if (const FieldDecl *Field = dyn_cast<FieldDecl>(Decl))
@@ -8094,6 +8104,10 @@ QualType Sema::GetInteropType(const ValueDecl *Decl) {
   return QualType();;
 }
 
+/// Get the bounds-safe interface type for the Entity being initialized, if
+/// there is one.  Return an empty QualType otherwise. For entities being
+/// initialized, bounds-safe interface sare allowed only for global variables,
+/// parameters, and members of structures/unions.
 QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
   switch (Entity.getKind()) {
     case InitializedEntity::EntityKind::EK_Variable:
@@ -8104,6 +8118,10 @@ QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
   return QualType();
 }
 
+/// Get the bounds-safe interface type for the left-hand of an assignment.
+/// Return an empty QualType otherwise.  For the left-hand sides of
+/// assignments, only global variables, parameters, and members of
+/// structures/unions have bounds-safe interfaces.
 QualType Sema::GetCheckedCInteropType(ExprResult LHS) {
   if (!LHS.isInvalid()) {
     Expr *LHSExpr = LHS.get();

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8139,6 +8139,14 @@ QualType Sema::GetCheckedCInteropType(ExprResult LHS) {
   return QualType();
 }
 
+/// Helper function for type checking an assignment whose LHS has a Checked C
+/// bounds-safe interface.  This function chooses which type to use for the LHS
+/// of the assignment: the type computed via normal C type checking (LHSType)
+/// or the Checked C interoperation type for the LHS.  It tries type checking
+/// the assignment using LHSType. If that does not work, it tries
+/// LHSInteropType.  It returns the first type that works.  If neither type
+/// works, it returns the LHSType (this will cause any diagnostic messages for
+/// the type checking failure to refer to the LHSType).
 QualType Sema::ResolveSingleAssignmentType(QualType LHSType,
                                            QualType LHSInteropType,
                                            ExprResult &RHS) {
@@ -8149,7 +8157,7 @@ QualType Sema::ResolveSingleAssignmentType(QualType LHSType,
   if (TrialConvTy == Sema::AssignConvertType::Incompatible) {
     TrialConvTy = 
       CheckSingleAssignmentConstraints(LHSInteropType, RHS,
-                                         false, false, false);
+                                       false, false, false);
     if (TrialConvTy != Sema::AssignConvertType::Incompatible)
       Result = LHSInteropType;
   }

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -7953,3 +7953,17 @@ Sema::PerformCopyInitialization(const InitializedEntity &Entity,
 
   return Result;
 }
+
+/// Get the bounds-safe interface type for the Entity being initialized, if
+/// there is one.  Return a null QualType otherwise. For entities being
+/// initialized, bounds-safe interfaces are allowed only for global variables,
+/// parameters, and members of structures/unions.
+QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
+  switch (Entity.getKind()) {
+  case InitializedEntity::EntityKind::EK_Variable:
+  case InitializedEntity::EntityKind::EK_Parameter:
+  case InitializedEntity::EntityKind::EK_Member:
+    return GetCheckedCInteropType(Entity.getDecl());
+  }
+  return QualType();
+}

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -7960,10 +7960,13 @@ Sema::PerformCopyInitialization(const InitializedEntity &Entity,
 /// parameters, and members of structures/unions.
 QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
   switch (Entity.getKind()) {
-  case InitializedEntity::EntityKind::EK_Variable:
-  case InitializedEntity::EntityKind::EK_Parameter:
-  case InitializedEntity::EntityKind::EK_Member:
-    return GetCheckedCInteropType(Entity.getDecl());
+    case InitializedEntity::EntityKind::EK_Variable:
+    case InitializedEntity::EntityKind::EK_Parameter:
+    case InitializedEntity::EntityKind::EK_Member:
+      ValueDecl *D = Entity.getDecl();
+      if (D != nullptr) 
+        return GetCheckedCInteropType(D);
+      break;
   }
   return QualType();
 }

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -3612,9 +3612,11 @@ QualType Sema::GetCheckedCInteropType(const ValueDecl *Decl) {
     TargetDecl = Var;
 
   QualType ResultType = QualType();
-  if (TargetDecl) {
-    if (const BoundsExpr *Bounds = TargetDecl->getBoundsExpr()) {
-      switch (Bounds->getKind()) {
+  if (!TargetDecl)
+    return ResultType;
+
+  if (const BoundsExpr *Bounds = TargetDecl->getBoundsExpr()) {
+    switch (Bounds->getKind()) {
       case BoundsExpr::Kind::InteropTypeAnnotation: {
         const InteropTypeBoundsAnnotation *Annot =
           dyn_cast<InteropTypeBoundsAnnotation>(Bounds);
@@ -3628,7 +3630,7 @@ QualType Sema::GetCheckedCInteropType(const ValueDecl *Decl) {
       case BoundsExpr::Kind::Range: {
         QualType Ty;
         // The types for parameter variables that have array types are adjusted
-        // to be pointer types.  We'll work with the original array type instead.
+        // to be pointer type.  We'll work with the original array type instead.
         // For multi-dimensional array types, the nested array types need to
         // become checked array types too.
         if (const ParmVarDecl *ParmVar = dyn_cast<ParmVarDecl>(TargetDecl))
@@ -3650,7 +3652,6 @@ QualType Sema::GetCheckedCInteropType(const ValueDecl *Decl) {
       }
       default:
         break;
-      }
     }
   }
 

--- a/test/CheckedC/README.md
+++ b/test/CheckedC/README.md
@@ -1,0 +1,8 @@
+This directory contains clang-implementation specific tests for Checked C.
+It does not contain language conformance tests for the Checked C extension.
+Those are stored separately in the Checked C project repository.  Those tests
+are available under llvm\projects\checkedc-wrapper\checkedc\tests.  You 
+will need to place the Checked C repo at the checkedc subdirectory.
+
+
+

--- a/test/CheckedC/README.md
+++ b/test/CheckedC/README.md
@@ -1,8 +1,8 @@
-This directory contains clang-implementation specific tests for Checked C.
-It does not contain language conformance tests for the Checked C extension.
-Those are stored separately in the Checked C project repository.  Those tests
-are available under llvm\projects\checkedc-wrapper\checkedc\tests.  You 
-will need to place the Checked C repo at the checkedc subdirectory.
+This directory contains clang-implementation specific tests for the Checked C
+language extension.
 
-
-
+It does not contain language conformance tests for the extension.  Those tests
+are stored separately in the Checked C project repository.  If you have
+placed the Checked C repo at llvm\projects\checkedc-wrapper\checkedc,
+the language conformance tests are in the tests subdirectory of the checkedc
+directory.

--- a/test/CheckedC/no-param-decl.c
+++ b/test/CheckedC/no-param-decl.c
@@ -1,0 +1,18 @@
+// Bug repro from testing bounds-safe interface implementation.
+//
+// Initializing parameter assignments do not have declarations available
+// for parameters for  indirect function calls.  This caused a null pointer
+// dereference in the bound-safe interface implementation.
+//
+// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// expected-no-diagnostics
+
+void bad_mut(int *a) {
+}
+
+void bad_mut_driver(void) {
+  _Ptr<void (int*)> bad_mut_ptr  = &bad_mut;
+  int a = 0;
+  int *b = &a;
+  bad_mut_ptr(b);
+}


### PR DESCRIPTION
This change implements implicit conversions from checked pointers to unchecked pointers at bounds-safe interfaces.  This conversions may happen at assignments to variables or members and at function calls.

The conversions are straightforward to implement.  The code needs to choose whether to use the original type or the interoperation type.  This change adds code to SemaExpr.cpp and SemaInit.cpp that makes this decision.    Because the code is quite similar in both cases, we do not put the decision-making inline around the current calls to CheckSingleAssignmentConstraints.  Instead we factor it into a function called ResolveSingleAssignmentType.  This also helps deal with fact that CheckSingleAssignmentContraints is tricky to use: it has default parameters that control whether it emits diagnostics and side-effects the right-hand side expression.   ResolveSingleAssignmentType needs to try each potential left-hand side by calling CheckSingleAssignmentConstraints.  It invokes CheckSingleAssignmentContraints with parameters that prevent side-effects.   

This change also adds code that computes the Checked C interop type for a variable, member, or expression being initialized.

Testing:
- A new file interop.c will be committed separately to the Checked C repo.  The file has tests for implicit conversions at bounds-safe interfaces.  It will be added to the test\typechecking subdirectory.
- Passes existing clang and Checked C tests.
