### PR TITLE
Restrictions on redeclarations of no prototype functions.

### DIFF
--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2335,6 +2335,10 @@ public:
   /// differ in some other way than checkedness.
   bool isEqualIgnoringChecked(QualType T1, QualType T2) const;
 
+  /// \brief Return true if this type is a checked type that is not
+  /// allowed to be passed or returned from a no prototype function.
+  bool isNotAllowedForNoProtoTypeFunction(QualType T1) const;
+
   // Methods to support checking assignments in the presence of
   // checked pointers.
 

--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2337,7 +2337,7 @@ public:
 
   /// \brief Return true if this type is a checked type that is not
   /// allowed to be passed or returned from a no prototype function.
-  bool isNotAllowedForNoProtoTypeFunction(QualType T1) const;
+  bool isNotAllowedForNoPrototypeFunction(QualType T1) const;
 
   // Methods to support checking assignments in the presence of
   // checked pointers.

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4552,9 +4552,9 @@ public:
   }
 
 
-  SourceLocation getStartLoc() { return StartLoc; }
-  SourceLocation getEndLoc() { return EndLoc; }
-  SourceLocation getRParenLoc() { return EndLoc; }
+  SourceLocation getStartLoc() const { return StartLoc; }
+  SourceLocation getEndLoc() const { return EndLoc; }
+  SourceLocation getRParenLoc() const { return EndLoc; }
 
   SourceLocation getLocStart() const LLVM_READONLY { return StartLoc; }
   SourceLocation getLocEnd() const LLVM_READONLY { return EndLoc; }
@@ -4565,27 +4565,27 @@ public:
     BoundsExprBits.Kind = Kind;
   }
 
-  bool isInvalid() {
+  bool isInvalid() const {
     return getKind() == Invalid;
   }
 
-  bool isNone() {
+  bool isNone() const {
     return getKind() == None;
   }
 
-  bool isElementCount() {
+  bool isElementCount() const {
     return getKind() == ElementCount;
   }
 
-  bool isByteCount() {
+  bool isByteCount() const {
     return getKind() == ByteCount;
   }
 
-  bool isRange() {
+  bool isRange() const {
     return getKind() == Range;
   }
 
-  bool isInteropTypeAnnotation() {
+  bool isInteropTypeAnnotation() const {
     return getKind() == InteropTypeAnnotation;
   }
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8822,20 +8822,23 @@ def err_bounds_type_annotation_lost_checking : Error<
   "loses checking of declared type}0,1">;
 
  def err_no_prototype_function_with_checked_return_type : Error<
-   "function without prototype cannot return a checked value">;
+   "function with no prototype cannot have a return type that is a "
+   "%select{checked type|structure with a member with a checked type|"
+   "union with a member with a checked type}0">;
 
  def err_no_prototype_function_with_return_bounds : Error<
-   "function without prototype cannot have a return bounds">;
+   "function with no prototype cannot have a return bounds">;
 
  def err_no_prototype_function_redeclared_with_checked_arg : Error<
-   "redeclaring a no-prototype function with checked argument is not allowed">;
+   "cannot redeclare a function with no prototype to have an argument type that is a "
+   "%select{checked type|structure with a member with a checked type|"
+   "union with a member with a checked type}0">;
 
  def err_no_prototype_function_redeclared_with_arg_bounds : Error<
-   "redeclaring a no-prototype function with an argument bounds is not"
-   " allowed">;
+   "cannot redeclare a function with no prototype to have an argument bounds">;
 
  def err_checkedc_incompatible_no_prototype_redeclaration : Error<
-   "redeclaring function that has a checked argument or argument "
-   "bounds as a no-prototype function is not allowed">;
+   "cannot redeclare a function that has a checked argument or argument "
+   "bounds to have no prototype">;
 
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8828,8 +8828,14 @@ def err_bounds_type_annotation_lost_checking : Error<
    "function without prototype cannot have a return bounds">;
 
  def err_no_prototype_function_redeclared_with_checked_arg : Error<
-   "redeclaring a no-prototype function with checked argument not allowed">;
+   "redeclaring a no-prototype function with checked argument is not allowed">;
 
  def err_no_prototype_function_redeclared_with_arg_bounds : Error<
-   "redeclaring a no-prototype function with an argument bounds not allowed">;
+   "redeclaring a no-prototype function with an argument bounds is not"
+   " allowed">;
+
+ def err_checkedc_incompatible_no_prototype_redeclaration : Error<
+   "redeclaring function that has a checked argument or argument "
+   "bounds as a no-prototype function is not allowed">;
+
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8821,4 +8821,15 @@ def err_bounds_type_annotation_lost_checking : Error<
   "type %diff{$ loses checking of declared type $|"
   "loses checking of declared type}0,1">;
 
+ def err_no_prototype_function_with_checked_return_type : Error<
+   "function without prototype cannot return a checked value">;
+
+ def err_no_prototype_function_with_return_bounds : Error<
+   "function without prototype cannot have a return bounds">;
+
+ def err_no_prototype_function_redeclared_with_checked_arg : Error<
+   "redeclaring a no-prototype function with checked argument not allowed">;
+
+ def err_no_prototype_function_redeclared_with_arg_bounds : Error<
+   "redeclaring a no-prototype function with an argument bounds not allowed">;
 } // end of sema component.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2248,11 +2248,16 @@ public:
   bool MergeCompatibleFunctionDecls(FunctionDecl *New, FunctionDecl *Old,
                                     Scope *S, bool MergeTypeWithOld);
   void mergeObjCMethodDecls(ObjCMethodDecl *New, ObjCMethodDecl *Old);
-  bool mergeFunctionDeclBounds(FunctionDecl *New, FunctionDecl *Old);
   void MergeVarDecl(VarDecl *New, LookupResult &Previous);
   void MergeVarDeclTypes(VarDecl *New, VarDecl *Old, bool MergeTypeWithOld);
   void MergeVarDeclExceptionSpecs(VarDecl *New, VarDecl *Old);
   bool MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old, Scope *S);
+
+  // Checked C specific methods for merging function declarations.
+  bool CheckedCFunctionDeclCompatibility(FunctionDecl *New, FunctionDecl *Old);
+  bool CheckedCMergeFunctionDecls(FunctionDecl *New, FunctionDecl *Old);
+  bool DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
+                                             FunctionDecl *Old);
 
   // AssignmentAction - This is used by all the assignment diagnostic functions
   // to represent what is actually causing the operation

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2248,6 +2248,7 @@ public:
   bool MergeCompatibleFunctionDecls(FunctionDecl *New, FunctionDecl *Old,
                                     Scope *S, bool MergeTypeWithOld);
   void mergeObjCMethodDecls(ObjCMethodDecl *New, ObjCMethodDecl *Old);
+  bool mergeFunctionDeclBounds(FunctionDecl *New, FunctionDecl *Old);
   void MergeVarDecl(VarDecl *New, LookupResult &Previous);
   void MergeVarDeclTypes(VarDecl *New, VarDecl *Old, bool MergeTypeWithOld);
   void MergeVarDeclExceptionSpecs(VarDecl *New, VarDecl *Old);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2259,6 +2259,15 @@ public:
   bool DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
                                              FunctionDecl *Old);
 
+  // used for %select in diagnostics for errors involving checked types.
+  enum class CheckedTypeClassification {
+    CCT_Any,
+    CCT_Struct,
+    CCT_Union
+  };
+
+  CheckedTypeClassification classifyForCheckedTypeDiagnostic(QualType qt);
+
   // AssignmentAction - This is used by all the assignment diagnostic functions
   // to represent what is actually causing the operation
   enum AssignmentAction {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -7743,7 +7743,7 @@ QualType ASTContext::mergeFunctionTypes(QualType lhs, QualType rhs,
 
       // For Checked C, a no prototype function is not compatible
       // with a prototype with a checked argument.
-      if (isCheckedC && isNotAllowedForNoProtoTypeFunction(paramTy))
+      if (isCheckedC && isNotAllowedForNoPrototypeFunction(paramTy))
         return QualType();
     }
 
@@ -8417,26 +8417,26 @@ bool ASTContext::isEqualIgnoringChecked(QualType T1, QualType T2) const {
 // argument or return type for a no-prototype function.   This computes the
 // set of allowed types described in Section 5.5 of the Checked C
 // specification.
-bool ASTContext::isNotAllowedForNoProtoTypeFunction(QualType QT) const {
+bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
   if (const PointerType *PT = QT->getAs<PointerType>()) {
     if (PT->isChecked())
       return true;
     if (PT->isFunctionPointerType())
-      return isNotAllowedForNoProtoTypeFunction(PT->getPointeeType());
+      return isNotAllowedForNoPrototypeFunction(PT->getPointeeType());
     // Unchecked pointer types are allowed
     return false;
   } else if (QT->isCheckedArrayType())
     return true;
   else if (const FunctionType *FT = QT->getAs<FunctionType>()) {
     QualType RetType = FT->getReturnType();
-    if (isNotAllowedForNoProtoTypeFunction(RetType))
+    if (isNotAllowedForNoPrototypeFunction(RetType))
       return true;
     if (const FunctionProtoType *FPT = FT->getAs<FunctionProtoType>())
       for (QualType Param : FPT->getParamTypes()) {
         // TODO: Github checkedc-clang issue #20.  When function types
         // incorporate parameter bounds information, check for
         // parameter bounds.
-        if (isNotAllowedForNoProtoTypeFunction(Param))
+        if (isNotAllowedForNoPrototypeFunction(Param))
           return true;
       }
   } else if (const RecordType *RT = QT->getAs<RecordType>()) {
@@ -8444,7 +8444,7 @@ bool ASTContext::isNotAllowedForNoProtoTypeFunction(QualType QT) const {
      if (const RecordDecl *Def = RD->getDefinition()) {
        for (const auto *FieldDecl : Def->fields()) {
          QualType FieldType = FieldDecl->getType();
-         if (isNotAllowedForNoProtoTypeFunction(FieldType))
+         if (isNotAllowedForNoPrototypeFunction(FieldType))
            return true;
          if (FieldDecl->getBoundsExpr() &&
              !FieldType->isUncheckedPointerType())

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -3329,9 +3329,9 @@ void Sema::mergeObjCMethodDecls(ObjCMethodDecl *newMethod,
 }
 
 /// \brief Diagnose Checked C-specific compatibility issues for function decls.
-/// Handle cases where one declaration  has no prototype and the other
+/// Handle cases where one declaration has no prototype and the other
 /// one has a prototype that uses a checked type or has a bounds interface
-/// (Checked C compatibility rules are decribe in Section 5.5 of the Checked C
+/// (Checked C compatibility rules are described in Section 5.5 of the Checked C
 /// language extension specification).  Returns true if it was able to diagnose
 /// a problem, false otherwise.
 bool Sema::DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
@@ -3348,11 +3348,12 @@ bool Sema::DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
   for (unsigned int i = 0; i < paramCount; i++) {
     const ParmVarDecl *Param = Prototype->getParamDecl(i);
     QualType ParamType = Param->getType();
-    if (Context.isNotAllowedForNoProtoTypeFunction(ParamType)) {
+    if (Context.isNotAllowedForNoPrototypeFunction(ParamType)) {
       Err = true;
       if (NewHasPrototype)
         Diag(Param->getLocation(),
-             diag::err_no_prototype_function_redeclared_with_checked_arg);
+             diag::err_no_prototype_function_redeclared_with_checked_arg)
+          << (unsigned) classifyForCheckedTypeDiagnostic(ParamType);
     }
     else if (Param->getBoundsExpr() &&
              !ParamType->isUncheckedPointerType()) {

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -3664,6 +3664,15 @@ QualType Sema::GetCheckedCInteropType(const ValueDecl *Decl) {
   return ResultType;
 }
 
+Sema::CheckedTypeClassification Sema::classifyForCheckedTypeDiagnostic(QualType QT) {
+  if (QT->isStructureType())
+    return CheckedTypeClassification::CCT_Struct;
+  else if (QT->isUnionType())
+    return CheckedTypeClassification::CCT_Union;
+  else
+    return CheckedTypeClassification::CCT_Any;
+}
+
 static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
                                                 QualType declSpecType,
                                                 TypeSourceInfo *TInfo) {
@@ -4323,9 +4332,10 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
       // or have return bounds.  See Section 5.5 of the Checked C
       // language extension specification.
       if (LangOpts.CheckedC && !FTI.NumParams) {
-        if (Context.isNotAllowedForNoProtoTypeFunction(T)) {
+        if (Context.isNotAllowedForNoPrototypeFunction(T)) {
           S.Diag(DeclType.Loc,
-                 diag::err_no_prototype_function_with_checked_return_type);
+                 diag::err_no_prototype_function_with_checked_return_type)
+            << (unsigned) S.classifyForCheckedTypeDiagnostic(T);
           D.setInvalidType(true);
         }
         if (!T->isUncheckedPointerType() &&

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -1,0 +1,30 @@
+// Tests for clang-specific tests of typechecking of Checked C
+// extensions.  It includes clang-specific error messages as well
+// tests of clang-specific extensions.
+//
+// The Checked C repo contains many tests of typechecking as part
+// of its extension conformance test suite that also check clang error
+// messages.  The extension conformance tests are designed to test overall
+// compiler compliance with the Checked C specification.  This file is
+// for more detailed tests of error messages, such as notes and correction 
+// hints emitted as part of clang diagnostics.
+//
+// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+
+char fn41() : count(5); // expected-error {{expected 'fn41' to have a pointer return type}} // expected-error {{function without prototype cannot have a return bounds}}
+
+// Prototype of a function followed by an old-style K&R definition
+// of the function. 
+
+// The Checked C specification does not allow no prototype functions
+// to return checked values. Techncally, the K& R style function 
+// definition is a no prototype function, so we could say it is illegal.
+// However, clang enforce the prototype declration at the definition of 
+// f100, so this seems OK to accept.
+_Ptr<int> f100(int a, int b);
+
+_Ptr<int> f100(a, b)
+     int a;
+     int b;
+{
+}

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -11,15 +11,15 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-char fn41() : count(5); // expected-error {{expected 'fn41' to have a pointer return type}} // expected-error {{function without prototype cannot have a return bounds}}
+char fn41() : count(5); // expected-error {{expected 'fn41' to have a pointer return type}} // expected-error {{function with no prototype cannot have a return bounds}}
 
 // Prototype of a function followed by an old-style K&R definition
-// of the function. 
+// of the function.
 
-// The Checked C specification does not allow no prototype functions
-// to return checked values. Techncally, the K& R style function 
+// The Checked C specification does not allow no prototype functions to have
+// return types that are checked types.  Technically, the K&R style function
 // definition is a no prototype function, so we could say it is illegal.
-// However, clang enforce the prototype declration at the definition of 
+// However, clang enforces the prototype declaration at the definition of
 // f100, so this seems OK to accept.
 _Ptr<int> f100(int a, int b);
 


### PR DESCRIPTION
Calls to no-prototype functions are not type checked according to the C specification (Section 6.5.2.2 of the C11 specification).  The lack of type checking allows the checking of bounds declarations to be bypassed.   For the Checked C extension, this is addressed by not allowing redeclarations of no-prototype functions to have prototypes that use checked types, as well as not allowing checked values to be passed to no-prototype functions.  Section 5.5 of the Checked C extension specification describes the restrictions.  

This change implements the Checked C restrictions on redeclarations of no-prototype functions.  It is  part of work on issue #30.    The restrictions are implemented by changing the implementation of C type compatibility in clang.   We make no-prototype function types incompatible with function types that take arguments or return values that have checked types, contain values with checked types embedded within them, or are recursively pointers to function types that take or return check types.  We also change the construction of function types from function declarators to enforce the Checked C rule that a no-prototype function cannot have a checked return type.

When two declarations of a function are incompatible, we try to diagnose whether a failure is due to a Checked C type compatibility rule and print descriptive error messages.   We do this only when the failure  is because of the presence or absence of a prototype of a declaration.  We do not try to diagnose type compatibility problems involving parameters with function pointer types,  In that case, programmers will get a generic "types are not compatible" message.

There is a subtle complication when checking redeclarations in the presence of incomplete structure or union types.  In the Checked C rules, a function type with an incomplete type is compatible with a no-prototype function (because the incomplete type is unknown).  For a series of declarations of a function, clang merges the types so that the latest declaration has the merged type.  This means that a function could start as a no-prototype function, be given a prototype with an incomplete type, the incomplete type could be completed to be  checked type, and then the function could be declared again:
```
int f();      // decl 1
struct S;
int f(S v);   // decl 2
// complete the type
struct S {
  ptr<int> p;
}
...
int f(S v) {  // decl 3 (possibly a definition)
  ...
}
```
clang looks at only the type of the prior declaration when merging declaration types.  For Checked C, this misses the fact that `f` was declared originally  as a no-prototype function at `decl 1`.   The prototype was allowed only because it involved an incomplete type at `decl 2`.  If we had the complete type at `decl 2`, the prototype would not have been allowed.  Instead of looking at just the prior declaration, we look back at all prior declarations of a function to make sure they are compatible with the current declaration of the function.

Note that we still need to prevent `decl 2` from being used after `S` is complete.  The current change only addresses redeclarations of `f`, not uses of `f`.   That is  future work tracked by issue #75. 

In the implementation of type compatibility, we miss the case of no-prototype function pointers being incompatible with prototype function pointers that take integer arguments with bounds.  This depends on issue #20 (adding bounds to function types).  We will address this case as part of issue #20.

Testing:
- This change uncovered places in existing tests in the Checked C repo where we were using no prototype functions.  Update the tests to properly declare the functions as having no arguments (using the `f(void)` pattern).
- Add a new tests on to Checked C repo in typechecking\no_prototype_functions.c.
- Add some clang-specific tests under tests\CheckedC\typechecking.c.
- Passes the updated and new Checked C tests.
- Passes the existing clang regression tests.