### PR TITLE
Adds dynamic non-null checks

### DIFF
--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2285,12 +2285,12 @@ public:
   void EmitAsmStmt(const AsmStmt &S);
 
   void EmitExplicitDynamicCheck(const Expr *Condition);
-  void EmitCheckedCSubscriptCheck(const LValue Addr, const BoundsExpr *Bounds);
-  void EmitCheckedCDerefCheck(const LValue Addr, const BoundsExpr *Bounds);
-  void EmitCheckedCMemberCheck(const LValue Addr, const BoundsExpr *Bounds);
-  void EmitCheckedCArrowCheck(const LValue Addr, const BoundsExpr *Bounds);
-  void EmitDynamicNonNullCheck(const LValue Addr);
-  void EmitDynamicBoundsCheck(const LValue Addr, const BoundsExpr *Bounds);
+  void EmitDynamicNonNullCheck(const Address BaseAddr, const QualType BaseTy);
+  void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy, const Address PtrAddr);
+  void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds);
+  /// \brief Create a basic block that will call the trap intrinsic, and emit
+  /// a conditional branch to it, for Checked C's dynamic checks.
+  void EmitDynamicCheckBlocks(llvm::Value *Condition);
 
   void EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S);
   void EmitObjCAtTryStmt(const ObjCAtTryStmt &S);
@@ -3230,9 +3230,6 @@ public:
   /// "trap-func-name" if specified.
   llvm::CallInst *EmitTrapCall(llvm::Intrinsic::ID IntrID);
 
-  /// \brief Create a basic block that will call the trap intrinsic, and emit
-  /// a conditional branch to it, for Checked C _Dynamic_checks expressions.
-  void EmitDynamicCheckBlocks(llvm::Value *Condition);
 
   /// \brief Emit a cross-DSO CFI failure handling function.
   void EmitCfiCheckFail();

--- a/test/CheckedC/dynamic-checks/array-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-increment-code-gen.c
@@ -41,6 +41,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
@@ -73,6 +76,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<int>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -105,6 +111,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -138,6 +147,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -171,6 +183,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<int>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -188,6 +203,11 @@ void f1(void) {
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -220,6 +240,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
@@ -253,6 +276,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<int>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -286,6 +312,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -320,6 +349,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -353,6 +385,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<int>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -370,6 +405,11 @@ void f2(_Array_ptr<int> lp1 : count(1),
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -400,6 +440,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -429,6 +470,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -459,6 +501,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -488,6 +531,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -517,6 +561,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -563,6 +608,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
@@ -595,6 +643,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<int>':'_Array_ptr<int>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -627,6 +678,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -660,6 +714,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -692,6 +749,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<int>':'_Array_ptr<int>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -708,6 +768,12 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG1]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -742,6 +808,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -774,6 +841,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -808,6 +876,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -843,6 +912,7 @@ void f5() {
   // CHECK-AST-NEXT: UnaryOperator {{.*}} prefix '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -874,6 +944,7 @@ void f5() {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -905,6 +976,7 @@ void f5() {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -952,7 +1024,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -989,7 +1067,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1027,7 +1111,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1066,7 +1156,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1101,7 +1197,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
@@ -1136,8 +1238,14 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG3]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
@@ -1154,6 +1262,18 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG3]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/array-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-read-code-gen.c
@@ -39,6 +39,9 @@ void f1(void) {
 
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
@@ -69,6 +72,9 @@ void f1(void) {
 
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -97,6 +103,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -127,6 +136,9 @@ void f1(void) {
 
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -156,6 +168,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -172,6 +187,11 @@ void f1(void) {
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -200,6 +220,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<int>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
@@ -229,6 +252,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -257,6 +283,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -286,6 +315,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -314,6 +346,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<int>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -329,6 +364,11 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: store i32 [[REG5]], i32* %y5
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -356,6 +396,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -381,6 +422,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -406,6 +448,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -431,6 +474,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}), {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
@@ -455,6 +499,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -499,6 +544,9 @@ void f4(int la1 _Checked[1],
 
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
@@ -527,6 +575,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<int>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -554,6 +605,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<int>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -583,6 +637,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -612,6 +669,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -628,6 +688,12 @@ void f4(int la1 _Checked[1],
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -658,6 +724,7 @@ void f5() {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -685,6 +752,7 @@ void f5() {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -714,6 +782,7 @@ void f5() {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -743,6 +812,7 @@ void f5() {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -770,6 +840,8 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
+
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -797,6 +869,7 @@ void f5() {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -839,7 +912,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -871,7 +950,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -904,7 +989,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -937,7 +1028,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -969,7 +1066,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
@@ -1000,8 +1103,14 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG3]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
@@ -1017,6 +1126,18 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: store i32 [[REG7]], i32* %z6
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/array-update-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-update-code-gen.c
@@ -41,6 +41,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
@@ -73,6 +76,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -105,6 +111,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -138,6 +147,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -171,6 +183,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -188,6 +203,11 @@ void f1(void) {
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -220,6 +240,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
@@ -253,6 +276,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -286,6 +312,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -320,6 +349,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -353,6 +385,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -370,6 +405,11 @@ void f2(_Array_ptr<int> lp1 : count(1),
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -400,6 +440,7 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -429,6 +470,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -459,6 +501,7 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -488,6 +531,7 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -517,6 +561,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -563,6 +608,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
@@ -595,6 +643,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -627,6 +678,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -660,6 +714,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -692,6 +749,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -708,6 +768,12 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: store i32 [[REG7]], i32* [[REG1]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -742,6 +808,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -774,6 +841,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -808,6 +876,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -843,6 +912,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -874,6 +944,7 @@ void f5() {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -905,6 +976,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -952,7 +1024,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -989,7 +1067,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1027,7 +1111,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1066,7 +1156,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1101,7 +1197,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
@@ -1136,8 +1238,14 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG3]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
@@ -1154,6 +1262,18 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG3]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/array-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-write-code-gen.c
@@ -41,6 +41,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
@@ -71,6 +74,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -101,6 +107,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -132,6 +141,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
@@ -162,6 +174,9 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -176,6 +191,11 @@ void f1(void) {
   // CHECK-IR-NEXT: store i32 5, i32* [[REG1]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -208,6 +228,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
@@ -238,6 +261,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -268,6 +294,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -299,6 +328,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
@@ -329,6 +361,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -343,6 +378,11 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: store i32 5, i32* [[REG1]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -373,6 +413,7 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -399,6 +440,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
@@ -426,6 +468,7 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -453,6 +496,7 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -480,6 +524,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
@@ -524,6 +569,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
@@ -554,6 +602,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
@@ -584,6 +635,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -615,6 +669,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
@@ -645,6 +702,9 @@ void f4(int la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
@@ -663,7 +723,14 @@ void f4(int la1 _Checked[1],
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
 }
+
 
 
 
@@ -693,6 +760,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -723,6 +791,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -755,6 +824,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -788,6 +858,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -817,6 +888,7 @@ void f5() {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -846,6 +918,7 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
+  // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
   // CHECK-IR-SAME: (i1 icmp sle ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
@@ -891,7 +964,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -926,7 +1005,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -962,7 +1047,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -999,7 +1090,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1032,7 +1129,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
@@ -1065,8 +1168,14 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG3]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
@@ -1081,6 +1190,18 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: store i32 6, i32* [[REG3]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/ptr-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/ptr-increment-code-gen.c
@@ -1,0 +1,96 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+struct S1 {
+  int f1;
+};
+
+extern _Ptr<int> gp1;
+extern _Ptr<struct S1> gp2;
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Pointers
+  //
+
+  (*gp1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Ptr<int>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG2]], 1
+  // CHECK-IR-NEXT: store i32 [[REG3]], i32* [[REG1]]
+
+  (gp2->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp2' '_Ptr<struct S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG3]], 1
+  // CHECK-IR-NEXT: store i32 [[REG4]], i32* [[REG2]]
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Ptr<int> lp1,
+        _Ptr<struct S1> lp2) {
+  //
+  // Local Pointers
+  //
+
+  (*lp1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Ptr<int>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG2]], 1
+  // CHECK-IR-NEXT: store i32 [[REG3]], i32* [[REG1]]
+
+  (lp2->f1)++;
+  // CHECK-AST: UnaryOperator {{.*}} 'int' postfix '++'
+  // CHECK-AST-NEXT: ParenExpr
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp2' '_Ptr<struct S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp2.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG3]], 1
+  // CHECK-IR-NEXT: store i32 [[REG4]], i32* [[REG2]]
+}

--- a/test/CheckedC/dynamic-checks/ptr-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/ptr-read-code-gen.c
@@ -1,0 +1,92 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+struct S1 {
+  int f1;
+};
+
+extern _Ptr<int> gp1;
+extern _Ptr<struct S1> gp2;
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Pointers
+  //
+
+  int x1 = *gp1;
+  // CHECK-AST: VarDecl {{.*}} x1 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Ptr<int>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
+  // CHECK-IR-NEXT: store i32 [[REG2]], i32* %x1
+
+  int x2 = gp2->f1;
+  // CHECK-AST: VarDecl {{.*}} x2 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp2' '_Ptr<struct S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
+  // CHECK-IR-NEXT: store i32 [[REG3]], i32* %x2
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Ptr<int> lp1,
+        _Ptr<struct S1> lp2) {
+  //
+  // Local Pointers
+  //
+
+  int x1 = *lp1;
+  // CHECK-AST: VarDecl {{.*}} x1 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Ptr<int>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
+  // CHECK-IR-NEXT: store i32 [[REG2]], i32* %x1
+
+  int x2 = lp2->f1;
+  // CHECK-AST: VarDecl {{.*}} x2 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp2' '_Ptr<struct S1>'
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp2.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
+  // CHECK-IR-NEXT: store i32 [[REG3]], i32* %x2
+}

--- a/test/CheckedC/dynamic-checks/ptr-update-code-gen.c
+++ b/test/CheckedC/dynamic-checks/ptr-update-code-gen.c
@@ -1,0 +1,96 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+struct S1 {
+  int f1;
+};
+
+extern _Ptr<int> gp1;
+extern _Ptr<struct S1> gp2;
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Pointers
+  //
+
+  *gp1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Ptr<int>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG2]], 1
+  // CHECK-IR-NEXT: store i32 [[REG3]], i32* [[REG1]]
+
+  gp2->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp2' '_Ptr<struct S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG3]], 1
+  // CHECK-IR-NEXT: store i32 [[REG4]], i32* [[REG2]]
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Ptr<int> lp1,
+        _Ptr<struct S1> lp2) {
+  //
+  // Local Pointers
+  //
+
+  *lp1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Ptr<int>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG2]], 1
+  // CHECK-IR-NEXT: store i32 [[REG3]], i32* [[REG1]]
+
+  lp2->f1 += 1;
+  // CHECK-AST: CompoundAssignOperator {{.*}} 'int' '+='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp2' '_Ptr<struct S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp2.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG3]], 1
+  // CHECK-IR-NEXT: store i32 [[REG4]], i32* [[REG2]]
+}

--- a/test/CheckedC/dynamic-checks/ptr-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/ptr-write-code-gen.c
@@ -1,0 +1,88 @@
+
+// RUN: %clang_cc1 -fcheckedc-extension %s -ast-dump | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
+
+// In the following generated IR, we do not verify the alignment of any loads/stores
+// ie, the IR checked by line 37 might read "%1 = load i32*, i32** @gp1, align 4"
+// but we discard the "align 4" at the end. This is because alignment is type-size
+// dependent, which in turn is very platform dependent.
+// It is better to elide these checks, because we really care about the order of
+// loads, checks and stores, in these tests, not their specific alignment.
+
+struct S1 {
+  int f1;
+};
+
+extern _Ptr<int> gp1;
+extern _Ptr<struct S1> gp2;
+
+// CHECK-AST: FunctionDecl {{.*}} f1
+// CHECK-IR: define void @f1
+void f1(void) {
+  //
+  // Global Pointers
+  //
+
+  *gp1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Ptr<int>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG1]]
+
+  gp2->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp2' '_Ptr<struct S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG2]]
+}
+
+// CHECK-AST: FunctionDecl {{.*}} f2
+// CHECK-IR: define void @f2
+void f2(_Ptr<int> lp1,
+        _Ptr<struct S1> lp2) {
+  //
+  // Local Pointers
+  //
+
+  *lp1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: UnaryOperator {{.*}} 'int' lvalue prefix '*'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Ptr<int>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i32* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG1]]
+
+  lp2->f1 = 1;
+  // CHECK-AST: BinaryOperator {{.*}} 'int' '='
+  // CHECK-AST-NEXT: MemberExpr {{.*}} ->f1
+  // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp2' '_Ptr<struct S1>'
+  // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
+
+  // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp2.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
+  // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
+  // CHECK-IR-NEXT: store i32 1, i32* [[REG2]]
+}

--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -115,6 +115,7 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
@@ -477,6 +478,7 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}

--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -42,6 +42,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -74,6 +77,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -110,6 +116,9 @@ void f1(void) {
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -127,6 +136,9 @@ void f1(void) {
   // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -156,6 +168,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -189,6 +204,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -226,6 +244,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -244,6 +265,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -271,6 +295,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
@@ -300,6 +325,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
@@ -332,6 +358,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
@@ -377,6 +404,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -409,6 +439,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -445,6 +478,9 @@ void f4(S1 la1 _Checked[1],
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -462,6 +498,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -42,6 +42,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -73,6 +76,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -108,6 +114,9 @@ void f1(void) {
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -124,6 +133,9 @@ void f1(void) {
   // CHECK-IR-NEXT: store i32 [[REG7]], i32* %x3
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -153,6 +165,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -185,6 +200,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -221,6 +239,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -238,6 +259,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -265,6 +289,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
@@ -293,6 +318,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
@@ -324,6 +350,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
@@ -368,6 +395,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -399,6 +429,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -434,6 +467,9 @@ void f4(S1 la1 _Checked[1],
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -450,6 +486,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: store i32 [[REG7]], i32* %x3
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -113,6 +113,7 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
@@ -466,6 +467,7 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}

--- a/test/CheckedC/dynamic-checks/struct-update-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-update-code-gen.c
@@ -112,6 +112,7 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
@@ -465,6 +466,7 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}

--- a/test/CheckedC/dynamic-checks/struct-update-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-update-code-gen.c
@@ -41,6 +41,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -72,6 +75,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -107,6 +113,9 @@ void f1(void) {
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -124,6 +133,9 @@ void f1(void) {
   // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -152,6 +164,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -184,6 +199,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -220,6 +238,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -238,6 +259,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -264,6 +288,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
@@ -292,6 +317,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
@@ -323,6 +349,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
@@ -367,6 +394,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -398,6 +428,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -433,6 +466,9 @@ void f4(S1 la1 _Checked[1],
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -450,6 +486,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: store i32 [[REG8]], i32* [[REG6]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -108,6 +108,7 @@ void f1(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
@@ -443,6 +444,7 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // NOTE: no check here, because we don't yet do checks at pointer arithmetic
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -41,6 +41,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -70,6 +73,9 @@ void f1(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -103,6 +109,9 @@ void f1(void) {
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -118,6 +127,9 @@ void f1(void) {
   // CHECK-IR-NEXT: store i32 1, i32* [[REG6]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -146,6 +158,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp1' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -176,6 +191,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lp3' '_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -210,6 +228,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -226,6 +247,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
 
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
@@ -252,6 +276,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
@@ -278,6 +303,7 @@ void f3(void) {
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 icmp slt ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
@@ -307,6 +333,7 @@ void f3(void) {
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
+  // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR: br i1 and
@@ -349,6 +376,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la1' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
@@ -378,6 +408,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'la3' '_Array_ptr<S1>':'_Array_ptr<S1>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG1]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
@@ -411,6 +444,9 @@ void f4(S1 la1 _Checked[1],
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 2
+  // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne %struct.S1* [[REG2]], null
+  // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
+  // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
@@ -426,6 +462,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: store i32 1, i32* [[REG6]]
 
   // CHECK-IR: ret void
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
+  // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap
   // CHECK-IR: call void @llvm.trap


### PR DESCRIPTION
This commit adds non-null checks to Checked C. 

They are inserted during code generation of the following expressions:
- `*e` (checking `e` is non-null)
- `e->f` (checking `e` is non-null)
- `e1[e2]` (checking `e1` is non-null)

In particular, we call the original pointer that we calculate the offset from (in the case of subscript/arrow) the "base" pointer, and check it is non-null before performing any pointer offset calculations. These checks trap in exactly the same way that bounds checks trap, all containing their own trap block in LLVM IR. 

Testing:
- Not tested at all yet. Don't merge until there are some tests. 