### PR TITLE
Fix compiler assert during bounds inference.

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -739,8 +739,12 @@ namespace {
     bool AddMemberBaseBoundsCheck(MemberExpr *E) {
       Expr *Base = E->getBase();
       // E.F
-      if (!E->isArrow())
-        return AddBoundsCheck(Base);
+      if (!E->isArrow()) {
+        // The base expression only needs a bounds check if it is an lvalue.
+        if (Base->isLValue())
+          return AddBoundsCheck(Base);
+        return false;
+      }
 
       // E->F.  This is equivalent to (*E).F.
       if (Base->getType()->isCheckedPointerArrayType()){

--- a/test/CheckedC/inferred-bounds/rvalue-member-base.c
+++ b/test/CheckedC/inferred-bounds/rvalue-member-base.c
@@ -1,0 +1,27 @@
+// Regression test for the case where a member base expression is not an
+// lvalue.  The Checked C compiler asserted during bounds inference when
+// it saw this (Github issue #231).
+//
+// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// expected-no-diagnostics
+
+struct S {
+  int m;
+};
+
+struct S f1(void) {
+  struct S tmp;
+  tmp.m = 0;
+  return tmp;
+}
+
+int f2(void) {
+  int i = f1().m;
+  return i;
+}
+
+int f3(void) {
+  struct S a;
+  int i = (a = f1()).m;
+  return i;
+}


### PR DESCRIPTION
The LLVM nightly test MultiSource/Benchmarks/McCat/09-vor is failing with an
internal compiler error during bounds inference.

The problem is that we were assuming that all base expressions of structures
are lvalues. According to the C specification, they do not have to be lvalues.
For example, a call can produce a structure value.  The result of a call is
not an lvalue. There can be a member reference on the value, for example:
  g().f;

The fix is to check that base expressions are lvalues before trying to
add bounds checks.

Testing:
- Added a new regression test that shows the issue.
- Passed Checked C regression tests.