### PR TITLE
Track location of equal token for initializers.

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -827,6 +827,8 @@ protected:
   /// C++ default argument.
   mutable InitType Init;
 
+  SourceLocation InitializerStartLoc;
+
 private:
   class VarDeclBitfields {
     friend class VarDecl;
@@ -1171,6 +1173,20 @@ public:
   Stmt **getInitAddress();
 
   void setInit(Expr *I);
+
+  /// \brief Set the location of the first token of the initializer
+  /// expression.  For C-style intializers, this is the location of
+  /// the equal token.
+  void setInitializerStartLoc(SourceLocation Loc) {
+    InitializerStartLoc = Loc;
+  }
+
+  /// \brief Get the location of the first token of the initializer
+  /// expression.  For C-style intializers, this is the location of
+  /// the equal token.
+  SourceLocation getInitializerStartLoc() {
+    return InitializerStartLoc;
+  }
 
   /// \brief Determine whether this variable's value can be used in a
   /// constant expression, according to the relevant language standard.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -1778,7 +1778,8 @@ public:
                                SourceLocation EqualLoc);
 
   void AddInitializerToDecl(Decl *dcl, Expr *init, bool DirectInit,
-                            bool TypeMayContainAuto);
+                            bool TypeMayContainAuto, 
+                            SourceLocation EqualLoc = SourceLocation());
   void ActOnUninitializedDecl(Decl *dcl, bool TypeMayContainAuto);
   void ActOnInitializerError(Decl *Dcl);
   void ActOnPureSpecifier(Decl *D, SourceLocation PureSpecLoc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2165,7 +2165,8 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
         Actions.ActOnInitializerError(ThisDecl);
       } else
         Actions.AddInitializerToDecl(ThisDecl, Init.get(),
-                                     /*DirectInit=*/false, TypeContainsAuto);
+                                     /*DirectInit=*/false, TypeContainsAuto,
+                                     EqualLoc);
     }
   } else if (Tok.is(tok::l_paren)) {
     // Parse C++ direct initializer: '(' expression-list ')'

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -9884,7 +9884,8 @@ QualType Sema::deduceVarTypeFromInitializer(VarDecl *VDecl,
 /// declaration dcl. If DirectInit is true, this is C++ direct
 /// initialization rather than copy initialization.
 void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
-                                bool DirectInit, bool TypeMayContainAuto) {
+                                bool DirectInit, bool TypeMayContainAuto,
+                                SourceLocation EqualLoc) {
   // If there is no declaration, there was an error parsing it.  Just ignore
   // the initializer.
   if (!RealDecl || RealDecl->isInvalidDecl()) {
@@ -10166,6 +10167,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
 
   // Attach the initializer to the decl.
   VDecl->setInit(Init);
+  VDecl->setInitializerStartLoc(EqualLoc);
 
   if (VDecl->isLocalVarDecl()) {
     // C99 6.7.8p4: All the expressions in an initializer for an object that has


### PR DESCRIPTION
The Checked C source-to-source rewriter needs this informaton to be able
to rewrite initializers properly.  This increases the size of VarDecl.
We could consider alternative approaches where the location is stored
in the initializer expression itself if this becomes an issue later.

Testing:
- This new functionality isn't tested.  I'll rely on Andrew trying to use the
  line number information in the rewriter.
- Checked C tests build and pass.
