### PR TITLE
Clears up Dynamic Check generation and adds methods for next steps

### DIFF
--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2287,6 +2287,8 @@ public:
   void EmitExplicitDynamicCheck(const Expr *Condition);
   void EmitCheckedCSubscriptCheck(const LValue Addr, const BoundsExpr *Bounds);
   void EmitCheckedCDerefCheck(const LValue Addr, const BoundsExpr *Bounds);
+  void EmitCheckedCMemberCheck(const LValue Addr, const BoundsExpr *Bounds);
+  void EmitCheckedCArrowCheck(const LValue Addr, const BoundsExpr *Bounds);
   void EmitDynamicNonNullCheck(const LValue Addr);
   void EmitDynamicBoundsCheck(const LValue Addr, const BoundsExpr *Bounds);
 


### PR DESCRIPTION
We had lots of stats we weren't using, and some don't make any sense any more.

We can no longer tell the expression origin of a given check beyond its immediate expression such as `*e1`, `e1[e2]`, `e1.f`, `e1->f` or `dynamic_check()`, which means there's no way to record if the check came from an assignment, update, increment or read.

I've also added two stub methods for Member expressions (`e.f`) and Arrow expressions (`e->f`). Though these are not particularly different in the AST (both represented by MemberExprs), I think the logic may be different so I've split them apart. 