### PR TITLE
Fix automation for checking out branches on Windows.

### DIFF
--- a/automation/Windows/config-vars.bat
+++ b/automation/Windows/config-vars.bat
@@ -140,6 +140,7 @@ echo.  TEST_SUITE: %TEST_SUITE%
 echo.
 echo.  Directories:
 echo.    BUILD_SOURCESDIRECTORY: %BUILD_SOURCESDIRECTORY%
+echo.    BUILD_BINARIESDIRECTORY: %BUILD_BINARIESDIRECTORY%
 echo.    LLVM_OBJ_DIR: %LLVM_OBJ_DIR%
 echo.
 echo.  Branch and commit information:

--- a/automation/Windows/setup-files.bat
+++ b/automation/Windows/setup-files.bat
@@ -2,20 +2,29 @@ rem Create directories and sync files
 
 set OLD_DIR=%CD%
 
-if not exist %BUILD_SOURCESDIRECTORY%\llvm (
+if not exist %BUILD_SOURCESDIRECTORY%\llvm\.git (
   git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-llvm %BUILD_SOURCESDIRECTORY%\llvm
   if ERRORLEVEL 1 (goto cmdfailed)
+)
 
+if not exist %BUILD_SOURCESDIRECTORY%\llvm\tools\clang\.git (
   git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-clang %BUILD_SOURCESDIRECTORY%\llvm\tools\clang
   if ERRORLEVEL 1 (goto cmdfailed)
+)
 
+if not exist %BUILD_SOURCESDIRECTORY%\llvm\projects\checkedc-wrapper\checkedc\.git (
   git clone https://github.com/Microsoft/checkedc %BUILD_SOURCESDIRECTORY%\llvm\projects\checkedc-wrapper\checkedc
   if ERRORLEVEL 1 (goto cmdfailed)
 )
 
 rem set up LLVM sources
 cd %BUILD_SOURCESDIRECTORY%\llvm
-git pull origin %LLVM_BRANCH%
+if ERRORLEVEL 1 (goto cmdfailed)
+git fetch origin
+if ERRORLEVEL 1 (goto cmdfailed)
+git checkout -f %LLVM_BRANCH%
+if ERRORLEVEL 1 (goto cmdfailed)
+git pull -f origin %LLVM_BRANCH%
 if ERRORLEVEL 1 (goto cmdfailed)
 
 git checkout %LLVM_COMMIT%
@@ -23,7 +32,12 @@ if ERRORLEVEL 1 (goto cmdfailed)
 
 rem set up Checked C sources
 cd %BUILD_SOURCESDIRECTORY%\llvm\projects\checkedc-wrapper\checkedc
-git pull origin %CHECKEDC_BRANCH%
+if ERRORLEVEL 1 (goto cmdfailed)
+git fetch origin
+if ERRORLEVEL 1 (goto cmdfailed)
+git checkout -f %CHECKEDC_BRANCH%
+if ERRORLEVEL 1 (goto cmdfailed)
+git pull -f origin %CHECKEDC_BRANCH%
 if ERRORLEVEL 1 (goto cmdfailed)
 
 git checkout %CHECKEDC_COMMIT%
@@ -31,7 +45,12 @@ if ERRORLEVEL 1 (goto cmdfailed)
 
 rem Set up clang sources
 cd %BUILD_SOURCESDIRECTORY%\llvm\tools\clang
-git pull origin %CLANG_BRANCH%
+if ERRORLEVEL 1 (goto cmdfailed)
+git fetch origin
+if ERRORLEVEL 1 (goto cmdfailed)
+git checkout -f %CHECKEDC_BRANCH%
+if ERRORLEVEL 1 (goto cmdfailed)
+git pull -f origin %CLANG_BRANCH%
 if ERRORLEVEL 1 (goto cmdfailed)
 
 git checkout %CLANG_COMMIT%


### PR DESCRIPTION
The commands for checking out branches were not right and could cause
merges when branches were specified explicitly.  Use the same commands
that we use for the Linux scripts.  We don't have functions, so just
place the commands inline.

Also make the clone commands more resilient in the Windows scripts.  We only
checked for the presence of the LLVM source directory, so if we something went
wrong with the clones of clang or Checked C, we would not clone them the next
time they ran.  Follow the sasme approach used in the Linux scripts where
each the clone of each repo is checked separately.

Print out the BINARIES_DIRECTORY variable at the end of the config-vars
script, in case it was set incorrectly.

Testing:
- Ran automatation scripts locally on Windows.
- Built and run the modified config-vars script for Linux under the
  Windows Subsystem for Linux.