### PR TITLE
Adds Ranges to Diagnostics for better information

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -716,7 +716,7 @@ namespace {
         NeedsBoundsCheck = true;
         LValueBounds = S.InferLValueBounds(S.getASTContext(), E);
         if (LValueBounds->isNone()) {
-          S.Diag(E->getLocStart(), diag::err_expected_bounds);
+          S.Diag(E->getLocStart(), diag::err_expected_bounds) << E->getSourceRange();
           LValueBounds = S.CreateInvalidBoundsExpr();
         }
         if (UnaryOperator *UO = dyn_cast<UnaryOperator>(Deref)) {
@@ -750,7 +750,7 @@ namespace {
       if (Base->getType()->isCheckedPointerArrayType()){
         BoundsExpr *Bounds = S.InferRValueBounds(S.getASTContext(), Base);
         if (Bounds->isNone()) {
-          S.Diag(E->getLocStart(), diag::err_expected_bounds);
+          S.Diag(Base->getLocStart(), diag::err_expected_bounds) << Base->getSourceRange();
           Bounds = S.CreateInvalidBoundsExpr();
         }
         E->setBoundsExpr(Bounds);
@@ -788,7 +788,7 @@ namespace {
           else
             RHSBounds = S.InferRValueBounds(S.Context, RHS);
           if (RHSBounds->isNone()) {
-             S.Diag(RHS->getLocStart(), diag::err_expected_bounds);
+             S.Diag(RHS->getLocStart(), diag::err_expected_bounds) << RHS->getSourceRange();
              RHSBounds = S.CreateInvalidBoundsExpr();
           }
         }
@@ -825,7 +825,7 @@ namespace {
           S.InferRValueBounds(S.getASTContext(), E->getSubExpr());
         if (SrcBounds->isNone()) {
           // TODO: produce more informative error message.
-          S.Diag(E->getSubExpr()->getLocStart(), diag::err_expected_bounds);
+          S.Diag(E->getSubExpr()->getLocStart(), diag::err_expected_bounds) << E->getSubExpr()->getSourceRange();
           SrcBounds = S.CreateInvalidBoundsExpr();
         }
         assert(SrcBounds);
@@ -903,7 +903,7 @@ namespace {
         BoundsExpr *InitBounds = S.InferRValueBounds(S.getASTContext(), Init);
         if (InitBounds->isNone()) {
           // TODO: need some place to record the initializer bounds
-          S.Diag(Init->getLocStart(), diag::err_expected_bounds);
+          S.Diag(Init->getLocStart(), diag::err_expected_bounds) << Init->getSourceRange();
           InitBounds = S.CreateInvalidBoundsExpr();
         }
         if (DumpBounds)


### PR DESCRIPTION
This adds source ranges to the diagnostic. Doesn't sound like much, but can make a big difference when attempting to correct an error.

Lack of bounds errors go from looking like:
```
/Users/ashe2/Code/checkedc-travis-builder/llvm-test-suite/MultiSource/Benchmarks/Olden/em3d/make_graph.c:88:23: error:
      expression has no bounds
        local_table = table[dest_proc];
                      ^
```

To looking like: 
```
/Users/ashe2/Code/checkedc-travis-builder/llvm-test-suite/MultiSource/Benchmarks/Olden/em3d/make_graph.c:88:23: error:
      expression has no bounds
        local_table = table[dest_proc];
                      ^~~~~~~~~~~~~~~~
```

This immediately gives better information as to which expression we don't have bounds for, whether it's just `table`, or whether it's `table[dest_proc]`.