### PR TITLE
Increase amount of logging done for automated builds on Windows.

### DIFF
--- a/automation/VSTS/config-vars.bat
+++ b/automation/VSTS/config-vars.bat
@@ -1,9 +1,8 @@
 @if not defined SYSTEM_DEBUG (
   echo off
-  set MSBUILD_VERBOSITY=m
-) else (
-  set MSBUILD_VERBOSITY=n
 )
+
+@set MSBUILD_VERBOSITY=n
 
 rem 
 rem Validate and set configuration variables.   Other scripts should only 


### PR DESCRIPTION
We set the logging for msbuild to /m (minimal).  It is too minimal and we cannot tell what tests are failing.  Set it to /n (for normal).
