### PR TITLE
Error messages for mismatched bounds declarations.

### DIFF
--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2266,7 +2266,8 @@ public:
 
   /// Compatibility predicates used to check assignment expressions.
   bool typesAreCompatible(QualType T1, QualType T2, 
-                          bool CompareUnqualified = false); // C99 6.2.7p1
+                          bool CompareUnqualified = false, // C99 6.2.7p1
+                          bool IgnoreBounds = false);
 
   bool propertyTypesAreCompatible(QualType, QualType); 
   bool typesAreBlockPointerCompatible(QualType, QualType); 
@@ -2301,15 +2302,18 @@ public:
 
   // Functions for calculating composite types
   QualType mergeTypes(QualType, QualType, bool OfBlockPointer=false,
-                      bool Unqualified = false, bool BlockReturnType = false);
+                      bool Unqualified = false, bool BlockReturnType = false,
+                      bool IgnoreBounds = false);
   QualType mergeFunctionTypes(QualType, QualType, bool OfBlockPointer=false,
-                              bool Unqualified = false);
+                              bool Unqualified = false, bool IgnoreBounds = false);
   QualType mergeFunctionParameterTypes(QualType, QualType,
                                        bool OfBlockPointer = false,
-                                       bool Unqualified = false);
+                                       bool Unqualified = false,
+                                       bool IgnoreBounds = false);
   QualType mergeTransparentUnionType(QualType, QualType,
                                      bool OfBlockPointer=false,
-                                     bool Unqualified = false);
+                                     bool Unqualified = false,
+                                     bool IgnoreBounds = false);
   
   QualType mergeObjCGCQualifiers(QualType, QualType);
     

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8616,7 +8616,7 @@ def err_objc_type_arg_explicit_nullability : Error<
   "type argument %0 cannot explicitly specify nullability">;
 
 def err_objc_type_param_bound_explicit_nullability : Error<
-  "type parameter %0 bound %1 cannot explicitly specify nullability">;
+  "type parameter %0 bound %1 cannot explicitly specif nullability">;
 
 }
 
@@ -8841,6 +8841,28 @@ def err_bounds_type_annotation_lost_checking : Error<
    "cannot redeclare a function that has a checked argument or argument "
    "bounds to have no prototype">;
 
+ def note_previous_bounds_decl : Note<"previous bounds declaration is here">;
+ 
+ def err_conflicting_parameter_bounds : Error<
+   "function redeclaration has conflicting parameter bounds">;
+
+ def err_conflicting_return_bounds : Error<
+   "function redeclaration has conflicting return bounds">;
+
+  def err_added_bounds_for_return : Error<
+    "function redeclaration added return bounds">;
+
+  def err_missing_bounds_for_return : Error <
+    "function redeclaration dropped return bounds">;
+
+  def err_added_bounds_for_parameter : Error<
+    "function redeclaration added bounds for parameter">;
+
+  def err_missing_bounds_for_parameter : Error<
+    "function redeclaration dropped bounds for parameter">;
+
+  def err_conflicting_bounds : Error<"conflicting bounds for %0">;
+
   def err_out_of_scope_function_type_local : Error<
     "out-of-scope variable for bounds in a function type (a function type "
     "cannot reference local variables)">;
@@ -8848,5 +8870,4 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_out_of_scope_function_type_parameter : Error<
     "out-of-scope variable for bounds in a function type (a function type can "
     "only reference parameters from its own parameter list)">;
-
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8616,7 +8616,7 @@ def err_objc_type_arg_explicit_nullability : Error<
   "type argument %0 cannot explicitly specify nullability">;
 
 def err_objc_type_param_bound_explicit_nullability : Error<
-  "type parameter %0 bound %1 cannot explicitly specif nullability">;
+  "type parameter %0 bound %1 cannot explicitly specify nullability">;
 
 }
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2256,6 +2256,7 @@ public:
   // Checked C specific methods for merging function declarations.
   bool CheckedCFunctionDeclCompatibility(FunctionDecl *New, FunctionDecl *Old);
   bool CheckedCMergeFunctionDecls(FunctionDecl *New, FunctionDecl *Old);
+
   bool DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
                                              FunctionDecl *Old);
 

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -10,6 +10,7 @@
 // hints emitted as part of clang diagnostics.
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// expected-no-diagnostics
 
 // Prototype of a function followed by an old-style K&R definition
 // of the function.

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -10,7 +10,6 @@
 // hints emitted as part of clang diagnostics.
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
-// expected-no-diagnostics
 
 // Prototype of a function followed by an old-style K&R definition
 // of the function.
@@ -32,6 +31,7 @@ _Ptr<int> f100(a, b)
 // Test error checking for invalid combinations of declaration specifiers.   //
 // Incorrect code similar to this caused a crash in clang                    //
 ///////////////////////////////////////////////////////////////////////////////
+
 void f101(void) {
   _Array_ptr<int> void a; // expected-error {{cannot combine with previous '_ArrayPtr' declaration specifier}}
   int _Array_ptr<int> b;  // expected-error {{cannot combine with previous 'int' declaration specifier}}


### PR DESCRIPTION
Add better error messages for mismatched bounds declaration when functions are redeclared.  The current error message is just "type mismatch", which is not helpful.   This address issue #83.

With this change,
- Errors that involve only bounds declarations are diagnosed as mismatched  bounds errors.
- Type compatibility errors involving prior no-prototype and prototype declarations of the same function continue to be diagnosed specially.
- If a function declaration has both bounds declarations mismatches and a type mismatch when bounds are ignored, there will be error messages for both.

When an error message is emitted for mismatched bounds declarations, also emit a note that points at the most specific context from the prior declaration that  is helpful for understanding the error.  By being specific, this makesit easier for programmers to understand the error.
- If the prior declaration has a bounds expression, point at that.
- If not, use the prior declaration.  This will be the parameter declaration for parameter bounds, which is still pretty specific. It will be the entire function declaration for return bounds.

Identifying prior bounds expressions requires some special care for unchecked pointer types.  A declaration of a function with a bounds-safe interface for a parameter or return with unchecked pointer type is compatible with a declaration with no bounds-safe interface.  The prior declaration
may not actually have a bounds expression for a parameter or return. An even earlier definition may have the bounds expression, so we need to search for that.

We identify errors that only involve bounds declarations by checking whether type merging succeeds when bounds declarations are ignored.  If it does, this is a "bounds-only" error.   To implement this, parameterize type merging by an additional parameter that controls whether bounds information is
ignored.

Testing:
- Passes Checked C regression tests, once the error messages for regression  tests of bounds mismatches have been updated.
- Passes clang regression tests.
