### PR TITLE
Allow type qualifiers and static keyword in parameter type annotations.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8790,4 +8790,7 @@ def err_typecheck_non_count_bounds_decl : Error<
 def err_typecheck_non_count_return_bounds : Error<
   "expected %0 to have a pointer or integer return type">;
 
+def err_typecheck_bounds_type_annotation_identifier: Error<
+  "type name cannot have identifier in it">;
+
 } // end of sema component.

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1665,8 +1665,9 @@ private:
   bool StartsInteropTypeAnnotation(Token &tok);
 
   ExprResult ParseBoundsExpression();
-  ExprResult ParseInteropTypeAnnotation();
-  ExprResult ParseBoundsExpressionOrInteropType();
+  ExprResult ParseInteropTypeAnnotation(Declarator &D, bool IsReturn=false);
+  ExprResult ParseBoundsExpressionOrInteropType(Declarator &D,
+                                                bool IsReturn=false);
   bool ConsumeAndStoreBoundsExpression(CachedTokens &Toks);
   ExprResult DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks);
 

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1665,8 +1665,8 @@ private:
   bool StartsInteropTypeAnnotation(Token &tok);
 
   ExprResult ParseBoundsExpression();
-  ExprResult ParseInteropTypeAnnotation(Declarator &D, bool IsReturn=false);
-  ExprResult ParseBoundsExpressionOrInteropType(Declarator &D,
+  ExprResult ParseInteropTypeAnnotation(const Declarator &D, bool IsReturn=false);
+  ExprResult ParseBoundsExpressionOrInteropType(const Declarator &D,
                                                 bool IsReturn=false);
   bool ConsumeAndStoreBoundsExpression(CachedTokens &Toks);
   ExprResult DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5966,7 +5966,8 @@ void Parser::ParseFunctionDeclarator(Declarator &D,
   if (getLangOpts().CheckedC && Tok.is(tok::colon)) {
     BoundsColonLoc = Tok.getLocation();
     ConsumeToken();
-    ExprResult BoundsExprResult = ParseBoundsExpressionOrInteropType();
+    ExprResult BoundsExprResult =
+      ParseBoundsExpressionOrInteropType(D,/*IsReturn=*/true);
     if (BoundsExprResult.isInvalid())
       // We don't have enough context to try to do syntactic error recovery
       // here.  It is done instead in Parser::ParseDeclGroup, which recognizes

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2090,7 +2090,7 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
   // annotation.
   if (getLangOpts().CheckedC && Tok.is(tok::colon)) {
     ConsumeToken();
-    ExprResult Bounds = ParseBoundsExpressionOrInteropType();
+    ExprResult Bounds = ParseBoundsExpressionOrInteropType(D);
     if (Bounds.isInvalid())
       SkipUntil(tok::comma, tok::equal, StopAtSemi | StopBeforeMatch);
 
@@ -3724,14 +3724,16 @@ void Parser::ParseStructDeclaration(
     if (TryConsumeToken(tok::colon)) {
       if (getLangOpts().CheckedC && StartsBoundsExpression(Tok)) {
         std::unique_ptr<CachedTokens> BoundsExprTokens(new CachedTokens);
-        bool ParsingError = !ConsumeAndStoreBoundsExpression(*BoundsExprTokens);
+        bool ParsingError =
+          !ConsumeAndStoreBoundsExpression(*BoundsExprTokens);
         if (ParsingError)
           SkipUntil(tok::semi, StopBeforeMatch);
         // always set BoundsExprTokens: the delayed parsing is what
         // issues any parsing error messages.
         DeclaratorInfo.BoundsExprTokens = std::move(BoundsExprTokens);
       } else if (getLangOpts().CheckedC && StartsInteropTypeAnnotation(Tok)) {
-        ExprResult BoundsResult = ParseInteropTypeAnnotation();
+        ExprResult BoundsResult =
+          ParseInteropTypeAnnotation(DeclaratorInfo.D);
         if (BoundsResult.isInvalid())
           SkipUntil(tok::semi, StopBeforeMatch);
         else {
@@ -6226,8 +6228,8 @@ void Parser::ParseParameterDeclarationClause(
         if (StartsBoundsExpression(Tok)) {
           // Consume and store tokens until a bounds-like expression has been
           // read or a parsing error has happened.  Store the tokens even if a
-          // parsing error occurs so that ParseBoundsExpression can generate the
-          // error message.  This way the error messages from parsing of bounds
+          // parsing error occurs so that ParseBoundsExpression can generate
+          // the error message.  This way the error messages from parsing of bounds
           // expressions will be the same or very similar regardless of whether
           // parsing is deferred or not.
           std::unique_ptr<CachedTokens> BoundsExprTokens{ new CachedTokens };
@@ -6239,13 +6241,15 @@ void Parser::ParseParameterDeclarationClause(
         else {
            // fall back to general code that eagerly parses a bounds expression
            // bounds-safe interface type annotation
-          ExprResult BoundsAnnotation = ParseBoundsExpressionOrInteropType();
+          ExprResult BoundsAnnotation =
+            ParseBoundsExpressionOrInteropType(ParmDeclarator);
           if (BoundsAnnotation.isInvalid()) {
             SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
             Actions.ActOnInvalidBoundsDecl(Param);
           }
           else
-            Actions.ActOnBoundsDecl(Param, cast<BoundsExpr>(BoundsAnnotation.get()));
+            Actions.ActOnBoundsDecl(Param,
+                                    cast<BoundsExpr>(BoundsAnnotation.get()));
         }
       }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5967,7 +5967,7 @@ void Parser::ParseFunctionDeclarator(Declarator &D,
     BoundsColonLoc = Tok.getLocation();
     ConsumeToken();
     ExprResult BoundsExprResult =
-      ParseBoundsExpressionOrInteropType(D,/*IsReturn=*/true);
+      ParseBoundsExpressionOrInteropType(D, /*IsReturn=*/true);
     if (BoundsExprResult.isInvalid())
       // We don't have enough context to try to do syntactic error recovery
       // here.  It is done instead in Parser::ParseDeclGroup, which recognizes

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2791,8 +2791,7 @@ ExprResult Parser::ParseInteropTypeAnnotation(Declarator &D, bool IsReturn) {
       return ExprError();
     }
     ExprResult Result = Actions.ActOnBoundsInteropType(TypeKWLoc, Ty.get(),
-                                                       Tok.getLocation(),
-                                                       IsReturn);
+                                                       Tok.getLocation());
     PT.consumeClose();
     return Result;
   }

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -5439,9 +5439,14 @@ void LocInfoType::getAsStringInternal(std::string &Str,
 
 TypeResult Sema::ActOnTypeName(Scope *S, Declarator &D) {
   // C99 6.7.6: Type names have no identifier.  This is already validated by
-  // the parser.
-  assert(D.getIdentifier() == nullptr &&
+  // the parser when the context is TypeName.
+  assert((D.getContext() != Declarator::TypeNameContext ||
+         D.getIdentifier() == nullptr) &&
          "Type name should have no identifier!");
+  if (D.getIdentifier()) {
+     Diag(D.getIdentifierLoc(), diag::err_typecheck_bounds_type_annotation_identifier);
+     return true;
+  }
 
   TypeSourceInfo *TInfo = GetTypeForDeclarator(D, S);
   QualType T = TInfo->getType();


### PR DESCRIPTION
This change extends the parsing of interop type annotations for parameters.  The code now allows the static keyword or type qualifiers to occur inside the first dimension of an array type in an interop type annotation, just as they can occur for regular parameter types.

This required adding the declarator as an argument to some parsing methods for interop type annotations, so that the code can tell when it is in the special context of parsing an interop type   annotation for a parameter declaration.

The code for parsing type names allows a Context value to be passed in.  It can fail an assert in SemaType.cpp if a Context other than TypeName is passed in, though.  Other contexts can allow variable names to occur within the parsing of  a type name.  Modify the assert in SemaType.cpp to apply to only the TypeName context and issue an error message if an identifier is used in other contexts.  I weighed adding a new context for parsing interop bounds expression, but that change seem worse, requiring fixing up a bunch of places in the code.  It seemed better to generalize parsing of type names slightly instead.

This fixes a few places where existing code for Checked C exceeded the 80 character line limit for the LLVM coding convention.  The parameter IsReturn is intentionally unused.  This change was extracted from a larger commit that uses it.

Testing:
- Passes clang regression tests.
- Passes existing Checked C regression tests.
- Added new tests for parsing interop bounds declarations with array types to the Checked C GitHub repo.  The tests will be added to tests/parsing/interop_types.c.  They will be committed separately.