### PR TITLE
Adds Dynamic Bounds Checks in arrow expressions

### DIFF
--- a/lib/CodeGen/CGDynamicCheck.cpp
+++ b/lib/CodeGen/CGDynamicCheck.cpp
@@ -30,7 +30,6 @@ STATISTIC(NumDynamicChecksRange,   "The # of dynamic bounds checks found");
 STATISTIC(NumDynamicChecksExplicit,  "The # of dynamic checks inserted from _Dynamic_check(cond)");
 STATISTIC(NumDynamicChecksDeref,     "The # of dynamic checks inserted from *exp");
 STATISTIC(NumDynamicChecksSubscript, "The # of dynamic checks inserted from exp[exp]");
-STATISTIC(NumDynamicChecksMember,    "The # of dynamic checks inserted from exp.f");
 STATISTIC(NumDynamicChecksArrow,     "The # of dynamic checks inserted from exp->f");
 
 //
@@ -76,18 +75,6 @@ void CodeGenFunction::EmitCheckedCDerefCheck(const LValue Addr,
 
   ++NumDynamicChecksFound;
   ++NumDynamicChecksDeref;
-
-  EmitDynamicBoundsCheck(Addr, Bounds);
-}
-
-void CodeGenFunction::EmitCheckedCMemberCheck(const LValue Addr,
-                                              const BoundsExpr *Bounds) {
-
-  if (Bounds->isAny() || Bounds->isInvalid())
-    return;
-
-  ++NumDynamicChecksFound;
-  ++NumDynamicChecksMember;
 
   EmitDynamicBoundsCheck(Addr, Bounds);
 }

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -3275,10 +3275,11 @@ LValue CodeGenFunction::EmitMemberExpr(const MemberExpr *E) {
     BaseLV = MakeAddrLValue(Addr, PtrTy, AlignSource);
 
     // We only check the Base LValue, as we assume that any field is definitely
-    // within the size of the struct. This may not be the case with a final
-    // zero-length array (https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html)
-    // but this is an array, so is either unchecked, or is a checked array with
-    // its own bounds.
+    // within the size of the struct. This may not be the case with a "flexible
+    // array member" (6.7.2.1.18), but this member is an array, so is either
+    // unchecked, or is a checked array with its own bounds.
+    // A second reason for always checking the BaseLV is that it is the same for
+    // all the fields in the struct, so more of the checks should optimize away.
     if (E->hasBoundsExpr())
       EmitCheckedCArrowCheck(BaseLV, E->getBoundsExpr());
 

--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -1,0 +1,468 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+typedef struct {
+  int f1;
+} S1;
+
+extern _Array_ptr<S1> gp1 : count(1);
+extern _Array_ptr<S1> gp3 : count(3);
+
+extern S1 ga1 _Checked[1];
+extern S1 ga3 _Checked[3];
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Array_Ptrs
+  //
+
+  (gp1->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  (gp3->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  ((gp3 + 2)->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG7]], 1
+  // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Array_ptr<S1> lp1 : count(1),
+        _Array_ptr<S1> lp3 : count(3)) {
+  //
+  // Local Array_Ptrs
+  //
+
+  (lp1->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+
+  (lp3->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+
+  ((lp3+2)->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG7]], 1
+  // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
+
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f3
+// CHECK-IR: define void @f3
+void f3(void) {
+  //
+  // Global Checked Arrays
+  //
+
+  (ga1->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+
+  (ga3->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+
+  ((ga3+2)->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 and
+  // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: i1 icmp slt ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f4
+// CHECK-IR: define void @f4
+void f4(S1 la1 _Checked[1],
+        S1 la3 _Checked[3]) {
+  //
+  // Local Checked Arrays
+  //
+
+  (la1->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  (la3->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  ((la3+2)->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG7]], 1
+  // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -1,0 +1,456 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+typedef struct {
+  int f1;
+} S1;
+
+extern _Array_ptr<S1> gp1 : count(1);
+extern _Array_ptr<S1> gp3 : count(3);
+
+extern S1 ga1 _Checked[1];
+extern S1 ga3 _Checked[3];
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Array_Ptrs
+  //
+
+  int x1 = gp1->f1;
+  // CHECK-AST: VarDecl {{.*}} x1 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x1
+
+  int x2 = gp3->f1;
+  // CHECK-AST: VarDecl {{.*}} x2 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x2
+
+  int x3 = (gp3 + 2)->f1;
+  // CHECK-AST: VarDecl {{.*}} x3 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* %x3
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Array_ptr<S1> lp1 : count(1),
+        _Array_ptr<S1> lp3 : count(3)) {
+  //
+  // Local Array_Ptrs
+  //
+
+  int x1 = lp1->f1;
+  // CHECK-AST: VarDecl {{.*}} x1 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x1
+
+
+  int x2 = lp3->f1;
+  // CHECK-AST: VarDecl {{.*}} x2 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x2
+
+
+  int x3 = (lp3+2)->f1;
+  // CHECK-AST: VarDecl {{.*}} x3 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* %x3
+
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f3
+// CHECK-IR: define void @f3
+void f3(void) {
+  //
+  // Global Checked Arrays
+  //
+
+  int x1 = ga1->f1;
+  // CHECK-AST: VarDecl {{.*}} x1 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x1
+
+  int x2 = ga3->f1;
+  // CHECK-AST: VarDecl {{.*}} x2 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x2
+
+  int x3 = (ga3+2)->f1;
+  // CHECK-AST: VarDecl {{.*}} x3 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 and
+  // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: i1 icmp slt ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x3
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f4
+// CHECK-IR: define void @f4
+void f4(S1 la1 _Checked[1],
+        S1 la3 _Checked[3]) {
+  //
+  // Local Checked Arrays
+  //
+
+  int x1 = la1->f1;
+  // CHECK-AST: VarDecl {{.*}} x1 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x1
+
+  int x2 = la3->f1;
+  // CHECK-AST: VarDecl {{.*}} x2 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x2
+
+  int x3 = (la3+2)->f1;
+  // CHECK-AST: VarDecl {{.*}} x3 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* %x3
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}

--- a/test/CheckedC/dynamic-checks/struct-update-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-update-code-gen.c
@@ -1,0 +1,456 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+typedef struct {
+  int f1;
+} S1;
+
+extern _Array_ptr<S1> gp1 : count(1);
+extern _Array_ptr<S1> gp3 : count(3);
+
+extern S1 ga1 _Checked[1];
+extern S1 ga3 _Checked[3];
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Array_Ptrs
+  //
+
+  gp1->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  gp3->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  (gp3 + 2)->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG7]], 1
+  // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Array_ptr<S1> lp1 : count(1),
+        _Array_ptr<S1> lp3 : count(3)) {
+  //
+  // Local Array_Ptrs
+  //
+
+  lp1->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+
+  lp3->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+
+  (lp3+2)->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG7]], 1
+  // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
+
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f3
+// CHECK-IR: define void @f3
+void f3(void) {
+  //
+  // Global Checked Arrays
+  //
+
+  ga1->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+
+  ga3->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+
+  (ga3+2)->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 and
+  // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: i1 icmp slt ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f4
+// CHECK-IR: define void @f4
+void f4(S1 la1 _Checked[1],
+        S1 la3 _Checked[3]) {
+  //
+  // Local Checked Arrays
+  //
+
+  la1->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  la3->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG5]]
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG5]]
+
+  (la3+2)->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG6]]
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG7]], 1
+  // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -1,0 +1,432 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+typedef struct {
+  int f1;
+} S1;
+
+extern _Array_ptr<S1> gp1 : count(1);
+extern _Array_ptr<S1> gp3 : count(3);
+
+extern S1 ga1 _Checked[1];
+extern S1 ga3 _Checked[3];
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Array_Ptrs
+  //
+
+  gp1->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG5]]
+
+  gp3->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG5]]
+
+  (gp3 + 2)->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG6]]
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Array_ptr<S1> lp1 : count(1),
+        _Array_ptr<S1> lp3 : count(3)) {
+  //
+  // Local Array_Ptrs
+  //
+
+  lp1->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG5]]
+
+
+  lp3->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG5]]
+
+
+  (lp3+2)->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG6]]
+
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f3
+// CHECK-IR: define void @f3
+void f3(void) {
+  //
+  // Global Checked Arrays
+  //
+
+  ga1->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: store i32 1, i32* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+
+  ga3->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: store i32 1, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0)
+
+  (ga3+2)->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
+  // The following line of LLVM IR is very long
+  // CHECK-IR: br i1 and
+  // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
+  // CHECK-IR-SAME: i1 icmp slt ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
+  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
+  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
+  // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: store i32 1, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f4
+// CHECK-IR: define void @f4
+void f4(S1 la1 _Checked[1],
+        S1 la3 _Checked[3]) {
+  //
+  // Local Checked Arrays
+  //
+
+  la1->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG5]]
+
+  la3->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG5]]
+
+  (la3+2)->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: Bounds
+  // CHECK-AST-NEXT: RangeBoundsExpr
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: BinaryOperator
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp sle {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
+  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp slt {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG6]]
+
+  // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+}


### PR DESCRIPTION
This is the code to emit bounds checks in arrow expressions, such as `e->f` where e is a pointer to a struct with field f. 

I need to write tests, wait for them before review/merging.

There is a bug in this somewhere, and in some cases we insert duplicate checks. `-O1` can get rid of them, because they all check the same thing, but it's worth working out how we fix this. 