### PR TITLE
Fixes failing driver test on Mac

### DIFF
--- a/test/Driver/checkedc-notsupported.cl
+++ b/test/Driver/checkedc-notsupported.cl
@@ -8,6 +8,6 @@
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
 // Have clang-cl compile this file as a C file.
-// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC -- %s
 
 void f() {}

--- a/test/Driver/checkedc-notsupported.cpp
+++ b/test/Driver/checkedc-notsupported.cpp
@@ -8,7 +8,7 @@
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
 // Have clang-cl compile this file as a C file.
-// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC -- %s
 
 extern void f() {}
 

--- a/test/Driver/checkedc-notsupported.cu
+++ b/test/Driver/checkedc-notsupported.cu
@@ -8,7 +8,7 @@
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
 // Have clang-cl compile this file as a C file.
-// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC -- %s
 
 void f() {}
 

--- a/test/Driver/checkedc-notsupported.m
+++ b/test/Driver/checkedc-notsupported.m
@@ -8,7 +8,7 @@
 // RUN: %clang -c -fcheckedc-extension -x c %s
 //
 // Have clang-cl compile this file as a C file.
-// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC %s
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension /TC -- %s
 
 extern void f() {}
 

--- a/test/Driver/checkedc-supported.c
+++ b/test/Driver/checkedc-supported.c
@@ -3,7 +3,7 @@
 // compiled as another language.
 //
 // RUN: %clang -c -fcheckedc-extension %s
-// RUN: %clang_cl -c -Xclang -fcheckedc-extension %s
+// RUN: %clang_cl -c -Xclang -fcheckedc-extension -- %s
 //
 // Have clang compile this file as C++ file.
 // RUN: not %clang -c -fcheckedc-extension -x c++ %s 2>&1 \
@@ -11,7 +11,7 @@
 // check-cpp: warning: Checked C extension not supported with 'C++'; ignoring '-fcheckedc-extension'
 //
 // Have clang-cl compile this file as a C++ file.
-// RUN: not %clang_cl -c -Xclang -fcheckedc-extension /TP %s 2>&1 \
+// RUN: not %clang_cl -c -Xclang -fcheckedc-extension /TP -- %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=clcheck-cpp
 // clcheck-cpp: warning: Checked C extension not supported with 'C++'; ignoring '-fcheckedc-extension'
 //


### PR DESCRIPTION
All the `%clang_cl` driver tests fail on Mac, it seems because of an argument parsing issue. I looked at how `%clang_cl` is used in other places, and they all seem to have a `--` between the last options and the first filename, so I did that, which fixes the build! 