### PR TITLE
Warn on invalid use of Checked C extension flag.

### DIFF
--- a/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/include/clang/Basic/DiagnosticDriverKinds.td
@@ -219,6 +219,8 @@ def warn_drv_enabling_rtti_with_exceptions : Warning<
 def warn_drv_disabling_vptr_no_rtti_default : Warning<
   "implicitly disabling vptr sanitizer because rtti wasn't enabled">,
   InGroup<DiagGroup<"auto-disable-vptr-sanitizer">>;
+def warn_drv_checkedc_extension_notsupported : Warning<
+  "Checked C extension not supported with '%1'; ignoring '%0'">;
 
 def note_drv_command_failed_diag_msg : Note<
   "diagnostic msg: %0">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1903,7 +1903,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     }
 
     if (disallowed.size() > 0) {
-      Diags.Report(diag::err_drv_argument_not_allowed_with) <<
+      Diags.Report(diag::warn_drv_checkedc_extension_notsupported) <<
         "-fcheckedc-extension" << disallowed;
     } else
       Opts.CheckedC = true;

--- a/test/Driver/checkedc-notsupported.cl
+++ b/test/Driver/checkedc-notsupported.cl
@@ -1,8 +1,8 @@
 // Checked C extension is not supported for OpenCL.   Make sure driver
 // rejects the flag.
 //
-// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
-// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'OpenCL'
+// RUN: %clang -c -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: warning: Checked C extension not supported with 'OpenCL'; ignoring '-fcheckedc-extension'
 //
 // Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s
@@ -10,5 +10,4 @@
 // Have clang-cl compile this file as a C file.
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
-extern void f() {}
-
+void f() {}

--- a/test/Driver/checkedc-notsupported.cpp
+++ b/test/Driver/checkedc-notsupported.cpp
@@ -1,8 +1,8 @@
 // Checked C extension is not supported for C++.   Make sure driver
-// rejects the flag.
+// warns about the -fchecked-extension and ignores it.
 //
-// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
-// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+// RUN: %clang -c -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: warning: Checked C extension not supported with 'C++'; ignoring '-fcheckedc-extension'
 //
 // Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s

--- a/test/Driver/checkedc-notsupported.cu
+++ b/test/Driver/checkedc-notsupported.cu
@@ -1,8 +1,8 @@
 // Checked C extension is not supported for CUDA.   Make sure driver
 // rejects the flag.
 //
-// RUN: not %clang -fcheckedc-extension -nocudalib -nocudainc %s 2>&1 | FileCheck %s
-// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'CUDA'
+// RUN: %clang -fcheckedc-extension -nocudalib -nocudainc -fsyntax-only -c %s 2>&1 | FileCheck %s
+// CHECK: warning: Checked C extension not supported with 'CUDA'; ignoring '-fcheckedc-extension'
 //
 // Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s
@@ -10,6 +10,6 @@
 // Have clang-cl compile this file as a C file.
 // RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
 
-extern void f() {}
+void f() {}
 
 

--- a/test/Driver/checkedc-notsupported.m
+++ b/test/Driver/checkedc-notsupported.m
@@ -1,8 +1,8 @@
 // Checked C extension is not supported for Objective C.   Make sure driver
-// rejects the flag.
+// warns about the flag for the extension and ignores it.
 //
-// RUN: not %clang -fcheckedc-extension %s 2>&1 | FileCheck %s
-// CHECK: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C'
+// RUN: %clang -c -fcheckedc-extension %s 2>&1 | FileCheck %s
+// CHECK: warning: Checked C extension not supported with 'Objective C'; ignoring '-fcheckedc-extension'
 //
 // Have clang compile this file as a C file.
 // RUN: %clang -c -fcheckedc-extension -x c %s

--- a/test/Driver/checkedc-supported.c
+++ b/test/Driver/checkedc-supported.c
@@ -8,28 +8,27 @@
 // Have clang compile this file as C++ file.
 // RUN: not %clang -c -fcheckedc-extension -x c++ %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-cpp
-// check-cpp: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+// check-cpp: warning: Checked C extension not supported with 'C++'; ignoring '-fcheckedc-extension'
 //
 // Have clang-cl compile this file as a C++ file.
 // RUN: not %clang_cl -c -Xclang -fcheckedc-extension /TP %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=clcheck-cpp
-// clcheck-cpp: error: invalid argument '-fcheckedc-extension' not allowed with 'C++'
+// clcheck-cpp: warning: Checked C extension not supported with 'C++'; ignoring '-fcheckedc-extension'
 //
 // RUN: not %clang -c -fcheckedc-extension -x cuda -nocudalib -nocudainc %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-cuda
-// check-cuda: error: invalid argument '-fcheckedc-extension' not allowed with 'CUDA'
+// check-cuda: warning: Checked C extension not supported with 'CUDA'; ignoring '-fcheckedc-extension'
 //
 // RUN: not %clang -c -fcheckedc-extension -x cl %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-opencl
-// check-opencl: error: invalid argument '-fcheckedc-extension' not allowed with 'OpenCL'
+// check-opencl: warning: Checked C extension not supported with 'OpenCL'; ignoring '-fcheckedc-extension'
 //
 // RUN: not %clang -c -fcheckedc-extension -x objective-c %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-objc
-// check-objc: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C'
+// check-objc: warning: Checked C extension not supported with 'Objective C'; ignoring '-fcheckedc-extension'
 //
 // RUN: not %clang -c -fcheckedc-extension -x objective-c++ %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-objcpp
-// check-objcpp: error: invalid argument '-fcheckedc-extension' not allowed with 'Objective C/C++'
-
+// check-objcpp: warning: Checked C extension not supported with 'Objective C/C++'; ignoring '-fcheckedc-extension'
 
 extern void f(_Ptr<int> p) {}


### PR DESCRIPTION
The Checked C clang compiler issues an error message when the
`-fcheckedc-extension` is used with an invalid language target (such as C++
or Objective C).   This change modifies the compiler to issue a warning message
and ignore the flag instead when that happens.  This allows the flag to be
added to the set of compiler flags in a build without breaking the
build.  There will be a warning when compiling C++ programs.

I hit this issue using the LNT --cflags option to pass the -fcheckedc-extension
flag to the compiiler when running LLVM nightly tests.  The flag was passed to
compilations of C++  programs, which caused them to fail to compile.

This change updates the driver tests that use the -fcheckedc-extension
flag while compiling languages other than C to reflect the new behavior.

Testing:
- The nightly tests in the original branch of
checkedc-llvm-test-suite pass when the -fcheckedc-extension
flag is set (2495 tests).  Of course, none of these tests use the
Checked C extension, so this just verifies that we haven't broken any
of the tests with the compiler modifications for Checked C.
- Ran the driver tests using LIT.