### PR TITLE
Adds non-modifying expression check of bounds annotations

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8877,7 +8877,7 @@ def err_bounds_type_annotation_lost_checking : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
   def err_not_non_modifying_expr : Error<
-	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed "
-	"in dynamic check expression">;
+	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "
+	"%select{expression|dynamic check expression|count annotation|byte count annotation|bounds range annotation}1">;
 
 } // end of sema component.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8878,6 +8878,6 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def err_not_non_modifying_expr : Error<
 	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "
-	"%select{expression|dynamic check expression|count annotation|byte count annotation|bounds range annotation}1">;
+	"%select{expression|dynamic check expression|count annotation|byte count annotation|bounds annotation}1">;
 
 } // end of sema component.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4292,9 +4292,19 @@ public:
   /// not within a function body.
   void CheckTopLevelBoundsDecls(VarDecl *VD);
 
+  // Represents where the requirement that the checked expression is non-modifying
+  // comes from.
+  enum NonModifiyingExprRequirement {
+    NMER_Unknown,
+    NMER_Dynamic_Check,
+    NMER_Bounds_Count,
+    NMER_Bounds_Byte_Count,
+    NMER_Bounds_Range
+  };
+
   /// CheckNonModifyingExpr - checks whether an expression is non-modifying
   /// (see Checked C Spec, 3.6.1)
-  bool CheckIsNonModifyingExpr(Expr *E);
+  bool CheckIsNonModifyingExpr(Expr *E, NonModifiyingExprRequirement Req);
 
   //===---------------------------- Clang Extensions ----------------------===//
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -31,7 +31,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/Basic/TargetBuiltins.h"
 #include "TreeTransform.h"
 
 using namespace clang;

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -579,19 +579,6 @@ namespace {
 
       return true;
     }
-
-    bool VisitRangeBoundsExpr(const RangeBoundsExpr *E) {
-      S.CheckIsNonModifyingExpr(E->getLowerExpr());
-      S.CheckIsNonModifyingExpr(E->getUpperExpr());
-
-      return true;
-    }
-
-    bool VisitCountBoundsExpr(const CountBoundsExpr *E) {
-      S.CheckIsNonModifyingExpr(E->getCountExpr());
-      
-      return true;
-    }
   };
 }
 
@@ -608,17 +595,6 @@ void Sema::CheckTopLevelBoundsDecls(VarDecl *D) {
 namespace {
   class NonModifiyingExprSema : public RecursiveASTVisitor<NonModifiyingExprSema> {
 
-  public:
-    // Represents where the requirement that the checked expression is non-modifying
-    // comes from.
-    enum NonModifyingExprRequirement {
-      NMER_Unknown,
-      NMER_Dynamic_Check,
-      NMER_Bounds_Count,
-      NMER_Bounds_Byte_Count,
-      NMER_Bounds_Range
-    };
-
   private:
     // Represents which kind of modifying expression we have found
     enum ModifyingExprKind {
@@ -630,7 +606,7 @@ namespace {
     };
 
   public:
-    NonModifiyingExprSema(Sema &S, NonModifyingExprRequirement From) : 
+    NonModifiyingExprSema(Sema &S, Sema::NonModifiyingExprRequirement From) :
       S(S), FoundModifyingExpr(false), ReqFrom(From) {}
 
     bool isNonModifyingExpr() { return !FoundModifyingExpr; }
@@ -685,37 +661,17 @@ namespace {
   private:
     Sema &S;
     bool FoundModifyingExpr;
-    NonModifyingExprRequirement ReqFrom;
+    Sema::NonModifiyingExprRequirement ReqFrom;
 
     void addError(Expr *E, ModifyingExprKind Kind) {
       S.Diag(E->getLocStart(), diag::err_not_non_modifying_expr)
-        << Kind << ReqFrom
-        << E->getSourceRange();
+        << Kind << ReqFrom << E->getSourceRange();
     }
   };
 }
 
-bool Sema::CheckIsNonModifyingExpr(Expr *E) {
-  auto requirement = NonModifiyingExprSema::NMER_Unknown;
-  if (const CallExpr *Call = dyn_cast<CallExpr>(E)) {
-    if (Call->getBuiltinCallee() == Builtin::BI_Dynamic_check) {
-      requirement = NonModifiyingExprSema::NMER_Dynamic_Check;
-    }
-  }
-  else if (isa<RangeBoundsExpr>(E)) {
-    requirement = NonModifiyingExprSema::NMER_Bounds_Range;
-  }
-  else if (const CountBoundsExpr *Count = dyn_cast<CountBoundsExpr>(E)) {
-    if (Count->getKind() == BoundsExpr::ElementCount) {
-      requirement = NonModifiyingExprSema::NMER_Bounds_Count;
-    }
-    else if (Count->getKind() == BoundsExpr::ByteCount) {
-      requirement = NonModifiyingExprSema::NMER_Bounds_Byte_Count;
-    }
-  }
-
-
-  NonModifiyingExprSema Checker(*this, NonModifiyingExprSema::NMER_Unknown);
+bool Sema::CheckIsNonModifyingExpr(Expr *E, Sema::NonModifiyingExprRequirement Req = Sema::NMER_Unknown) {
+  NonModifiyingExprSema Checker(*this, Req);
   Checker.TraverseStmt(E);
 
   return Checker.isNonModifyingExpr();

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -1072,7 +1072,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (!getLangOpts().CheckedC)
       break;
 
-    if (!CheckIsNonModifyingExpr(TheCall->getArg(0)))
+    if (!CheckIsNonModifyingExpr(TheCall->getArg(0), NMER_Dynamic_Check))
       return ExprError();
     break;
   }

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11824,6 +11824,21 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr) {
   if (Ty.isNull())
     return;
 
+  if (Expr) {
+    NonModifiyingExprRequirement req = NMER_Unknown;
+    if (isa<RangeBoundsExpr>(Expr)) {
+      req = NMER_Bounds_Range;
+    }
+    else if (const CountBoundsExpr *CountBounds = dyn_cast<CountBoundsExpr>(Expr)) {
+      req = CountBounds->isByteCount() ? NMER_Bounds_Byte_Count : NMER_Bounds_Count;
+    }
+
+    if (!CheckIsNonModifyingExpr(Expr, req)) {
+      ActOnInvalidBoundsDecl(D);
+      return;
+    }
+  }
+
   if (Expr && Expr->isInvalid()) {
     D->setBoundsExpr(Expr);
     return;


### PR DESCRIPTION
As required by the spec, we make sure that bounds expressions only contain non-modifying expressions. 

This uses most of the machinery from when the same check is used on `dynamic_check(e)` expressions, but expands it to add clearer error messages.