### PR TITLE
Updates LNT Repo URL to our fork

### DIFF
--- a/automation/UNIX/setup-files.sh
+++ b/automation/UNIX/setup-files.sh
@@ -38,7 +38,7 @@ clone_or_update llvm/projects/checkedc-wrapper/checkedc https://github.com/Micro
 
 ## Comment out LNT-related stuff for now.  We are not ready to automate that yet.
 # Check out LNT
-# clone_or_update lnt https://github.com/llvm-mirror/lnt master
+# clone_or_update lnt https://github.com/Microsoft/checkedc-lnt master
 
 # Check out Test Suite
 # clone_or_update llvm-test-suite https://github.com/Microsoft/checkedc-llvm-test-suite master

--- a/automation/travis/checkout.sh
+++ b/automation/travis/checkout.sh
@@ -33,7 +33,7 @@ clone_or_update llvm/tools/clang https://github.com/Microsoft/checkedc-clang mas
 clone_or_update llvm/projects/checkedc-wrapper/checkedc https://github.com/Microsoft/checkedc master
 
 # Check out LNT
-clone_or_update lnt https://github.com/llvm-mirror/lnt master
+clone_or_update lnt https://github.com/Microsoft/checkedc-lnt master
 
 # Check out Test Suite
 clone_or_update llvm-test-suite https://github.com/Microsoft/checkedc-llvm-test-suite master


### PR DESCRIPTION
We've just forked LNT so we can add our own changes. While these changes will eventually go back to LLVM itself, we should build based on our fork. This updates some URLs (not that we're currently using either)