### PR TITLE
Corrects matcher in struct tests to abstract over GEP Index types

### DIFF
--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -343,9 +343,9 @@ void f3(void) {
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0)
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
-  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0)
 
   // CHECK-IR: ret void
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -335,7 +335,7 @@ void f3(void) {
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0)
   // CHECK-IR-NEXT: store i32 [[REG6]], i32* %x3
 
   // CHECK-IR: ret void

--- a/test/CheckedC/dynamic-checks/struct-update-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-update-code-gen.c
@@ -334,9 +334,9 @@ void f3(void) {
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0)
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = add nsw i32 [[REG6]], 1
-  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: store i32 [[REG7]], i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0)
 
   // CHECK-IR: ret void
   // CHECK-IR: call void @llvm.trap

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -318,7 +318,7 @@ void f3(void) {
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
-  // CHECK-IR-NEXT: store i32 1, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2, i32 0)
+  // CHECK-IR-NEXT: store i32 1, i32* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0)
 
   // CHECK-IR: ret void
   // CHECK-IR: call void @llvm.trap


### PR DESCRIPTION
This should turn the build from red to green again.

Struct tests pass on my machine (windows 32 bit)