### PR TITLE
Explicit dynamic check statistics

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4307,6 +4307,10 @@ public:
   /// (see Checked C Spec, 3.6.1)
   bool CheckIsNonModifyingExpr(Expr *E, NonModifiyingExprRequirement Req);
 
+  // WarnDynamicCheckAlwaysFails - Adds a warning if an explicit dynamic check
+  // will always fail.
+  void WarnDynamicCheckAlwaysFails(const Expr *Condition);
+
   //===---------------------------- Clang Extensions ----------------------===//
 
   /// __builtin_convertvector(...)

--- a/lib/CodeGen/CGBuiltin.cpp
+++ b/lib/CodeGen/CGBuiltin.cpp
@@ -2433,27 +2433,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
     if (!getLangOpts().CheckedC)
       break;
 
-    const Expr *CheckExpr = E->getArg(0);
-
-    bool CheckConstant;
-    if (ConstantFoldsToSimpleInteger(CheckExpr, CheckConstant, /*AllowLabels=*/false)) {
-      // Dynamic Check condition's value can be found at compile-time
-
-      if (CheckConstant) {
-        // Dynamic Check always passes, leave it out
-        return RValue::get(nullptr);
-      }
-      else {
-        // Dynamic Check always fails, emit warning
-        CGM.getDiags().Report(CheckExpr->getLocStart(), diag::warn_dynamic_check_condition_fail)
-          << E->getSourceRange();
-      }
-    }
-
-    // Dynamic Check relies on runtime behaviour (or we believe it will always fail),
-    // so emit the required check
-    Value *CheckVal = EvaluateExprAsBool(CheckExpr);
-    EmitDynamicCheck(CheckVal);
+    const Expr *Condition = E->getArg(0);
+    EmitExplicitDynamicCheck(Condition);
 
     return RValue::get(nullptr);
   }

--- a/lib/CodeGen/CGDynamicCheck.cpp
+++ b/lib/CodeGen/CGDynamicCheck.cpp
@@ -1,0 +1,53 @@
+//===---- CGDynamicCheck.cpp - Emit LLVM Code for Checked C Dynamic Checks -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code to emit Checked C Dynamic Checks as LLVM code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CodeGenFunction.h"
+
+using namespace clang;
+using namespace CodeGen;
+using namespace llvm;
+
+void CodeGenFunction::EmitExplicitDynamicCheck(const Expr *Condition) {
+  bool ConditionConstant;
+  if (ConstantFoldsToSimpleInteger(Condition, ConditionConstant, /*AllowLabels=*/false)
+    && ConditionConstant) {
+    // Dynamic Check will always pass, leave it out.
+
+    return;
+  }
+
+  // Dynamic Check relies on runtime behaviour (or we believe it will always fail),
+  // so emit the required check
+  Value *ConditionVal = EvaluateExprAsBool(Condition);
+  EmitDynamicCheckBlocks(ConditionVal);
+}
+
+void CodeGenFunction::EmitDynamicCheckBlocks(llvm::Value *Condition) {
+  llvm::BasicBlock *Begin, *DyCkSuccess, *DyCkFail;
+  Begin = Builder.GetInsertBlock();
+  DyCkSuccess = createBasicBlock("_Dynamic_check_succeeded");
+  DyCkFail = createBasicBlock("_Dynamic_check_failed", this->CurFn);
+
+  Builder.SetInsertPoint(DyCkFail);
+  llvm::CallInst *TrapCall = Builder.CreateCall(CGM.getIntrinsic(llvm::Intrinsic::trap));
+  TrapCall->setDoesNotReturn();
+  TrapCall->setDoesNotThrow();
+  Builder.CreateUnreachable();
+
+  Builder.SetInsertPoint(Begin);
+  Builder.CreateCondBr(Condition, DyCkSuccess, DyCkFail);
+  // This ensures the success block comes directly after the branch
+  EmitBlock(DyCkSuccess);
+
+  Builder.SetInsertPoint(DyCkSuccess);
+}

--- a/lib/CodeGen/CGDynamicCheck.cpp
+++ b/lib/CodeGen/CGDynamicCheck.cpp
@@ -20,21 +20,21 @@ using namespace llvm;
 
 #define DEBUG_TYPE "DynamicCheckCodeGen"
 
-STATISTIC(DynamicChecksFound, "Number of Dynamic Checks Found");
-STATISTIC(DynamicChecksElided, "Number of Dynamic Checks Elided (Due to Constant Folding)");
-STATISTIC(DynamicChecksInserted, "Number of Dynamic Checks Found");
-STATISTIC(DynamicChecksExplicit, "Number of Dynamic Checks from _Dynamic_check");
+STATISTIC(NumDynamicChecksFound,    "The # of dynamic checks found");
+STATISTIC(NumDynamicChecksElided,   "The # of dynamic checks elided (due to constant folding)");
+STATISTIC(NumDynamicChecksInserted, "The # of dynamic checks found");
+STATISTIC(NumDynamicChecksExplicit, "The # of dynamic checks from _Dynamic_check(exp)");
 
 void CodeGenFunction::EmitExplicitDynamicCheck(const Expr *Condition) {
-  ++DynamicChecksFound;
-  ++DynamicChecksExplicit;
+  ++NumDynamicChecksFound;
+  ++NumDynamicChecksExplicit;
 
   bool ConditionConstant;
   if (ConstantFoldsToSimpleInteger(Condition, ConditionConstant, /*AllowLabels=*/false)
     && ConditionConstant) {
     // Dynamic Check will always pass, leave it out.
 
-    ++DynamicChecksElided;
+    ++NumDynamicChecksElided;
 
     return;
   }
@@ -46,7 +46,7 @@ void CodeGenFunction::EmitExplicitDynamicCheck(const Expr *Condition) {
 }
 
 void CodeGenFunction::EmitDynamicCheckBlocks(llvm::Value *Condition) {
-  ++DynamicChecksInserted;
+  ++NumDynamicChecksInserted;
 
   llvm::BasicBlock *Begin, *DyCkSuccess, *DyCkFail;
   Begin = Builder.GetInsertBlock();

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -2767,27 +2767,6 @@ llvm::CallInst *CodeGenFunction::EmitTrapCall(llvm::Intrinsic::ID IntrID) {
   return TrapCall;
 }
 
-void CodeGenFunction::EmitDynamicCheck(llvm::Value *Checked) {
-
-  llvm::BasicBlock *Begin, *DyCkSuccess, *DyCkFail;
-  Begin = Builder.GetInsertBlock();
-  DyCkSuccess = createBasicBlock("_Dynamic_check_succeeded");
-  DyCkFail = createBasicBlock("_Dynamic_check_failed", this->CurFn);
-
-  Builder.SetInsertPoint(DyCkFail);
-  llvm::CallInst *TrapCall = Builder.CreateCall(CGM.getIntrinsic(llvm::Intrinsic::trap));
-  TrapCall->setDoesNotReturn();
-  TrapCall->setDoesNotThrow();
-  Builder.CreateUnreachable();
-
-  Builder.SetInsertPoint(Begin);
-  Builder.CreateCondBr(Checked, DyCkSuccess, DyCkFail);
-  // This ensures the success block comes directly after the branch
-  EmitBlock(DyCkSuccess);
-
-  Builder.SetInsertPoint(DyCkSuccess);
-}
-
 Address CodeGenFunction::EmitArrayToPointerDecay(const Expr *E,
                                                  AlignmentSource *AlignSource) {
   assert(E->getType()->isArrayType() &&

--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -45,6 +45,7 @@ add_clang_library(clangCodeGen
   CGDebugInfo.cpp
   CGDecl.cpp
   CGDeclCXX.cpp
+  CGDynamicCheck.cpp
   CGException.cpp
   CGExpr.cpp
   CGExprAgg.cpp

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2284,6 +2284,8 @@ public:
   void EmitCaseStmtRange(const CaseStmt &S);
   void EmitAsmStmt(const AsmStmt &S);
 
+  void EmitExplicitDynamicCheck(const Expr *Condition);
+
   void EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S);
   void EmitObjCAtTryStmt(const ObjCAtTryStmt &S);
   void EmitObjCAtThrowStmt(const ObjCAtThrowStmt &S);
@@ -3224,7 +3226,7 @@ public:
 
   /// \brief Create a basic block that will call the trap intrinsic, and emit
   /// a conditional branch to it, for Checked C _Dynamic_checks expressions.
-  void EmitDynamicCheck(llvm::Value *Checked);
+  void EmitDynamicCheckBlocks(llvm::Value *Condition);
 
   /// \brief Emit a cross-DSO CFI failure handling function.
   void EmitCfiCheckFail();

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -977,3 +977,14 @@ bool Sema::CheckIsNonModifyingExpr(Expr *E, Sema::NonModifiyingExprRequirement R
 
   return Checker.isNonModifyingExpr();
 }
+
+void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
+  bool ConditionConstant;
+  if (Condition->EvaluateAsBooleanCondition(ConditionConstant, Context)) {
+    if (!ConditionConstant) {
+      // Dynamic Check always fails, emit warning
+      Diag(Condition->getLocStart(), diag::warn_dynamic_check_condition_fail)
+        << Condition->getSourceRange();
+    }
+  }
+}

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -1072,8 +1072,13 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (!getLangOpts().CheckedC)
       break;
 
-    if (!CheckIsNonModifyingExpr(TheCall->getArg(0), NMER_Dynamic_Check))
+    Expr *Conditional = TheCall->getArg(0);
+
+    if (!CheckIsNonModifyingExpr(Conditional, NMER_Dynamic_Check))
       return ExprError();
+
+    WarnDynamicCheckAlwaysFails(Conditional);
+
     break;
   }
   }

--- a/test/CheckedC/dynamic_check-nme-checks.c
+++ b/test/CheckedC/dynamic_check-nme-checks.c
@@ -62,10 +62,10 @@ void f2(int i) {
   _Dynamic_check(3);
 
   // Cast Expressions
-  _Dynamic_check((int)'\0');
+  _Dynamic_check((int)'A');
 
   // Address-of Expressions
-  _Dynamic_check(&i == &j);
+  _Dynamic_check(&i != &j);
 
   // Unary Plus/Minus Expressions
   _Dynamic_check(+i);


### PR DESCRIPTION
In order to prepare for adding a lot more code generation for dynamic checks, I have moved some code around and added statistics. 

Statistics of code generation can be viewed with the `-print-stats` argument to `clang -cc1`. 

I have also moved the warning about failing dynamic checks into semantic analysis instead of code generation, because this seems like a much better place for it. It used to only be added when you asked `clang -cc1` to do codegen (via `-emit-llvm` or similar), but now it's run with all the other semantic analysis, so I had to update some tests which now produced warnings. 