### PR TITLE
Add bounds expressions to function types

### DIFF
--- a/docs/checkedc/Implementation-Notes.md
+++ b/docs/checkedc/Implementation-Notes.md
@@ -21,7 +21,120 @@ to handle checked extensions at this time. LLVM/clang will only allow
 the Checked C extension to be used with C and will not allow it to
 be used with C++, Objective C, or OpenCL.
 
-## Processing extensions to the IR
+## IR Extensions
+
+### Types
+
+Pointer types and array types are extended with information about whether the
+types are checked.  For pointer types, an enum is used to represent the
+different kinds of pointers.  For array types, a boolean flag is used to
+represent whether the array type is checked or not.  This information is used
+when determining type compatibility: two pointers types are compatible only
+when their kinds are the same and two array types are compatible only when
+they have the same checked property.
+
+Function types are extended with optional bounds expressions for parameters
+and the return value.  For parameters, the bounds expressions are recorded
+in a variably-sized array allocated within the function type.  The array
+is not allocated if there are no bounds expressions on parameters.
+
+Bounds expressions are canonicalized for function types. References to
+parameters are abstracted to the index of the parameter in the argument
+list, so that names of arguments do not matter.
+
+### Bounds expressions
+
+Bounds expressions are represented using subclasses of the Expr
+class.  This allows the usual machinery for expressions to be
+reused.  There are three kinds of bounds expressions:
+
+- Nullary bounds expressions.  These do not refer to any other
+  expressions.  There are two kinds of nullary bounds expressions:
+  None and Invalid.  Invalid represents bounds expressions that
+  are invalid for some reason.  They are used to prevent errors
+  from cascading during semantic processing.  Just ignoring an invalid
+  bounds expressions could trigger downstream semantic checking errors.
+- Count bounds expressions, which refer to a single expression
+  that is the count.  There are two kinds of count bounds expressions:
+  element count and byte counts.
+- Range bounds expressions, which refer to lower and upper bound
+  expressions.
+
+There is an abtract base class `BoundsExpr` for bounds expressions.
+A unified kind is stored on this base class.
+
+Type annotations are also represented as a subclass of `BoundsExpr`.
+They can appear syntactically where bounds expressions can apppear.
+The type for the type annotation is stored as the type of the
+type annotation expression.
+
+### Other expressions
+
+The `PositionalParameterExpr` class represents a reference to a parameter
+that has been abstracted to the index of the parameter in an argument list.
+This is used in the represention of function types with bounds expressions:
+the bounds expressions are modified to use `PositionalParameterExpr`
+instead of `DeclRefExpr`s that are pointing to `ParmVarDecl`.
+
+For example, given
+
+```
+int f(_Array_ptr<int> arr : bounds(arr, arr + len), int len);
+```
+
+`arr` is given the positional index 0 and `len` is given the positional
+index `1.
+
+This makes type canonicalization of function types with bounds expressions
+straightforward.  The comparion of parameters is easy: two parameters are the
+same if their positional parameter expressions have the same index and type.
+The current type canonicalization algorithm is used, and it is extended to
+check that each bounds expression is identical.  Each bounds expression is
+structurally compared, including any subexpressions of the bounds expression.
+
+We could have modified the type canonicalization algorithm to handle
+canonicalization of parameters specially for the case of function bounds
+expressions. Parameter variables do have the positional index recorded.
+However, this would make the IR confusing to understand. Programmers would
+have to remember that parameters in bounds expressions behave specially, and
+that the names need to be ignored.  It seemed better to encode this directly
+into the IR and avoid a special case that is implicit and based on context.
+
+The downside of extending the IR this way is that functions that do case-by-case
+analysis of expressions might need to be extended, if they are applied to
+bounds expressions in function types.  This seems likely to be rare.
+
+Note that function types with bounds expressions are closed with respect to
+local variables in scope at the definition of a function type.  They
+cannot refer to them.  This includes parameters not declared by
+the function type too.   The following code is illegal:
+
+```
+int f(_Array_ptr<int> arr : bounds(arr, arr + len), int len) {
+ typedef int myfunc(_Array_ptr<int> arg : bounds(arr, arr + len));
+ ...
+}
+```
+The implication is that most dataflow analyses of variables
+can ignore function types. An exception is dataflow analysis
+analyses that are checking the correctness of bounds declarations.
+
+### Declarations
+
+A declaration may have an optional bounds expression.  The `DeclaratorDecl`
+class is extended with an optional bounds expression.  The bounds expression
+is meaningful for the following subclasses of `DeclaratorDecl`:
+
+- Variable declarations (`VarDecl`), including parameter, local, and global variable
+declarations.  The bounds declaration describes the bounds of values stored in a
+variable.
+- Function declarations (`FunctionDecl`). The bounds expression declares the return bounds of
+of a function.
+- Field member declarations (`FieldDecl`).  The bounds declaration describe the bounds
+of values stored in a member.   The bounds expression may refer to other field members
+in the structure or union type.
+
+## Processing Checked C extensions
 
 Processing of Checked C is controlled by a feature flag (`-fcheckedc-extension`).
 The feature  flag sets a language extension flag.  Lexing and parsing will 
@@ -31,20 +144,10 @@ language extension flag.  Checked C is backwards-compatible with C, so the IR
 has additional information in it that represents either original C concepts or
 the Checked C extensions.  The processing uses this information.
 
-## Lexing and parsing
+### Lexing and parsing
 
 Lexing only recognizes Checked C keywords when the language extension flag is
 enabled.  Parsing of Checked C extensions currently depends on keywords being 
 present.  These will not be seen when the feature flag is disabled. In the 
 future, we expect to conditionalize a few places in the parsing phase to 
 recognize new syntax.
-
-## Typechecking
-
-Pointer types and array types are extended with information about whether the
-types are checked.  For pointer types, an enum is used to represent the 
-different kinds of pointers.  For array types, a boolean flag is used to
-represent whether the array type is checked or not.  This information is used
-when determining type compatibility: two pointers types are compatible only 
-when their kinds are the same and two array types are compatible only when 
-they have the same checked property.

--- a/docs/checkedc/Implementation-Notes.md
+++ b/docs/checkedc/Implementation-Notes.md
@@ -83,7 +83,7 @@ int f(_Array_ptr<int> arr : bounds(arr, arr + len), int len);
 ```
 
 `arr` is given the positional index 0 and `len` is given the positional
-index `1.
+index 1.
 
 This makes type canonicalization of function types with bounds expressions
 straightforward.  The comparion of parameters is easy: two parameters are the

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4737,6 +4737,42 @@ public:
   }
 };
 
+// Represent a parameter as its index in the parameter list.
+// This is used within canonicalized bounds expressions.
+class PositionalParameterExpr : public Expr {
+  private:
+    unsigned Index;
+    friend class ASTStmtReader;
+
+  public:
+    PositionalParameterExpr(unsigned ParameterIndex, QualType QT) : Expr(
+      PositionalParameterExprClass, QT, ExprValueKind::VK_LValue,
+      ExprObjectKind::OK_Ordinary, false, false, false, false),
+      Index(ParameterIndex) {
+    }
+
+    explicit PositionalParameterExpr(EmptyShell Empty) :
+      Expr(InteropTypeBoundsAnnotationClass, Empty) {
+    }
+
+
+    unsigned getIndex() const {
+      return Index;
+    }
+
+    SourceLocation getLocStart() const LLVM_READONLY { return SourceLocation(); }
+    SourceLocation getLocEnd() const LLVM_READONLY { return SourceLocation(); }
+
+    static bool classof(const Stmt *T) {
+      return T->getStmtClass() == PositionalParameterExprClass;
+    }
+
+    // Iterators
+    child_range children() {
+      return child_range(child_iterator(), child_iterator());
+    }
+};
+
 
 //===----------------------------------------------------------------------===//
 // Clang Extensions

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4738,7 +4738,8 @@ public:
 };
 
 // Represent a parameter as its index in the parameter list.
-// This is used within canonicalized bounds expressions.
+// This is used in the representation of canonicalized bounds
+// expressions in function types.
 class PositionalParameterExpr : public Expr {
   private:
     unsigned Index;

--- a/include/clang/AST/RecursiveASTVisitor.h
+++ b/include/clang/AST/RecursiveASTVisitor.h
@@ -2426,6 +2426,7 @@ DEF_TRAVERSE_STMT(CountBoundsExpr, {})
 DEF_TRAVERSE_STMT(NullaryBoundsExpr, {})
 DEF_TRAVERSE_STMT(RangeBoundsExpr, {})
 DEF_TRAVERSE_STMT(InteropTypeBoundsAnnotation, {})
+DEF_TRAVERSE_STMT(PositionalParameterExpr, {})
 
 // For coroutines expressions, traverse either the operand
 // as written or the implied calls, depending on what the

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3289,6 +3289,8 @@ private:
   /// Whether this function has bounds information for parameters.
   unsigned HasParamBounds : 1;
 
+  // The return bounds for a function.  Null when a function has no return
+  // bounds.
   const BoundsExpr *const ReturnBounds;
 
   // ParamInfo - There is an variable size array after the class in memory that
@@ -3380,7 +3382,7 @@ public:
     if (hasExtParameterInfos())
       EPI.ExtParameterInfos = getExtParameterInfosBuffer();
     EPI.ParamBounds = hasParamBounds() ? param_bounds_begin() : nullptr;
-    EPI.ReturnBounds = getReturnBounds();
+    EPI.ReturnBounds = hasReturnBounds() ? getReturnBounds() : nullptr;
     return EPI;
   }
 

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3348,6 +3348,14 @@ public:
     return llvm::makeArrayRef(param_type_begin(), param_type_end());
   }
 
+  const BoundsExpr *const getParamBounds(unsigned i) const {
+    assert(i < NumParams && "invalid parameter index");
+    if (hasParamBounds())
+      return param_bounds_begin()[i];
+    else
+      return nullptr;
+  }
+
   ExtProtoInfo getExtProtoInfo() const {
     ExtProtoInfo EPI;
     EPI.ExtInfo = getExtInfo();

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3229,12 +3229,12 @@ public:
     ExtProtoInfo()
         : Variadic(false), HasTrailingReturn(false), TypeQuals(0),
           RefQualifier(RQ_None), ExtParameterInfos(nullptr),
-          ParamBounds(nullptr) {}
+          ParamBounds(nullptr), ReturnBounds(nullptr) {}
 
     ExtProtoInfo(CallingConv CC)
         : ExtInfo(CC), Variadic(false), HasTrailingReturn(false), TypeQuals(0),
           RefQualifier(RQ_None), ExtParameterInfos(nullptr),
-          ParamBounds(nullptr) {}
+          ParamBounds(nullptr), ReturnBounds(nullptr) {}
 
     ExtProtoInfo withExceptionSpec(const ExceptionSpecInfo &O) {
       ExtProtoInfo Result(*this);
@@ -3250,6 +3250,7 @@ public:
     ExceptionSpecInfo ExceptionSpec;
     const ExtParameterInfo *ExtParameterInfos;
     const BoundsExpr *const *ParamBounds;
+    const BoundsExpr *ReturnBounds;
   };
 
 private:
@@ -3287,6 +3288,8 @@ private:
 
   /// Whether this function has bounds information for parameters.
   unsigned HasParamBounds : 1;
+
+  const BoundsExpr *const ReturnBounds;
 
   // ParamInfo - There is an variable size array after the class in memory that
   // holds the parameter types.
@@ -3377,6 +3380,7 @@ public:
     if (hasExtParameterInfos())
       EPI.ExtParameterInfos = getExtParameterInfosBuffer();
     EPI.ParamBounds = hasParamBounds() ? param_bounds_begin() : nullptr;
+    EPI.ReturnBounds = getReturnBounds();
     return EPI;
   }
 
@@ -3459,6 +3463,8 @@ public:
 
   bool hasParamBounds() const { return HasParamBounds; }
 
+  bool hasReturnBounds() const { return ReturnBounds != nullptr; }
+
   /// Retrieve the ref-qualifier associated with this function type.
   RefQualifierKind getRefQualifier() const {
     return static_cast<RefQualifierKind>(FunctionTypeBits.RefQualifier);
@@ -3494,6 +3500,11 @@ public:
       return param_bounds_begin();
     else
       return param_bounds_begin() + NumParams;
+  }
+
+  // Checked C return bounds information
+  const BoundsExpr *getReturnBounds() const {
+    return ReturnBounds;
   }
 
   typedef const QualType *exception_iterator;

--- a/include/clang/Basic/StmtNodes.td
+++ b/include/clang/Basic/StmtNodes.td
@@ -176,6 +176,7 @@ def NullaryBoundsExpr : DStmt<BoundsExpr>;
 def CountBoundsExpr : DStmt<BoundsExpr>;
 def RangeBoundsExpr : DStmt<BoundsExpr>;
 def InteropTypeBoundsAnnotation : DStmt<BoundsExpr>;
+def PositionalParameterExpr : DStmt<Expr>;
 
 // CUDA Expressions.
 def CUDAKernelCallExpr : DStmt<CallExpr>;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4251,7 +4251,7 @@ public:
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
 
-  ExprResult AbstractForType(BoundsExpr *Expr);
+  ExprResult AbstractForFunctionType(BoundsExpr *Expr);
 
   //===---------------------------- Clang Extensions ----------------------===//
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4251,7 +4251,7 @@ public:
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
 
-  ExprResult AbstractForFunctionType(BoundsExpr *Expr);
+  BoundsExpr *AbstractForFunctionType(BoundsExpr *Expr);
 
   //===---------------------------- Clang Extensions ----------------------===//
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4244,10 +4244,14 @@ public:
   ExprResult CreateBoundsInteropType(SourceLocation TypeKWLoc,
                                      TypeSourceInfo *TInfo,
                                      SourceLocation RParenLoc);
+  ExprResult CreatePositionalParameterExpr(unsigned Index, QualType QT);
+
   void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr,
                        bool isReturnDecl=false);
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
+
+  ExprResult AbstractForType(BoundsExpr *Expr);
 
   //===---------------------------- Clang Extensions ----------------------===//
 

--- a/include/clang/Serialization/ASTBitCodes.h
+++ b/include/clang/Serialization/ASTBitCodes.h
@@ -1444,6 +1444,7 @@ namespace clang {
       EXPR_NULLARY_BOUNDS_EXPR,    // NullaryBoundsExpr
       EXPR_RANGE_BOUNDS_EXPR,      // RangeBoundsExpr
       EXPR_INTEROPTYPE_BOUNDS_ANNOTATION,// InteropTypeBoundsAnnotation
+      EXPR_POSITIONAL_PARAMETER_EXPR, // PositionalParameterExpr
 
       // OpenCL
       EXPR_ASTYPE,                 // AsTypeExpr

--- a/include/clang/Serialization/ASTReader.h
+++ b/include/clang/Serialization/ASTReader.h
@@ -2084,6 +2084,9 @@ public:
   /// \brief Reads an expression.
   Expr *ReadExpr(ModuleFile &F);
 
+  /// \brief Reads a bounds expression.
+  BoundsExpr *ReadBoundsExpr(ModuleFile &F);
+
   /// \brief Reads a sub-statement operand during statement reading.
   Stmt *ReadSubStmt() {
     assert(ReadingKind == Read_Stmt &&

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3166,8 +3166,9 @@ ASTContext::getFunctionType(QualType ResultTy, ArrayRef<QualType> ArgArray,
   }
 
   // FunctionProtoType objects are allocated with extra bytes after
-  // them for three variable size arrays at the end:
+  // them for four variable size arrays at the end:
   //  - parameter types
+  //  - parameter bounds
   //  - exception types
   //  - extended parameter information
   // Instead of the exception types, there could be a noexcept
@@ -3175,6 +3176,10 @@ ASTContext::getFunctionType(QualType ResultTy, ArrayRef<QualType> ArgArray,
   // specification.
   size_t Size = sizeof(FunctionProtoType) +
                 NumArgs * sizeof(QualType);
+
+  if (EPI.ParamBounds) {
+    Size += NumArgs * sizeof(BoundsExpr *);
+  }
 
   if (EPI.ExceptionSpec.Type == EST_Dynamic) {
     Size += EPI.ExceptionSpec.Exceptions.size() * sizeof(QualType);
@@ -3185,6 +3190,7 @@ ASTContext::getFunctionType(QualType ResultTy, ArrayRef<QualType> ArgArray,
   } else if (EPI.ExceptionSpec.Type == EST_Unevaluated) {
     Size += sizeof(FunctionDecl*);
   }
+
 
   // Put the ExtParameterInfos last.  If all were equal, it would make
   // more sense to put these before the exception specification, because

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -340,10 +340,8 @@ namespace  {
         QualType PT = T->getParamType(i);
         dumpTypeAsChild(PT);
         if (hasBounds)
-          if (const BoundsExpr *const Bounds = T->getParamBounds(i)) {
-            OS << " : ";
+          if (const BoundsExpr *const Bounds = T->getParamBounds(i))
             dumpStmt(Bounds);
-          }
       }
       if (EPI.Variadic)
         dumpChild([=] { OS << "..."; });
@@ -592,6 +590,7 @@ namespace  {
     void VisitInteropTypeBoundsAnnotation(
       const InteropTypeBoundsAnnotation *Node);
     void dumpBoundsKind(BoundsExpr::Kind kind);
+    void VisitPositionalParameterExpr(const PositionalParameterExpr *Node);
   };
 }
 
@@ -2517,6 +2516,13 @@ void ASTDumper::VisitInteropTypeBoundsAnnotation(
   VisitExpr(Node);
   if (Node->getKind() != BoundsExpr::Kind::InteropTypeAnnotation)
     dumpBoundsKind(Node->getKind());
+}
+
+void ASTDumper::VisitPositionalParameterExpr(
+  const PositionalParameterExpr *Node) {
+  VisitExpr(Node);
+  OS << " arg #";
+  OS << Node->getIndex();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -341,10 +341,18 @@ namespace  {
         dumpTypeAsChild(PT);
         if (hasBounds)
           if (const BoundsExpr *const Bounds = T->getParamBounds(i))
-            dumpStmt(Bounds);
+            dumpChild([=] {
+              OS << "Bounds";
+              dumpStmt(Bounds);
+            });
       }
       if (EPI.Variadic)
         dumpChild([=] { OS << "..."; });
+      if (EPI.ReturnBounds)
+        dumpChild([=] {
+          OS << "Return bounds";
+          dumpStmt(EPI.ReturnBounds);
+        });
     }
     void VisitUnresolvedUsingType(const UnresolvedUsingType *T) {
       dumpDeclRef(T->getDecl());

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -334,8 +334,17 @@ namespace  {
       // FIXME: Exception specification.
       // FIXME: Consumed parameters.
       VisitFunctionType(T);
-      for (QualType PT : T->getParamTypes())
+      int numParams = T->getNumParams();
+      bool hasBounds = T->hasParamBounds();
+      for (unsigned i = 0; i < numParams; i++) {
+        QualType PT = T->getParamType(i);
         dumpTypeAsChild(PT);
+        if (hasBounds)
+          if (const BoundsExpr *const Bounds = T->getParamBounds(i)) {
+            OS << " : ";
+            dumpStmt(Bounds);
+          }
+      }
       if (EPI.Variadic)
         dumpChild([=] { OS << "..."; });
     }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -334,7 +334,7 @@ namespace  {
       // FIXME: Exception specification.
       // FIXME: Consumed parameters.
       VisitFunctionType(T);
-      int numParams = T->getNumParams();
+      unsigned numParams = T->getNumParams();
       bool hasBounds = T->hasParamBounds();
       for (unsigned i = 0; i < numParams; i++) {
         QualType PT = T->getParamType(i);
@@ -584,6 +584,14 @@ namespace  {
     void visitVerbatimBlockComment(const VerbatimBlockComment *C);
     void visitVerbatimBlockLineComment(const VerbatimBlockLineComment *C);
     void visitVerbatimLineComment(const VerbatimLineComment *C);
+
+    // Checked C bounds expressions.
+    void VisitNullaryBoundsExpr(const NullaryBoundsExpr *Node);
+    void VisitCountBoundsExpr(const CountBoundsExpr *Node);
+    void VisitRangeBoundsExpr(const RangeBoundsExpr *Node);
+    void VisitInteropTypeBoundsAnnotation(
+      const InteropTypeBoundsAnnotation *Node);
+    void dumpBoundsKind(BoundsExpr::Kind kind);
   };
 }
 
@@ -1175,6 +1183,9 @@ void ASTDumper::VisitFunctionDecl(const FunctionDecl *D) {
     for (const ParmVarDecl *Parameter : D->parameters())
       dumpDecl(Parameter);
 
+  if (D->hasBoundsExpr())
+    dumpStmt(D->getBoundsExpr());
+
   if (const CXXConstructorDecl *C = dyn_cast<CXXConstructorDecl>(D))
     for (CXXConstructorDecl::init_const_iterator I = C->init_begin(),
                                                  E = C->init_end();
@@ -1195,6 +1206,8 @@ void ASTDumper::VisitFieldDecl(const FieldDecl *D) {
 
   if (D->isBitField())
     dumpStmt(D->getBitWidth());
+  if (D->hasBoundsExpr())
+    dumpStmt(D->getBoundsExpr());
   if (Expr *Init = D->getInClassInitializer())
     dumpStmt(Init);
 }
@@ -1218,6 +1231,8 @@ void ASTDumper::VisitVarDecl(const VarDecl *D) {
     OS << " inline";
   if (D->isConstexpr())
     OS << " constexpr";
+  if (D->hasBoundsExpr())
+    dumpStmt(D->getBoundsExpr());
   if (D->hasInit()) {
     switch (D->getInitStyle()) {
     case VarDecl::CInit: OS << " cinit"; break;
@@ -2463,6 +2478,45 @@ void ASTDumper::visitVerbatimBlockLineComment(
 
 void ASTDumper::visitVerbatimLineComment(const VerbatimLineComment *C) {
   OS << " Text=\"" << C->getText() << "\"";
+}
+
+//===----------------------------------------------------------------------===//
+// Checked C bounds expressions
+//===----------------------------------------------------------------------===//
+
+void ASTDumper::dumpBoundsKind(BoundsExpr::Kind K) {
+  switch (K) {
+    case BoundsExpr::Kind::Invalid: OS << " Invalid"; break;
+    case BoundsExpr::Kind::None: OS << " None"; break;
+    case BoundsExpr::Kind::ElementCount: OS << " Element"; break;
+    case BoundsExpr::Kind::ByteCount: OS << " Byte"; break;
+    case BoundsExpr::Kind::Range: OS << " Range"; break;
+    case BoundsExpr::Kind::InteropTypeAnnotation: OS << " InteropTypeAnnotation"; break;
+    default: OS << " <<err>>"; break;
+  }
+}
+
+void ASTDumper::VisitNullaryBoundsExpr(const NullaryBoundsExpr *Node) {
+  VisitExpr(Node);
+  dumpBoundsKind(Node->getKind());
+}
+
+void ASTDumper::VisitCountBoundsExpr(const CountBoundsExpr *Node) {
+  VisitExpr(Node);
+  dumpBoundsKind(Node->getKind());
+}
+
+void ASTDumper::VisitRangeBoundsExpr(const RangeBoundsExpr *Node) {
+  VisitExpr(Node);
+  if (Node->getKind() != BoundsExpr::Kind::Range)
+    dumpBoundsKind(Node->getKind());
+}
+
+void ASTDumper::VisitInteropTypeBoundsAnnotation(
+  const InteropTypeBoundsAnnotation *Node) {
+  VisitExpr(Node);
+  if (Node->getKind() != BoundsExpr::Kind::InteropTypeAnnotation)
+    dumpBoundsKind(Node->getKind());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/ExprConstant.cpp
+++ b/lib/AST/ExprConstant.cpp
@@ -9514,6 +9514,10 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
     }
     return ICEDiag(IK_NotICE, E->getLocStart());
   }
+  case Expr::PositionalParameterExprClass: {
+    // These are parameter variables and are never constants.
+    return ICEDiag(IK_NotICE, SourceLocation());
+  }
   case Expr::UnaryOperatorClass: {
     const UnaryOperator *Exp = cast<UnaryOperator>(E);
     switch (Exp->getOpcode()) {

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1886,8 +1886,14 @@ void StmtPrinter::VisitInteropTypeBoundsAnnotation(
   }
 }
 
-// PositionalParameterExpr is used by the type system and should never appear directly 
-// in the AST.  Print something anyway if it does appear.
+// PositionalParameterExpr is used in the representation of bounds
+// expressions that appear in function types.
+//
+// - If we are dumping the AST, these may appear.
+// - If we're printing C code from the AST, we should never end up printing
+//   one of these.  The printing code never directly prints the clang function
+//   type data structure to C code because important information may have been
+//   lost.
 void StmtPrinter::VisitPositionalParameterExpr(PositionalParameterExpr *E) {
   OS << "arg #";
   OS << (E->getIndex());

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1886,6 +1886,13 @@ void StmtPrinter::VisitInteropTypeBoundsAnnotation(
   }
 }
 
+// PositionalParameterExpr is used by the type system and should never appear directly 
+// in the AST.  Print something anyway if it does appear.
+void StmtPrinter::VisitPositionalParameterExpr(PositionalParameterExpr *E) {
+  OS << "arg #";
+  OS << (E->getIndex());
+}
+
 // C++
 void StmtPrinter::VisitCXXOperatorCallExpr(CXXOperatorCallExpr *Node) {
   const char *OpStrings[NUM_OVERLOADED_OPERATORS] = {

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1014,12 +1014,14 @@ void StmtProfiler::VisitRangeBoundsExpr(const RangeBoundsExpr *S) {
 void StmtProfiler::VisitInteropTypeBoundsAnnotation(
   const InteropTypeBoundsAnnotation *S) {
   VisitExpr(S);
+  VisitType(S->getTypeAsWritten());
   ID.AddInteger(S->getKind());
 }
 
 void StmtProfiler::VisitPositionalParameterExpr(
   const PositionalParameterExpr *P) {
   VisitExpr(P);
+  VisitType(P->getType());
   ID.AddInteger(P->getIndex());
 }
 

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1017,6 +1017,12 @@ void StmtProfiler::VisitInteropTypeBoundsAnnotation(
   ID.AddInteger(S->getKind());
 }
 
+void StmtProfiler::VisitPositionalParameterExpr(
+  const PositionalParameterExpr *P) {
+  VisitExpr(P);
+  ID.AddInteger(P->getIndex());
+}
+
 void StmtProfiler::VisitAtomicExpr(const AtomicExpr *S) {
   VisitExpr(S);
   ID.AddInteger(S->getOp());

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2665,7 +2665,8 @@ FunctionProtoType::FunctionProtoType(QualType result, ArrayRef<QualType> params,
       ExceptionSpecType(epi.ExceptionSpec.Type),
       HasExtParameterInfos(epi.ExtParameterInfos != nullptr),
       Variadic(epi.Variadic), HasTrailingReturn(epi.HasTrailingReturn),
-      HasParamBounds(epi.ParamBounds != nullptr) {
+      HasParamBounds(epi.ParamBounds != nullptr),
+      ReturnBounds(epi.ReturnBounds) {
   assert(NumParams == params.size() && "function has too many parameters");
 
   FunctionTypeBits.TypeQuals = epi.TypeQuals;
@@ -2875,6 +2876,7 @@ void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID, QualType Result,
         ID.AddPointer(nullptr);
     }
   }
+  ID.AddPointer(epi.ReturnBounds);
 
   if (epi.ExtParameterInfos) {
     for (unsigned i = 0; i != NumParams; ++i)

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -835,6 +835,11 @@ void TypePrinter::printFunctionProtoAfter(const FunctionProtoType *T,
     print(T->getReturnType(), OS, StringRef());
   } else
     printAfter(T->getReturnType(), OS);
+
+  if (const BoundsExpr *ReturnBounds = T->getReturnBounds()) {
+    OS << " : ";
+    ReturnBounds->printPretty(OS, nullptr, Policy);
+  }
 }
 
 void TypePrinter::printFunctionNoProtoBefore(const FunctionNoProtoType *T, 

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -715,6 +715,7 @@ void TypePrinter::printFunctionProtoAfter(const FunctionProtoType *T,
   OS << '(';
   {
     ParamPolicyRAII ParamPolicy(Policy);
+    bool HasBounds = T->hasParamBounds();
     for (unsigned i = 0, e = T->getNumParams(); i != e; ++i) {
       if (i) OS << ", ";
 
@@ -725,6 +726,12 @@ void TypePrinter::printFunctionProtoAfter(const FunctionProtoType *T,
         OS << "__attribute__((" << getParameterABISpelling(ABI) << ")) ";
 
       print(T->getParamType(i), OS, StringRef());
+      if (HasBounds) {
+        if (const BoundsExpr *const Bounds = T->getParamBounds(i)) {
+          OS << " : ";
+          Bounds->printPretty(OS, nullptr, Policy);
+        }
+      }
     }
   }
   

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -20,6 +20,7 @@ add_clang_library(clangSema
   Sema.cpp
   SemaAccess.cpp
   SemaAttr.cpp
+  SemaBounds.cpp
   SemaCXXScopeSpec.cpp
   SemaCast.cpp
   SemaChecking.cpp

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -16,11 +16,12 @@
 //    - References to other VarDecls's are changed to use canonical
 //      declarations.
 //
-//    Line number information is lift in place for expressions, though.  It
-//    would be a lot of coding to strip it out. The canonicalization of types
-//    ignores line number information in determining if two expressions are the
-//    same.  Users of bounds expressions that have been abstracted need to be
-//    aware that line number information may be inaccurate.
+//    Line number information is left in place for expressions, though.  It
+//    would be a lot of work to write functions to change the line numbers to
+//    the invalid line number. The canonicalization of types ignores line number
+//    information in determining if two expressions are the same.  Users of bounds
+//    expressions that have been abstracted need to be aware that line number
+//    information may be inaccurate.
 //===----------------------------------------------------------------------===//
 
 #include "TreeTransform.h"

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -61,6 +61,20 @@ namespace {
   };
 }
 
-ExprResult Sema::AbstractForFunctionType(BoundsExpr *Expr) {
-  return AbstractBoundsExpr(*this).TransformExpr(Expr);
+BoundsExpr *Sema::AbstractForFunctionType(BoundsExpr *Expr) {
+  if (!Expr)
+    return Expr;
+
+  BoundsExpr *Result;
+  ExprResult AbstractedBounds = AbstractBoundsExpr(*this).TransformExpr(Expr);
+  if (AbstractedBounds.isInvalid()) {
+    llvm_unreachable("unexpected failure to abstract bounds");
+    Result = nullptr;
+  }
+  else {
+    Result = dyn_cast<BoundsExpr>(AbstractedBounds.get());
+    assert(Result && "unexpected dyn_cast failure");
+    return Result;
+  }
 }
+

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1,0 +1,88 @@
+//===---------- SemaBounds.cpp - Operations On Bounds Expressions --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements operations on bounds expressions for semantic analysis.
+//  The operations include:
+//  * Abstracting bounds expressions so that they can be used in function types.
+//    This removes extraneous details:
+//    - references to ParamVarDecl's are abstracted to positional index numbers
+//      in argument lists.
+//    - references to other VarDecls's are changed to use canonical 
+//      declarations.
+//    - Line number information is removed because it might be inaccurate after
+//      types with bounds expressions are converted to canonical types.
+//===----------------------------------------------------------------------===//
+
+#include "TreeTransform.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTLambda.h"
+#include "clang/AST/ASTMutationListener.h"
+#include "clang/AST/CXXInheritance.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/EvaluatedExprVisitor.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/ExprObjC.h"
+#include "clang/AST/ExprOpenMP.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/TypeLoc.h"
+#include "clang/Basic/PartialDiagnostic.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Basic/TargetInfo.h"
+#include "clang/Lex/LiteralSupport.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Sema/AnalysisBasedWarnings.h"
+#include "clang/Sema/DeclSpec.h"
+#include "clang/Sema/DelayedDiagnostic.h"
+#include "clang/Sema/Designator.h"
+#include "clang/Sema/Initialization.h"
+#include "clang/Sema/Lookup.h"
+#include "clang/Sema/ParsedTemplate.h"
+#include "clang/Sema/Scope.h"
+#include "clang/Sema/ScopeInfo.h"
+#include "clang/Sema/SemaFixItUtils.h"
+#include "clang/Sema/SemaInternal.h"
+#include "clang/Sema/Template.h"
+#include "llvm/Support/ConvertUTF.h"
+using namespace clang;
+using namespace sema;
+
+namespace {
+  class AbstractBoundsExpr : public TreeTransform<AbstractBoundsExpr> {
+    typedef TreeTransform<AbstractBoundsExpr> BaseTransform;
+
+  public:
+    AbstractBoundsExpr(Sema &SemaRef) : BaseTransform(SemaRef) { }
+
+    Decl *TransformDecl(SourceLocation Loc, Decl *D) {
+      return D->getCanonicalDecl();
+    }
+
+    ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
+      ValueDecl *D = E->getDecl();
+      if (ParmVarDecl *PD = dyn_cast<ParmVarDecl>(D))
+        return SemaRef.CreatePositionalParameterExpr(
+          PD->getFunctionScopeIndex(),
+          PD->getType());
+
+      ValueDecl *ND = 
+        dyn_cast_or_null<ValueDecl>(BaseTransform::TransformDecl(
+          SourceLocation(), D));
+      if (D == ND || ND == nullptr)
+        return E;
+      else {
+        clang::NestedNameSpecifierLoc QualifierLoc  = E->getQualifierLoc();
+        clang::DeclarationNameInfo NameInfo = E->getNameInfo();
+        return getDerived().RebuildDeclRefExpr(QualifierLoc, ND, NameInfo, nullptr);
+      }
+    }
+  };
+}

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12362,6 +12362,10 @@ ExprResult Sema::CreateBoundsInteropType(SourceLocation TypeKWLoc, TypeSourceInf
                                                    TInfo);
 }
 
+ExprResult Sema::CreatePositionalParameterExpr(unsigned Index, QualType QT) {
+  return new (Context) PositionalParameterExpr(Index, QT);
+}
+
 //===----------------------------------------------------------------------===//
 // Clang Extensions.
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4524,14 +4524,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
           BoundsExpr *Bounds = Param->getBoundsExpr();
           if (Bounds) {
             HasAnyParameterBounds = true;
-            ExprResult AbstractedBounds = S.AbstractForFunctionType(Bounds);
-            if (AbstractedBounds.isInvalid()) {
-              llvm_unreachable("unexpected failure to abstract bounds");
-              Bounds = nullptr;
-            } else {
-               Bounds = dyn_cast<BoundsExpr>(AbstractedBounds.get());
-               assert(Bounds && "unexpected dyn_cast failure");
-            }
+            Bounds = S.AbstractForFunctionType(Bounds);
           }
           ParamBounds.push_back(Bounds);
 
@@ -4549,9 +4542,11 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
           ParamTys.push_back(ParamTy);
         }
 
-        // Record parameter bounds for Checked C extension, if there are any.
+        // Record bounds for Checked C extension.  Only record parameter bounds array if there are
+        // parameter bounds.
         if (HasAnyParameterBounds)
           EPI.ParamBounds = ParamBounds.data();
+        EPI.ReturnBounds = S.AbstractForFunctionType(FTI.getReturnBounds());
 
         if (HasAnyInterestingExtParameterInfos) {
           EPI.ExtParameterInfos = ExtParameterInfos.data();

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -2367,6 +2367,10 @@ public:
     return getSema().CreateBoundsInteropType(StartLoc, Ty, RParenLoc);
   }
 
+  ExprResult RebuildPositionalParameterExpr(unsigned Index, QualType QT) {
+    return getSema().CreatePositionalParameterExpr(Index, QT);
+  }
+  \
   /// \brief Build a new overloaded operator call expression.
   ///
   /// By default, performs semantic analysis to build the new expression.
@@ -11550,6 +11554,16 @@ TreeTransform<Derived>::TransformInteropTypeBoundsAnnotation(
   return getDerived().
     RebuildInteropTypeBoundsAnnotation(E->getStartLoc(), TInfo,
                                        E->getRParenLoc());
+}
+
+template<typename Derived>
+ExprResult
+TreeTransform<Derived>::TransformPositionalParameterExpr(
+  PositionalParameterExpr *E) {
+  unsigned Index = E->getIndex();
+  QualType QT = getDerived().TransformType(E->getType());
+  return getDerived().
+    RebuildPositionalParameterExpr(Index, QT);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -5482,14 +5482,15 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
       SmallVector<const BoundsExpr *, 16> ParamBounds;
       for (unsigned I = 0; I != NumParams; ++I) {
         Expr *E = ReadExpr(*Loc.F);
-        BoundsExpr *B = nullptr;
+        BoundsExpr *B;
         if (E) {
           B = dyn_cast<BoundsExpr>(E);
           assert(B && "failure reading BoundsExpr");
-        }
+        } else
+          B = nullptr;
         ParamBounds.push_back(B);
-        EPI.ParamBounds = ParamBounds.data();
-     }
+      }
+      EPI.ParamBounds = ParamBounds.data();
     } else
       EPI.ParamBounds = nullptr;
 
@@ -5632,7 +5633,6 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
       = ReadDeclAs<ObjCInterfaceDecl>(*Loc.F, Record, Idx);
     return Context.getObjCInterfaceType(ItfD->getCanonicalDecl());
   }
-
   case TYPE_OBJC_OBJECT: {
     unsigned Idx = 0;
     QualType Base = readType(*Loc.F, Record, Idx);

--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -5472,6 +5472,7 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
     EPI.RefQualifier = static_cast<RefQualifierKind>(Record[Idx++]);
     SmallVector<QualType, 8> ExceptionStorage;
     readExceptionSpec(*Loc.F, ExceptionStorage, EPI.ExceptionSpec, Record, Idx);
+    EPI.ReturnBounds = ReadBoundsExpr(*Loc.F);
 
     unsigned NumParams = Record[Idx++];
     SmallVector<QualType, 16> ParamTypes;
@@ -5481,14 +5482,7 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
     if (HasParamBounds) {
       SmallVector<const BoundsExpr *, 16> ParamBounds;
       for (unsigned I = 0; I != NumParams; ++I) {
-        Expr *E = ReadExpr(*Loc.F);
-        BoundsExpr *B;
-        if (E) {
-          B = dyn_cast<BoundsExpr>(E);
-          assert(B && "failure reading BoundsExpr");
-        } else
-          B = nullptr;
-        ParamBounds.push_back(B);
+        ParamBounds.push_back(ReadBoundsExpr(*Loc.F));
       }
       EPI.ParamBounds = ParamBounds.data();
     } else

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -2930,6 +2930,16 @@ Expr *ASTReader::ReadExpr(ModuleFile &F) {
   return cast_or_null<Expr>(ReadStmt(F));
 }
 
+BoundsExpr *ASTReader::ReadBoundsExpr(ModuleFile &F) {
+  Expr *E = ReadExpr(F);
+  BoundsExpr *B = nullptr;
+  if (E) {
+    B = dyn_cast<BoundsExpr>(E);
+    assert(B && "failure reading BoundsExpr");
+  }
+  return B;
+}
+
 Expr *ASTReader::ReadSubExpr() {
   return cast_or_null<Expr>(ReadSubStmt());
 }

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -988,6 +988,13 @@ void ASTStmtReader::VisitInteropTypeBoundsAnnotation(
   E->EndLoc = ReadSourceLocation(Record, Idx);
 }
 
+void ASTStmtReader::VisitPositionalParameterExpr(
+  PositionalParameterExpr *E) {
+  VisitExpr(E);
+  E->Index = Record[Idx++];
+}
+
+
 //===----------------------------------------------------------------------===//
 // Objective-C Expressions and Statements
 

--- a/lib/Serialization/ASTWriter.cpp
+++ b/lib/Serialization/ASTWriter.cpp
@@ -305,8 +305,13 @@ void ASTTypeWriter::VisitFunctionProtoType(const FunctionProtoType *T) {
       Record.push_back(T->getExtParameterInfo(I).getOpaqueValue());
   }
 
+  // AbbrevToUse indicates whether to compress a record in a domain-specifc
+  // way.  ASTWriter::WriteTypeAbbrevs omits these fields in the template
+  // for the compressed record for function prototypes, so disable the
+  // compression when these fields are present.  Note that, confusingly,
+  // compression of function prototypes does not appear to ever be enabled.
   if (T->isVariadic() || T->hasTrailingReturn() || T->hasParamBounds() ||
-      T->hasReturnBounds() || T->getTypeQuals() ||T->getRefQualifier() ||
+      T->hasReturnBounds() || T->getTypeQuals() || T->getRefQualifier() ||
       T->getExceptionSpecType() != EST_None || T->hasExtParameterInfos())
     AbbrevToUse = 0;
 

--- a/lib/Serialization/ASTWriter.cpp
+++ b/lib/Serialization/ASTWriter.cpp
@@ -290,6 +290,7 @@ void ASTTypeWriter::VisitFunctionProtoType(const FunctionProtoType *T) {
   Record.push_back(T->getTypeQuals());
   Record.push_back(static_cast<unsigned>(T->getRefQualifier()));
   addExceptionSpec(T, Record);
+  Record.AddStmt(const_cast<BoundsExpr *>(T->getReturnBounds()));
 
   Record.push_back(T->getNumParams());
   for (unsigned I = 0, N = T->getNumParams(); I != N; ++I)
@@ -305,7 +306,7 @@ void ASTTypeWriter::VisitFunctionProtoType(const FunctionProtoType *T) {
   }
 
   if (T->isVariadic() || T->hasTrailingReturn() || T->hasParamBounds() ||
-      T->getTypeQuals() ||T->getRefQualifier() ||
+      T->hasReturnBounds() || T->getTypeQuals() ||T->getRefQualifier() ||
       T->getExceptionSpecType() != EST_None || T->hasExtParameterInfos())
     AbbrevToUse = 0;
 

--- a/lib/Serialization/ASTWriter.cpp
+++ b/lib/Serialization/ASTWriter.cpp
@@ -286,6 +286,7 @@ void ASTTypeWriter::VisitFunctionProtoType(const FunctionProtoType *T) {
 
   Record.push_back(T->isVariadic());
   Record.push_back(T->hasTrailingReturn());
+  Record.push_back(T->hasParamBounds());
   Record.push_back(T->getTypeQuals());
   Record.push_back(static_cast<unsigned>(T->getRefQualifier()));
   addExceptionSpec(T, Record);
@@ -294,14 +295,18 @@ void ASTTypeWriter::VisitFunctionProtoType(const FunctionProtoType *T) {
   for (unsigned I = 0, N = T->getNumParams(); I != N; ++I)
     Record.AddTypeRef(T->getParamType(I));
 
+  if (T->hasParamBounds())
+    for (unsigned I = 0, N = T->getNumParams(); I != N; ++I)
+      Record.AddStmt(const_cast<BoundsExpr *>(T->getParamBounds(I)));
+
   if (T->hasExtParameterInfos()) {
     for (unsigned I = 0, N = T->getNumParams(); I != N; ++I)
       Record.push_back(T->getExtParameterInfo(I).getOpaqueValue());
   }
 
-  if (T->isVariadic() || T->hasTrailingReturn() || T->getTypeQuals() ||
-      T->getRefQualifier() || T->getExceptionSpecType() != EST_None ||
-      T->hasExtParameterInfos())
+  if (T->isVariadic() || T->hasTrailingReturn() || T->hasParamBounds() ||
+      T->getTypeQuals() ||T->getRefQualifier() ||
+      T->getExceptionSpecType() != EST_None || T->hasExtParameterInfos())
     AbbrevToUse = 0;
 
   Code = TYPE_FUNCTION_PROTO;

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -946,6 +946,12 @@ void ASTStmtWriter::VisitInteropTypeBoundsAnnotation(
   Code = serialization::EXPR_INTEROPTYPE_BOUNDS_ANNOTATION;
 }
 
+void ASTStmtWriter::VisitPositionalParameterExpr(
+  PositionalParameterExpr *E) {
+  VisitExpr(E);
+  Code = serialization::EXPR_POSITIONAL_PARAMETER_EXPR;
+}
+
 //===----------------------------------------------------------------------===//
 // Objective-C Expressions and Statements.
 //===----------------------------------------------------------------------===//

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -949,6 +949,7 @@ void ASTStmtWriter::VisitInteropTypeBoundsAnnotation(
 void ASTStmtWriter::VisitPositionalParameterExpr(
   PositionalParameterExpr *E) {
   VisitExpr(E);
+  Record.push_back(E->getIndex());
   Code = serialization::EXPR_POSITIONAL_PARAMETER_EXPR;
 }
 

--- a/test/CheckedC/ast-dump-bounds.c
+++ b/test/CheckedC/ast-dump-bounds.c
@@ -189,7 +189,7 @@ int *f23(void) : itype(_Ptr<int>);
 
 // CHECK: FunctionDecl
 // CHECK: f23
-// CHECK: 'int *(void)'
+// CHECK: 'int *(void) : _Ptr<int>'
 // CHECK-NEXT: InteropTypeBoundsAnnotation
 // CHECK: '_Ptr<int>'
 
@@ -240,7 +240,7 @@ struct S1 {
 };
 
 //===================================================================
-// Dumps of bounds expressions for function types
+// Dumps of bounds expressions for parameters of function types
 //===================================================================
 
 void f30(_Array_ptr<int> arr : bounds(arr, arr + len), int len);
@@ -261,7 +261,7 @@ void f31(int (*fn)(_Array_ptr<int> arr : bounds(arr, arr + len), int len));
 // CHECK: fn
 // CHECK: 'int (*)(_Array_ptr<int> : bounds(arg #0, arg #0 + arg #1), int)'
 
-typedef float fn_sum(int lower, int upper,
+typedef float fn_sum1(int lower, int upper,
                      _Array_ptr<float> arr : bounds(arr - lower, arr + upper));
 
 // CHECK: TypedefDecl
@@ -281,9 +281,10 @@ typedef float fn_sum(int lower, int upper,
 // CHECK: float
 
 //
-// range-expression for the _Array_ptr<float> parameter
+// Bounds expression for the _Array_ptr<float> parameter
 //
 
+// CHECK-NEXT: Bounds
 // CHECK-NEXT: RangeBoundsExpr
 
 // arg #2 - arg #0
@@ -313,3 +314,91 @@ typedef float fn_sum(int lower, int upper,
 // CHECK-NEXT: PositionalParameterExpr
 // CHECK: arg
 // CHECK: #1
+
+//===================================================================
+// Dumps of bounds expressions for returns of function types
+//===================================================================
+
+_Array_ptr<int> f40(int len) : count(len);
+
+// CHECK-NEXT: FunctionDecl
+// CHECK: f40
+// CHECK: '_Array_ptr<int> (int) : count(arg #0)'
+// CHECK-NEXT ParmVarDecl
+// CHECK: len
+// CHECK-NEXT: CountBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: len
+// CHECK: 'int'
+
+_Array_ptr<int> f41(int len) : byte_count(4 * len);
+
+// CHECK-NEXT: FunctionDecl
+// CHECK: f41
+// CHECK: '_Array_ptr<int> (int) : byte_count(4 * arg #0)'
+// CHECK-NEXT: ParmVarDecl
+// CHECK: len
+// CHECK-NEXT: CountBoundsExpr
+// CHECK-NEXT: BinaryOperator
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 4
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: len
+
+_Array_ptr<int> f42(_Array_ptr<int> arr : count(len), int len) : bounds(arr, arr + len);
+
+// CHECK-NEXT: FunctionDecl
+// CHECK: f42
+// CHECK: '_Array_ptr<int> (_Array_ptr<int> : count(arg #1), int) : bounds(arg #0, arg #0 + arg #1)'
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr
+// CHECK-NEXT: CountBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: len
+// CHECK-NEXT: ParmVarDecl
+// CHECK: len
+// CHECK-NEXT: RangeBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: 'arr'
+// CHECK-NEXT: BinaryOperator
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: arr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: len
+
+typedef _Array_ptr<float> fn_vector_add(_Array_ptr<float> vec : count(len),
+ int len, int c) : count(len);
+
+ // CHECK-NEXT: TypedefDecl
+ // CHECK: '_Array_ptr<float> (_Array_ptr<float> : count(arg #1), int, int) : count(arg #1)'
+ // CHECK-NEXT: FunctionProtoType
+ // CHECK-NEXT: PointerType
+ // CHECK: '_Array_ptr<float>'
+ // CHECK-NEXT: BuiltinType
+ // CHECK: float
+ // CHECK-NEXT: PointerType
+ // CHECK: '_Array_ptr<float>'
+ // CHECK-NEXT: BuiltinType
+ // CHECK: float
+ // CHECK-NEXT: Bounds
+ // CHECK-NEXT: CountBoundsExpr
+ // CHECK-NEXT: ImplicitCastExpr
+ // CHECK-NEXT: PositionalParameterExpr
+ // CHECK: 'int'
+ // CHECK: #1
+ // CHECK-NEXT: BuiltinType
+ // CHECK: 'int'
+ // CHECK-NEXT: BuiltinType
+ // CHECK: 'int'
+ // CHECK-NEXT: Return bounds
+ // CHECK-NEXT: CountBoundsExpr
+ // CHECK-NEXT: ImplicitCastExpr
+ // CHECK-NEXT: PositionalParameterExpr
+ // CHECK: 'int'
+ // CHECK: #1

--- a/test/CheckedC/ast-dump-bounds.c
+++ b/test/CheckedC/ast-dump-bounds.c
@@ -239,3 +239,77 @@ struct S1 {
   // CHECK: '_Ptr<int>'
 };
 
+//===================================================================
+// Dumps of bounds expressions for function types
+//===================================================================
+
+void f30(_Array_ptr<int> arr : bounds(arr, arr + len), int len);
+
+// CHECK: FunctionDecl
+// CHECK: f30
+// CHECK: 'void (_Array_ptr<int> : bounds(arg #0, arg #0 + arg #1), int)'
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr '_Array_ptr<int>'
+// CHECK-NEXT: RangeBoundsExpr
+
+void f31(int (*fn)(_Array_ptr<int> arr : bounds(arr, arr + len), int len));
+
+// CHECK: FunctionDecl
+// CHECK: f31
+// CHECK: 'void (int (*)(_Array_ptr<int> : bounds(arg #0, arg #0 + arg #1), int))'
+// CHECK: ParmVarDecl
+// CHECK: fn
+// CHECK: 'int (*)(_Array_ptr<int> : bounds(arg #0, arg #0 + arg #1), int)'
+
+typedef float fn_sum(int lower, int upper,
+                     _Array_ptr<float> arr : bounds(arr - lower, arr + upper));
+
+// CHECK: TypedefDecl
+// CHECK: fn_sum
+// CHECK: 'float (int, int, _Array_ptr<float> : bounds(arg #2 - arg #0, arg #2 + arg #1))'
+// CHECK-NEXT: FunctionProtoType
+// CHECK: 'float (int, int, _Array_ptr<float> : bounds(arg #2 - arg #0, arg #2 + arg #1))'
+// CHECK-NEXT: BuiltinType
+// CHECK: float
+// CHECK-NEXT: BuiltinType
+// CHECK: int
+// CHECK-NEXT: BuiltinType
+// CHECK: int
+// CHECK-NEXT: PointerType
+// CHECK: _Array_ptr<float>
+// CHECK-NEXT: BuiltinType
+// CHECK: float
+
+//
+// range-expression for the _Array_ptr<float> parameter
+//
+
+// CHECK-NEXT: RangeBoundsExpr
+
+// arg #2 - arg #0
+
+// CHECK-NEXT: BinaryOperator
+// CHECK: '_Array_ptr<float>'
+// CHECK: '-'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: PositionalParameterExpr
+// CHECK: arg
+// CHECK: #2
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: PositionalParameterExpr
+// CHECK: arg
+// CHECK: #0
+
+// arg #2 + arg #1
+
+// CHECK-NEXT: BinaryOperator
+// CHECK: '_Array_ptr<float>'
+// CHECK: '+'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: PositionalParameterExpr
+// CHECK: arg
+// CHECK: #2
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: PositionalParameterExpr
+// CHECK: arg
+// CHECK: #1

--- a/test/CheckedC/ast-dump-bounds.c
+++ b/test/CheckedC/ast-dump-bounds.c
@@ -1,0 +1,241 @@
+// Tests for dumping of ASTS with Checked C extensions.
+// This makes sure that additional information appears as
+// expected.
+//
+// RUN: %clang_cc1 -ast-dumps -fcheckedc-extension %s | FileCheck %s
+
+//===================================================================
+// Dumps of different kinds of bounds expressions on global variables
+//===================================================================
+
+_Array_ptr<int> g_arr1 : count(5);
+
+// CHECK: VarDecl
+// CHECK: g_arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 'int' 5
+
+_Array_ptr<int> g_arr2 : byte_count(sizeof(int) * 5);
+
+// CHECK: VarDecl
+// CHECK: g_arr2 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Byte
+// CHECK-NEXT: BinaryOperator
+// CHECK: IntegerLiteral
+// CHECK: 'int' 5
+
+_Array_ptr<int> g_arr3 : bounds(g_arr3, g_arr3 + 5);
+
+// CHECK: VarDecl
+// CHECK: g_arr3 '_Array_ptr<int>'
+// CHECK-NEXT: RangeBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: g_arr3
+// CHECK-NEXT: BinaryOperator
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK: g_arr3
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 'int' 5
+
+int * g_arr4 : itype(_Ptr<int>);
+
+// CHECK: VarDecl
+// CHECK: g_arr4 'int *'
+// CHECK-NEXT: InteropTypeBoundsAnnotation
+// CHECK: '_Ptr<int>'
+
+//===================================================================
+// Dumps of different kinds of bounds expressions on local variables
+//===================================================================
+
+void f1() {
+  _Array_ptr<int> arr1 : count(5) = 0;
+
+// CHECK: VarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 'int' 5
+
+  _Array_ptr<int> arr2 : byte_count(sizeof(int) * 5) = 0;
+
+// CHECK: VarDecl
+// CHECK: arr2 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Byte
+// CHECK-NEXT: BinaryOperator
+// CHECK: IntegerLiteral
+// CHECK: 'int' 5
+
+  _Array_ptr<int> arr3 : bounds(arr3, arr3 + 5) = 0;
+
+// CHECK: VarDecl
+// CHECK: arr3 '_Array_ptr<int>'
+// CHECK-NEXT: RangeBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: arr3
+// CHECK-NEXT: BinaryOperator
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK: arr3
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 'int' 5
+
+  int * arr4 : itype(_Ptr<int>) = 0;
+
+// CHECK: VarDecl
+// CHECK: arr4 'int *'
+// CHECK-NEXT: InteropTypeBoundsAnnotation
+// CHECK: '_Ptr<int>'
+}
+
+//=============================================================
+// Dumps of different kinds of bounds expressions on parameters
+//=============================================================
+
+void f10(_Array_ptr<int> arr1 : count(5));
+// CHECK: FunctionDecl
+// CHECK: f10
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+
+void f11(_Array_ptr<int> arr1 : byte_count(sizeof(int) * 5));
+
+// CHECK: FunctionDecl
+// CHECK: f11
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Byte
+
+void f12(_Array_ptr<int> arr1 : bounds(arr1, arr1 + 5));
+
+// CHECK: FunctionDecl
+// CHECK: f12
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: RangeBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: arr1
+// CHECK-NEXT: BinaryOperator
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK: arr1
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 'int' 5
+
+void f13(int *pint : itype(_Ptr<int>));
+
+// CHECK: FunctionDecl
+// CHECK: f13
+// CHECK-NEXT: ParmVarDecl
+// CHECK: pint 'int *'
+// CHECK-NEXT: InteropTypeBoundsAnnotation
+// CHECK: '_Ptr<int>'
+
+void f14(int arr1 _Checked[] : count(5));
+// CHECK: FunctionDecl
+// CHECK: f14
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+// CHECK-NEXT: IntegerLiteral
+// CHECK 'int' 5
+
+//===================================================================
+// Dumps of different kinds of bounds expressions on function returns
+//===================================================================
+
+_Array_ptr<int> f20(void) : count(5);
+// CHECK: FunctionDecl
+// CHECK: 20
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+// CHECK-NEXT: IntegerLiteral
+// CHECK 'int' 5
+
+_Array_ptr<int> f21(void) : byte_count(sizeof(int) * 5);
+
+// CHECK: FunctionDecl
+// CHECK: f21
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Byte
+// CHECK: IntegerLiteral
+// CHECK 'int' 5
+
+_Array_ptr<int> f22(_Array_ptr<int> arr1 : count(5)) : bounds(arr1, arr1 + 5);
+
+// CHECK: FunctionDecl
+// CHECK: f22
+// CHECK: RangeBoundsExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK: arr1
+// CHECK-NEXT: BinaryOperator
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK: arr1
+// CHECK-NEXT: IntegerLiteral
+// CHECK: 'int' 5
+
+int *f23(void) : itype(_Ptr<int>);
+
+// CHECK: FunctionDecl
+// CHECK: f23
+// CHECK: 'int *(void)'
+// CHECK-NEXT: InteropTypeBoundsAnnotation
+// CHECK: '_Ptr<int>'
+
+//===================================================================
+// Dumps of different kinds of bounds expressions on structure members
+//===================================================================
+
+struct S1 {
+  _Array_ptr<int> arr1 : count(5);
+
+  // CHECK: FieldDecl
+  // CHECK: arr1 '_Array_ptr<int>'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK: Element
+  // CHECK-NEXT: IntegerLiteral
+  // CHECK: 'int' 5
+
+  _Array_ptr<int> arr2 : byte_count(sizeof(int) * 5);
+
+  // CHECK: FieldDecl
+  // CHECK: arr2 '_Array_ptr<int>'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK: Byte
+  // CHECK-NEXT: BinaryOperator
+  // CHECK: IntegerLiteral
+  // CHECK: 'int' 5
+
+  _Array_ptr<int> arr3 : bounds(arr3, arr3 + 5);
+
+  // CHECK: FieldDecl
+  // CHECK: arr3 '_Array_ptr<int>'
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr
+  // CHECK: arr3
+  // CHECK-NEXT: BinaryOperator
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK: arr3
+  // CHECK-NEXT: IntegerLiteral
+  // CHECK: 'int' 5
+
+  int * arr4 : itype(_Ptr<int>);
+
+  // CHECK: FieldDecl
+  // CHECK: arr4 'int *'
+  // CHECK-NEXT: InteropTypeBoundsAnnotation
+  // CHECK: '_Ptr<int>'
+};
+


### PR DESCRIPTION
Function types incorporate bounds information in Checked C.  This change extends the clang IR to represent bounds information for parameters and returns of function types.   This issues #81 and #82.

- The change adds another dynamically-sized array to the FunctionProtoType data structure that holds bounds for parameters.    If a parameter has no bounds, a null pointer is stored for the corresponding entry in the array. The array is not allocated if there are no bounds expressions for any of the parameters.
- It add a member to FunctionType to hold the return bounds expression. We could save space for FunctionType objects that do not have return bounds by storing the return bounds as part of the dynamically-allocated array for parameter bounds.  We do not do that for now. There's no pressing need to save space and it would make the implementation a little more complicated.
- In the Checked C specification, function type compatibility involves renaming parameters so that corresponding parameters have the same name.  This is awkward to do in a compiler, so instead we chose another representation for parameters in bounds expressions that occur in function types.  We represent parameters using their position in the argument list.  We create an expression PositionalParameterExpr that represents this abstraction of parameters.  To check if two parameters are the same, we just compare the positional parameter expressions by value (using the index and type).

We update AST dumping and AST serialization to handle the new information.  We also change the code for memoizing function types (implemented by functions named "Profile") to take into account the new information.    We use the clang meta-template approach to abstract bounds expressions for parameters of function types.  It only ends up being about 40 lines of code.

Update the Checked C implementation documentation to describe the IR choices and explain
why we chose to use PositionalParameterExpr instead of taking another approach.

While we add the information, we don't do much with it yet.  This change does not update type compatibility testing or the checking of redeclarations.

The memory management surrounding construction of function types is a little tricky and deserves some explanation.  The class ExtProtoInfo holds additional information about a function type being constructed.  We add the bounds information for parameters there.  It includes pointers to arrays that are allocated during function type construction and deallocated after function type construction.   The FunctionType class is allocated with extra space at the end for a number of variably-sized arrays (side note: this could be a lot cleaner and safer when Checked C is extended to handle variable-sized array members).   The array contents are copied into the extra space.   The bounds expressions themselves are allocated in a memory region associated with the AST context.  They live as long as the entire AST.     Later on, we'll need to be careful to not allocate bounds expressions to live forever.   However, for the purposes of constructing the IR, this is fine.

Testing:
- Add new tests to AST dumping that test function types with bounds expressions, making sure
  that parameters have been abstracted properly.
- Passes existing Checked C regression tests.
- Passes clang regression tests.
