### PR TITLE
Explicit dynamic check warning flag

### DIFF
--- a/include/clang/Basic/DiagnosticGroups.td
+++ b/include/clang/Basic/DiagnosticGroups.td
@@ -881,3 +881,5 @@ def UnknownArgument : DiagGroup<"unknown-argument">;
 // A warning group for warnings about code that clang accepts when
 // compiling OpenCL C/C++ but which is not compatible with the SPIR spec.
 def SpirCompat : DiagGroup<"spir-compat">;
+
+def CheckedC : DiagGroup<"checkedc">;

--- a/include/clang/Basic/DiagnosticGroups.td
+++ b/include/clang/Basic/DiagnosticGroups.td
@@ -882,4 +882,5 @@ def UnknownArgument : DiagGroup<"unknown-argument">;
 // compiling OpenCL C/C++ but which is not compatible with the SPIR spec.
 def SpirCompat : DiagGroup<"spir-compat">;
 
+// A warning group for all Checked C warnings
 def CheckedC : DiagGroup<"checkedc">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8893,7 +8893,8 @@ def err_bounds_type_annotation_lost_checking : Error<
 	"expressions with function type">;
 
   def warn_dynamic_check_condition_fail : Warning<
-    "dynamic check will always fail">;
+    "dynamic check will always fail">,
+	InGroup<CheckedC>;
 
   def err_not_non_modifying_expr : Error<
 	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8709,6 +8709,7 @@ def ext_warn_gnu_final : ExtWarn<
   InGroup<GccCompat>;
 
 // Checked C diagnostic messages
+let CategoryName = "Checked C" in {
 
 def err_checked_vla : Error<
   "checked variable-length array not allowed">;
@@ -8899,5 +8900,7 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_not_non_modifying_expr : Error<
 	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "
 	"%select{expression|dynamic check expression|count expression|byte count expression|bounds expression}1">;
+
+} // end of Checked C Category
 
 } // end of sema component.

--- a/test/CheckedC/dynamic_check-warning.c
+++ b/test/CheckedC/dynamic_check-warning.c
@@ -1,0 +1,23 @@
+// Tests for Code Generation with Checked C Extension
+// This makes sure we're generating something sensible for _Dynamic_check
+// invocations.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -verify -emit-llvm %s
+
+void f0(void) {
+  _Dynamic_check(1);
+}
+
+// Function with single dynamic check
+void f1(void) {
+  _Dynamic_check(0); // expected-warning {{dynamic check will always fail}}
+}
+
+void f2(void) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcheckedc"
+
+  _Dynamic_check(0);
+
+#pragma clang diagnostic pop
+}

--- a/test/CheckedC/dynamic_check-warning.c
+++ b/test/CheckedC/dynamic_check-warning.c
@@ -2,7 +2,7 @@
 // This makes sure we're generating something sensible for _Dynamic_check
 // invocations.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify -emit-llvm %s
+// RUN: %clang_cc1 -fcheckedc-extension -verify -emit-llvm %s -o %t
 
 void f0(void) {
   _Dynamic_check(1);


### PR DESCRIPTION
One of the Clang tests verifies that if we add more warnings, then we should add a command-line switch so users can disable this warning. This commit adds the switch for Checked C. 

The switch is called `-Wcheckedc`. I think passing `-Wno-checkedc` will disable the warnings, as the example clang pragma also does. 