### PR TITLE
Check bounds declarations for function pointer return types.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8730,11 +8730,14 @@ def err_unchecked_array_of_typedef_checked_array : Error<
 def err_unchecked_array_of_checked_array : Error<
   "unchecked array of checked array not allowed">;
 
-def err_bounds_safe_interface_unchecked_local_pointer : Error<
-  "expected local variable %0 to have _Array_ptr type">;
+def err_bounds_declaration_unchecked_local_pointer : Error<
+  "bounds declaration not allowed for local variable with unchecked pointer type">;
 
-def err_bounds_safe_interface_unchecked_local_array : Error<
-  "expected local variable %0 to have checked array type">;
+def err_bounds_declaration_unchecked_local_array : Error<
+  "bounds declaration not allowed for local variable with unchecked array type">;
+
+def err_bounds_safe_interface_type_annotation_local_variable : Error<
+  "bounds-safe interface type annotation not allowed for local variable">;
 
 def err_typecheck_ptr_subscript : Error<
   "subscript of %0">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8764,31 +8764,31 @@ def err_typecheck_ptr_decl_with_bounds : Error<
   "bounds declaration not allowed because %0 has a _Ptr type">;
 
 def err_typecheck_ptr_return_with_bounds : Error<
-  "bounds declaration not allowed because %0 has a _Ptr return type">;
+  "bounds declaration not allowed for a _Ptr return type">;
 
 def err_typecheck_function_pointer_decl_with_bounds : Error<
   "bounds declaration not allowed because %0 has a function pointer type">;
 
 def err_typecheck_function_pointer_return_with_bounds : Error<
-  "bounds declaration not allowed because %0 has a function pointer return type">;
+  "bounds declaration not allowed for a function pointer return type">;
 
 def err_typecheck_count_bounds_decl : Error<
   "expected %0 to have a pointer or array type">;
 
 def err_typecheck_count_return_bounds : Error<
-  "expected %0 to have a pointer return type">;
+  "count bounds expression only allowed for pointer return type">;
 
 def err_typecheck_void_pointer_count_bounds_decl : Error<
   "expected %0 to have a non-void pointer type">;
 
 def err_typecheck_void_pointer_count_return_bounds : Error<
-  "expected %0 to have a non-void pointer return type">;
+  "count bounds expression not allowed for a void pointer return type">;
 
 def err_typecheck_non_count_bounds_decl : Error<
   "expected %0 to have a pointer, array, or integer type">;
 
 def err_typecheck_non_count_return_bounds : Error<
-  "expected %0 to have a pointer or integer return type">;
+  "bounds declaration only allowed for a pointer or integer return type">;
 
 def err_typecheck_bounds_type_annotation_identifier: Error<
   "type name cannot have identifier in it">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4246,8 +4246,11 @@ public:
                                      SourceLocation RParenLoc);
   ExprResult CreatePositionalParameterExpr(unsigned Index, QualType QT);
 
+  bool DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
+                              BoundsExpr *Expr, bool IsReturnBounds);
   void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr,
                        bool isReturnDecl=false);
+
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4248,8 +4248,7 @@ public:
 
   bool DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
                               BoundsExpr *Expr, bool IsReturnBounds);
-  void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr,
-                       bool isReturnDecl=false);
+  void ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr);
 
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4542,11 +4542,19 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
           ParamTys.push_back(ParamTy);
         }
 
+        BoundsExpr *ReturnBounds = FTI.getReturnBounds();
+        if (ReturnBounds) {
+          // if (S.DiagnoseBoundsDeclType(T, nullptr, ReturnBounds, true))
+          // ReturnBounds = S.CreateInvalidBoundsExpr();
+          // else
+            ReturnBounds = S.AbstractForFunctionType(ReturnBounds);
+        }
+
         // Record bounds for Checked C extension.  Only record parameter bounds array if there are
         // parameter bounds.
         if (HasAnyParameterBounds)
           EPI.ParamBounds = ParamBounds.data();
-        EPI.ReturnBounds = S.AbstractForFunctionType(FTI.getReturnBounds());
+        EPI.ReturnBounds = ReturnBounds;
 
         if (HasAnyInterestingExtParameterInfos) {
           EPI.ExtParameterInfos = ExtParameterInfos.data();

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4544,9 +4544,9 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
 
         BoundsExpr *ReturnBounds = FTI.getReturnBounds();
         if (ReturnBounds) {
-          // if (S.DiagnoseBoundsDeclType(T, nullptr, ReturnBounds, true))
-          // ReturnBounds = S.CreateInvalidBoundsExpr();
-          // else
+          if (S.DiagnoseBoundsDeclType(T, nullptr, ReturnBounds, true))
+            ReturnBounds = S.CreateInvalidBoundsExpr();
+          else
             ReturnBounds = S.AbstractForFunctionType(ReturnBounds);
         }
 

--- a/test/CheckedC/ast-dump-bounds.c
+++ b/test/CheckedC/ast-dump-bounds.c
@@ -85,13 +85,6 @@ void f1() {
 // CHECK: arr3
 // CHECK-NEXT: IntegerLiteral
 // CHECK: 'int' 5
-
-  int * arr4 : itype(_Ptr<int>) = 0;
-
-// CHECK: VarDecl
-// CHECK: arr4 'int *'
-// CHECK-NEXT: InteropTypeBoundsAnnotation
-// CHECK: '_Ptr<int>'
 }
 
 //=============================================================

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -10,8 +10,7 @@
 // hints emitted as part of clang diagnostics.
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
-
-char fn41() : count(5); // expected-error {{expected 'fn41' to have a pointer return type}} // expected-error {{function with no prototype cannot have a return bounds}}
+// expected-no-diagnostics
 
 // Prototype of a function followed by an old-style K&R definition
 // of the function.
@@ -25,6 +24,6 @@ _Ptr<int> f100(int a, int b);
 
 _Ptr<int> f100(a, b)
      int a;
-     int b;
-{
+     int b; {
+  return 0;
 }


### PR DESCRIPTION
This change adds checking of bounds declarations for function pointer return types.  This addresses GitHub issue #89.   The checking was being done as part of constructing a function declaration.  However, function declarations are not constructed for variables with function pointer types.  Move the checking from construction of function declarations to construction of function types.

To support this, refactor the code for checking bounds declarations so that there are now separate methods for (1) checking that a bounds expression is valid for a type (2) checking that a bounds declaration is valid for a declaration.  Checking for function return types invokes the first method.   The existing checking for variable declarations invokes the first method.

As part of the refactoring, check that bounds-safe interface types are not declared for local variables. This addresses Github issue #77.

Revamp the error messages for return types that have bounds declarations and bounds-safe interface type annotations.  There may not be a named entity to refer to in the error messages, so remove mention of that and just point at the problematic bounds expression or annotation type in the error
message.

It may be useful to make the error messages for variable declarations with bounds be similar to the error messages for return types.  Put that off for now to avoid including an unrelated change with this change.

Testing:
- There will be a separate commit updating the Checked C regression tests in the Checked C repo.   That commit will:
-- Fix errors found in existing tests because of the additional checking
-- Add additional tests of function pointer parameters and returns with bounds declarations and bounds-safe interfaces.
-- Update existing error messages involving bounds declarations and return types
-- Add tests making sure that bounds-safe interface types are not allowed for local variables.
-- Add tests for unnamed parameters, to make sure that compilers handle  this.  The clang error messages are confusing when the parameter has no name.  We can fix this as part of updating the error messages for variable declarations with bounds.
- Update Checked C clang tests.  One test checked for two error messages, but there is only one now.  It is covered by existing tests, so delete it.   Another test was declaring an interface type for a local variable, which is  not allowed, so delete that case.
- Passes existing clang regression tests.