### PR TITLE
Fix some build warnings introduced by changes for Checked C

### DIFF
--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3354,7 +3354,7 @@ public:
     return llvm::makeArrayRef(param_type_begin(), param_type_end());
   }
 
-  const BoundsExpr *const getParamBounds(unsigned i) const {
+  const BoundsExpr *getParamBounds(unsigned i) const {
     assert(i < NumParams && "invalid parameter index");
     if (hasParamBounds())
       return param_bounds_begin()[i];

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2860,6 +2860,13 @@ bool Expr::HasSideEffects(const ASTContext &Ctx,
   case ObjCAvailabilityCheckExprClass:
   case CXXUuidofExprClass:
   case OpaqueValueExprClass:
+  case PositionalParameterExprClass:
+    // Checked C bounds expressions are not allowed to have assignments
+    // embedded within them.
+  case CountBoundsExprClass:
+  case InteropTypeBoundsAnnotationClass:
+  case NullaryBoundsExprClass:
+  case RangeBoundsExprClass:
     // These never have a side-effect.
     return false;
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2860,12 +2860,12 @@ bool Expr::HasSideEffects(const ASTContext &Ctx,
   case ObjCAvailabilityCheckExprClass:
   case CXXUuidofExprClass:
   case OpaqueValueExprClass:
-  case PositionalParameterExprClass:
     // Checked C bounds expressions are not allowed to have assignments
     // embedded within them.
   case CountBoundsExprClass:
   case InteropTypeBoundsAnnotationClass:
   case NullaryBoundsExprClass:
+  case PositionalParameterExprClass:
   case RangeBoundsExprClass:
     // These never have a side-effect.
     return false;

--- a/lib/AST/ExprClassification.cpp
+++ b/lib/AST/ExprClassification.cpp
@@ -404,8 +404,18 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
 
   case Expr::CoawaitExprClass:
     return ClassifyInternal(Ctx, cast<CoawaitExpr>(E)->getResumeExpr());
-  }
 
+  // We might need to classify positional parameters, which occur
+  // as subexpressions of bounds expressions.
+  case Expr::PositionalParameterExprClass:
+    return Cl::CL_LValue;
+
+  case Expr::CountBoundsExprClass:
+  case Expr::InteropTypeBoundsAnnotationClass:
+  case Expr::NullaryBoundsExprClass:
+  case Expr::RangeBoundsExprClass:
+    llvm_unreachable("should not classify bounds expressions");
+  }
   llvm_unreachable("unhandled expression kind in classification");
 }
 

--- a/lib/AST/ExprConstant.cpp
+++ b/lib/AST/ExprConstant.cpp
@@ -9438,6 +9438,10 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
   case Expr::CXXFoldExprClass:
   case Expr::CoawaitExprClass:
   case Expr::CoyieldExprClass:
+  case Expr::CountBoundsExprClass:
+  case Expr::InteropTypeBoundsAnnotationClass:
+  case Expr::NullaryBoundsExprClass:
+  case Expr::RangeBoundsExprClass:
     return ICEDiag(IK_NotICE, E->getLocStart());
 
   case Expr::InitListExprClass: {

--- a/lib/AST/ExprConstant.cpp
+++ b/lib/AST/ExprConstant.cpp
@@ -9441,6 +9441,8 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
   case Expr::CountBoundsExprClass:
   case Expr::InteropTypeBoundsAnnotationClass:
   case Expr::NullaryBoundsExprClass:
+  case Expr::PositionalParameterExprClass:
+    // These are parameter variables and are never constants,
   case Expr::RangeBoundsExprClass:
     return ICEDiag(IK_NotICE, E->getLocStart());
 
@@ -9517,10 +9519,6 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
       }
     }
     return ICEDiag(IK_NotICE, E->getLocStart());
-  }
-  case Expr::PositionalParameterExprClass: {
-    // These are parameter variables and are never constants.
-    return ICEDiag(IK_NotICE, SourceLocation());
   }
   case Expr::UnaryOperatorClass: {
     const UnaryOperator *Exp = cast<UnaryOperator>(E);

--- a/lib/AST/ItaniumMangle.cpp
+++ b/lib/AST/ItaniumMangle.cpp
@@ -3272,6 +3272,11 @@ recurse:
   case Expr::AsTypeExprClass:
   case Expr::PseudoObjectExprClass:
   case Expr::AtomicExprClass:
+  case Expr::PositionalParameterExprClass:
+  case Expr::CountBoundsExprClass:
+  case Expr::InteropTypeBoundsAnnotationClass:
+  case Expr::NullaryBoundsExprClass:
+  case Expr::RangeBoundsExprClass:
   {
     if (!NullOut) {
       // As bad as this diagnostic is, it's better than crashing.

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -339,6 +339,8 @@ bool Declarator::isDeclarationOfFunction() const {
     case TST_unspecified:
     case TST_void:
     case TST_wchar:
+    case TST_arrayPtr:
+    case TST_plainPtr:
 #define GENERIC_IMAGE_TYPE(ImgType, Id) case TST_##ImgType##_t:
 #include "clang/Basic/OpenCLImageTypes.def"
       return false;

--- a/lib/Sema/SemaExceptionSpec.cpp
+++ b/lib/Sema/SemaExceptionSpec.cpp
@@ -1194,6 +1194,13 @@ CanThrowResult Sema::canThrow(const Expr *E) {
   case Expr::MSPropertySubscriptExprClass:
     llvm_unreachable("Invalid class for expression");
 
+  case Expr::PositionalParameterExprClass:
+  case Expr::CountBoundsExprClass:
+  case Expr::InteropTypeBoundsAnnotationClass:
+  case Expr::NullaryBoundsExprClass:
+  case Expr::RangeBoundsExprClass:
+    llvm_unreachable("do not expect bounds expressions");
+
 #define STMT(CLASS, PARENT) case Expr::CLASS##Class:
 #define STMT_RANGE(Base, First, Last)
 #define LAST_STMT_RANGE(BASE, FIRST, LAST)

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -7962,10 +7962,27 @@ QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
   switch (Entity.getKind()) {
     case InitializedEntity::EntityKind::EK_Variable:
     case InitializedEntity::EntityKind::EK_Parameter:
-    case InitializedEntity::EntityKind::EK_Member:
+    case InitializedEntity::EntityKind::EK_Member: {
       ValueDecl *D = Entity.getDecl();
-      if (D != nullptr) 
+      if (D != nullptr)
         return GetCheckedCInteropType(D);
+      break;
+    }
+    case InitializedEntity::EK_ArrayElement:
+    case InitializedEntity::EK_Base:
+    case InitializedEntity::EK_Binding:
+    case InitializedEntity::EK_BlockElement:
+    case InitializedEntity::EK_ComplexElement:
+    case InitializedEntity::EK_CompoundLiteralInit:
+    case InitializedEntity::EK_Delegating:
+    case InitializedEntity::EK_Exception:
+    case InitializedEntity::EK_LambdaCapture:
+    case InitializedEntity::EK_New:
+    case InitializedEntity::EK_RelatedResult:
+    case InitializedEntity::EK_Result:
+    case InitializedEntity::EK_Temporary:
+    case InitializedEntity::EK_VectorElement:
+    case InitializedEntity::EK_Parameter_CF_Audited:
       break;
   }
   return QualType();

--- a/lib/Sema/SemaTemplateVariadic.cpp
+++ b/lib/Sema/SemaTemplateVariadic.cpp
@@ -702,7 +702,9 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
   case TST_typename:
   case TST_typeofType:
   case TST_underlyingType:
-  case TST_atomic: {
+  case TST_atomic:
+  case TST_plainPtr:
+  case TST_arrayPtr: {
     QualType T = DS.getRepAsType().get();
     if (!T.isNull() && T->containsUnexpandedParameterPack())
       return true;

--- a/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -751,7 +751,7 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
   assert(!isa<Expr>(S) || S == cast<Expr>(S)->IgnoreParens());
 
   switch (S->getStmtClass()) {
-    // C++, Checked C, and ARC stuff we don't support yet.
+    // C++ and ARC stuff we don't support yet.
     case Expr::ObjCIndirectCopyRestoreExprClass:
     case Stmt::CXXDependentScopeMemberExprClass:
     case Stmt::CXXInheritedCtorInitExprClass:

--- a/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -751,7 +751,7 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
   assert(!isa<Expr>(S) || S == cast<Expr>(S)->IgnoreParens());
 
   switch (S->getStmtClass()) {
-    // C++ and ARC stuff we don't support yet.
+    // C++, Checked C, and ARC stuff we don't support yet.
     case Expr::ObjCIndirectCopyRestoreExprClass:
     case Stmt::CXXDependentScopeMemberExprClass:
     case Stmt::CXXInheritedCtorInitExprClass:
@@ -1342,6 +1342,15 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
       Bldr.addNodes(Dst);
       break;
     }
+    // The static analyzer knows nothing about Checked C extensions to
+    // the AST, so we should never see these.
+    case Stmt::PositionalParameterExprClass:
+    case Stmt::CountBoundsExprClass:
+    case Stmt::InteropTypeBoundsAnnotationClass:
+    case Stmt::NullaryBoundsExprClass:
+    case Stmt::RangeBoundsExprClass:
+      llvm_unreachable("Do not expect to see Checked C extensions");
+      break;
   }
 }
 

--- a/tools/libclang/CXCursor.cpp
+++ b/tools/libclang/CXCursor.cpp
@@ -656,6 +656,15 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
   case Stmt::OMPTeamsDistributeDirectiveClass:
     K = CXCursor_OMPTeamsDistributeDirective;
     break;
+
+  // For now, do not expose Checked C extensions.
+  case Stmt::PositionalParameterExprClass:
+  case Stmt::CountBoundsExprClass:
+  case Stmt::InteropTypeBoundsAnnotationClass:
+  case Stmt::NullaryBoundsExprClass:
+  case Stmt::RangeBoundsExprClass:
+    K = CXCursor_UnexposedExpr;
+    break;
   }
 
   CXCursor C = { K, 0, { Parent, S, TU } };


### PR DESCRIPTION
This change fixes some warnings during the build of clang introduced by changes for Checked C.   This is for issue #97.  We decided to make bounds expressions be subclasses of expressions to re-use the template metaprogramming support for expressions.   This avoids having to introduce additional template meta-programming support for bounds expressions.  The cost is that it introduces unhandled cases for switch statements over expressions.

For cases where bounds expressions are not expected to occur, I've introduced `llvm_unreachable` statements.  For example, the static analyzer knows nothing about the AST changes that add bounds expressions, so I would expect bounds expressions to never occur there.   For cases where bounds expressions might reasonably occur, such as `HasSideEffects`, I've filled in the missing cases.   `HasSideEffects` apparently defines a side-effect as an assignment (mutation of state).  Bounds expressions must have non-modifying subexpressions, so they have no side-effect according to this definition.

Testing:

- Built and ran clang and Checked C tests on a Linux x64 Ubuntu box.   I did not observe any build warnings except for a missing case in ASTReader (issue #99).   Interestingly, 3 of the Checked C test cases failed because of environmental differences.   There are 32 vs. 64-bit pointer problems related to tests trying to test integers with bounds (https://github.com/Microsoft/checkedc/issues/92). There's also a missing header file problem.  These don't appear to be related to the changes that I made.
- Passed all Checked C tests for a Windowx x86 build.
