### PR TITLE
Adds Non-Modifying Expression check to Dynamic Checks

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8877,7 +8877,7 @@ def err_bounds_type_annotation_lost_checking : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
   def err_not_non_modifying_expr : Error<
-	"%select{assignment|increment|decrement|call|comma|volatile}0 expression not allowed "
-	"within non-modifying expression in dynamic_check">;
+	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed "
+	"in dynamic check expression">;
 
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8876,4 +8876,8 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_initializer_expected_for_ptr : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
+  def err_not_non_modifying_expr : Error<
+	"%select{assignment|increment|decrement|call|comma|volatile}0 expression not allowed "
+	"within non-modifying expression in dynamic_check">;
+
 } // end of sema component.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4287,6 +4287,10 @@ public:
   /// not within a function body.
   void CheckTopLevelBoundsDecls(VarDecl *VD);
 
+  /// CheckNonModifyingExpr - checks whether an expression is non-modifying
+  /// (see Checked C Spec, 3.6.1)
+  bool CheckIsNonModifyingExpr(Expr *E, Expr *Outer);
+
   //===---------------------------- Clang Extensions ----------------------===//
 
   /// __builtin_convertvector(...)

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4289,7 +4289,7 @@ public:
 
   /// CheckNonModifyingExpr - checks whether an expression is non-modifying
   /// (see Checked C Spec, 3.6.1)
-  bool CheckIsNonModifyingExpr(Expr *E, Expr *Outer);
+  bool CheckIsNonModifyingExpr(Expr *E);
 
   //===---------------------------- Clang Extensions ----------------------===//
 

--- a/lib/CodeGen/CGBuiltin.cpp
+++ b/lib/CodeGen/CGBuiltin.cpp
@@ -2426,6 +2426,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
     break;
   }
   case Builtin::BI_Dynamic_check: {
+    if (!getLangOpts().CheckedC)
+      break;
+
     const Expr *CheckExpr = E->getArg(0);
     Value *CheckVal = EvaluateExprAsBool(CheckExpr);
     EmitDynamicCheck(CheckVal);

--- a/lib/CodeGen/CGBuiltin.cpp
+++ b/lib/CodeGen/CGBuiltin.cpp
@@ -2426,6 +2426,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
     break;
   }
   case Builtin::BI_Dynamic_check: {
+    // This disables specific code generation for dynamic checks
+    // if Checked C is not enabled. Code Generation will fall-through
+    // to emitting a "Unknown Builtin" error.
     if (!getLangOpts().CheckedC)
       break;
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -362,7 +362,7 @@ namespace {
     };
 
   public:
-    NonModifiyingExprSema(Sema &S, Expr *Outer) : S(S), Outer(Outer) {}
+    NonModifiyingExprSema(Sema &S) : S(S) {}
 
     // Assignments are of course modifying
     bool VisitBinAssign(BinaryOperator* E) {
@@ -413,7 +413,6 @@ namespace {
 
   private:
     Sema &S;
-    Expr *Outer;
 
     void addError(Expr *E, ModifyingExprKind Kind) {
       S.Diag(E->getLocStart(), diag::err_not_non_modifying_expr)
@@ -423,9 +422,9 @@ namespace {
   };
 }
 
-bool Sema::CheckIsNonModifyingExpr(Expr *E, Expr *Outer) {
+bool Sema::CheckIsNonModifyingExpr(Expr *E) {
   // TraverseStmt returns 'false' if traversal exits early.
   // Traversal only ends early if we meet a modifying expression
   // So, if we end early, then we met a modifying expression
-  return NonModifiyingExprSema(*this, Outer).TraverseStmt(E);
+  return NonModifiyingExprSema(*this).TraverseStmt(E);
 }

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -1070,7 +1070,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (!getLangOpts().CheckedC)
       break;
 
-    if (!CheckIsNonModifyingExpr(TheCall->getArg(0), TheCall))
+    if (!CheckIsNonModifyingExpr(TheCall->getArg(0)))
       return ExprError();
     break;
   }

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -1065,6 +1065,15 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BIget_kernel_preferred_work_group_size_multiple:
     if (SemaOpenCLBuiltinKernelWorkGroupSize(*this, TheCall))
       return ExprError();
+    break;
+  case Builtin::BI_Dynamic_check: {
+    if (!getLangOpts().CheckedC)
+      break;
+
+    if (!CheckIsNonModifyingExpr(TheCall->getArg(0), TheCall))
+      return ExprError();
+    break;
+  }
   }
 
   // Since the target specific builtins for each arch overlap, only check those

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -1067,6 +1067,8 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
       return ExprError();
     break;
   case Builtin::BI_Dynamic_check: {
+    // This disables any semantic analysis (in particular, errors or warnings)
+    // if Checked C is not enabled
     if (!getLangOpts().CheckedC)
       break;
 

--- a/test/CheckedC/dynamic_check-nme-checks.c
+++ b/test/CheckedC/dynamic_check-nme-checks.c
@@ -17,42 +17,38 @@ union U1 {
 // Expressions explicitly banned by spec within Non-Modifying Expressions
 void f1(int i) {
   // Conventional Assignment is a modifying expression
-  _Dynamic_check(i = 1);       // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(0 + (i = 1)); // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i = 1);       // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(1 + (i = 1)); // expected-error {{assignment expression not allowed in dynamic check expression}}
 
   // Compound Assignment is a modifying expression
-  _Dynamic_check(i += 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i -= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i *= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i /= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i %= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i <<= 1); // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i >>= 1); // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i &= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i ^= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i |= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i += 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i -= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i *= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i /= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i %= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i <<= 1); // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i >>= 1); // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i &= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i ^= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
+  _Dynamic_check(i |= 1);  // expected-error {{assignment expression not allowed in dynamic check expression}}
 
   // Increments are modifying expressions
-  _Dynamic_check(i++); // expected-error {{increment expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(++i); // expected-error {{increment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i++); // expected-error {{increment expression not allowed in dynamic check expression}}
+  _Dynamic_check((i++, i)); // expected-error {{increment expression not allowed in dynamic check expression}}
+  _Dynamic_check(++i); // expected-error {{increment expression not allowed in dynamic check expression}}
+  _Dynamic_check(1 + 1 - 1 + ++i); // expected-error {{increment expression not allowed in dynamic check expression}}
 
   // Decrements are modifying expressions
-  _Dynamic_check(i--); // expected-error {{decrement expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(--i); // expected-error {{decrement expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i--); // expected-error {{decrement expression not allowed in dynamic check expression}}
+  _Dynamic_check(--i); // expected-error {{decrement expression not allowed in dynamic check expression}}
 
   // Calls are modifying expressions
-  _Dynamic_check(f0());     // expected-error {{call expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(1 + f0()); // expected-error {{call expression not allowed within non-modifying expression in dynamic_check}}
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused"
-  // Commas are modifying expressions
-  _Dynamic_check((i+2, i+1000000, i)); // expected-error {{comma expression not allowed within non-modifying expression in dynamic_check}}
-#pragma clang diagnostic pop
+  _Dynamic_check(f0());     // expected-error {{call expression not allowed in dynamic check expression}}
+  _Dynamic_check(1 + f0()); // expected-error {{call expression not allowed in dynamic check expression}}
 
   volatile int j;
-  _Dynamic_check(j);     // expected-error {{volatile expression not allowed within non-modifying expression in dynamic_check}}
-  _Dynamic_check(i + j); // expected-error {{volatile expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(j);     // expected-error {{volatile expression not allowed in dynamic check expression}}
+  _Dynamic_check(i + j); // expected-error {{volatile expression not allowed in dynamic check expression}}
 }
 
 // Expressions explicitly allowed by spec within Non-Modifying Expressions

--- a/test/CheckedC/dynamic_check-nme-checks.c
+++ b/test/CheckedC/dynamic_check-nme-checks.c
@@ -1,0 +1,128 @@
+// Tests for Non-Modifying Expressions with Checked C Extension
+// This makes sure we raise errors when a programmer puts a modifying expression within a
+// _Dynamic_check invocation.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+
+int f0(void);
+
+struct S1 {
+  int m1;
+};
+
+union U1 {
+  int m1;
+};
+
+// Expressions explicitly banned by spec within Non-Modifying Expressions
+void f1(int i) {
+  // Conventional Assignment is a modifying expression
+  _Dynamic_check(i = 1);       // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(0 + (i = 1)); // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+
+  // Compound Assignment is a modifying expression
+  _Dynamic_check(i += 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i -= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i *= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i /= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i %= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i <<= 1); // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i >>= 1); // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i &= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i ^= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i |= 1);  // expected-error {{assignment expression not allowed within non-modifying expression in dynamic_check}}
+
+  // Increments are modifying expressions
+  _Dynamic_check(i++); // expected-error {{increment expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(++i); // expected-error {{increment expression not allowed within non-modifying expression in dynamic_check}}
+
+  // Decrements are modifying expressions
+  _Dynamic_check(i--); // expected-error {{decrement expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(--i); // expected-error {{decrement expression not allowed within non-modifying expression in dynamic_check}}
+
+  // Calls are modifying expressions
+  _Dynamic_check(f0());     // expected-error {{call expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(1 + f0()); // expected-error {{call expression not allowed within non-modifying expression in dynamic_check}}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused"
+  // Commas are modifying expressions
+  _Dynamic_check((i+2, i+1000000, i)); // expected-error {{comma expression not allowed within non-modifying expression in dynamic_check}}
+#pragma clang diagnostic pop
+
+  volatile int j;
+  _Dynamic_check(j);     // expected-error {{volatile expression not allowed within non-modifying expression in dynamic_check}}
+  _Dynamic_check(i + j); // expected-error {{volatile expression not allowed within non-modifying expression in dynamic_check}}
+}
+
+// Expressions explicitly allowed by spec within Non-Modifying Expressions
+void f2(int i) {
+  int j;
+
+  // Local variables and Parameter Variables
+  _Dynamic_check(i + j);
+
+  // Constants
+  _Dynamic_check(3);
+
+  // Cast Expressions
+  _Dynamic_check((int)'\0');
+
+  // Address-of Expressions
+  _Dynamic_check(&i == &j);
+
+  // Unary Plus/Minus Expressions
+  _Dynamic_check(+i);
+  _Dynamic_check(-i);
+
+  // One's Complement Expressions
+  _Dynamic_check(~i);
+
+  // Logical Negation Expressions
+  _Dynamic_check(!i);
+
+  // Sizeof Expressions
+  _Dynamic_check(sizeof(i) == sizeof(int));
+
+  // Multiplicative Expressions
+  _Dynamic_check(i * 1 / 1 % 1);
+
+  // Additive Expressions
+  _Dynamic_check(i + 1 - 1);
+
+  // Shift Expressions
+  _Dynamic_check(i << 1 >> 1);
+
+  // Relational and Equality Expressions
+  _Dynamic_check(i > j);
+  _Dynamic_check(i < j);
+  _Dynamic_check(i <= j);
+  _Dynamic_check(i >= j);
+  _Dynamic_check(i == j);
+
+  // Bitwise Expressions
+  _Dynamic_check(i & j);
+  _Dynamic_check(i ^ j);
+  _Dynamic_check(i | j);
+
+  // Logical Expressions
+  _Dynamic_check(i && j);
+  _Dynamic_check(i || j);
+
+  // Conditional Expressions
+  _Dynamic_check(i ? j : 0);
+
+  // Member references
+  union U1 u1;
+  struct S1 s1;
+  _Dynamic_check(u1.m1);
+  _Dynamic_check(s1.m1);
+
+  // Indirect member references
+  struct S1 *ps1;
+  _Dynamic_check(ps1->m1);
+
+  // Pointer Dereferences
+  int *k;
+  _Dynamic_check(*k);
+}


### PR DESCRIPTION
Though we have not yet updated the specification, our intention is to require explicit `dynamic_check`s contain non--modifying expressions, in part so we can run them as and when we want to, without fear of side effects. This also partly conveys the expectation that these checks should be lightweight.

I have implemented this as a new `RecursiveASTVisitor` in `SemaBounds.cpp`. If this visitor finishes early, it shows we found something not allowed in a non-modifying expression. The error message tries to clarify what part of the expression exactly we don't like. 

