### PR TITLE
Adds Inferred BoundsExprs to Exprs in AST

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1964,10 +1964,10 @@ void ASTDumper::VisitCastExpr(const CastExpr *Node) {
   }
   dumpBasePath(OS, Node);
   OS << ">";
-  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+  if (const BoundsExpr *InferredBounds = Node->getInferredBoundsExpr()) {
     dumpChild([=] {
       OS << "Inferred Bounds";
-      dumpStmt(Bounds);
+      dumpStmt(InferredBounds);
     });
   }
 }
@@ -2062,10 +2062,10 @@ void ASTDumper::VisitUnaryOperator(const UnaryOperator *Node) {
   VisitExpr(Node);
   OS << " " << (Node->isPostfix() ? "postfix" : "prefix")
      << " '" << UnaryOperator::getOpcodeStr(Node->getOpcode()) << "'";
-  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+  if (const BoundsExpr *InferredBounds = Node->getInferredBoundsExpr()) {
     dumpChild([=] {
       OS << "Inferred Bounds";
-      dumpStmt(Bounds);
+      dumpStmt(InferredBounds);
     });
   }
 }
@@ -2095,10 +2095,10 @@ void ASTDumper::VisitMemberExpr(const MemberExpr *Node) {
   VisitExpr(Node);
   OS << " " << (Node->isArrow() ? "->" : ".") << *Node->getMemberDecl();
   dumpPointer(Node->getMemberDecl());
-  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+  if (const BoundsExpr *InferredBounds = Node->getInferredBoundsExpr()) {
     dumpChild([=] {
       OS << "Inferred Bounds";
-      dumpStmt(Bounds);
+      dumpStmt(InferredBounds);
     });
   }
 }
@@ -2111,10 +2111,10 @@ void ASTDumper::VisitExtVectorElementExpr(const ExtVectorElementExpr *Node) {
 void ASTDumper::VisitBinaryOperator(const BinaryOperator *Node) {
   VisitExpr(Node);
   OS << " '" << BinaryOperator::getOpcodeStr(Node->getOpcode()) << "'";
-  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+  if (const BoundsExpr *InferredBounds = Node->getInferredBoundsExpr()) {
     dumpChild([=] {
       OS << "Inferred Bounds";
-      dumpStmt(Bounds);
+      dumpStmt(InferredBounds);
     });
   }
 }
@@ -2143,10 +2143,10 @@ void ASTDumper::VisitOpaqueValueExpr(const OpaqueValueExpr *Node) {
 
 void ASTDumper::VisitArraySubscriptExpr(const ArraySubscriptExpr *Node) {
   VisitExpr(Node);
-  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+  if (const BoundsExpr *InferredBounds = Node->getInferredBoundsExpr()) {
     dumpChild([=] {
       OS << "Inferred Bounds";
-      dumpStmt(Bounds);
+      dumpStmt(InferredBounds);
     });
   }
 }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -541,6 +541,7 @@ namespace  {
     void VisitAddrLabelExpr(const AddrLabelExpr *Node);
     void VisitBlockExpr(const BlockExpr *Node);
     void VisitOpaqueValueExpr(const OpaqueValueExpr *Node);
+    void VisitArraySubscriptExpr(const ArraySubscriptExpr *Node);
 
     // C++
     void VisitCXXNamedCastExpr(const CXXNamedCastExpr *Node);
@@ -1963,6 +1964,12 @@ void ASTDumper::VisitCastExpr(const CastExpr *Node) {
   }
   dumpBasePath(OS, Node);
   OS << ">";
+  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+    dumpChild([=] {
+      OS << "Inferred Bounds";
+      dumpStmt(Bounds);
+    });
+  }
 }
 
 void ASTDumper::VisitDeclRefExpr(const DeclRefExpr *Node) {
@@ -2055,6 +2062,12 @@ void ASTDumper::VisitUnaryOperator(const UnaryOperator *Node) {
   VisitExpr(Node);
   OS << " " << (Node->isPostfix() ? "postfix" : "prefix")
      << " '" << UnaryOperator::getOpcodeStr(Node->getOpcode()) << "'";
+  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+    dumpChild([=] {
+      OS << "Inferred Bounds";
+      dumpStmt(Bounds);
+    });
+  }
 }
 
 void ASTDumper::VisitUnaryExprOrTypeTraitExpr(
@@ -2082,6 +2095,12 @@ void ASTDumper::VisitMemberExpr(const MemberExpr *Node) {
   VisitExpr(Node);
   OS << " " << (Node->isArrow() ? "->" : ".") << *Node->getMemberDecl();
   dumpPointer(Node->getMemberDecl());
+  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+    dumpChild([=] {
+      OS << "Inferred Bounds";
+      dumpStmt(Bounds);
+    });
+  }
 }
 
 void ASTDumper::VisitExtVectorElementExpr(const ExtVectorElementExpr *Node) {
@@ -2092,6 +2111,12 @@ void ASTDumper::VisitExtVectorElementExpr(const ExtVectorElementExpr *Node) {
 void ASTDumper::VisitBinaryOperator(const BinaryOperator *Node) {
   VisitExpr(Node);
   OS << " '" << BinaryOperator::getOpcodeStr(Node->getOpcode()) << "'";
+  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+    dumpChild([=] {
+      OS << "Inferred Bounds";
+      dumpStmt(Bounds);
+    });
+  }
 }
 
 void ASTDumper::VisitCompoundAssignOperator(
@@ -2114,6 +2139,16 @@ void ASTDumper::VisitOpaqueValueExpr(const OpaqueValueExpr *Node) {
 
   if (Expr *Source = Node->getSourceExpr())
     dumpStmt(Source);
+}
+
+void ASTDumper::VisitArraySubscriptExpr(const ArraySubscriptExpr *Node) {
+  VisitExpr(Node);
+  if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
+    dumpChild([=] {
+      OS << "Inferred Bounds";
+      dumpStmt(Bounds);
+    });
+  }
 }
 
 // GNU extensions.

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -550,6 +550,10 @@ void ASTStmtReader::VisitUnaryOperator(UnaryOperator *E) {
   E->setSubExpr(Reader.ReadSubExpr());
   E->setOpcode((UnaryOperator::Opcode)Record[Idx++]);
   E->setOperatorLoc(ReadSourceLocation(Record, Idx));
+  bool hasBoundsExpr = Record[Idx++];
+  if (hasBoundsExpr) {
+    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  }
 }
 
 void ASTStmtReader::VisitOffsetOfExpr(OffsetOfExpr *E) {
@@ -612,6 +616,10 @@ void ASTStmtReader::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   E->setLHS(Reader.ReadSubExpr());
   E->setRHS(Reader.ReadSubExpr());
   E->setRBracketLoc(ReadSourceLocation(Record, Idx));
+  bool hasBoundsExpr = Record[Idx++];
+  if (hasBoundsExpr) {
+    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  }
 }
 
 void ASTStmtReader::VisitOMPArraySectionExpr(OMPArraySectionExpr *E) {
@@ -670,6 +678,10 @@ void ASTStmtReader::VisitCastExpr(CastExpr *E) {
   assert(NumBaseSpecs == E->path_size());
   E->setSubExpr(Reader.ReadSubExpr());
   E->setCastKind((CastKind)Record[Idx++]);
+  bool hasBoundsExpr = Record[Idx++];
+  if (hasBoundsExpr) {
+    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  }
   CastExpr::path_iterator BaseI = E->path_begin();
   while (NumBaseSpecs--) {
     CXXBaseSpecifier *BaseSpec = new (Reader.getContext()) CXXBaseSpecifier;
@@ -685,6 +697,10 @@ void ASTStmtReader::VisitBinaryOperator(BinaryOperator *E) {
   E->setOpcode((BinaryOperator::Opcode)Record[Idx++]);
   E->setOperatorLoc(ReadSourceLocation(Record, Idx));
   E->setFPContractable((bool)Record[Idx++]);
+  bool hasBoundsExpr = Record[Idx++];
+  if (hasBoundsExpr) {
+    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  }
 }
 
 void ASTStmtReader::VisitCompoundAssignOperator(CompoundAssignOperator *E) {
@@ -3197,6 +3213,12 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       bool IsArrow = Record[Idx++];
       SourceLocation OperatorLoc = ReadSourceLocation(F, Record, Idx);
 
+      bool HadBoundsExpr = Record[Idx++];
+      BoundsExpr *Bounds = nullptr;
+      if (HadBoundsExpr) {
+        Bounds = ReadBoundsExpr(F);
+      }
+
       S = MemberExpr::Create(Context, Base, IsArrow, OperatorLoc, QualifierLoc,
                              TemplateKWLoc, MemberD, FoundDecl, MemberNameInfo,
                              HasTemplateKWAndArgsInfo ? &ArgInfo : nullptr, T,
@@ -3205,6 +3227,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
                              MemberD->getDeclName(), Record, Idx);
       if (HadMultipleCandidates)
         cast<MemberExpr>(S)->setHadMultipleCandidates(true);
+      if (HadBoundsExpr)
+        cast<MemberExpr>(S)->setBoundsExpr(Bounds);
       break;
     }
 

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -550,9 +550,9 @@ void ASTStmtReader::VisitUnaryOperator(UnaryOperator *E) {
   E->setSubExpr(Reader.ReadSubExpr());
   E->setOpcode((UnaryOperator::Opcode)Record[Idx++]);
   E->setOperatorLoc(ReadSourceLocation(Record, Idx));
-  bool hasBoundsExpr = Record[Idx++];
-  if (hasBoundsExpr) {
-    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  bool hasInferredBoundsExpr = Record[Idx++];
+  if (hasInferredBoundsExpr) {
+    E->setInferredBoundsExpr(Reader.ReadBoundsExpr(F));
   }
 }
 
@@ -616,9 +616,9 @@ void ASTStmtReader::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   E->setLHS(Reader.ReadSubExpr());
   E->setRHS(Reader.ReadSubExpr());
   E->setRBracketLoc(ReadSourceLocation(Record, Idx));
-  bool hasBoundsExpr = Record[Idx++];
-  if (hasBoundsExpr) {
-    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  bool hasInferredBoundsExpr = Record[Idx++];
+  if (hasInferredBoundsExpr) {
+    E->setInferredBoundsExpr(Reader.ReadBoundsExpr(F));
   }
 }
 
@@ -678,9 +678,9 @@ void ASTStmtReader::VisitCastExpr(CastExpr *E) {
   assert(NumBaseSpecs == E->path_size());
   E->setSubExpr(Reader.ReadSubExpr());
   E->setCastKind((CastKind)Record[Idx++]);
-  bool hasBoundsExpr = Record[Idx++];
-  if (hasBoundsExpr) {
-    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  bool hasInferredBoundsExpr = Record[Idx++];
+  if (hasInferredBoundsExpr) {
+    E->setInferredBoundsExpr(Reader.ReadBoundsExpr(F));
   }
   CastExpr::path_iterator BaseI = E->path_begin();
   while (NumBaseSpecs--) {
@@ -697,9 +697,9 @@ void ASTStmtReader::VisitBinaryOperator(BinaryOperator *E) {
   E->setOpcode((BinaryOperator::Opcode)Record[Idx++]);
   E->setOperatorLoc(ReadSourceLocation(Record, Idx));
   E->setFPContractable((bool)Record[Idx++]);
-  bool hasBoundsExpr = Record[Idx++];
-  if (hasBoundsExpr) {
-    E->setBoundsExpr(Reader.ReadBoundsExpr(F));
+  bool hasInferredBoundsExpr = Record[Idx++];
+  if (hasInferredBoundsExpr) {
+    E->setInferredBoundsExpr(Reader.ReadBoundsExpr(F));
   }
 }
 
@@ -3213,10 +3213,10 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       bool IsArrow = Record[Idx++];
       SourceLocation OperatorLoc = ReadSourceLocation(F, Record, Idx);
 
-      bool HadBoundsExpr = Record[Idx++];
-      BoundsExpr *Bounds = nullptr;
-      if (HadBoundsExpr) {
-        Bounds = ReadBoundsExpr(F);
+      bool HadInferredBoundsExpr = Record[Idx++];
+      BoundsExpr *InferredBounds = nullptr;
+      if (HadInferredBoundsExpr) {
+        InferredBounds = ReadBoundsExpr(F);
       }
 
       S = MemberExpr::Create(Context, Base, IsArrow, OperatorLoc, QualifierLoc,
@@ -3227,8 +3227,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
                              MemberD->getDeclName(), Record, Idx);
       if (HadMultipleCandidates)
         cast<MemberExpr>(S)->setHadMultipleCandidates(true);
-      if (HadBoundsExpr)
-        cast<MemberExpr>(S)->setBoundsExpr(Bounds);
+      if (HadInferredBoundsExpr)
+        cast<MemberExpr>(S)->setInferredBoundsExpr(InferredBounds);
       break;
     }
 

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -2124,7 +2124,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   // CastExpr
   Abv->Add(BitCodeAbbrevOp(0)); // PathSize
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 6)); // CastKind
-  Abv->Add(BitCodeAbbrevOp(0)); // hasBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0)); // hasInferredBoundsExpr
   // ImplicitCastExpr
   ExprImplicitCastAbbrev = Stream.EmitAbbrev(Abv);
 

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -2124,6 +2124,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   // CastExpr
   Abv->Add(BitCodeAbbrevOp(0)); // PathSize
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 6)); // CastKind
+  Abv->Add(BitCodeAbbrevOp(0)); // hasBoundsExpr
   // ImplicitCastExpr
   ExprImplicitCastAbbrev = Stream.EmitAbbrev(Abv);
 

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -485,9 +485,9 @@ void ASTStmtWriter::VisitUnaryOperator(UnaryOperator *E) {
   Record.AddStmt(E->getSubExpr());
   Record.push_back(E->getOpcode()); // FIXME: stable encoding
   Record.AddSourceLocation(E->getOperatorLoc());
-  Record.push_back(E->hasBoundsExpr());
-  if (E->hasBoundsExpr()) {
-    Record.AddStmt(E->getBoundsExpr());
+  Record.push_back(E->hasInferredBoundsExpr());
+  if (E->hasInferredBoundsExpr()) {
+    Record.AddStmt(E->getInferredBoundsExpr());
   }
   Code = serialization::EXPR_UNARY_OPERATOR;
 }
@@ -546,9 +546,9 @@ void ASTStmtWriter::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   Record.AddStmt(E->getLHS());
   Record.AddStmt(E->getRHS());
   Record.AddSourceLocation(E->getRBracketLoc());
-  Record.push_back(E->hasBoundsExpr());
-  if (E->hasBoundsExpr()) {
-    Record.AddStmt(E->getBoundsExpr());
+  Record.push_back(E->hasInferredBoundsExpr());
+  if (E->hasInferredBoundsExpr()) {
+    Record.AddStmt(E->getInferredBoundsExpr());
   }
   Code = serialization::EXPR_ARRAY_SUBSCRIPT;
 }
@@ -606,9 +606,9 @@ void ASTStmtWriter::VisitMemberExpr(MemberExpr *E) {
   Record.AddSourceLocation(E->getMemberLoc());
   Record.push_back(E->isArrow());
   Record.AddSourceLocation(E->getOperatorLoc());
-  Record.push_back(E->hasBoundsExpr());
-  if (E->hasBoundsExpr()) {
-    Record.AddStmt(E->getBoundsExpr());
+  Record.push_back(E->hasInferredBoundsExpr());
+  if (E->hasInferredBoundsExpr()) {
+    Record.AddStmt(E->getInferredBoundsExpr());
   }
   Record.AddDeclarationNameLoc(E->MemberDNLoc,
                                E->getMemberDecl()->getDeclName());
@@ -645,9 +645,9 @@ void ASTStmtWriter::VisitCastExpr(CastExpr *E) {
   Record.push_back(E->path_size());
   Record.AddStmt(E->getSubExpr());
   Record.push_back(E->getCastKind()); // FIXME: stable encoding
-  Record.push_back(E->hasBoundsExpr());
-  if (E->hasBoundsExpr()) {
-    Record.AddStmt(E->getBoundsExpr());
+  Record.push_back(E->hasInferredBoundsExpr());
+  if (E->hasInferredBoundsExpr()) {
+    Record.AddStmt(E->getInferredBoundsExpr());
   }
 
   for (CastExpr::path_iterator
@@ -662,9 +662,9 @@ void ASTStmtWriter::VisitBinaryOperator(BinaryOperator *E) {
   Record.push_back(E->getOpcode()); // FIXME: stable encoding
   Record.AddSourceLocation(E->getOperatorLoc());
   Record.push_back(E->isFPContractable());
-  Record.push_back(E->hasBoundsExpr());
-  if (E->hasBoundsExpr()) {
-    Record.AddStmt(E->getBoundsExpr());
+  Record.push_back(E->hasInferredBoundsExpr());
+  if (E->hasInferredBoundsExpr()) {
+    Record.AddStmt(E->getInferredBoundsExpr());
   }
   Code = serialization::EXPR_BINARY_OPERATOR;
 }
@@ -702,7 +702,7 @@ ASTStmtWriter::VisitBinaryConditionalOperator(BinaryConditionalOperator *E) {
 void ASTStmtWriter::VisitImplicitCastExpr(ImplicitCastExpr *E) {
   VisitCastExpr(E);
 
-  if (E->path_size() == 0 && !E->hasBoundsExpr())
+  if (E->path_size() == 0 && !E->hasInferredBoundsExpr())
     AbbrevToUse = Writer.getExprImplicitCastAbbrev();
 
   Code = serialization::EXPR_IMPLICIT_CAST;

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -485,6 +485,10 @@ void ASTStmtWriter::VisitUnaryOperator(UnaryOperator *E) {
   Record.AddStmt(E->getSubExpr());
   Record.push_back(E->getOpcode()); // FIXME: stable encoding
   Record.AddSourceLocation(E->getOperatorLoc());
+  Record.push_back(E->hasBoundsExpr());
+  if (E->hasBoundsExpr()) {
+    Record.AddStmt(E->getBoundsExpr());
+  }
   Code = serialization::EXPR_UNARY_OPERATOR;
 }
 
@@ -542,6 +546,10 @@ void ASTStmtWriter::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   Record.AddStmt(E->getLHS());
   Record.AddStmt(E->getRHS());
   Record.AddSourceLocation(E->getRBracketLoc());
+  Record.push_back(E->hasBoundsExpr());
+  if (E->hasBoundsExpr()) {
+    Record.AddStmt(E->getBoundsExpr());
+  }
   Code = serialization::EXPR_ARRAY_SUBSCRIPT;
 }
 
@@ -598,6 +606,10 @@ void ASTStmtWriter::VisitMemberExpr(MemberExpr *E) {
   Record.AddSourceLocation(E->getMemberLoc());
   Record.push_back(E->isArrow());
   Record.AddSourceLocation(E->getOperatorLoc());
+  Record.push_back(E->hasBoundsExpr());
+  if (E->hasBoundsExpr()) {
+    Record.AddStmt(E->getBoundsExpr());
+  }
   Record.AddDeclarationNameLoc(E->MemberDNLoc,
                                E->getMemberDecl()->getDeclName());
   Code = serialization::EXPR_MEMBER;
@@ -633,6 +645,10 @@ void ASTStmtWriter::VisitCastExpr(CastExpr *E) {
   Record.push_back(E->path_size());
   Record.AddStmt(E->getSubExpr());
   Record.push_back(E->getCastKind()); // FIXME: stable encoding
+  Record.push_back(E->hasBoundsExpr());
+  if (E->hasBoundsExpr()) {
+    Record.AddStmt(E->getBoundsExpr());
+  }
 
   for (CastExpr::path_iterator
          PI = E->path_begin(), PE = E->path_end(); PI != PE; ++PI)
@@ -646,6 +662,10 @@ void ASTStmtWriter::VisitBinaryOperator(BinaryOperator *E) {
   Record.push_back(E->getOpcode()); // FIXME: stable encoding
   Record.AddSourceLocation(E->getOperatorLoc());
   Record.push_back(E->isFPContractable());
+  Record.push_back(E->hasBoundsExpr());
+  if (E->hasBoundsExpr()) {
+    Record.AddStmt(E->getBoundsExpr());
+  }
   Code = serialization::EXPR_BINARY_OPERATOR;
 }
 
@@ -682,7 +702,7 @@ ASTStmtWriter::VisitBinaryConditionalOperator(BinaryConditionalOperator *E) {
 void ASTStmtWriter::VisitImplicitCastExpr(ImplicitCastExpr *E) {
   VisitCastExpr(E);
 
-  if (E->path_size() == 0)
+  if (E->path_size() == 0 && !E->hasBoundsExpr())
     AbbrevToUse = Writer.getExprImplicitCastAbbrev();
 
   Code = serialization::EXPR_IMPLICIT_CAST;


### PR DESCRIPTION
Semantic analysis will infer bounds for us to check various statements
against. We need to store these bounds on the statements so we keep them
after analysis for code generation.

Implicit casts have an abbrev, which I have updated and disabled if a bounds expression is present on the cast. 

We add bounds expressions to the following expressions
- Unary Operators, for Deref, and Inc/Decrements
- Implict Casts, for LValueToRValue casts
- Array Subscript exprs
- Member expressions (field access)
- Binary Operators, for Assign, and Compound Assignment

For deref, casts, array subscript, and member expressions, the bounds we save are for checking the pointers against at read-time. The bounds saved in the assignment operator are for checking the bounds of the pointer in the lvalue we're assigning into. In the case of increment/decrement, and compound assignment, these bounds are checked at both read and write time of the pointer in the lvalue (or, are effectively, I believe we actually only have to check the lvalue read is in bounds, because the write is definitely in bounds if the read is)