### PR TITLE
Fix typos in methods recognizing starts of bounds expressions.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2752,18 +2752,18 @@ void Parser::ParseBlockId(SourceLocation CaretLoc) {
   Actions.ActOnBlockArguments(CaretLoc, DeclaratorInfo, getCurScope());
 }
 
-bool Parser::StartsBoundsExpression(Token &tok) {
-  if (tok.getKind() == tok::identifier) {
-    IdentifierInfo *Ident = Tok.getIdentifierInfo();
+bool Parser::StartsBoundsExpression(Token &T) {
+  if (T.getKind() == tok::identifier) {
+    IdentifierInfo *Ident = T.getIdentifierInfo();
     return (Ident == Ident_byte_count || Ident == Ident_count ||
             Ident == Ident_bounds);
   }
   return false;
 }
 
-bool Parser::StartsInteropTypeAnnotation(Token &tok) {
-  if (tok.getKind() == tok::identifier) {
-    IdentifierInfo *Ident = Tok.getIdentifierInfo();
+bool Parser::StartsInteropTypeAnnotation(Token &T) {
+  if (T.getKind() == tok::identifier) {
+    IdentifierInfo *Ident = T.getIdentifierInfo();
     return (Ident == Ident_itype);
   }
   return false;


### PR DESCRIPTION
This change fixes typos in methods recognizing the starts of bounds expressions and interop
type annotations.   This addresses issue #67.

The methods StartBoundsExpression and StartInteropTypeAnnotation both have a parameter named tok.  There is also a global variable named Tok that holds the current token.  The bodies of these functions are mistakenly using Tok instead of tok when getting the information for an identifier.  This
results in these methods misbehaving when passed in a token that is not the current token.

The fix is to rename the parameter to something other than tok so that we do not have variables whose names only differ in case.

Testing:
- Passed existing Checked C regression tests.