### PR TITLE
Walk IR for static checking of bounds declarations.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4517,16 +4517,18 @@ public:
     Invalid = 0,
     // bounds(none)
     None = 1,
+    // bounds(any)
+    Any = 2,
     // count(e)
-    ElementCount = 2,
+    ElementCount = 3,
     // byte_count(e)
-    ByteCount = 3,
+    ByteCount = 4,
     // bounds(e1, e2)
-    Range = 4,
+    Range = 5,
     // ptr interop annotation.  This isn't really a bounds expression.
     // To save space and for programmng convenience, we store the 
     // ": ptr" interop annotation as a bounds expression.
-    InteropTypeAnnotation = 5,
+    InteropTypeAnnotation = 6,
 
     // Sentinel marker for maximum bounds kind.
     MaxBoundsKind = InteropTypeAnnotation
@@ -4573,6 +4575,10 @@ public:
     return getKind() == None;
   }
 
+  bool isAny() const {
+    return getKind() == Any;
+  }
+
   bool isElementCount() const {
     return getKind() == ElementCount;
   }
@@ -4605,7 +4611,7 @@ class NullaryBoundsExpr : public BoundsExpr {
 public:
   NullaryBoundsExpr(Kind Kind, SourceLocation StartLoc, SourceLocation RParenLoc)
     : BoundsExpr(NullaryBoundsExprClass, Kind, StartLoc, RParenLoc)  {
-    assert(Kind == Invalid || Kind == None);
+    assert(Kind == Invalid || Kind == None || Kind == Any);
   }
 
   explicit NullaryBoundsExpr(EmptyShell Empty)

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8866,4 +8866,8 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_out_of_scope_function_type_parameter : Error<
     "out-of-scope variable for bounds in a function type (a function type can "
     "only reference parameters from its own parameter list)">;
+
+  def err_expected_bounds : Error<
+    "expression has no bounds">;
+
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8870,4 +8870,10 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_expected_bounds : Error<
     "expression has no bounds">;
 
+  def err_initializer_expected_with_bounds : Error<
+    "automatic variable %0 with bounds must have initializer">;
+
+  def err_initializer_expected_for_ptr : Error<
+    "automatic variable %0 with _Ptr type must have initializer">;
+
 } // end of sema component.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4267,6 +4267,22 @@ public:
   BoundsExpr *ConcretizeFromFunctionType(BoundsExpr *Expr,
                                          ArrayRef<ParmVarDecl *> Params);
 
+  /// InferLValueBounds - infer a bounds expression for an lvalue.
+  /// The bounds determine whether the lvalue to which an
+  /// expression evaluates in in range.
+  /// Allocate the nodes for the bounds expression in Ctx.
+  BoundsExpr *InferLValueBounds(ASTContext &Ctx, Expr *E);
+
+  /// InferRVa;ieBounds - infer a bounds expression for an rvalue.
+  /// The bounds determine whether the rvalue to which an
+  /// expression evaluates is in range.
+  /// Allocate the nodes for the bounds expression in Ctx.
+  BoundsExpr *InferRValueBounds(ASTContext &Ctx, Expr *E);
+
+  // CheckCheckedCFunctionBody - check bounds declarations within a function
+  // body.
+  void CheckCheckedCFunctionBody(FunctionDecl *FD, Stmt *Body);
+  
   //===---------------------------- Clang Extensions ----------------------===//
 
   /// __builtin_convertvector(...)

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4279,10 +4279,14 @@ public:
   /// Allocate the nodes for the bounds expression in Ctx.
   BoundsExpr *InferRValueBounds(ASTContext &Ctx, Expr *E);
 
-  // CheckCheckedCFunctionBody - check bounds declarations within a function
-  // body.
-  void CheckCheckedCFunctionBody(FunctionDecl *FD, Stmt *Body);
-  
+  /// CheckFunctionBodyBoundsDecls - check bounds declarations within a function
+  /// body.
+  void CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body);
+
+  /// CheckTopLevelBoundsDecls - check bounds declarations for variable declarations
+  /// not within a function body.
+  void CheckTopLevelBoundsDecls(VarDecl *VD);
+
   //===---------------------------- Clang Extensions ----------------------===//
 
   /// __builtin_convertvector(...)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2495,6 +2495,7 @@ void ASTDumper::dumpBoundsKind(BoundsExpr::Kind K) {
   switch (K) {
     case BoundsExpr::Kind::Invalid: OS << " Invalid"; break;
     case BoundsExpr::Kind::None: OS << " None"; break;
+    case BoundsExpr::Kind::Any: OS << "Any"; break;
     case BoundsExpr::Kind::ElementCount: OS << " Element"; break;
     case BoundsExpr::Kind::ByteCount: OS << " Byte"; break;
     case BoundsExpr::Kind::Range: OS << " Range"; break;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3827,7 +3827,7 @@ bool BoundsExpr::validateKind(Kind K) {
 
   switch (getStmtClass()) {
     case NullaryBoundsExprClass:
-      return K == None;
+      return (K == None || K == Any);
     case CountBoundsExprClass:
       return K == ElementCount || K == ByteCount;
     case RangeBoundsExprClass:

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -180,7 +180,7 @@ namespace {
   // 3. As the operand of the address-of (&) operator.
   // 4. If a member access operation e1.f denotes on lvalue, e1 denotes an lvalue.
   // Otherwise an expression denotes an rvalue.
-  class InferBoundsExpr {
+  class BoundsInference {
 
   private:
     // TODO: be more flexible about where bounds expression are allocated.
@@ -203,7 +203,7 @@ namespace {
     }
 
   public:
-    InferBoundsExpr(ASTContext &Ctx) : Context(Ctx) {
+    BoundsInference(ASTContext &Ctx) : Context(Ctx) {
     }
 
     BoundsExpr *LValueBounds(Expr *E) {
@@ -247,11 +247,11 @@ namespace {
 }
 
 BoundsExpr *Sema::InferLValueBounds(ASTContext &Ctx, Expr *E) {
-  return InferBoundsExpr(Ctx).LValueBounds(E);
+  return BoundsInference(Ctx).LValueBounds(E);
 }
 
 BoundsExpr *Sema::InferRValueBounds(ASTContext &Ctx, Expr *E) {
-  return InferBoundsExpr(Ctx).RValueBounds(E);
+  return BoundsInference(Ctx).RValueBounds(E);
 }
 
 namespace {

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -12264,6 +12264,9 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   if (getLangOpts().Coroutines && !getCurFunction()->CoroutineStmts.empty())
     CheckCompletedCoroutineBody(FD, Body);
 
+  if (getLangOpts().CheckedC)
+    CheckCheckedCFunctionBody(FD, Body);
+
   if (FD) {
     FD->setBody(Body);
 

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -10801,6 +10801,9 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
                                                CurInitSegLoc));
   }
 
+  if (getLangOpts().CheckedC)
+    CheckTopLevelBoundsDecls(var);
+
   // All the following checks are C++ only.
   if (!getLangOpts().CPlusPlus) return;
 
@@ -12265,7 +12268,7 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
     CheckCompletedCoroutineBody(FD, Body);
 
   if (getLangOpts().CheckedC)
-    CheckCheckedCFunctionBody(FD, Body);
+    CheckFunctionBodyBoundsDecls(FD, Body);
 
   if (FD) {
     FD->setBody(Body);

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -35,7 +35,7 @@ _Ptr<int> f100(a, b)
 void f101(void) {
   _Array_ptr<int> void a; // expected-error {{cannot combine with previous '_ArrayPtr' declaration specifier}}
   int _Array_ptr<int> b;  // expected-error {{cannot combine with previous 'int' declaration specifier}}
-  _Ptr<int> void c;       // expected-error {{cannot combine with previous '_Ptr' declaration specifier}}
+  _Ptr<int> void c = 0;   // expected-error {{cannot combine with previous '_Ptr' declaration specifier}}
   int _Ptr<int> d;        // expected-error {{cannot combine with previous 'int' declaration specifier}}
 }
 


### PR DESCRIPTION
Add initial code for walking expressions and declarations for static checking of bounds declarations.  The checking code will be invoked by this walking code.

To test the walking code, check some simple properties of bounds for assignments and variables declarations.    If the left-hand side of an assignment has a bounds requirement, check that the right-hand side of the assignment has the right form to have an inferred bounds expression.   This is done by calling a stubbed out inference method that returns bounds(any) for expression forms that might have a bounds expression.  Do a similar check for initializers for variables declarations with bounds.  Also check that automatic variables that have bounds declarations or _Ptr type have initializers.

Add the 'Any` bounds to the IR for bounds expressions.

Testing:
- There will be a separate pull request for the GitHub Checked C repo that updates tests where initializers were missing.    The pull request will also add tests of error messages for missing initializers.
- Passes existing clang regression tests.

