### PR TITLE
Rewriter uses bounds information to add constraints for _Ptr types

### DIFF
--- a/test/CheckedCRewriter/bounds_interface.c
+++ b/test/CheckedCRewriter/bounds_interface.c
@@ -1,8 +1,29 @@
 // Tests for the Checked C rewriter tool.
+//
+// RUN: checked-c-convert %s -- -fcheckedc-extension | FileCheck -match-full-lines %s
+// RUN: checked-c-convert %s -- -fcheckedc-extension | %clang_cc1 -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+//
+
 
 extern void bar(int *q : itype(_Ptr<int>));
+//CHECK: extern void bar(int* q : itype(_Ptr<int>));
+
+extern void bar2(int *q : itype(_Ptr<int>), int *z : itype(_Ptr<int>));
+//CHEcK: extern void bar2(int* q : itype(_Ptr<int>), int* z : itype(_Ptr<int>));
+
+extern int *baz(void) : itype(_Ptr<int>);
+//CHECK: extern int* baz(void) : itype(_Ptr<int>);
 
 void foo(int *p : itype(_Ptr<int>)) {
 	*p = 0;
 	return;
 }
+//CHECK: void foo(int* p : itype(_Ptr<int>)) {
+
+int foo2(int *j) {
+	int *a = baz();
+	return *a + *j; 
+}
+//CHECK: int foo2(_Ptr<int>  j) {
+//CHECK-NEXT: _Ptr<int>  a = baz();

--- a/test/CheckedCRewriter/bounds_interface.c
+++ b/test/CheckedCRewriter/bounds_interface.c
@@ -1,0 +1,8 @@
+// Tests for the Checked C rewriter tool.
+
+extern void bar(int *q : itype(_Ptr<int>));
+
+void foo(int *p : itype(_Ptr<int>)) {
+	*p = 0;
+	return;
+}

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -494,10 +494,6 @@ public:
     return true;
   }
 
-  void applyConstraintsForBounds(const ParmVarDecl *P, const BoundsExpr *B) {
-    return;
-  }
-
   bool VisitFunctionDecl(FunctionDecl *D) {
     FullSourceLoc FL = Context->getFullLoc(D->getLocStart());
 
@@ -512,20 +508,6 @@ public:
 
         // Visit the body of the function and build up information.
         FV.TraverseStmt(Body);
-      }
-
-      // Look at the declared parameters and see if there are any 
-      // Checked-C annotations on them. 
-      for (unsigned int i = 0; i < D->getNumParams(); i++) {
-        const ParmVarDecl *PD = D->getParamDecl(i);
-
-        if (PD->hasBoundsExpr()) {
-          const BoundsExpr *BE = PD->getBoundsExpr();
-          
-          // This parameter has a bounds expr, evaluate it to figure out 
-          // how we should constrain the parameter declaration. 
-          applyConstraintsForBounds(PD, BE); 
-        }
       }
     }
 

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -494,6 +494,10 @@ public:
     return true;
   }
 
+  void applyConstraintsForBounds(const ParmVarDecl *P, const BoundsExpr *B) {
+    return;
+  }
+
   bool VisitFunctionDecl(FunctionDecl *D) {
     FullSourceLoc FL = Context->getFullLoc(D->getLocStart());
 
@@ -508,6 +512,20 @@ public:
 
         // Visit the body of the function and build up information.
         FV.TraverseStmt(Body);
+      }
+
+      // Look at the declared parameters and see if there are any 
+      // Checked-C annotations on them. 
+      for (unsigned int i = 0; i < D->getNumParams(); i++) {
+        const ParmVarDecl *PD = D->getParamDecl(i);
+
+        if (PD->hasBoundsExpr()) {
+          const BoundsExpr *BE = PD->getBoundsExpr();
+          
+          // This parameter has a bounds expr, evaluate it to figure out 
+          // how we should constrain the parameter declaration. 
+          applyConstraintsForBounds(PD, BE); 
+        }
       }
     }
 

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -218,6 +218,10 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
     const FunctionProtoType *FT = Ty->getAs<FunctionProtoType>();
     assert(FT != nullptr); 
     returnType = FT->getReturnType();
+
+    // Extract the types for the parameters to this function. If the parameter
+    // has a bounds expression associated with it, substitute the type of that
+    // bounds expression for the other type. 
     for (unsigned i = 0; i < FT->getNumParams(); i++) {
       QualType QT;
 

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -42,7 +42,18 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, uint32_
 	while (Ty->isPointerType()) {
 		// Allocate a new constraint variable for this level of pointer.
 		vars.insert(K);
-		CS.getOrCreateVar(K);
+		VarAtom * V = CS.getOrCreateVar(K);
+   
+    if (Ty->isCheckedPointerType()) {
+      if (Ty->isCheckedPointerPtrType()) {
+        // Constrain V so that it can't be either wild or an array.
+        CS.addConstraint(CS.createNot(CS.createEq(V, CS.getArr()))); 
+        CS.addConstraint(CS.createNot(CS.createEq(V, CS.getWild())));
+        ConstrainedVars.insert(K);
+      } else if (Ty->isCheckedPointerArrayType()) {
+        llvm_unreachable("unsupported!");
+      }
+    } 
 
 		// Save here if QTy is qualified or not into a map that 
 		// indexes K to the qualification of QTy, if any.
@@ -51,9 +62,9 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, uint32_
 				std::pair<uint32_t, Qualification>(K, ConstQualification));
 
 		K++;
-        std::string TyName = tyToStr(Ty);
-        // TODO: Github issue #61: improve handling of types for
-        // variable arguments.
+    std::string TyName = tyToStr(Ty);
+    // TODO: Github issue #61: improve handling of types for
+    // // variable arguments.
 		if (TyName == "struct __va_list_tag *" || TyName == "va_list")
 			break;
 
@@ -127,11 +138,17 @@ PointerVariableConstraint::mkString(Constraints::EnvironmentMap &E) {
         if (q->second == ConstQualification)
           s = s + "const ";
 
-      emittedBase = false;
-      s = s + "_Ptr<";
+      // We need to check and see if this level of variable
+      // is constrained by a bounds safe interface. If it is, 
+      // then we shouldn't re-write it. 
+      if (ConstrainedVars.find(V) == ConstrainedVars.end()) {
+        emittedBase = false;
+        s = s + "_Ptr<";
 
-      caratsToAdd++;
-      break;
+        caratsToAdd++;
+        break;
+      }
+      // ELSE FALL THROUGH! 
     case Atom::A_Arr:
     case Atom::A_Wild:
       if (emittedBase) {
@@ -201,8 +218,18 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
     const FunctionProtoType *FT = Ty->getAs<FunctionProtoType>();
     assert(FT != nullptr); 
     returnType = FT->getReturnType();
-    for (unsigned i = 0; i < FT->getNumParams(); i++) 
-      paramTypes.push_back(FT->getParamType(i));
+    for (unsigned i = 0; i < FT->getNumParams(); i++) {
+      QualType QT;
+
+      if(const BoundsExpr *BE = FT->getParamBounds(i))
+        QT = BE->getType();
+      else
+        QT = FT->getParamType(i);
+         
+      paramTypes.push_back(QT);
+    }
+    if (FT->hasReturnBounds()) 
+      returnType = FT->getReturnBounds()->getType();
     hasproto = true;
   }
   else if (Ty->isFunctionNoProtoType()) {
@@ -217,7 +244,7 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
   // aren't pointer types. If we need to re-emit the function signature
   // as a type, then we will need the types for all the parameters and the
   // return values
- 
+
   returnVars.insert(new PVConstraint(returnType, K, N, CS, Ctx));
   for ( const auto &V : returnVars) {
     if (PVConstraint *PVC = dyn_cast<PVConstraint>(V)) {
@@ -235,13 +262,13 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
   }
 }
 
-void FunctionVariableConstraint::constrainTo(Constraints &CS, ConstAtom *A) {
+void FunctionVariableConstraint::constrainTo(Constraints &CS, ConstAtom *A, bool checkSkip) {
   for (const auto &V : returnVars)
-    V->constrainTo(CS, A);
+    V->constrainTo(CS, A, checkSkip);
 
   for (const auto &V : paramVars)
     for (const auto &U : V)
-      U->constrainTo(CS, A);
+      U->constrainTo(CS, A, checkSkip);
 }
 
 bool FunctionVariableConstraint::anyChanges(Constraints::EnvironmentMap &E) {
@@ -253,12 +280,23 @@ bool FunctionVariableConstraint::anyChanges(Constraints::EnvironmentMap &E) {
   return f;
 }
 
-void PointerVariableConstraint::constrainTo(Constraints &CS, ConstAtom *A) {
-  for (const auto &V : vars)
-    CS.addConstraint(CS.createEq(CS.getOrCreateVar(V), A));
+void PointerVariableConstraint::constrainTo(Constraints &CS, ConstAtom *A, bool checkSkip) {
+  for (const auto &V : vars) {
+    // Check and see if we've already constrained this variable. This is currently 
+    // only done when the bounds-safe interface has refined a type for an external
+    // function, and we don't want the linking phase to un-refine it by introducing
+    // a conflicting constraint. 
+    bool doAdd = true;
+    if (checkSkip) 
+      if (ConstrainedVars.find(V) != ConstrainedVars.end())
+        doAdd = false;
+
+    if (doAdd)
+      CS.addConstraint(CS.createEq(CS.getOrCreateVar(V), A));
+  }
 
   if (FV)
-    FV->constrainTo(CS, A);
+    FV->constrainTo(CS, A, checkSkip);
 }
 
 bool PointerVariableConstraint::anyChanges(Constraints::EnvironmentMap &E) {
@@ -505,8 +543,8 @@ bool ProgramInfo::link() {
           // which case we don't need to constrain anything.
           if (P1->hasProtoType() && P2->hasProtoType()) {
             // Nope, we have no choice. Constrain everything to wild.
-            P1->constrainTo(CS, CS.getWild());
-            P2->constrainTo(CS, CS.getWild());
+            P1->constrainTo(CS, CS.getWild(), true);
+            P2->constrainTo(CS, CS.getWild(), true);
           }
         }
         ++I;
@@ -516,7 +554,7 @@ bool ProgramInfo::link() {
   }
 
   // For every global function that is an unresolved external, constrain 
-  // its parameter types to be wild.
+  // its parameter types to be wild. Unless it has a bounds-safe annotation. 
   for (const auto &U : ExternFunctions) {
     // If we've seen this symbol, but never seen a body for it, constrain
     // everything about it.
@@ -528,12 +566,13 @@ bool ProgramInfo::link() {
       const std::set<FVConstraint*> &Gs = (*I).second;
 
       for (const auto &G : Gs) {
-        for(const auto &U : G->getReturnVars()) 
-          U->constrainTo(CS, CS.getWild());
+        for(const auto &U : G->getReturnVars()) {
+          U->constrainTo(CS, CS.getWild(), true);
+        }
 
         for(unsigned i = 0; i < G->numParams(); i++) 
           for(const auto &U : G->getParamVar(i)) 
-            U->constrainTo(CS, CS.getWild());
+            U->constrainTo(CS, CS.getWild(), true);
       }
     }
   }

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -54,6 +54,10 @@ private:
   ConstraintVariableKind Kind;
 protected:
   std::string BaseType;
+  // Set of constraint variables that have been constrained due to a 
+  // bounds-safe interface. They are remembered as being constrained
+  // so that later on we do not introduce a spurious constraint 
+  // making those variables WILD. 
   std::set<uint32_t> ConstrainedVars;
 public:
   ConstraintVariable(ConstraintVariableKind K, std::string T) : 
@@ -67,6 +71,9 @@ public:
   virtual void dump() const = 0;
 
   // Constrain everything 'within' this ConstraintVariable to be equal to C.
+  // Set checkSkip to true if you would like constrainTo to consider the 
+  // ConstrainedVars when applying constraints. This should be set when
+  // applying constraints due to external symbols, during linking. 
   virtual void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false) = 0;
 
   // Returns true if any of the constraint variables 'within' this instance

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -54,6 +54,7 @@ private:
   ConstraintVariableKind Kind;
 protected:
   std::string BaseType;
+  std::set<uint32_t> ConstrainedVars;
 public:
   ConstraintVariable(ConstraintVariableKind K, std::string T) : 
     Kind(K),BaseType(T) {}
@@ -66,7 +67,7 @@ public:
   virtual void dump() const = 0;
 
   // Constrain everything 'within' this ConstraintVariable to be equal to C.
-  virtual void constrainTo(Constraints &CS, ConstAtom *C) = 0;
+  virtual void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false) = 0;
 
   // Returns true if any of the constraint variables 'within' this instance
   // have a binding in E other than top. E should be the EnvironmentMap that
@@ -75,6 +76,14 @@ public:
   virtual bool anyChanges(Constraints::EnvironmentMap &E) = 0;
 
   std::string getTy() { return BaseType; }
+
+  void constrainedVariable(uint32_t K) {
+    ConstrainedVars.insert(K);
+  }
+
+  bool isConstrained(uint32_t K) { 
+    return ConstrainedVars.find(K) != ConstrainedVars.end(); 
+  }
 };
 
 class PointerVariableConstraint;
@@ -119,7 +128,7 @@ public:
 
   void print(llvm::raw_ostream &O) const ;
   void dump() const { print(llvm::errs()); }
-  void constrainTo(Constraints &CS, ConstAtom *C);
+  void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);
   bool anyChanges(Constraints::EnvironmentMap &E);
 };
 
@@ -167,7 +176,7 @@ public:
   std::string mkString(Constraints::EnvironmentMap &E);
   void print(llvm::raw_ostream &O) const;
   void dump() const { print(llvm::errs()); }
-  void constrainTo(Constraints &CS, ConstAtom *C);
+  void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);
   bool anyChanges(Constraints::EnvironmentMap &E);
 };
 


### PR DESCRIPTION
The rewriter can now check for bounds safe interfaces and update the constraints based on what it finds. Right now, it adds constraints that are not understood by the constraint solving algorithm, and making the constraint solving algorithm understand them is next. 