### PR TITLE
Restrict variable references in bounds expressions in function types.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8833,12 +8833,20 @@ def err_bounds_type_annotation_lost_checking : Error<
    "function with no prototype cannot have a return bounds">;
 
  def err_no_prototype_function_redeclared_with_checked_arg : Error<
-   "cannot redeclare a function with no prototype to have an argument type that is a "
-   "%select{checked type|structure with a member with a checked type|"
+   "cannot redeclare a function with no prototype to have an argument type "
+   "that is a %select{checked type|structure with a member with a checked type|"
    "union with a member with a checked type}0">;
 
  def err_checkedc_incompatible_no_prototype_redeclaration : Error<
    "cannot redeclare a function that has a checked argument or argument "
    "bounds to have no prototype">;
+
+  def err_out_of_scope_function_type_local : Error<
+    "out-of-scope variable for bounds in a function type (a function type "
+    "cannot reference local variables)">;
+
+  def err_out_of_scope_function_type_parameter : Error<
+    "out-of-scope variable for bounds in a function type (a function type can "
+    "only reference parameters from its own parameter list)">;
 
 } // end of sema component.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4253,7 +4253,8 @@ public:
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
 
-  BoundsExpr *AbstractForFunctionType(BoundsExpr *Expr);
+  BoundsExpr *AbstractForFunctionType(BoundsExpr *Expr,
+                                      ArrayRef<DeclaratorChunk::ParamInfo> Params);
   BoundsExpr *ConcretizeFromFunctionType(BoundsExpr *Expr,
                                          ArrayRef<ParmVarDecl *> Params);
 

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4454,6 +4454,9 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         SmallVector<FunctionProtoType::ExtParameterInfo, 16>
           ExtParameterInfos(FTI.NumParams);
         bool HasAnyInterestingExtParameterInfos = false;
+        auto ParamInfo =
+          llvm::makeArrayRef<DeclaratorChunk::ParamInfo>(FTI.Params,
+                                                         FTI.NumParams);
 
         for (unsigned i = 0, e = FTI.NumParams; i != e; ++i) {
           ParmVarDecl *Param = cast<ParmVarDecl>(FTI.Params[i].Param);
@@ -4517,7 +4520,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
           BoundsExpr *Bounds = Param->getBoundsExpr();
           if (Bounds) {
             HasAnyParameterBounds = true;
-            Bounds = S.AbstractForFunctionType(Bounds);
+            Bounds = S.AbstractForFunctionType(Bounds, ParamInfo);
           }
           ParamBounds.push_back(Bounds);
 
@@ -4540,7 +4543,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
           if (S.DiagnoseBoundsDeclType(T, nullptr, ReturnBounds, true))
             ReturnBounds = S.CreateInvalidBoundsExpr();
           else
-            ReturnBounds = S.AbstractForFunctionType(ReturnBounds);
+            ReturnBounds = S.AbstractForFunctionType(ReturnBounds, ParamInfo);
         }
 
         // Record bounds for Checked C extension.  Only record parameter bounds array if there are


### PR DESCRIPTION
We have chosen a representation of bounds expressions for function types
that only supports references to global variables or parameters declared
in the function declarator for a function type.  Typechecking will not work
properly for the cases of references to variables in enclosing function
declarators.  The uses of local variables in function types will always
lead to errors.   There is no way to create a non-null function pointer with a
type that involves a local variable.

Add checks that detect the unsupported usage of variables in bounds expressions
for function types.  Also add clang-specific tests that detect this.   This addresses issue #92.

For what is worth, we could probably support references to parameters
in enclosing function declarators pretty straightforwardly.  Local variables
would be much more challenging.  Typechecking would involve reasoning
about the values of those local variables.  We'd be into the
dependently-typed case that isn't supported by existing type checkers
for C, even for variable-length arrays.  We would need to extend typechecking
of function types with bounds expressions with a context. In any case, both
cases would require some thought, so prevent their use right now.

Also fix some lines that are too long.

Testing:
- Passes existing Checked C regression tests.
- Passes clang test suite.