### PR TITLE
Fix rewriter test vargs.c that is failing on  x86.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND CLANG_TEST_DEPS
   c-index-test diagtool
   clang-tblgen
   clang-offload-bundler
+  checked-c-convert
   )
   
 if(CLANG_ENABLE_STATIC_ANALYZER)

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -15,6 +15,8 @@ using namespace clang;
 // Special-case handling for decl introductions. For the moment this covers:
 //  * void-typed variables
 //  * va_list-typed variables
+// TODO: Github issue #61: improve handling of types for
+// variable arguments.
 static
 void specialCaseVarIntros(ValueDecl *D, ProgramInfo &Info, ASTContext *C) {
   // Constrain everything that is void to wild.
@@ -22,7 +24,7 @@ void specialCaseVarIntros(ValueDecl *D, ProgramInfo &Info, ASTContext *C) {
 
   // Special-case for va_list, constrain to wild.
   if (D->getType().getAsString() == "va_list" ||
-      D->getType().getAsString() == "void") {
+      D->getType()->isVoidType()) {
     for (const auto &I : Info.getVariable(D, C))
       if (const PVConstraint *PVC = dyn_cast<PVConstraint>(I))
         for (const auto &J : PVC->getCvars())

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -51,8 +51,10 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, uint32_
 				std::pair<uint32_t, Qualification>(K, ConstQualification));
 
 		K++;
-
-		if (tyToStr(Ty) == "struct __va_list_tag *")
+        std::string TyName = tyToStr(Ty);
+        // TODO: Github issue #61: improve handling of types for
+        // variable arguments.
+		if (TyName == "struct __va_list_tag *" || TyName == "va_list")
 			break;
 
 		// Iterate.
@@ -82,7 +84,10 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, uint32_
 	}
 
 	// Special case for void to not make _Ptr<void> pointers.
-	if (Ty->isVoidType() || BaseType == "struct __va_list_tag *")
+    // TODO: Github issue #61: improve handling of types for
+    // variable arguments.
+	if (Ty->isVoidType() || BaseType == "struct __va_list_tag *" ||
+        BaseType == "va_list")
 		for (const auto &V : vars)
 			CS.addConstraint(CS.createEq(CS.getOrCreateVar(V), CS.getWild()));
 }


### PR DESCRIPTION
The vargs.c test now fails on x86.    The converter is rewriting a parameter with type va_list to _Ptr<char> on x86.   I debugged the converter on the example and it appears that the converter is never constraining the parameter to wild.    

There are two places in the code that try to handle `va_list`-typed variables: specialCaseVarIntros in ConstraintBuilder.cpp and PointerVariableConstraint in ProgramInfo.cpp.  The former seems to only be applied to local variable definitions and looks for types named `va_list`.  It was not called for the parameter variables in the falling test. The latter checks at all constraints being added for pointer types, but looks for the x86-x64 ABI-specific type to which `__builtin_va_list` is typedef'ed.  

We can fix the failure by changing the check in PointerVariableConstraint to also check for `va_list`.   We'll make a targeted fix for now.  A broader clean up is tracked by issue #61.

Note that there are formatting issues: the source files for the rewriter have tabs in them, which they aren't supposed to have.  The code that I added doesn't use tabs.  I'll fix the formatting issues in a separate commit..

Testing:
- The Checked C rewriter tests now pass on x86.
