### PR TITLE
Adds Checked C driver warning to Checked C warnings switch

### DIFF
--- a/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/include/clang/Basic/DiagnosticDriverKinds.td
@@ -220,7 +220,8 @@ def warn_drv_disabling_vptr_no_rtti_default : Warning<
   "implicitly disabling vptr sanitizer because rtti wasn't enabled">,
   InGroup<DiagGroup<"auto-disable-vptr-sanitizer">>;
 def warn_drv_checkedc_extension_notsupported : Warning<
-  "Checked C extension not supported with '%1'; ignoring '%0'">;
+  "Checked C extension not supported with '%1'; ignoring '%0'">,
+  InGroup<CheckedC>;
 
 def note_drv_command_failed_diag_msg : Note<
   "diagnostic msg: %0">;


### PR DESCRIPTION
Tests fail if we don't add warnings to a warnings group, but we have a checked c warnings group, so I just added this warning to it.