### PR TITLE
Check additional expressions for valid bounds.

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4270,10 +4270,9 @@ public:
   BoundsExpr *ConcretizeFromFunctionType(BoundsExpr *Expr,
                                          ArrayRef<ParmVarDecl *> Params);
 
-  /// LValueDerivedFromArrayPtr - determine if an lvalue is derived from
-  /// an _Array_ptr value and needs a bounds a bounds check when it is
-  /// read or written
-  bool LValueDerivedFromArrayPtr(Expr *E);
+  /// LValueIsArrayPtrDereference - determine if an lvalue expression is
+  /// a dereference of an Array_ptr (via '*" or an array subscript operator).
+  bool LValueIsArrayPtrDereference(Expr *E);
 
   /// InferLValueBounds - infer a bounds expression for an lvalue.
   /// The bounds determine whether the lvalue to which an

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4254,6 +4254,7 @@ public:
   ExprResult CreateBoundsInteropType(SourceLocation TypeKWLoc,
                                      TypeSourceInfo *TInfo,
                                      SourceLocation RParenLoc);
+
   ExprResult CreatePositionalParameterExpr(unsigned Index, QualType QT);
 
   bool DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
@@ -4262,11 +4263,17 @@ public:
 
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
   BoundsExpr *CreateInvalidBoundsExpr();
+  BoundsExpr *CreateCountForArrayType(QualType QT);
 
   BoundsExpr *AbstractForFunctionType(BoundsExpr *Expr,
                                       ArrayRef<DeclaratorChunk::ParamInfo> Params);
   BoundsExpr *ConcretizeFromFunctionType(BoundsExpr *Expr,
                                          ArrayRef<ParmVarDecl *> Params);
+
+  /// LValueDerivedFromArrayPtr - determine if an lvalue is derived from
+  /// an _Array_ptr value and needs a bounds a bounds check when it is
+  /// read or written
+  bool LValueDerivedFromArrayPtr(Expr *E);
 
   /// InferLValueBounds - infer a bounds expression for an lvalue.
   /// The bounds determine whether the lvalue to which an

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -205,6 +205,17 @@ namespace {
                                              SourceLocation());
     }
 
+    BoundsExpr *CreateSingleElementBounds(Expr *LowerBounds) {
+      assert(LowerBounds->isRValue());
+      // Create an unsigned integer 1
+      IntegerLiteral *One =
+        CreateIntegerLiteral(llvm::APInt(1, 1, /*isSigned=*/false));
+      CountBoundsExpr CBE = CountBoundsExpr(BoundsExpr::Kind::ElementCount,
+                                            One, SourceLocation(),
+                                            SourceLocation());
+      return ExpandToRange(LowerBounds, &CBE);
+    }
+
     Expr *CreateImplicitCast(QualType Target, CastKind CK, Expr *E) {
       return ImplicitCastExpr::Create(Context, Target, CK, E, nullptr,
                                        ExprValueKind::VK_RValue);
@@ -234,6 +245,24 @@ namespace {
       return Lit;
     }
 
+  public:
+    // Given an array type with constant dimension size, produce a count
+    // expression with that size.
+    BoundsExpr *CreateBoundsForArrayType(QualType QT) {
+      const ConstantArrayType *CAT = Context.getAsConstantArrayType(QT);
+      if (!CAT)
+        return CreateBoundsNone();
+
+      IntegerLiteral *Size = CreateIntegerLiteral(CAT->getSize());
+
+      CountBoundsExpr *CBE =
+         new (Context) CountBoundsExpr(BoundsExpr::Kind::ElementCount,
+                                       Size, SourceLocation(),
+                                       SourceLocation());
+      return CBE;
+    }
+
+  private:
     // Given a byte_count or count bounds expression for the expression Base,
     // expand it to a range bounds expression:
     //  E : Count(C) expands to Bounds(E, E + C)
@@ -289,23 +318,18 @@ namespace {
 
     // Compute bounds for a variable with an array type.
     BoundsExpr *ArrayVariableBounds(DeclRefExpr *DR) {
-      QualType QT = DR->getType();
-      const ConstantArrayType *CAT = Context.getAsConstantArrayType(QT);
-      if (!CAT)
-        return CreateBoundsNone();
-
       VarDecl *D = dyn_cast<VarDecl>(DR->getDecl());
       if (!D)
         return CreateBoundsNone();
 
-      IntegerLiteral *Size = CreateIntegerLiteral(CAT->getSize());
-      Expr *Base = CreateImplicitCast(Context.getDecayedType(QT),
+      BoundsExpr *BE = CreateBoundsForArrayType(D->getType());
+      if (BE->isNone())
+        return BE;
+
+      Expr *Base = CreateImplicitCast(Context.getDecayedType(D->getType()),
                                       CastKind::CK_ArrayToPointerDecay,
                                       DR);
-      CountBoundsExpr CBE = CountBoundsExpr(BoundsExpr::Kind::ElementCount,
-                                            Size, SourceLocation(),
-                                            SourceLocation());
-      return ExpandToRange(Base, &CBE);
+      return ExpandToRange(Base, BE);
     }
 
     // Infer bounds for an lvalue.  The bounds determine whether
@@ -330,14 +354,8 @@ namespace {
         if (DR->getType()->isFunctionType())
           return CreateBoundsNone();
 
-        // Create an unsigned integer 1
-        IntegerLiteral *One =
-          CreateIntegerLiteral(llvm::APInt(1, 1, /*isSigned=*/false));
         Expr *AddrOf = CreateAddressOfOperator(DR);
-        CountBoundsExpr CBE = CountBoundsExpr(BoundsExpr::Kind::ElementCount,
-                                              One, SourceLocation(),
-                                              SourceLocation());
-        return ExpandToRange(AddrOf, &CBE);
+        return CreateSingleElementBounds(AddrOf);
       }
       case Expr::UnaryOperatorClass: {
         UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
@@ -374,12 +392,25 @@ namespace {
     }
 
     // Compute bounds for the target of an lvalue.  Values assigned through
-    // the lvalue must meet satisfy these bounds.   Values read through the
+    // the lvalue must satisfy these bounds.   Values read through the
     // lvalue will meet these bounds.
     BoundsExpr *LValueTargetBounds(Expr *E) {
       assert(E->isLValue());
       // TODO: handle side effects within E
       E = E->IgnoreParens();
+      QualType QT = E->getType();
+
+      // If the target value v is a Ptr type, it has no required bounds
+      // if it is a function pointer type.  Otherwise it has bounds(v, v + 1);
+      if (QT->isCheckedPointerPtrType()) {
+         if (QT->isFunctionPointerType())
+           return CreateBoundsNone();
+
+        Expr *Base = CreateImplicitCast(E->getType(),
+                                        CastKind::CK_LValueToRValue, E);
+        return CreateSingleElementBounds(Base);
+      }
+
       switch (E->getStmtClass()) {
         case Expr::DeclRefExprClass: {
           DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
@@ -395,8 +426,7 @@ namespace {
           if (!B || B->isNone())
             return CreateBoundsNone();
 
-           Expr *Base = CreateImplicitCast(E->getType(),
-                                           CastKind::CK_LValueToRValue, E);
+           Expr *Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, E);
            return ExpandToRange(Base, B);
         }
         case Expr::MemberExprClass: {
@@ -414,8 +444,7 @@ namespace {
           if (!B || B->isNone())
             return CreateBoundsNone();
 
-          Expr *Base = CreateImplicitCast(E->getType(),
-                                          CastKind::CK_LValueToRValue, E);
+          Expr *Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, E);
           return ExpandToRange(Base, B);
         }
         default:
@@ -491,8 +520,13 @@ namespace {
             return CreateBoundsNone();
           }
           switch (UO->getOpcode()) {
-            case UnaryOperatorKind::UO_AddrOf:
-              return LValueBounds(UO->getSubExpr());
+            case UnaryOperatorKind::UO_AddrOf: {
+              Expr *SubExpr = UO->getSubExpr();
+              if (SubExpr->getType()->isFunctionType())
+                return CreateBoundsNone();
+
+              return LValueBounds(SubExpr);
+            }
             default:
               // TODO: fill in other cases
               return CreateBoundsNone();
@@ -512,6 +546,66 @@ namespace {
   };
 }
 
+bool Sema::LValueDerivedFromArrayPtr(Expr *E) {
+  while (1) {
+    assert(E->isLValue());
+    E = E->IgnoreParens();
+    switch (E->getStmtClass()) {
+      case Expr::DeclRefExprClass:
+        return E->getType()->isCheckedArrayType();
+      case Expr::UnaryOperatorClass: {
+        UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
+        if (!UO) {
+          assert("unexpected cast failure");
+          return false;
+        }
+        return (UO->getOpcode() == UnaryOperatorKind::UO_Deref &&
+                UO->getSubExpr()->getType()->isCheckedPointerArrayType());
+      }
+      case Expr::ArraySubscriptExprClass: {
+        // e1[e2] is a synonym for *(e1 + e2).  The expression is derived from
+        // _Array_ptr type if whichever subexpression has a pointer type has an
+        // _Array_ptr type.
+
+        ArraySubscriptExpr *AS = dyn_cast<ArraySubscriptExpr>(E);
+        if (!AS) {
+          assert("unexpected cast failure");
+          return false;
+        }
+        // An important invariant for array types in Checked C is that all
+        // dimensions of multi-dimensional array are either checked or
+        // unchecked.  This ensures that the intermediate values for
+        // multi-dimensional array accesses have checked type and preserve
+        //  the "checkedness" of the outermost array.  In practical terms,
+        // we only need to look at the type.
+
+        // getBase returns the pointer-typed expression.
+        return AS->getBase()->getType()->isCheckedPointerArrayType();
+      }
+      case Expr::MemberExprClass: {
+        MemberExpr *ME = dyn_cast<MemberExpr>(E);
+        if (!ME) {
+          assert("unexpected cast failure");
+          return false;
+        }
+        // Two cases: ME->F and ME.F.  ME->F is the same as (*ME).F
+        Expr *Base = ME->getBase();
+        if (ME->isArrow())
+          return Base->getType()->isCheckedPointerArrayType();
+
+        E = Base;
+        continue;
+      }
+      case Expr::CompoundLiteralExprClass:
+        return E->getType()->isCheckedArrayType();
+      default: {
+        llvm_unreachable("unexpected lvalue expression");
+        return false;
+      }
+    }
+  }
+}
+
 BoundsExpr *Sema::InferLValueBounds(ASTContext &Ctx, Expr *E) {
   return BoundsInference(Ctx).LValueBounds(E);
 }
@@ -524,6 +618,10 @@ BoundsExpr *Sema::InferRValueBounds(ASTContext &Ctx, Expr *E) {
   return BoundsInference(Ctx).RValueBounds(E);
 }
 
+BoundsExpr *Sema::CreateCountForArrayType(QualType QT) {
+  return BoundsInference(getASTContext()).CreateBoundsForArrayType(QT);
+}
+
 namespace {
   class CheckBoundsDeclarations :
     public RecursiveASTVisitor<CheckBoundsDeclarations> {
@@ -531,24 +629,63 @@ namespace {
     Sema &S;
     bool DumpBounds;
 
-    void DumpInferredBounds(raw_ostream &OS, BinaryOperator *E,
-                            BoundsExpr *Target, BoundsExpr *B) {
+    void DumpAssignmentBounds(raw_ostream &OS, BinaryOperator *E,
+                            BoundsExpr *LValueBounds,
+                            BoundsExpr *LValueTargetBounds,
+                            BoundsExpr *RHSBounds) {
       OS << "\nAssignment:\n";
       E->dump(OS);
-      OS << "Target Bounds:\n";
-      Target->dump(OS);
-      OS << "RHS Bounds:\n ";
-      B->dump(OS);;
+      if (LValueBounds) {
+        OS << "LValue Bounds:\n";
+        LValueBounds->dump(OS);
+      }
+      if (LValueTargetBounds) {
+        OS << "Target Bounds:\n";
+        LValueTargetBounds->dump(OS);
+      }
+      if (RHSBounds) {
+        OS << "RHS Bounds:\n ";
+        RHSBounds->dump(OS);
+      }
     }
 
-    void DumpInferredBounds(raw_ostream &OS, VarDecl *D,
-                            BoundsExpr *Target, BoundsExpr *B) {
+    void DumpInitializerBounds(raw_ostream &OS, VarDecl *D,
+                               BoundsExpr *Target, BoundsExpr *B) {
       OS << "\nDeclaration:\n";
       D->dump(OS);
       OS << "Declared Bounds:\n";
       Target->dump(OS);
       OS << "Initializer Bounds:\n ";
       B->dump(OS);;
+    }
+
+    void DumpPtrReadBounds(raw_ostream &OS, Expr *E,
+                           BoundsExpr *B) {
+      OS << "\nExpression:\n";
+      E->dump(OS);
+      OS << "Bounds for memory read:\n";
+      B->dump(OS);
+    }
+
+    void DumpPtrCastBounds(raw_ostream &OS, Expr *E,
+                              BoundsExpr *B) {
+      OS << "\nExpression:\n";
+      E->dump(OS);
+      OS << "Ptr cast source bounds:\n";
+      B->dump(OS);
+    }
+
+    // If an lvalue is derived from a checked array ptr,
+    // compute the bounds for the lvalue and return them.
+    // Otherwise return null.
+    BoundsExpr *ValidateLValueBounds(Expr *E) {
+      BoundsExpr *LValueBounds = nullptr;
+      if (S.LValueDerivedFromArrayPtr(E)) {
+        LValueBounds = S.InferLValueBounds(S.getASTContext(), E);
+        if (LValueBounds->isNone())
+          S.Diag(E->getLocStart(), diag::err_expected_bounds);
+      }
+      return LValueBounds;
     }
 
   public:
@@ -559,22 +696,60 @@ namespace {
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
       QualType LHSType = LHS->getType();
-      if (E->getOpcode() == BinaryOperatorKind::BO_Assign &&
-          (LHSType->isCheckedPointerType() ||
-           LHSType->isIntegralOrEnumerationType())) {
-        BoundsExpr *LHSTargetBounds =
+      if (!E->isAssignmentOp())
+        return true;
+
+      // Bounds of the lvalue that is being assigned to
+      BoundsExpr *LValueBounds = nullptr;
+      // Bounds of the target of the lvalue
+      BoundsExpr *LHSTargetBounds = nullptr;
+      // Bounds of the right-hand side of the assignment
+      BoundsExpr *RHSBounds = nullptr;
+
+      if (LHSType->isCheckedPointerType() ||
+          LHSType->isIntegralOrEnumerationType()) {
+        LHSTargetBounds =
           S.InferLValueTargetBounds(S.getASTContext(), LHS);
         if (!LHSTargetBounds->isNone()) {
-          BoundsExpr *RHSBounds = S.InferRValueBounds(S.getASTContext(), RHS);
+          RHSBounds = S.InferRValueBounds(S.getASTContext(), RHS);
           if (RHSBounds->isNone())
-             S.Diag(LHS->getLocStart(), diag::err_expected_bounds);
-          if (DumpBounds)
-            DumpInferredBounds(llvm::outs(), E, LHSTargetBounds, RHSBounds);
+             S.Diag(RHS->getLocStart(), diag::err_expected_bounds);
+
         }
       }
+      LValueBounds = ValidateLValueBounds(LHS);
+      if (DumpBounds && (LValueBounds || LHSTargetBounds || RHSBounds))
+        DumpAssignmentBounds(llvm::outs(), E, LValueBounds, LHSTargetBounds, RHSBounds);
       return true;
     }
 
+    // This includes both ImplicitCastExprs and CStyleCastExprs
+    bool VisitCastExpr(CastExpr *E) {
+      CheckDisallowedFunctionPtrCasts(E);
+
+      CastKind CK = E->getCastKind();
+      if (CK == CK_LValueToRValue && !E->getType()->isArrayType()) {
+        BoundsExpr *B = ValidateLValueBounds(E->getSubExpr());
+        if (DumpBounds && B)
+          DumpPtrReadBounds(llvm::outs(), E, B);
+        return true;
+      }
+
+      // Casts to _Ptr type must have a source for which we can infer bounds.
+      if ((CK == CK_BitCast && CK == CK_IntegralToPointer) &&
+          E->getType()->isCheckedPointerPtrType()) {
+        BoundsExpr *SrcBounds =
+          S.InferRValueBounds(S.getASTContext(), E->getSubExpr());
+        if (SrcBounds->isNone())
+          // TODO: produce more informative error message.
+          S.Diag(E->getSubExpr()->getLocStart(), diag::err_expected_bounds);
+
+        if (DumpBounds)
+          DumpPtrCastBounds(llvm::outs(), E, SrcBounds);
+        return true;
+      }
+      return true;
+    }
     bool VisitVarDecl(VarDecl *D) {
       if (D->isInvalidDecl())
         return true;
@@ -616,7 +791,7 @@ namespace {
         if (InitBounds->isNone())
           S.Diag(Init->getLocStart(), diag::err_expected_bounds);
         if (DumpBounds)
-          DumpInferredBounds(llvm::outs(), D, DeclaredBounds, InitBounds);
+          DumpInitializerBounds(llvm::outs(), D, DeclaredBounds, InitBounds);
         // TODO: check that it meets the bounds requirements for the variable.
       }
       else {
@@ -629,13 +804,6 @@ namespace {
         // value for bounds, if there is no initializer.  See the prior comment
         // for isCheckedPointerPtrType.
       }
-
-      return true;
-    }
-
-    // This includes both ImplicitCastExprs and CStyleCastExprs
-    bool VisitCastExpr(CastExpr *E) {
-      CheckDisallowedFunctionPtrCasts(E);
 
       return true;
     }

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11481,6 +11481,9 @@ ParmVarDecl *Sema::CheckParameter(DeclContext *DC, SourceLocation StartLoc,
   ParmVarDecl *New = ParmVarDecl::Create(Context, DC, StartLoc, NameLoc, Name,
                                          Context.getAdjustedParameterType(T),
                                          TSInfo, SC, nullptr);
+  if (T->isCheckedArrayType()) {
+     New->setBoundsExpr(CreateCountForArrayType(T));
+  }
 
   // Parameters can not be abstract class types.
   // For record types, this is done by the AbstractClassUsageDiagnoser once

--- a/test/CheckedC/ast-dump-bounds.c
+++ b/test/CheckedC/ast-dump-bounds.c
@@ -143,6 +143,19 @@ void f14(int arr1 _Checked[] : count(5));
 // CHECK-NEXT: IntegerLiteral
 // CHECK 'int' 5
 
+// Parameters with checked array type have a bounds expression implicitly
+// created for them when they are retyped as a pointer type.
+void f15(int arr1 _Checked[6]);
+
+// CHECK: FunctionDecl
+// CHECK: f15
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+// CHECK-NEXT: IntegerLiteral
+// CHECK 'int' 6
+
 //===================================================================
 // Dumps of different kinds of bounds expressions on function returns
 //===================================================================

--- a/test/CheckedC/ast-dump-bounds.c
+++ b/test/CheckedC/ast-dump-bounds.c
@@ -156,6 +156,19 @@ void f15(int arr1 _Checked[6]);
 // CHECK-NEXT: IntegerLiteral
 // CHECK 'int' 6
 
+// However, any bounds declared by the programmer override a bounds implicitly
+// created based on the first dimension size.
+void f16(int arr1 _Checked[6] : count(3));
+
+// CHECK: FunctionDecl
+// CHECK: f16
+// CHECK-NEXT: ParmVarDecl
+// CHECK: arr1 '_Array_ptr<int>'
+// CHECK-NEXT: CountBoundsExpr
+// CHECK: Element
+// CHECK-NEXT: IntegerLiteral
+// CHECK 'int' 3
+
 //===================================================================
 // Dumps of different kinds of bounds expressions on function returns
 //===================================================================

--- a/test/CheckedC/inferred-bounds-basic.c
+++ b/test/CheckedC/inferred-bounds-basic.c
@@ -1,5 +1,10 @@
 // Tests of inferred bounds for expressions in assignments and declarations.
-// The goal is to check that the bounds are being inferred correctly.  
+// The goal is to check that the bounds are being inferred correctly.  This
+// file covers:
+// - Assignments to variables with _Array_ptr and declarations of
+//   variables of pointer type,
+// - where the right-hand side or intializing expression is an integer,
+//    variable, or address-of expression.
 //
 // The tests have the general form:
 // 1. Some C code.

--- a/test/CheckedC/inferred-bounds-ptr-reads.c
+++ b/test/CheckedC/inferred-bounds-ptr-reads.c
@@ -1,7 +1,5 @@
-// Tests of inferred bounds for expressions in assignments and declarations.
-// The goal is to check that the bounds are being inferred correctly.  This
-// file covers:
-// - Reads of memory through checked pointers, including checked arrays.
+// Tests of inferred bounds for reads though pointers.  The goal is to check
+// that the bounds are being inferred correctly.
 //
 // The tests have the general form:
 // 1. Some C code.
@@ -15,26 +13,157 @@
 // expected-no-diagnostics
 
 //-------------------------------------------------------------------------//
-// Test assignment of integers to _Array_ptr variables.  This covers both  //
-// 0 (NULL) and non-zero integers (the results of casts).                  //
+// Test assignment through a pointer passed as parameter.                  //
 //-------------------------------------------------------------------------//
 
 int f1(_Array_ptr<int> a : bounds(a, a + 5)) {
   int x = *a;
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int' lvalue prefix '*'
+// CHECK:  `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
   int y = a[3];
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
   return x + y;
 }
+
+//-------------------------------------------------------------------------//
+// Test reading an element of a single-dimensional local array             //
+//-------------------------------------------------------------------------//
 
 int f2(void) {
   int arr _Checked[6] = { 0, 1, 2, 3, 4 };
   int x = *arr;
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int' lvalue prefix '*'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
+
   int y = arr[2];
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
+
   return x + y;
 }
+
+//--------------------------------------------------------------------------//
+// Test readomg an element of a single-dimensional array passed as a        //
+// parameter                                                                //
+//--------------------------------------------------------------------------//
 
 int f3(int b _Checked[7]) {
   int x = *b;
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int' lvalue prefix '*'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 7
+
   int y = b[3];
-  return x + y;
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 7
+
+   return x + y;
 }
 
+//--------------------------------------------------------------------------//
+// Test reading an element of a multi-dimensional array passed as a         //
+// parameter                                                                //
+//--------------------------------------------------------------------------//
+
+int f4(int arr _Checked[][10] : count(len), int i, int j, int len) {
+  int x = arr[i++][j];
+  return x;
+}
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int checked[10]' lvalue
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: |   `-UnaryOperator {{0x[0-9a-f]+}} 'int' postfix '++'
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'

--- a/test/CheckedC/inferred-bounds-ptr-reads.c
+++ b/test/CheckedC/inferred-bounds-ptr-reads.c
@@ -1,0 +1,40 @@
+// Tests of inferred bounds for expressions in assignments and declarations.
+// The goal is to check that the bounds are being inferred correctly.  This
+// file covers:
+// - Reads of memory through checked pointers, including checked arrays.
+//
+// The tests have the general form:
+// 1. Some C code.
+// 2. A description of the inferred bounds for that C code:
+//  a. The expression
+//  b. The inferred bounds.
+// The description uses AST dumps.
+//
+// This line is for the clang test infrastructure:
+// RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
+// expected-no-diagnostics
+
+//-------------------------------------------------------------------------//
+// Test assignment of integers to _Array_ptr variables.  This covers both  //
+// 0 (NULL) and non-zero integers (the results of casts).                  //
+//-------------------------------------------------------------------------//
+
+int f1(_Array_ptr<int> a : bounds(a, a + 5)) {
+  int x = *a;
+  int y = a[3];
+  return x + y;
+}
+
+int f2(void) {
+  int arr _Checked[6] = { 0, 1, 2, 3, 4 };
+  int x = *arr;
+  int y = arr[2];
+  return x + y;
+}
+
+int f3(int b _Checked[7]) {
+  int x = *b;
+  int y = b[3];
+  return x + y;
+}
+

--- a/test/CheckedC/inferred-bounds-ptr-writes.c
+++ b/test/CheckedC/inferred-bounds-ptr-writes.c
@@ -1,0 +1,200 @@
+// Tests of inferred bounds for writes though pointers.  The goal is to check
+// that the bounds are being inferred correctly.
+//
+// The tests have the general form:
+// 1. Some C code.
+// 2. A description of the inferred bounds for that C code:
+//  a. The expression
+//  b. The inferred bounds.
+// The description uses AST dumps.
+//
+// This line is for the clang test infrastructure:
+// RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
+// expected-no-diagnostics
+
+//-------------------------------------------------------------------------//
+// Test assignment through a pointer passed as parameter.                  //
+//-------------------------------------------------------------------------//
+
+void f1(_Array_ptr<int> a : bounds(a, a + 5)) {
+  *a = 100;
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int' lvalue prefix '*'
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 100
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+
+  a[3] = 101;
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: | |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 101
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+
+}
+
+//-------------------------------------------------------------------------//
+// Test assignment to an element of a single-dimensional local array       //
+//-------------------------------------------------------------------------//
+
+int f2(void) {
+  int arr _Checked[6] = { 0, 1, 2, 3, 4 };
+  *arr = 3;
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int' lvalue prefix '*'
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+
+  arr[2] = 4;
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: | |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 4
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+
+  return arr[2];
+
+// CHECK: Expression:
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: Bounds for memory read:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
+
+}
+
+//--------------------------------------------------------------------------//
+// Test assignment to an element of a single-dimensional array passed as a  //
+// parameter                                                                //
+//--------------------------------------------------------------------------//
+
+void f3(int b _Checked[7]) {
+  *b = 102;
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int' lvalue prefix '*'
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 102
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 7
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+
+  b[3] = 103;
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: | |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 103
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 7
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+
+}
+
+//--------------------------------------------------------------------------//
+// Test assignment to an element of a multi-dimensional array passed as a   //
+// parameter                                                                //
+//--------------------------------------------------------------------------//
+
+void f4(int arg _Checked[10][10]) {
+   arg[5][5] = 314;
+}
+
+// CHECK: Assignment:
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int' '='
+// CHECK: |-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: | |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int checked[10]' lvalue
+// CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
+// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: | |   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 314
+// CHECK: LValue Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 10
+// CHECK: Target Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None


### PR DESCRIPTION
Check that assignments through array_ptrs and reads through array_ptrs use array_ptrs with bounds.
Check that casts to ptr type have sources with bounds.  Also check that member base expressions have bounds if the base expression is a pointer dereference of an array_ptr.

In C, a read through a pointer is done by an lvalue-to-rvalue cast and write through a pointer is done by assignment operation.
 - Add a function that determines if an lvalue is the result of a pointer dereference or array subscript operation involving an array_ptr.
- Use this function to check at an assignment whether a bounds check is needed before writing to the LHS of the assignment.  If it is, check that bounds can be inferred for the LHS lvalue.
- Also use this function at lvalue-to-rvalue casts to check if a bounds check is needed before reading memory.  If it is, check that bounds can be inferred for the lvalue.
- Check at a casts to ptr type that the source expressions has bounds.
- Check that a member base expression has bounds, if the member base expression is a pointer dereference involving an array_ptr.  For member reference expression we plan to bounds check base expressions.  This will ensure that the lvalue produced by the member expression is always in bounds.      - Add code to dump bounds for these new cases.

Clang represents parameters with array types with pointer types.  For parameters with checked array types, implicitly add a bounds expression as part of the retyping, so that bounds checking works out.

Add code that infers bounds for a ptr value by treating it as one element array. Don't infer bounds if the pointee type is a function type,because function types do not have sizes.

Testing:
- Add tests of inference for reads and writes through array_ptr pointers.
- Tests for casts to ptr types and for member base expressions are not written yet.
- Add feature tests to ast-dump-bounds that check that checked array parameters have bounds declarations added, and that the implicit bounds declarations do not override a programmer bounds declaration
- Existing Checked C and clang regression tests pass.  The additional checking found places in Checked C tests where bounds declarations were missing or illegal assignments from unchecked pointers to checked pointers were occurring.  The fixes will be committed separately to the Checked C repo.

