### PR TITLE
Infer bounds for address-of expressions.

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -330,7 +330,9 @@ namespace {
         if (DR->getType()->isFunctionType())
           return CreateBoundsNone();
 
-        IntegerLiteral *One = CreateIntegerLiteral(llvm::APInt(1, 1));
+        // Create an unsigned integer 1
+        IntegerLiteral *One =
+          CreateIntegerLiteral(llvm::APInt(1, 1, /*isSigned=*/false));
         Expr *AddrOf = CreateAddressOfOperator(DR);
         CountBoundsExpr CBE = CountBoundsExpr(BoundsExpr::Kind::ElementCount,
                                               One, SourceLocation(),

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -186,7 +186,7 @@ namespace {
   // 4. If a member access operation e1.f denotes on lvalue, e1 denotes an
   //    lvalue.
   // 5. In clang IR, as an operand to an LValueToRValue cast operation.
-  // Otherwise an expression denotes an rvalue.+
+  // Otherwise an expression denotes an rvalue.
   class BoundsInference {
 
   private:
@@ -235,7 +235,7 @@ namespace {
     }
 
     // Given a byte_count or count bounds expression for the expression Base,
-    // expand it a range bounds expression:
+    // expand it to a range bounds expression:
     //  E : Count(C) expands to Bounds(E, E + C)
     //  E : ByteCount(C)  exzpands to Bounds((char *) E, (char *) E + C)
     BoundsExpr *ExpandToRange(Expr *Base, BoundsExpr *B) {


### PR DESCRIPTION
This change adds inference of bounds of address-of expressions.  It addresses GitHub issue #120 .  An address-of expression converts an expression that is an lvalue to a pointer.   The bounds of the address-of expression are the bounds of the lvalue.

This change covers address expressions of the form &v, where v is a variable, &*e1, or &e1[e2]. The change adds inference of lvalue bounds for non-array variables, pointer dereference expressions, and array-subscript expressions.
 
Add a comment for ExpandToRange, as requested by  a code review for
a prior pull request.

Testing:
- Add feature tests of bound inferences for the various kinds of address-of expressions.
- Passes existing Checked C tests.
- Passes existing clang tests.