### PR TITLE
Better handling of syntax errors in return bounds declarations.

### DIFF
--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1066,6 +1066,12 @@ def err_for_co_await_not_range_for : Error<
 def err_expected_bounds_expr : Error<
   "expected bounds expression">;
 
+def err_unexpected_bounds_expr_after_declarator: Error<
+  "unexpected bounds expression after declarator">;
+
+def note_place_for_return_bounds_declarator : Note<
+  "if this is a return bounds declaration for %0, place it after the ')'">;
+
 def err_expected_bounds_interop_type : Error<
   "expected bounds-safe interface type">;
 


### PR DESCRIPTION
This change improves the error messages and recovery for syntax errors in
return bounds expressions.  It addresses issue #66.

Return bounds declarations are placed immediately after the argument list
in a function declarator, using the syntax `:` bounds-expression.  If the
bounds expression is syntactically incorrect, we would like to recover from
this error so that we can generate as many sensible error messages as
possible.   In particular, a function body might immediately follow
the bounds expression.

The code for parsing a function declarator tried to recover by scanning to
the body of a function body or a semi-colon.  This is not the right recovery
action. First, a function declarator can be embedded inside another declarator.
Second, this may be a semantic failure because clang does not differentiate
between semantic vs. parsing failures in the AST.  In that case, the code might
skip syntactically valid tokens, leading to confusing error messages.

This change moves the code for recovering from semantic/parsing failures for
return bounds expressions from function declarator parsing to
Parser::ParseDeclGroup.  This is the code in clang that recognizes whether
the parser is parsing a function body or a function declaration.  This is
a better place for error recovery because there is more context on what to
expect next.

We look for two cases: (1) the parsing/semantic analysis of the return bounds
expression failed and there is not a valid beginning of a function body or
end of function declaration (2) a misplaced bounds expression is encountered.
In the first case, the code tries to recover by doing the prior error action
of scanning to the beginning of the function body.   In the second case, we
guess that the user meant the bounds expression to be a return bounds
expression for the function declarator. The code emits an appropriate
diagnostic and points out where the bounds expression might be moved to.
The code then bails out on further processing of the function declaration or
body.

We do not add any code for recovery for the case where the function
declarator is nested within another declarator.  It is hard to know what
to do in this situation.  We could try to scan to the next token for the
enclosing declarator (a left parenthesis, a left bracket, or a right
parenthesis if the enclosing parameter is a paranethesized declarator.
It's not clear any of them put the parser in a sensible recovery position
in the case of a syntax error in a bounds expression, which could be any
syntactic form for a C expression. For now, we do nothing special here.

Testing:
* Passes existing clang tests.
* Passes existing Checked C tests for syntax errors in return bounds
  expressions.
* Add new tests to tests/parsing/return_bounds.c in the Checked C Github
  repo for a misplaced return bounds expression after a complex function
  declarator.  In a complex function declarator, the function declarator is
  nested within other declarators that construct the function return type.
  These tests will be committed separately.