### PR TITLE
Adds parsing of relative bounds expression (#037)

### DIFF
--- a/include/clang/AST/RecursiveASTVisitor.h
+++ b/include/clang/AST/RecursiveASTVisitor.h
@@ -2426,6 +2426,7 @@ DEF_TRAVERSE_STMT(CountBoundsExpr, {})
 DEF_TRAVERSE_STMT(NullaryBoundsExpr, {})
 DEF_TRAVERSE_STMT(RangeBoundsExpr, {})
 DEF_TRAVERSE_STMT(InteropTypeBoundsAnnotation, {})
+DEF_TRAVERSE_STMT(RelativeBoundsExpr, {})
 DEF_TRAVERSE_STMT(PositionalParameterExpr, {})
 
 // For coroutines expressions, traverse either the operand

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1066,6 +1066,11 @@ def err_for_co_await_not_range_for : Error<
 def err_expected_bounds_expr : Error<
   "expected bounds expression">;
 
+def err_expected_range_bounds_expr : Error<"expected range bounds expression">;
+
+def err_expected_relative_bounds_expr
+    : Error<"expected relative bounds expression">;
+
 def err_unexpected_bounds_expr_after_declarator: Error<
   "unexpected bounds expression after declarator">;
 

--- a/include/clang/Basic/StmtNodes.td
+++ b/include/clang/Basic/StmtNodes.td
@@ -175,6 +175,7 @@ def BoundsExpr : DStmt<Expr, 1>;
 def NullaryBoundsExpr : DStmt<BoundsExpr>;
 def CountBoundsExpr : DStmt<BoundsExpr>;
 def RangeBoundsExpr : DStmt<BoundsExpr>;
+def RelativeBoundsExpr : DStmt<BoundsExpr>;
 def InteropTypeBoundsAnnotation : DStmt<BoundsExpr>;
 def PositionalParameterExpr : DStmt<Expr>;
 

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -168,6 +168,9 @@ class Parser : public CodeCompletionHandler {
   /// \brief Identifier for "itype"
   IdentifierInfo *Ident_itype;
 
+  /// \brief Identifier for "rel_align"
+  IdentifierInfo *Ident_rel_align;
+
   // C++ type trait keywords that can be reverted to identifiers and still be
   // used as type traits.
   llvm::SmallDenseMap<IdentifierInfo *, tok::TokenKind> RevertibleTypeTraits;
@@ -1664,7 +1667,12 @@ private:
   /// type annotation.
   bool StartsInteropTypeAnnotation(Token &tok);
 
+  bool StartsRelativeBoundsExpression(Token &tok);
+
   ExprResult ParseBoundsExpression();
+
+  ExprResult ParseRelativeBoundsExpression(Expr *Expr);
+
   ExprResult ParseInteropTypeAnnotation(const Declarator &D, bool IsReturn=false);
   ExprResult ParseBoundsExpressionOrInteropType(const Declarator &D,
                                                 bool IsReturn=false);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4249,6 +4249,11 @@ public:
                                   SourceLocation RParenLoc);
   ExprResult ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc, Expr *LowerBound,
                                   Expr *UpperBound, SourceLocation RParenLoc);
+
+  ExprResult CreateRangeBoundsExpr(SourceLocation BoundsKWLoc, Expr *LowerBound,
+                                   Expr *UpperBound, Expr *Relative,
+                                   SourceLocation RParenLoc);
+
   ExprResult ActOnBoundsInteropType(SourceLocation TypeKWLoc, ParsedType Ty,
                                     SourceLocation RParenLoc);
   ExprResult CreateBoundsInteropType(SourceLocation TypeKWLoc,
@@ -4256,6 +4261,13 @@ public:
                                      SourceLocation RParenLoc);
 
   ExprResult CreatePositionalParameterExpr(unsigned Index, QualType QT);
+
+  ExprResult ActOnRelativeBoundsExpr(SourceLocation BoundsKWLoc, ParsedType Ty,
+                                     SourceLocation RParenLoc);
+
+  ExprResult CreateRelativeBoundsExpr(SourceLocation BoundsKWLoc,
+                                      TypeSourceInfo *TyInfo,
+                                      SourceLocation RParenLoc);
 
   bool DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
                               BoundsExpr *Expr, bool IsReturnBounds);

--- a/include/clang/Serialization/ASTBitCodes.h
+++ b/include/clang/Serialization/ASTBitCodes.h
@@ -1322,7 +1322,6 @@ namespace clang {
       EXPR_OBJC_ARRAY_LITERAL,
       EXPR_OBJC_DICTIONARY_LITERAL,
 
-    
       /// \brief An ObjCEncodeExpr record.
       EXPR_OBJC_ENCODE,
       /// \brief An ObjCSelectorExpr record.
@@ -1364,7 +1363,7 @@ namespace clang {
       EXPR_OBJC_AVAILABILITY_CHECK,
 
       // C++
-      
+
       /// \brief A CXXCatchStmt record.
       STMT_CXX_CATCH,
       /// \brief A CXXTryStmt record.
@@ -1398,66 +1397,67 @@ namespace clang {
       EXPR_CXX_STD_INITIALIZER_LIST,
       /// \brief A CXXBoolLiteralExpr record.
       EXPR_CXX_BOOL_LITERAL,
-      EXPR_CXX_NULL_PTR_LITERAL,  // CXXNullPtrLiteralExpr
-      EXPR_CXX_TYPEID_EXPR,       // CXXTypeidExpr (of expr).
-      EXPR_CXX_TYPEID_TYPE,       // CXXTypeidExpr (of type).
-      EXPR_CXX_THIS,              // CXXThisExpr
-      EXPR_CXX_THROW,             // CXXThrowExpr
-      EXPR_CXX_DEFAULT_ARG,       // CXXDefaultArgExpr
-      EXPR_CXX_DEFAULT_INIT,      // CXXDefaultInitExpr
-      EXPR_CXX_BIND_TEMPORARY,    // CXXBindTemporaryExpr
+      EXPR_CXX_NULL_PTR_LITERAL, // CXXNullPtrLiteralExpr
+      EXPR_CXX_TYPEID_EXPR,      // CXXTypeidExpr (of expr).
+      EXPR_CXX_TYPEID_TYPE,      // CXXTypeidExpr (of type).
+      EXPR_CXX_THIS,             // CXXThisExpr
+      EXPR_CXX_THROW,            // CXXThrowExpr
+      EXPR_CXX_DEFAULT_ARG,      // CXXDefaultArgExpr
+      EXPR_CXX_DEFAULT_INIT,     // CXXDefaultInitExpr
+      EXPR_CXX_BIND_TEMPORARY,   // CXXBindTemporaryExpr
 
       EXPR_CXX_SCALAR_VALUE_INIT, // CXXScalarValueInitExpr
       EXPR_CXX_NEW,               // CXXNewExpr
       EXPR_CXX_DELETE,            // CXXDeleteExpr
       EXPR_CXX_PSEUDO_DESTRUCTOR, // CXXPseudoDestructorExpr
-      
-      EXPR_EXPR_WITH_CLEANUPS,    // ExprWithCleanups
-      
+
+      EXPR_EXPR_WITH_CLEANUPS, // ExprWithCleanups
+
       EXPR_CXX_DEPENDENT_SCOPE_MEMBER,   // CXXDependentScopeMemberExpr
       EXPR_CXX_DEPENDENT_SCOPE_DECL_REF, // DependentScopeDeclRefExpr
       EXPR_CXX_UNRESOLVED_CONSTRUCT,     // CXXUnresolvedConstructExpr
       EXPR_CXX_UNRESOLVED_MEMBER,        // UnresolvedMemberExpr
       EXPR_CXX_UNRESOLVED_LOOKUP,        // UnresolvedLookupExpr
 
-      EXPR_CXX_EXPRESSION_TRAIT,  // ExpressionTraitExpr
-      EXPR_CXX_NOEXCEPT,          // CXXNoexceptExpr
+      EXPR_CXX_EXPRESSION_TRAIT, // ExpressionTraitExpr
+      EXPR_CXX_NOEXCEPT,         // CXXNoexceptExpr
 
-      EXPR_OPAQUE_VALUE,          // OpaqueValueExpr
-      EXPR_BINARY_CONDITIONAL_OPERATOR,  // BinaryConditionalOperator
-      EXPR_TYPE_TRAIT,            // TypeTraitExpr
-      EXPR_ARRAY_TYPE_TRAIT,      // ArrayTypeTraitIntExpr
-      
-      EXPR_PACK_EXPANSION,        // PackExpansionExpr
-      EXPR_SIZEOF_PACK,           // SizeOfPackExpr
-      EXPR_SUBST_NON_TYPE_TEMPLATE_PARM, // SubstNonTypeTemplateParmExpr
-      EXPR_SUBST_NON_TYPE_TEMPLATE_PARM_PACK,// SubstNonTypeTemplateParmPackExpr
-      EXPR_FUNCTION_PARM_PACK,    // FunctionParmPackExpr
-      EXPR_MATERIALIZE_TEMPORARY, // MaterializeTemporaryExpr
-      EXPR_CXX_FOLD,              // CXXFoldExpr
+      EXPR_OPAQUE_VALUE,                // OpaqueValueExpr
+      EXPR_BINARY_CONDITIONAL_OPERATOR, // BinaryConditionalOperator
+      EXPR_TYPE_TRAIT,                  // TypeTraitExpr
+      EXPR_ARRAY_TYPE_TRAIT,            // ArrayTypeTraitIntExpr
+
+      EXPR_PACK_EXPANSION,                    // PackExpansionExpr
+      EXPR_SIZEOF_PACK,                       // SizeOfPackExpr
+      EXPR_SUBST_NON_TYPE_TEMPLATE_PARM,      // SubstNonTypeTemplateParmExpr
+      EXPR_SUBST_NON_TYPE_TEMPLATE_PARM_PACK, // SubstNonTypeTemplateParmPackExpr
+      EXPR_FUNCTION_PARM_PACK,                // FunctionParmPackExpr
+      EXPR_MATERIALIZE_TEMPORARY,             // MaterializeTemporaryExpr
+      EXPR_CXX_FOLD,                          // CXXFoldExpr
 
       // CUDA
-      EXPR_CUDA_KERNEL_CALL,       // CUDAKernelCallExpr      
+      EXPR_CUDA_KERNEL_CALL, // CUDAKernelCallExpr
 
       // Checked C
-      EXPR_COUNT_BOUNDS_EXPR,      // CountBoundsExpr
-      EXPR_NULLARY_BOUNDS_EXPR,    // NullaryBoundsExpr
-      EXPR_RANGE_BOUNDS_EXPR,      // RangeBoundsExpr
-      EXPR_INTEROPTYPE_BOUNDS_ANNOTATION,// InteropTypeBoundsAnnotation
-      EXPR_POSITIONAL_PARAMETER_EXPR, // PositionalParameterExpr
+      EXPR_COUNT_BOUNDS_EXPR,             // CountBoundsExpr
+      EXPR_NULLARY_BOUNDS_EXPR,           // NullaryBoundsExpr
+      EXPR_RANGE_BOUNDS_EXPR,             // RangeBoundsExpr
+      EXPR_RELATIVE_BOUNDS_EXPR,          // RelativeBoundsExpr
+      EXPR_INTEROPTYPE_BOUNDS_ANNOTATION, // InteropTypeBoundsAnnotation
+      EXPR_POSITIONAL_PARAMETER_EXPR,     // PositionalParameterExpr
 
       // OpenCL
-      EXPR_ASTYPE,                 // AsTypeExpr
+      EXPR_ASTYPE, // AsTypeExpr
 
       // Microsoft
-      EXPR_CXX_PROPERTY_REF_EXPR, // MSPropertyRefExpr
+      EXPR_CXX_PROPERTY_REF_EXPR,       // MSPropertyRefExpr
       EXPR_CXX_PROPERTY_SUBSCRIPT_EXPR, // MSPropertySubscriptExpr
-      EXPR_CXX_UUIDOF_EXPR,       // CXXUuidofExpr (of expr).
-      EXPR_CXX_UUIDOF_TYPE,       // CXXUuidofExpr (of type).
-      STMT_SEH_LEAVE,             // SEHLeaveStmt
-      STMT_SEH_EXCEPT,            // SEHExceptStmt
-      STMT_SEH_FINALLY,           // SEHFinallyStmt
-      STMT_SEH_TRY,               // SEHTryStmt
+      EXPR_CXX_UUIDOF_EXPR,             // CXXUuidofExpr (of expr).
+      EXPR_CXX_UUIDOF_TYPE,             // CXXUuidofExpr (of type).
+      STMT_SEH_LEAVE,                   // SEHLeaveStmt
+      STMT_SEH_EXCEPT,                  // SEHExceptStmt
+      STMT_SEH_FINALLY,                 // SEHFinallyStmt
+      STMT_SEH_TRY,                     // SEHTryStmt
 
       // OpenMP directives
       STMT_OMP_PARALLEL_DIRECTIVE,
@@ -1502,10 +1502,10 @@ namespace clang {
       EXPR_OMP_ARRAY_SECTION,
 
       // ARC
-      EXPR_OBJC_BRIDGED_CAST,     // ObjCBridgedCastExpr
-      
-      STMT_MS_DEPENDENT_EXISTS,   // MSDependentExistsStmt
-      EXPR_LAMBDA                 // LambdaExpr
+      EXPR_OBJC_BRIDGED_CAST, // ObjCBridgedCastExpr
+
+      STMT_MS_DEPENDENT_EXISTS, // MSDependentExistsStmt
+      EXPR_LAMBDA               // LambdaExpr
     };
 
     /// \brief The kinds of designators that can occur in a

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -596,6 +596,7 @@ namespace  {
     void VisitNullaryBoundsExpr(const NullaryBoundsExpr *Node);
     void VisitCountBoundsExpr(const CountBoundsExpr *Node);
     void VisitRangeBoundsExpr(const RangeBoundsExpr *Node);
+    void VisitRelativeBoundsExpr(const RelativeBoundsExpr *Node);
     void VisitInteropTypeBoundsAnnotation(
       const InteropTypeBoundsAnnotation *Node);
     void dumpBoundsKind(BoundsExpr::Kind kind);
@@ -2547,6 +2548,16 @@ void ASTDumper::VisitRangeBoundsExpr(const RangeBoundsExpr *Node) {
   VisitExpr(Node);
   if (Node->getKind() != BoundsExpr::Kind::Range)
     dumpBoundsKind(Node->getKind());
+  if (Node->hasRelative()) {
+    RelativeBoundsExpr *Expr = cast<RelativeBoundsExpr>(Node->getRelative());
+    OS << " rel_align : ";
+    OS << (Expr->getTypeAsWritten()).getAsString();
+  }
+}
+
+void ASTDumper::VisitRelativeBoundsExpr(const RelativeBoundsExpr *Node) {
+  VisitExpr(Node);
+  dumpBoundsKind(Node->getKind());
 }
 
 void ASTDumper::VisitInteropTypeBoundsAnnotation(

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2867,6 +2867,7 @@ bool Expr::HasSideEffects(const ASTContext &Ctx,
   case NullaryBoundsExprClass:
   case PositionalParameterExprClass:
   case RangeBoundsExprClass:
+  case RelativeBoundsExprClass:
     // These never have a side-effect.
     return false;
 
@@ -3834,6 +3835,8 @@ bool BoundsExpr::validateKind(Kind K) {
       return K == Range;
     case InteropTypeBoundsAnnotationClass:
       return K == InteropTypeAnnotation;
+    case RelativeBoundsExprClass:
+      return K == Relative;
     default:
       return false;
   }

--- a/lib/AST/ExprClassification.cpp
+++ b/lib/AST/ExprClassification.cpp
@@ -414,6 +414,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
   case Expr::InteropTypeBoundsAnnotationClass:
   case Expr::NullaryBoundsExprClass:
   case Expr::RangeBoundsExprClass:
+  case Expr::RelativeBoundsExprClass:
     llvm_unreachable("should not classify bounds expressions");
   }
   llvm_unreachable("unhandled expression kind in classification");

--- a/lib/AST/ExprConstant.cpp
+++ b/lib/AST/ExprConstant.cpp
@@ -9442,7 +9442,8 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
   case Expr::InteropTypeBoundsAnnotationClass:
   case Expr::NullaryBoundsExprClass:
   case Expr::PositionalParameterExprClass:
-    // These are parameter variables and are never constants,
+  case Expr::RelativeBoundsExprClass:
+  // These are parameter variables and are never constants,
   case Expr::RangeBoundsExprClass:
     return ICEDiag(IK_NotICE, E->getLocStart());
 

--- a/lib/AST/ItaniumMangle.cpp
+++ b/lib/AST/ItaniumMangle.cpp
@@ -3276,6 +3276,7 @@ recurse:
   case Expr::CountBoundsExprClass:
   case Expr::InteropTypeBoundsAnnotationClass:
   case Expr::NullaryBoundsExprClass:
+  case Expr::RelativeBoundsExprClass:
   case Expr::RangeBoundsExprClass:
   {
     if (!NullOut) {

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1873,6 +1873,23 @@ void StmtPrinter::VisitRangeBoundsExpr(RangeBoundsExpr *Node) {
   OS << ", ";
   PrintExpr(Node->getUpperExpr());
   OS << ")";
+  if (Node->hasRelative()) {
+    OS << "rel_align(";
+    RelativeBoundsExpr *Expr = cast<RelativeBoundsExpr>(Node->getRelative());
+    (Expr->getTypeAsWritten()).print(OS, Policy);
+    OS << ")";
+  }
+}
+
+void StmtPrinter::VisitRelativeBoundsExpr(RelativeBoundsExpr *Node) {
+  BoundsExpr::Kind K = Node->getKind();
+  if (K == BoundsExpr::Kind::Invalid) {
+    OS << "invalid_range_bounds()";
+    return;
+  }
+  OS << "rel_align(";
+  (Node->getTypeAsWritten()).print(OS, Policy);
+  OS << ")";
 }
 
 void StmtPrinter::VisitInteropTypeBoundsAnnotation(

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1008,7 +1008,14 @@ void StmtProfiler::VisitNullaryBoundsExpr(const NullaryBoundsExpr *S) {
 
 void StmtProfiler::VisitRangeBoundsExpr(const RangeBoundsExpr *S) {
   VisitExpr(S);
+  if (S->hasRelative())
+    VisitType(cast<RelativeBoundsExpr>(S->getRelative())->getTypeAsWritten());
   ID.AddInteger(S->getKind());
+}
+
+void StmtProfiler::VisitRelativeBoundsExpr(const RelativeBoundsExpr *S) {
+  VisitExpr(S);
+  VisitType(S->getTypeAsWritten());
 }
 
 void StmtProfiler::VisitInteropTypeBoundsAnnotation(

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -500,12 +500,14 @@ void Parser::Initialize() {
     Ident_count = &PP.getIdentifierTable().get("count");
     Ident_none = &PP.getIdentifierTable().get("none");
     Ident_itype = &PP.getIdentifierTable().get("itype");
+    Ident_rel_align = &PP.getIdentifierTable().get("rel_align");
   } else {
     Ident_bounds = nullptr;
     Ident_byte_count = nullptr;
     Ident_count = nullptr;
     Ident_none = nullptr;
     Ident_itype = nullptr;
+    Ident_rel_align = nullptr;
   }
 
   Ident__except = nullptr;

--- a/lib/Sema/SemaExceptionSpec.cpp
+++ b/lib/Sema/SemaExceptionSpec.cpp
@@ -1199,6 +1199,7 @@ CanThrowResult Sema::canThrow(const Expr *E) {
   case Expr::InteropTypeBoundsAnnotationClass:
   case Expr::NullaryBoundsExprClass:
   case Expr::RangeBoundsExprClass:
+  case Expr::RelativeBoundsExprClass:
     llvm_unreachable("do not expect bounds expressions");
 
 #define STMT(CLASS, PARENT) case Expr::CLASS##Class:

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12359,6 +12359,26 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
                                        RParenLoc);
 }
 
+ExprResult Sema::CreateRangeBoundsExpr(SourceLocation BoundsKWLoc,
+                                       Expr *LowerBound, Expr *UpperBound,
+                                       Expr *Relative,
+                                       SourceLocation RParenLoc) {
+  RangeBoundsExpr *Range = nullptr;
+  ExprResult Result =
+      ActOnRangeBoundsExpr(BoundsKWLoc, LowerBound, UpperBound, RParenLoc);
+  Range = cast<RangeBoundsExpr>(Result.get());
+  Range->setRelativeBoundsExpr(Relative);
+  return Result;
+}
+
+ExprResult Sema::ActOnRelativeBoundsExpr(SourceLocation BoundsKWLoc,
+                                         ParsedType Ty,
+                                         SourceLocation RParneLoc) {
+  TypeSourceInfo *TyInfo = nullptr;
+  GetTypeFromParser(Ty, &TyInfo);
+  return CreateRelativeBoundsExpr(BoundsKWLoc, TyInfo, RParneLoc);
+}
+
 ExprResult Sema::ActOnBoundsInteropType(SourceLocation TypeKWLoc, ParsedType Ty,
                                         SourceLocation RParenLoc) {
   TypeSourceInfo *TInfo = nullptr;
@@ -12372,6 +12392,12 @@ ExprResult Sema::CreateBoundsInteropType(SourceLocation TypeKWLoc, TypeSourceInf
   QualType QT = TInfo->getType();
   return new (Context) InteropTypeBoundsAnnotation(QT, TypeKWLoc, RParenLoc,
                                                    TInfo);
+}
+
+ExprResult Sema::CreateRelativeBoundsExpr(SourceLocation BoundsKWLoc,
+                                          TypeSourceInfo *TyInfo,
+                                          SourceLocation RParenLoc) {
+  return new (Context) RelativeBoundsExpr(TyInfo, BoundsKWLoc, RParenLoc);
 }
 
 ExprResult Sema::CreatePositionalParameterExpr(unsigned Index, QualType QT) {

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -988,6 +988,8 @@ void ASTStmtReader::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   E->setKind((BoundsExpr::Kind)Record[Idx++]);
   E->setLowerExpr(Reader.ReadSubExpr());
   E->setUpperExpr(Reader.ReadSubExpr());
+  if (E->hasRelative())
+    E->setRelativeBoundsExpr(Reader.ReadSubExpr());
   E->StartLoc = ReadSourceLocation(Record, Idx);
   E->EndLoc = ReadSourceLocation(Record, Idx);
 }
@@ -1007,6 +1009,13 @@ void ASTStmtReader::VisitPositionalParameterExpr(
   E->Index = Record[Idx++];
 }
 
+void ASTStmtReader::VisitRelativeBoundsExpr(RelativeBoundsExpr *E) {
+  VisitExpr(E);
+  E->setKind((BoundsExpr::Kind)Record[Idx++]);
+  E->setAlignTypeInfoAsWritten(GetTypeSourceInfo(Record, Idx));
+  E->StartLoc = ReadSourceLocation(Record, Idx);
+  E->EndLoc = ReadSourceLocation(Record, Idx);
+}
 
 //===----------------------------------------------------------------------===//
 // Objective-C Expressions and Statements
@@ -3894,6 +3903,10 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
     case EXPR_RANGE_BOUNDS_EXPR:
       S = new (Context) RangeBoundsExpr(Empty);
+      break;
+
+    case EXPR_RELATIVE_BOUNDS_EXPR:
+      S = new (Context) RelativeBoundsExpr(Empty);
       break;
 
     case EXPR_INTEROPTYPE_BOUNDS_ANNOTATION:

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -948,6 +948,8 @@ void ASTStmtWriter::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   Record.push_back(E->getKind());
   Record.AddStmt(E->getLowerExpr());
   Record.AddStmt(E->getUpperExpr());
+  if (E->hasRelative())
+    Record.AddStmt(E->getRelative());
   Record.AddSourceLocation(E->getStartLoc());
   Record.AddSourceLocation(E->getRParenLoc());
   Code = serialization::EXPR_RANGE_BOUNDS_EXPR;
@@ -968,6 +970,15 @@ void ASTStmtWriter::VisitPositionalParameterExpr(
   VisitExpr(E);
   Record.push_back(E->getIndex());
   Code = serialization::EXPR_POSITIONAL_PARAMETER_EXPR;
+}
+
+void ASTStmtWriter::VisitRelativeBoundsExpr(RelativeBoundsExpr *E) {
+  VisitExpr(E);
+  Record.push_back(E->getKind());
+  Record.AddTypeSourceInfo(E->getAlignTypeInfoAsWritten());
+  Record.AddSourceLocation(E->getStartLoc());
+  Record.AddSourceLocation(E->getRParenLoc());
+  Code = serialization::EXPR_RELATIVE_BOUNDS_EXPR;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1348,6 +1348,7 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
     case Stmt::CountBoundsExprClass:
     case Stmt::InteropTypeBoundsAnnotationClass:
     case Stmt::NullaryBoundsExprClass:
+    case Stmt::RelativeBoundsExprClass:
     case Stmt::RangeBoundsExprClass:
       llvm_unreachable("Do not expect to see Checked C extensions");
       break;

--- a/tools/libclang/CXCursor.cpp
+++ b/tools/libclang/CXCursor.cpp
@@ -662,6 +662,7 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
   case Stmt::CountBoundsExprClass:
   case Stmt::InteropTypeBoundsAnnotationClass:
   case Stmt::NullaryBoundsExprClass:
+  case Stmt::RelativeBoundsExprClass:
   case Stmt::RangeBoundsExprClass:
     K = CXCursor_UnexposedExpr;
     break;


### PR DESCRIPTION
- Adds RelativeBoundsExpr for relative expression.
- Relative expression is parsed after bounds expression parsing is done and the tokencache for the function parameter is extended to the relative expression
- Adds variable and member functions in RangeBoundsExpr to handle relative bounds expression.
- Currently builtin type variable can be parsed.
- Adds write the type of relative bounds expression in RangeBoundsExpr AST like "rel_align : char"