### PR TITLE
Adds (De)Serialization of Declaration Bounds

### DIFF
--- a/lib/Serialization/ASTReaderDecl.cpp
+++ b/lib/Serialization/ASTReaderDecl.cpp
@@ -747,7 +747,7 @@ void ASTDeclReader::VisitDeclaratorDecl(DeclaratorDecl *DD) {
   VisitValueDecl(DD);
   DD->setInnerLocStart(ReadSourceLocation(Record, Idx));
 
-  if (Record[Idx++]) // hasBoundExpr
+  if (Record[Idx++]) // hasBoundsExpr
 	DD->setBoundsExpr(Reader.ReadBoundsExpr(F));
 
   if (Record[Idx++]) { // hasExtInfo

--- a/lib/Serialization/ASTReaderDecl.cpp
+++ b/lib/Serialization/ASTReaderDecl.cpp
@@ -786,7 +786,6 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
   FD->setCachedLinkage(Linkage(Record[Idx++]));
   FD->EndRangeLoc = ReadSourceLocation(Record, Idx);
 
-
   switch ((FunctionDecl::TemplatedKind)Record[Idx++]) {
   case FunctionDecl::TK_NonTemplate:
     mergeRedeclarable(FD, Redecl);

--- a/lib/Serialization/ASTReaderDecl.cpp
+++ b/lib/Serialization/ASTReaderDecl.cpp
@@ -746,6 +746,10 @@ void ASTDeclReader::VisitEnumConstantDecl(EnumConstantDecl *ECD) {
 void ASTDeclReader::VisitDeclaratorDecl(DeclaratorDecl *DD) {
   VisitValueDecl(DD);
   DD->setInnerLocStart(ReadSourceLocation(Record, Idx));
+
+  if (Record[Idx++]) // hasBoundExpr
+	DD->setBoundsExpr(Reader.ReadBoundsExpr(F));
+
   if (Record[Idx++]) { // hasExtInfo
     DeclaratorDecl::ExtInfo *Info
         = new (Reader.getContext()) DeclaratorDecl::ExtInfo();
@@ -781,6 +785,7 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
   FD->IsLateTemplateParsed = Record[Idx++];
   FD->setCachedLinkage(Linkage(Record[Idx++]));
   FD->EndRangeLoc = ReadSourceLocation(Record, Idx);
+
 
   switch ((FunctionDecl::TemplatedKind)Record[Idx++]) {
   case FunctionDecl::TK_NonTemplate:

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -501,6 +501,11 @@ void ASTDeclWriter::VisitEnumConstantDecl(EnumConstantDecl *D) {
 void ASTDeclWriter::VisitDeclaratorDecl(DeclaratorDecl *D) {
   VisitValueDecl(D);
   Record.AddSourceLocation(D->getInnerLocStart());
+
+  Record.push_back(D->hasBoundsExpr());
+  if (D->hasBoundsExpr())
+	Record.AddStmt(D->getBoundsExpr());
+
   Record.push_back(D->hasExtInfo());
   if (D->hasExtInfo())
     Record.AddQualifierInfo(*D->getExtInfo());
@@ -1714,6 +1719,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // FieldDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // isMutable
@@ -1747,6 +1753,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
+  Abv->Add(BitCodeAbbrevOp(0));                       // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // FieldDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // isMutable
@@ -1878,6 +1885,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // VarDecl
   Abv->Add(BitCodeAbbrevOp(0));                       // StorageClass
@@ -1954,6 +1962,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // VarDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // StorageClass
@@ -2002,6 +2011,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6));   // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6));   // InnerLocStart
+  Abv->Add(BitCodeAbbrevOp(0));                         // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                         // HasExtInfo
   // FunctionDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 11)); // IDNS

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -733,6 +733,7 @@ void ASTDeclWriter::VisitObjCIvarDecl(ObjCIvarDecl *D) {
       !D->isReferenced() &&
       !D->isModulePrivate() &&
       !D->getBitWidth() &&
+      !D->hasBoundsExpr() &&
       !D->hasExtInfo() &&
       D->getDeclName())
     AbbrevToUse = Writer.getDeclObjCIvarAbbrev();
@@ -867,6 +868,7 @@ void ASTDeclWriter::VisitFieldDecl(FieldDecl *D) {
       !D->isModulePrivate() &&
       !D->getBitWidth() &&
       !D->hasInClassInitializer() &&
+      !D->hasBoundsExpr() &&
       !D->hasExtInfo() &&
       !ObjCIvarDecl::classofKind(D->getKind()) &&
       !ObjCAtDefsFieldDecl::classofKind(D->getKind()) &&
@@ -945,6 +947,7 @@ void ASTDeclWriter::VisitVarDecl(VarDecl *D) {
       !D->isModulePrivate() &&
       !needsAnonymousDeclarationNumber(D) &&
       D->getDeclName().getNameKind() == DeclarationName::Identifier &&
+      !D->hasBoundsExpr() &&
       !D->hasExtInfo() &&
       D->getFirstDecl() == D->getMostRecentDecl() &&
       D->getInitStyle() == VarDecl::CInit &&
@@ -985,6 +988,7 @@ void ASTDeclWriter::VisitParmVarDecl(ParmVarDecl *D) {
   // know are true of all PARM_VAR_DECLs.
   if (D->getDeclContext() == D->getLexicalDeclContext() &&
       !D->hasAttrs() &&
+      !D->hasBoundsExpr() &&
       !D->hasExtInfo() &&
       !D->isImplicit() &&
       !D->isUsed(false) &&
@@ -1240,6 +1244,7 @@ void ASTDeclWriter::VisitCXXMethodDecl(CXXMethodDecl *D) {
       !D->hasAttrs() &&
       !D->isTopLevelDeclInObjCContainer() &&
       D->getDeclName().getNameKind() == DeclarationName::Identifier &&
+      !D->hasBoundsExpr() &&
       !D->hasExtInfo() &&
       !D->hasInheritedPrototype() &&
       D->hasWrittenPrototype())
@@ -1719,7 +1724,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
-  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // hasBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0));                       // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // FieldDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // isMutable
@@ -1885,7 +1890,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
-  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // hasBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0));                       // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // VarDecl
   Abv->Add(BitCodeAbbrevOp(0));                       // StorageClass
@@ -1962,7 +1967,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Type
   // DeclaratorDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // InnerStartLoc
-  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // hasBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0));                       // hasBoundsExpr
   Abv->Add(BitCodeAbbrevOp(0));                       // hasExtInfo
   // VarDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // StorageClass

--- a/test/CheckedC/pch.c
+++ b/test/CheckedC/pch.c
@@ -4,11 +4,11 @@
 // PCH is one of the few places where AST Deserialization is used.
 
 // Test this without PCH
-// R UN: %clang_cc1 -fcheckedc-extension -include %S/pch.h -fsyntax-only -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -fcheckedc-extension -include %S/pch.h -fsyntax-only -verify -verify-ignore-unexpected=note %s
 
 // Test PCH (so we know our changes to AST deserialization haven't broken it)
 // RUN: %clang_cc1 -fcheckedc-extension -emit-pch -o %t %S/pch.h
-// RUN: %clang_cc1 -fcheckedc-extension -include-pch %t -fsyntax-only -verify -verify-ignore-unexpected=note %s -ferror-limit 0
+// RUN: %clang_cc1 -fcheckedc-extension -include-pch %t -fsyntax-only -verify -verify-ignore-unexpected=note %s
 
 //
 // Bounds Expressions on global variables

--- a/test/CheckedC/pch.c
+++ b/test/CheckedC/pch.c
@@ -4,66 +4,114 @@
 // PCH is one of the few places where AST Deserialization is used.
 
 // Test this without PCH
-// RUN: %clang_cc1 -fcheckedc-extension -include %S/pch.h -fsyntax-only -verify -verify-ignore-unexpected=note %s
+// R UN: %clang_cc1 -fcheckedc-extension -include %S/pch.h -fsyntax-only -verify -verify-ignore-unexpected=note %s
 
 // Test PCH (so we know our changes to AST deserialization haven't broken it)
 // RUN: %clang_cc1 -fcheckedc-extension -emit-pch -o %t %S/pch.h
-// RUN: %clang_cc1 -fcheckedc-extension -include-pch %t -fsyntax-only -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -fcheckedc-extension -include-pch %t -fsyntax-only -verify -verify-ignore-unexpected=note %s -ferror-limit 0
 
-// Bounds Expressions on globals
+//
+// Bounds Expressions on global variables
+//
 
 // CountBounds
-one_element_array arr1 = (int[1]){ 0 };
+_Array_ptr<int> one_arr : count(1 + 1); // expected-error{{variable redeclaration has conflicting bounds}}
+_Array_ptr<int> one_arr : count(1);
+
+// Byte Count
+_Array_ptr<int> byte_arr : byte_count(sizeof(int));
 
 // NullaryBounds
-null_array arr2 = (int[]){ 0 };
+_Array_ptr<int> null_arr : count(1); // expected-error{{variable redeclaration has conflicting bounds}}
+_Array_ptr<int> null_arr : bounds(none);
 
 // RangeBounds
-ranged_array arr3 = two_arr;
+int two_arr[2];
+_Array_ptr<int> ranged_arr : bounds(&one_arr, &one_arr + 1); //expected-error{{variable redeclaration has conflicting bounds}}
+_Array_ptr<int> ranged_arr : bounds(&two_arr, &two_arr + 1);
 
 // InteropTypeBoundsAnnotation
-int seven = 7;
-integer_pointer seven_pointer1 = &seven;
-_Ptr<int> seven_pointer2 = &seven;
+int* int_ptr : itype(_Array_ptr<int>); // expected-error{{variable redeclaration has conflicting bounds}}
+int* int_ptr : itype(_Ptr<int>);
+int* int_ptr;
 
+//
 // Bounds Expressions on functions
-int accepts_singleton(_Array_ptr<int> one_arr : count(1)) {
-  return one_arr[0];
-}
-void uses_accepts_singleton(void) {
-  _Array_ptr<int> singleton : count(1) = (int[1]) { 0 };
-  int x = accepts_singleton(singleton);
-}
+//
+
+// CountBounds
+int count_fn(_Array_ptr<int> arr : count(2)); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int count_fn(_Array_ptr<int> arr : count(1));
+_Array_ptr<int> count_fn2(void) : count(2); // expected-error{{function redeclaration has conflicting return bounds}}
+_Array_ptr<int> count_fn2(void) : count(1);
+
+// Byte Count
+int byte_count_fn(_Array_ptr<int> arr : byte_count(sizeof(int) + 1)); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int byte_count_fn(_Array_ptr<int> arr : byte_count(sizeof(int)));
+_Array_ptr<int> byte_count_fn2(void) : byte_count(sizeof(int) + 1); // expected-error{{function redeclaration has conflicting return bounds}}
+_Array_ptr<int> byte_count_fn2(void) : byte_count(sizeof(int));
+
+// NullaryBounds
+int none_fn(_Array_ptr<int> null_arr : count(1)); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int none_fn(_Array_ptr<int> null_arr : bounds(none));
+_Array_ptr<int> none_fn2(void) : count(1); // expected-error{{function redeclaration has conflicting return bounds}}
+_Array_ptr<int> none_fn2(void) : bounds(none);
 
 // RangeBounds + PositionalParamater
-int sum_array(_Array_ptr<int> start : bounds(start, end), _Array_ptr<int> end) {
-  return 0;
-}
-void uses_sum_array(void) {
-  _Array_ptr<int> pair : count(2) = (int[2]) { 0,1 };
-  int x = sum_array(pair, pair+1);
+int range_fn(_Array_ptr<int> start : bounds(start, end - 1), _Array_ptr<int> end); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int range_fn(_Array_ptr<int> start : bounds(start, end), _Array_ptr<int> end);
+_Array_ptr<int> range_fn2(_Array_ptr<int> start) : bounds(start, start + 1); // expected-error{{function redeclaration has conflicting return bounds}}
+_Array_ptr<int> range_fn2(_Array_ptr<int> start) : bounds(start, start);
+
+// CountBounds + PositionalParameter
+int pos_fn(int len, _Array_ptr<char> str : count(len + 1)); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int pos_fn(int len, _Array_ptr<char> str : count(len));
+_Array_ptr<int> pos_fn2(int len) : count(len + 1); // expected-error{{function redeclaration has conflicting return bounds}}
+_Array_ptr<int> pos_fn2(int len) : count(len);
+
+// InteropTypeBoundsAnnotation
+int int_val(int *ptr : itype(_Array_ptr<int>)); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int int_val(int *ptr : itype(_Ptr<int>));
+int int_val(int *ptr);
+int* int_val2(void) : itype(_Array_ptr<int>); // expected-error{{function redeclaration has conflicting return bounds}}
+int* int_val2(void) : itype(_Ptr<int>);
+int* int_val2(void);
+
+
+//
+// Bounds Expressions on Struct Members
+//
+
+// CountBounds
+struct S1;
+void uses_S1(struct S1 data) {
+  _Array_ptr<int> arr : count(5) = data.arr;
 }
 
-// PositionalParameter
-int str_last(int len, _Array_ptr<char> str : count(len)) {
-  return 0;
+// Byte Count 
+struct S2;
+void uses_S2(struct S2 data) {
+  _Array_ptr<int> arr : byte_count(sizeof(int) * 5) = data.arr;
 }
-void uses_str_last(void) {
-  _Array_ptr<char> str : count(3) = (char[3]){ 'a', 'b', 'c' };
-  int last = str_last(3, str);
+
+// NullaryBounds
+struct S3;
+void uses_S3(struct S3 data) {
+  _Array_ptr<int> arr : bounds(none) = data.arr;
+}
+
+// RangeBounds
+struct S4;
+void uses_S4(struct S4 data) {
+  _Array_ptr<long> arr : bounds(data.arr, data.arr + 5) = data.arr;
 }
 
 // InteropTypeBoundsAnnotation
-int int_val(int *ptr : itype(_Ptr<int>)) {
-  return 0;
-}
-void uses_int_val(void) {
+struct S5;
+void uses_S5(struct S5 data) {
+  // Tests assigning a `_Ptr<int>` into an `int* : itype(_Ptr<int>)`
+  // This should be valid, according to the spec. 
   int i = 3;
-  _Ptr<int> i_star = &i;
-  int i2 = int_val(i_star);
-}
-
-// Dropping bounds errors
-int accepts_pair(_Array_ptr<int> two_arr) { // expected-error{{function redeclaration dropped bounds for parameter}}
-  return 3;
+  _Ptr<int> ip = &i;
+  data.i = ip;
 }

--- a/test/CheckedC/pch.h
+++ b/test/CheckedC/pch.h
@@ -1,39 +1,78 @@
 // Used with the pch.c test
 
-// Bounds Expressions on globals
+//
+// Bounds Expressions on global variables
+//
 
 // CountBounds
 _Array_ptr<int> one_arr : count(1);
-typedef typeof(one_arr) one_element_array;
+
+// Byte Count
+_Array_ptr<int> byte_arr : byte_count(sizeof(int));
 
 // NullaryBounds
 _Array_ptr<int> null_arr : bounds(none);
-typedef typeof(null_arr) null_array;
 
 // RangeBounds
-int two_arr[2] = { 0, 0 };
+int two_arr[2];
 _Array_ptr<int> ranged_arr : bounds(&two_arr, &two_arr + 1);
-typedef typeof(ranged_arr) ranged_array;
 
 // InteropTypeBoundsAnnotation
 int* int_ptr : itype(_Ptr<int>);
-typedef typeof(int_ptr) integer_pointer;
 
-
+//
 // Bounds Expressions on functions
-int accepts_singleton(_Array_ptr<int> one_arr : count(1));
+//
+
+// CountBounds
+int count_fn(_Array_ptr<int> arr : count(1));
+_Array_ptr<int> count_fn2(void) : count(1);
+
+// Byte Count
+int byte_count_fn(_Array_ptr<int> arr : byte_count(sizeof(int)));
+_Array_ptr<int> byte_count_fn2(void) : byte_count(sizeof(int));
 
 // NullaryBounds
-int accepts_null(_Array_ptr<int> null_arr : bounds(none));
+int none_fn(_Array_ptr<int> null_arr : bounds(none));
+_Array_ptr<int> none_fn2(void) : bounds(none);
 
 // RangeBounds + PositionalParameter
-int sum_array(_Array_ptr<int> start : bounds(start, end) , _Array_ptr<int> end);
+int range_fn(_Array_ptr<int> start : bounds(start, end), _Array_ptr<int> end);
+_Array_ptr<int> range_fn2(_Array_ptr<int> start) : bounds(start, start);
 
-// PositionalParameter
-int str_last(int len, _Array_ptr<char> str : count(len));
+// CountBounds +  PositionalParameter
+int pos_fn(int len, _Array_ptr<char> str : count(len));
+_Array_ptr<int> pos_fn2(int len) : count(len);
 
 // InteropTypeBoundsAnnotation
 int int_val(int *ptr : itype(_Ptr<int>));
+int* int_val2(void) : itype(_Ptr<int>);
 
-// dropping bounds errors
-int accepts_pair(_Array_ptr<int> two_arr : count(2));
+//
+// Bounds Expressions on Struct Members
+//
+
+// CountBounds
+struct S1 {
+  _Array_ptr<int> arr : count(5);
+};
+
+// Byte Count
+struct S2 {
+  _Array_ptr<int> arr : byte_count(sizeof(int) * 5);
+};
+
+// NullaryBounds
+struct S3 {
+  _Array_ptr<int> arr : bounds(none);
+};
+
+// RangeBounds
+struct S4 {
+  _Array_ptr<long> arr : bounds(arr, arr + 5);
+};
+
+// InteropTypeBoundsAnnotation
+struct S5 {
+  int* i : itype(_Ptr<int>);
+};


### PR DESCRIPTION
This pull request comprehensively revisits and expands the PCH tests, and adds (de)serialization of the bounds associated with global variables, function returns, and struct member fields. 

The only way at the moment to test that bounds declarations on global fields and functions are preserved is to redeclare the same function, which should error if you drop the bounds, and not error if you preserve the right bounds as in the precompiled header.

Bounds expressions on struct members are very hard to test, until we start inferring and solving bounds information. The test for `itype()` should work today, the others will become useful later.

As for serialization/deserialization. I've added the code to do so to the VisitDeclaratorDecl methods, because the bounds information is stored within that class (as opposed to its subclasses). Doing this alone caused an assertion failure in the bitcode writer, namely `"Invalid abbrev for record!", file ../llvm/include/llvm/Bitcode/BitstreamWriter.h, line 268`. (If this happens again, I hope searching turns up this ticket). I believe I have added the correct entries to the abbreviation system. The clang regression tests pass on 32-bit, I'm currently running them on 64-bit.

Closes #104. 

Relevant to #105 and #106 but I think the tests need more work before I can close those two.
