### PR TITLE
Add checking of redeclarations of variables with bounds.

### DIFF
--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1713,6 +1713,7 @@ public:
   bool isDependentSizedArrayType() const;
   /// \brief whether this is a Checked C checked array type.
   bool isCheckedArrayType() const;
+  bool isUncheckedArrayType() const;
   bool isRecordType() const;
   bool isClassType() const;
   bool isStructureType() const;
@@ -5667,6 +5668,12 @@ inline bool Type::isDependentSizedArrayType() const {
 inline bool Type::isCheckedArrayType() const {
   if (const ArrayType *T = dyn_cast<ArrayType>(CanonicalType))
     return T->isChecked();
+  else
+    return false;
+}
+inline bool Type::isUncheckedArrayType() const {
+  if (const ArrayType *T = dyn_cast<ArrayType>(CanonicalType))
+    return !T->isChecked();
   else
     return false;
 }

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8854,7 +8854,7 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def err_decl_dropped_bounds : Error<
     "%select{function redeclaration dropped bounds for parameter|function "
-    "redeclaration dropped return bounds|variable declaration dropped "
+    "redeclaration dropped return bounds|variable redeclaration dropped "
     "bounds}0">;
 
   def err_conflicting_bounds : Error<"conflicting bounds for %0">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8843,23 +8843,19 @@ def err_bounds_type_annotation_lost_checking : Error<
 
  def note_previous_bounds_decl : Note<"previous bounds declaration is here">;
  
- def err_conflicting_parameter_bounds : Error<
-   "function redeclaration has conflicting parameter bounds">;
+  def err_decl_conflicting_bounds : Error<
+    "%select{function redeclaration has conflicting parameter bounds|function "
+    "redeclaration has conflicting return bounds|variable redeclaration has "
+    "conflicting bounds}0">;
 
- def err_conflicting_return_bounds : Error<
-   "function redeclaration has conflicting return bounds">;
+  def err_decl_added_bounds : Error<
+    "%select{function redeclaration added bounds for parameter|function "
+    "redeclaration added return bounds|variable redeclaration added bounds}0">;
 
-  def err_added_bounds_for_return : Error<
-    "function redeclaration added return bounds">;
-
-  def err_missing_bounds_for_return : Error <
-    "function redeclaration dropped return bounds">;
-
-  def err_added_bounds_for_parameter : Error<
-    "function redeclaration added bounds for parameter">;
-
-  def err_missing_bounds_for_parameter : Error<
-    "function redeclaration dropped bounds for parameter">;
+  def err_decl_dropped_bounds : Error<
+    "%select{function redeclaration dropped bounds for parameter|function "
+    "redeclaration dropped return bounds|variable declaration dropped "
+    "bounds}0">;
 
   def err_conflicting_bounds : Error<"conflicting bounds for %0">;
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2249,6 +2249,7 @@ public:
                                     Scope *S, bool MergeTypeWithOld);
   void mergeObjCMethodDecls(ObjCMethodDecl *New, ObjCMethodDecl *Old);
   void MergeVarDecl(VarDecl *New, LookupResult &Previous);
+  void MergeVarDeclBounds(VarDecl *New, VarDecl *Old);
   void MergeVarDeclTypes(VarDecl *New, VarDecl *Old, bool MergeTypeWithOld);
   void MergeVarDeclExceptionSpecs(VarDecl *New, VarDecl *Old);
   bool MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old, Scope *S);
@@ -2265,6 +2266,14 @@ public:
     CCT_Any,
     CCT_Struct,
     CCT_Union
+  };
+
+  // used for %select in diagnostics for errors involving redeclarations
+  // with bounds
+  enum class CheckedCBoundsError {
+    CCBE_Parameter,
+    CCBE_Return,
+    CCBE_Variable
   };
 
   CheckedTypeClassification classifyForCheckedTypeDiagnostic(QualType qt);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2249,7 +2249,6 @@ public:
                                     Scope *S, bool MergeTypeWithOld);
   void mergeObjCMethodDecls(ObjCMethodDecl *New, ObjCMethodDecl *Old);
   void MergeVarDecl(VarDecl *New, LookupResult &Previous);
-  void MergeVarDeclBounds(VarDecl *New, VarDecl *Old);
   void MergeVarDeclTypes(VarDecl *New, VarDecl *Old, bool MergeTypeWithOld);
   void MergeVarDeclExceptionSpecs(VarDecl *New, VarDecl *Old);
   bool MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old, Scope *S);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2088,7 +2088,7 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
 
   // If this is a variable declarator in Checked C, parse the bounds expression
   // (if any) and set the bounds expression.  Function declarators are ignored
-  // here because return bounds expressions are/ parsed as part of function
+  // here because return bounds expressions are parsed as part of function
   // declarators already.
   if (getLangOpts().CheckedC && isa<VarDecl>(ThisDecl)) {
     VarDecl *ThisVarDecl = dyn_cast<VarDecl>(ThisDecl);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2086,7 +2086,6 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
 
   bool TypeContainsAuto = D.getDeclSpec().containsPlaceholderType();
 
-
   // If this is a variable declarator in Checked C, parse the bounds expression
   // (if any) and set the bounds expression.  Function declarators are ignored
   // here because return bounds expressions are/ parsed as part of function

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2086,22 +2086,25 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
 
   bool TypeContainsAuto = D.getDeclSpec().containsPlaceholderType();
 
-  // Parse the optional Checked C bounds expression or interop type
-  // annotation.
-  if (getLangOpts().CheckedC && Tok.is(tok::colon)) {
-    ConsumeToken();
-    ExprResult Bounds = ParseBoundsExpressionOrInteropType(D);
-    if (Bounds.isInvalid())
-      SkipUntil(tok::comma, tok::equal, StopAtSemi | StopBeforeMatch);
 
+  // If this is a variable declarator in Checked C, parse the bounds expression
+  // (if any) and set the bounds expression.  Function declarators are ignored
+  // here because return bounds expressions are/ parsed as part of function
+  // declarators already.
+  if (getLangOpts().CheckedC && isa<VarDecl>(ThisDecl)) {
     VarDecl *ThisVarDecl = dyn_cast<VarDecl>(ThisDecl);
-    if (ThisVarDecl) {
-      if (Bounds.isInvalid())
-        Actions.ActOnInvalidBoundsDecl(ThisVarDecl);
-      else
-        Actions.ActOnBoundsDecl(ThisVarDecl, cast<BoundsExpr>(Bounds.get()));
-    } else
-      llvm_unreachable("Unexpected decl type");
+    BoundsExpr *Bounds = nullptr;
+    // The optional Checked C bounds expression or interop type annotation.
+    if (Tok.is(tok::colon)) {
+      ConsumeToken();
+      ExprResult ParsedBounds = ParseBoundsExpressionOrInteropType(D);
+      if (ParsedBounds.isInvalid()) {
+        SkipUntil(tok::comma, tok::equal, StopAtSemi | StopBeforeMatch);
+        Bounds = Actions.CreateInvalidBoundsExpr();
+      } else
+        Bounds = cast<BoundsExpr>(ParsedBounds.get());
+    }
+    Actions.ActOnBoundsDecl(ThisVarDecl, Bounds);
   }
 
   // Parse declarator '=' initializer.

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -3411,14 +3411,14 @@ static void emitBoundsErrorDiagnostic(Sema &S, int DiagId,
 }
 
 // Shared logic for diagnosing bounds declaration conflicts for parameters,
-// returns, and variables
+// returns, and variables.
 //
 // * BoundsLoc is the source location of the bounds expression at which to
 // report the error.  If there is no bounds expression, this will be an invalid
 // source location. (We don't use the location from the new bounds expression
 // beacuse it is canonicalized and may not have valid line information.)
 // * OldBounds and NewBounds are canoncialized bounds expressions.  For
-// parameters and returns, they are bounds expression from a function type.
+// parameters and returns, they are bounds expressions from function types.
 // It is important to use canonicalized bound expressions these for bounds
 // comparisons.
 // * OldDecl and NewDecl provide the declarations for use in error messages.
@@ -3426,7 +3426,7 @@ static void emitBoundsErrorDiagnostic(Sema &S, int DiagId,
 // may not be attached to NewDecl yet.
 // * OldType and NewType are the types of the items whoses bounds declarations
 // are being checked.  We pass them in because it is easier to compute them at
-// the caller than than to compute them here.
+// the caller than to compute them here.
 // * Kind is what is being checked.
 //
 // Return true if an error involving bounds has been diagnosed, false if not.


### PR DESCRIPTION
This change adds checking of redeclarations of variables with bounds, ensuring that the redeclarations follow the Checked C rules.  This completes the work for issue #30.  For now, when bounds are required to match, we require them to be identical syntactically.  This will be generalized later.

The checking is done when bounds are attached to variable declarations, not during the merging of declarations.  Bounds are attached to variable declarations after declarators have been processed (the bounds may refer to the variable being declared, so the variable declaration needs to be built before we build the bounds expression).  This means bounds can't be checked during merging of declarations, which operates on just the declarators.
- ActOnBoundsDecl does the checking for conflicting bounds expressions on variable declarations.
- Generalize the existing code for checking for conflicting bounds expressions on declaration to handle non-parameter variables.  Also generalize the check for variables with unchecked types to include unchecked arrays.   Declarations of variables with unchecked pointer and unchecked array types and bounds-safe interfaces are compatible with the declarations that omit the bounds-safe interfaces.
- Rework the existing error messages for variable redeclarations to use the clang select mechanism for error messages.   This lets us use one diagnostic id in place of several diagnostic ids and simplify the code.

I discovered an error in the parsing of bounds expressions for function declarators.  I believe it was possible to write a bounds expression after a function declarator, which would have triggered an internal compiler assert:  `array_ptr<int> f(int len) : count(len) : count(5)`, for example.   The fix is to not try to parse a bounds expression after a function declarator.  The parsing of the function declarator already handled the bounds expression.

Testing:
- Added tests for redeclarations of variables to the Checked C regression tests.  This will be committed separately to the Checked C repo.
- Passes existing Checked C tests.
- Passes clang regression test suite.
