### PR TITLE
Compute rvalue bounds for more expressions.

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -275,7 +275,7 @@ namespace {
         case BoundsExpr::Kind::ElementCount: {
           CountBoundsExpr *BC = dyn_cast<CountBoundsExpr>(B);
           if (!BC) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
           Expr *Count = BC->getCountExpr();
@@ -344,7 +344,7 @@ namespace {
       case Expr::DeclRefExprClass: {
         DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
         if (!DR) {
-          assert("unexpected cast failure");
+          llvm_unreachable("unexpected cast failure");
           return CreateBoundsNone();
         }
 
@@ -360,7 +360,7 @@ namespace {
       case Expr::UnaryOperatorClass: {
         UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
         if (!UO) {
-          assert("unexpected cast failure");
+          llvm_unreachable("unexpected cast failure");
           return CreateBoundsNone();
         }
         if (UO->getOpcode() == UnaryOperatorKind::UO_Deref)
@@ -376,7 +376,7 @@ namespace {
         // of whichever subexpression has pointer type.
         ArraySubscriptExpr *AS = dyn_cast<ArraySubscriptExpr>(E);
         if (!AS) {
-          assert("unexpected cast failure");
+          llvm_unreachable("unexpected cast failure");
           return CreateBoundsNone();
         }
         // getBase returns the pointer-typed expression.
@@ -416,7 +416,7 @@ namespace {
         case Expr::DeclRefExprClass: {
           DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
           if (!DR) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
           VarDecl *D = dyn_cast<VarDecl>(DR->getDecl());
@@ -433,7 +433,7 @@ namespace {
         case Expr::MemberExprClass: {
           MemberExpr *M = dyn_cast<MemberExpr>(E);
           if (!M) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
 
@@ -483,7 +483,7 @@ namespace {
         case Expr::IntegerLiteralClass: {
          IntegerLiteral *Lit = dyn_cast<IntegerLiteral>(E);
          if (!Lit) {
-           assert("unexpected cast failure");
+           llvm_unreachable("unexpected cast failure");
            return CreateBoundsNone();
          }
          if (Lit->getValue() == 0)
@@ -494,7 +494,7 @@ namespace {
         case Expr::DeclRefExprClass: {
           DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
           if (!DR) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
           EnumConstantDecl *ECD = dyn_cast<EnumConstantDecl>(DR->getDecl());
@@ -507,7 +507,7 @@ namespace {
         case Expr::CStyleCastExprClass: {
           CastExpr *CE = dyn_cast<CastExpr>(E);
           if (!E) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
           return RValueCastBounds(CE->getCastKind(), CE->getSubExpr());
@@ -515,7 +515,7 @@ namespace {
         case Expr::UnaryOperatorClass: {
           UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
           if (!UO) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
           UnaryOperatorKind Op = UO->getOpcode();
@@ -525,7 +525,7 @@ namespace {
             if (SubExpr->getType()->isFunctionType())
               return CreateBoundsNone();
 
-              return LValueBounds(SubExpr);
+            return LValueBounds(SubExpr);
           }
 
           if (UnaryOperator::isIncrementDecrementOp(Op))
@@ -541,7 +541,7 @@ namespace {
         case Expr::CompoundAssignOperatorClass: {
           BinaryOperator *BO = dyn_cast<BinaryOperator>(E);
           if (!BO) {
-            assert("unexpected cast failure");
+            llvm_unreachable("unexpected cast failure");
             return CreateBoundsNone();
           }
           Expr *LHS = BO->getLHS();
@@ -564,8 +564,8 @@ namespace {
             return IsCompoundAssignment ?
               LValueTargetBounds(LHS) : RValueBounds(LHS);
           }
-          if (RHS->getType()->isPointerType() &&
-              LHS->getType()->isIntegerType() &&
+          if (LHS->getType()->isIntegerType() &&
+              RHS->getType()->isPointerType() &&
               BinaryOperator::isAdditiveOp(Op)) {
             assert(!IsCompoundAssignment);
             return RValueBounds(RHS);
@@ -611,7 +611,7 @@ bool Sema::LValueIsArrayPtrDereference(Expr *E) {
     case Expr::UnaryOperatorClass: {
       UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
       if (!UO) {
-        assert("unexpected cast failure");
+        llvm_unreachable("unexpected cast failure");
         return false;
       }
       return (UO->getOpcode() == UnaryOperatorKind::UO_Deref &&
@@ -621,7 +621,7 @@ bool Sema::LValueIsArrayPtrDereference(Expr *E) {
       // e1[e2] is a synonym for *(e1 + e2).
       ArraySubscriptExpr *AS = dyn_cast<ArraySubscriptExpr>(E);
       if (!AS) {
-        assert("unexpected cast failure");
+        llvm_unreachable("unexpected cast failure");
         return false;
       }
       // An important invariant for array types in Checked C is that all

--- a/test/CheckedC/inferred-bounds/ptr-arith.c
+++ b/test/CheckedC/inferred-bounds/ptr-arith.c
@@ -1,0 +1,221 @@
+// Tests of inferred bounds for expressions that do pointer arithmetic.
+//
+// The tests have the general form:
+// 1. Some C code.
+// 2. A description of the inferred bounds for that C code:
+//  a. The expression
+//  b. The inferred bounds.
+// The description uses AST dumps.
+//
+// This line is for the clang test infrastructure:
+// RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
+// expected-no-diagnostics
+
+//-------------------------------------------------------------------------//
+// Test post-increment of a pointer that is then dereferenced.             //
+//-------------------------------------------------------------------------//
+
+double f1(_Array_ptr<double> a : bounds(a, a + len), int len) {
+  double sum = 0;
+  _Array_ptr<double> p : bounds(a, a + len) = a;
+  _Array_ptr<double> end = a + len;
+  while (p < end) {
+    sum += *p++;
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' postfix '++'
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+
+  }
+  return sum;
+}
+
+//-------------------------------------------------------------------------//
+// Test post-decrement of a pointer that is then dereferenced.             //
+//-------------------------------------------------------------------------//
+
+double f2(_Array_ptr<double> a : count(2)) {
+  _Array_ptr<double> p : bounds(a, a + 2) = a + 1;
+  return *(p--);
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' postfix '--'
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+}
+
+//-------------------------------------------------------------------------//
+// Test pre-increment of a pointer that is then dereferenced.             //
+//-------------------------------------------------------------------------//
+
+double f3(_Array_ptr<double> a : count(2)) {
+ _Array_ptr<double> p : bounds(a, a + 2) = a;
+ return *(++p);
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' prefix '++'
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+
+}
+
+//-------------------------------------------------------------------------//
+// Test pre-decrement of a pointer that is then dereferenced.              //
+//-------------------------------------------------------------------------//
+
+double f4(_Array_ptr<double> a : count(2)) {
+  _Array_ptr<double> p : bounds(a, a + 2) = a + 1;
+  return *(--p);
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' prefix '--'
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+}
+
+//-------------------------------------------------------------------------//
+// Test pointer addition that is dereferenced.                             //
+//-------------------------------------------------------------------------//
+
+double f5(_Array_ptr<double> a : bounds(a, a + len), int len) {
+  double sum = 0;
+  _Array_ptr<double> p : bounds(a, a + len) = a;
+  for (int i = 0; i < len; i++) 
+    sum += *(p + i);
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK:       |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK:       | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+// CHECK:       `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:         `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue Var {{0x[0-9a-f]+}} 'i' 'int'
+
+  return sum;
+}
+
+//-------------------------------------------------------------------------//
+// Test pointer subtraction that is dereferenced.                          //
+//-------------------------------------------------------------------------//
+
+double f6(_Array_ptr<double> a : bounds(a, a + len), int len) {
+  double sum = 0;
+  _Array_ptr<double> p : bounds(a, a + len) = p + len - 1;
+  for (int i = 0; i < len; i++)
+    sum += *(p - i);
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '-'
+// CHECK:       |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK:       | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+// CHECK:       `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:         `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue Var {{0x[0-9a-f]+}} 'i' 'int'
+
+  return sum;
+}
+
+//-------------------------------------------------------------------------//
+// Test compound assignment addition that is then dereferenced.            //
+//-------------------------------------------------------------------------//
+
+double f7(_Array_ptr<double> a : count(2)) {
+  _Array_ptr<double> p : bounds(a, a + 2) = a;
+  return *(p += 1);
+}
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-CompoundAssignOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+=' ComputeLHSTy='_Array_ptr<double>' ComputeResultTy='_Array_ptr<double>'
+// CHECK:       |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+// CHECK:       `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+
+//-------------------------------------------------------------------------//
+// Test compound assignment subtraction that is then dereferenced.         //
+//-------------------------------------------------------------------------//
+
+double f8(_Array_ptr<double> a : count(2)) {
+  _Array_ptr<double> p : bounds(a, a + 2) = a + 1;
+  return *(p -= 1);
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'double' <LValueToRValue>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<double>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'double' lvalue prefix '*'
+// CHECK:   `-ParenExpr {{0x[0-9a-f]+}} '_Array_ptr<double>'
+// CHECK:     `-CompoundAssignOperator {{0x[0-9a-f]+}} '_Array_ptr<double>' '-=' ComputeLHSTy='_Array_ptr<double>' ComputeResultTy='_Array_ptr<double>'
+// CHECK:       |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<double>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<double>'
+// CHECK:       `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+}


### PR DESCRIPTION
This adds computation of rvalue bounds for the following pointer-typed expressions:
- Pointer addition and subtraction.
- Post/pre-increment and decrement.
- Assignments (assignments produce rvalues in C).
- Compound assiginments involving addition and subtraction.
This completes Github issue #121.

In addition, it adds computation of rvalue bounds for the following integer-typed expressions (section 5.4.2 in the the Checked C version 0.6 specification):
- Addition, subtracation, and multiplication.
- Post/pre-increment and decrement.
- Bitwise logical operations
- Unary +, -, and bitwise complement.

During testing, I found that the code for checking that compound assignment operators (+= and so on) have bounds was not correct and triggered an assert..  The code was just checking the bounds of the rhs expression.  We actually  need to check the rvalue bounds of the entire expression for compound assignment operators. For pointer arithmetic, this is a no-op (there's no possible way it could fail to have bounds), but for integer arithmetic, it is not a no-op.

Testing:
- Added new tests for inference of pointer arithmetic bounds.
- Still need to write tests for bounds-inference for integer-typed expressions.
- Passed Checked C regression tests.
- Passed clang regression tests.