### PR TITLE
Change keyword in bounds-safe interfaces from type to itype.

### DIFF
--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -165,8 +165,8 @@ class Parser : public CodeCompletionHandler {
   /// \brief Identifier for "none".
   IdentifierInfo *Ident_none;
 
-  /// \brief Identifier for "type"
-  IdentifierInfo *Ident_type;
+  /// \brief Identifier for "itype"
+  IdentifierInfo *Ident_itype;
 
   // C++ type trait keywords that can be reverted to identifiers and still be
   // used as type traits.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2764,7 +2764,7 @@ bool Parser::StartsBoundsExpression(Token &tok) {
 bool Parser::StartsInteropTypeAnnotation(Token &tok) {
   if (tok.getKind() == tok::identifier) {
     IdentifierInfo *Ident = Tok.getIdentifierInfo();
-    return (Ident == Ident_type);
+    return (Ident == Ident_itype);
   }
   return false;
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -499,13 +499,13 @@ void Parser::Initialize() {
     Ident_byte_count = &PP.getIdentifierTable().get("byte_count");
     Ident_count = &PP.getIdentifierTable().get("count");
     Ident_none = &PP.getIdentifierTable().get("none");
-    Ident_type = &PP.getIdentifierTable().get("type");
+    Ident_itype = &PP.getIdentifierTable().get("itype");
   } else {
     Ident_bounds = nullptr;
     Ident_byte_count = nullptr;
     Ident_count = nullptr;
     Ident_none = nullptr;
-    Ident_type = nullptr;
+    Ident_itype = nullptr;
   }
 
   Ident__except = nullptr;


### PR DESCRIPTION
This changes the contextual keyword for type annotations in bounds-safe interfaces from `type` to `itype`. This addresses issue #63.

Testing: 
- Checked C tests pass.
