### PR TITLE
Pointer_bounds_cast.c test fails on Windows 86.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2815,8 +2815,6 @@ private:
   }
 
 protected:
-  Stmt *Bounds;  // actually a bounds expression
-
   CastExpr(StmtClass SC, QualType ty, ExprValueKind VK, const CastKind kind,
            Expr *op, unsigned BasePathSize)
       : Expr(SC, ty, VK, OK_Ordinary,

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -1674,6 +1674,7 @@ private:
   SourceLocation Loc;
   Stmt *Val;
 
+  // Compiler-inferred bounds used for inserting a bounds check.
   BoundsExpr *Bounds;
 public:
 
@@ -2085,6 +2086,7 @@ class ArraySubscriptExpr : public Expr {
   Stmt* SubExprs[END_EXPR];
   SourceLocation RBracketLoc;
 
+  // Compiler-inferred bounds used for inserting a bounds check.
   BoundsExpr *Bounds;
 public:
   ArraySubscriptExpr(Expr *lhs, Expr *rhs, QualType t,
@@ -2402,8 +2404,8 @@ class MemberExpr final
     return HasTemplateKWAndArgsInfo ? 1 : 0;
   }
 
-  /// Bounds expression to be used to bounds check the base expression X
-  /// of X->F, if a bounds check is needed.
+  /// Compiler-inferred bounds expression to be used to bounds check the base
+  /// expression X of X->F, if a bounds check is needed.
   BoundsExpr *Bounds;
 
 public:
@@ -2687,15 +2689,117 @@ public:
   child_range children() { return child_range(&Init, &Init+1); }
 };
 
+/// \brief Represents a Checked C bounds expression.
+class BoundsExpr : public Expr {
+private:
+  SourceLocation StartLoc, EndLoc;
+  friend class ASTStmtReader;
+
+public:
+  enum Kind {
+    // Invalid bounds expressions are used to flag invalid bounds
+    // expressions and prevent spurious downstream error messages
+    // in bounds declaration checking.
+    Invalid = 0,
+    // bounds(none)
+    None = 1,
+    // bounds(any)
+    Any = 2,
+    // count(e)
+    ElementCount = 3,
+    // byte_count(e)
+    ByteCount = 4,
+    // bounds(e1, e2)
+    Range = 5,
+    // ptr interop annotation.  This isn't really a bounds expression.
+    // To save space and for programmng convenience, we store the
+    // ": ptr" interop annotation as a bounds expression.
+    InteropTypeAnnotation = 6,
+
+    // Sentinel marker for maximum bounds kind.
+    MaxBoundsKind = InteropTypeAnnotation
+  };
+
+  static_assert(MaxBoundsKind < (1 << NumBoundsExprKindBits), "kind field too small");
+
+  BoundsExpr(StmtClass StmtClass, QualType Ty, Kind BoundsKind, SourceLocation StartLoc,
+             SourceLocation EndLoc)
+    : Expr(StmtClass, Ty, VK_RValue, OK_Ordinary, false,
+           false, false, false), StartLoc(StartLoc), EndLoc(EndLoc) {
+    setKind(BoundsKind);
+  }
+
+  BoundsExpr(StmtClass StmtClass, Kind BoundsKind, SourceLocation StartLoc,
+             SourceLocation EndLoc)
+    : BoundsExpr(StmtClass, QualType(), BoundsKind, StartLoc, EndLoc) {
+  }
+
+  explicit BoundsExpr(StmtClass StmtClass, EmptyShell Empty) :
+    Expr(StmtClass, Empty) {
+    setKind(Invalid);
+  }
+
+
+  SourceLocation getStartLoc() const { return StartLoc; }
+  SourceLocation getEndLoc() const { return EndLoc; }
+  SourceLocation getRParenLoc() const { return EndLoc; }
+
+  SourceLocation getLocStart() const LLVM_READONLY { return StartLoc; }
+  SourceLocation getLocEnd() const LLVM_READONLY { return EndLoc; }
+
+  Kind getKind() const { return (Kind)BoundsExprBits.Kind; }
+  void setKind(Kind Kind) {
+    assert(validateKind(Kind));
+    BoundsExprBits.Kind = Kind;
+  }
+
+  bool isInvalid() const {
+    return getKind() == Invalid;
+  }
+
+  bool isNone() const {
+    return getKind() == None;
+  }
+
+  bool isAny() const {
+    return getKind() == Any;
+  }
+
+  bool isElementCount() const {
+    return getKind() == ElementCount;
+  }
+
+  bool isByteCount() const {
+    return getKind() == ByteCount;
+  }
+
+  bool isRange() const {
+    return getKind() == Range;
+  }
+
+  bool isInteropTypeAnnotation() const {
+    return getKind() == InteropTypeAnnotation;
+  }
+
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() >= firstBoundsExprConstant &&
+      T->getStmtClass() <= lastBoundsExprConstant;
+  }
+
+private:
+  /// \brief: check that the kind is valid for the type
+  /// of bounds expression.
+  bool validateKind(Kind kind);
+};
+
 /// CastExpr - Base class for type casts, including both implicit
 /// casts (ImplicitCastExpr) and explicit casts that have some
 /// representation in the source code (ExplicitCastExpr's derived
 /// classes).
 class CastExpr : public Expr {
 private:
-  Stmt *Op;
-
-  BoundsExpr *Bounds;
+  enum { OP, BOUNDS, END_EXPR = 2 };
+  Stmt* SubExprs[END_EXPR];
 
   bool CastConsistency() const;
 
@@ -2711,6 +2815,8 @@ private:
   }
 
 protected:
+  Stmt *Bounds;  // actually a bounds expression
+
   CastExpr(StmtClass SC, QualType ty, ExprValueKind VK, const CastKind kind,
            Expr *op, unsigned BasePathSize)
       : Expr(SC, ty, VK, OK_Ordinary,
@@ -2726,9 +2832,10 @@ protected:
              // unexpanded pack, even if its target type does.
              ((SC != ImplicitCastExprClass &&
                ty->containsUnexpandedParameterPack()) ||
-              (op && op->containsUnexpandedParameterPack()))),
-        Op(op), Bounds(nullptr) {
+              (op && op->containsUnexpandedParameterPack()))) {
     assert(kind != CK_Invalid && "creating cast with invalid cast kind");
+    SubExprs[OP] = op;
+    SubExprs[BOUNDS] = nullptr;
     CastExprBits.Kind = kind;
     setBasePathSize(BasePathSize);
     assert(CastConsistency());
@@ -2736,7 +2843,9 @@ protected:
 
   /// \brief Construct an empty cast.
   CastExpr(StmtClass SC, EmptyShell Empty, unsigned BasePathSize)
-    : Expr(SC, Empty), Bounds(nullptr) {
+    : Expr(SC, Empty) {
+    SubExprs[OP] = nullptr;
+    SubExprs[BOUNDS] = nullptr;
     setBasePathSize(BasePathSize);
   }
 
@@ -2745,9 +2854,9 @@ public:
   void setCastKind(CastKind K) { CastExprBits.Kind = K; }
   const char *getCastKindName() const;
 
-  Expr *getSubExpr() { return cast<Expr>(Op); }
-  const Expr *getSubExpr() const { return cast<Expr>(Op); }
-  void setSubExpr(Expr *E) { Op = E; }
+  Expr *getSubExpr() { return cast<Expr>(SubExprs[OP]); }
+  const Expr *getSubExpr() const { return cast<Expr>(SubExprs[OP]); }
+  void setSubExpr(Expr *E) { SubExprs[OP] = E; }
 
   /// \brief Retrieve the cast subexpression as it was written in the source
   /// code, looking through any implicit casts or other intermediate nodes
@@ -2772,29 +2881,42 @@ public:
   }
 
   // Iterators
-  child_range children() { return child_range(&Op, &Op+1); }
+  child_range children() {
+    // For bounds cast expression, the bounds are included as a subexpression
+    // in the AST because they are part of the source program.  For other
+    // cast expressions, the bounds are not included because they are
+    // inferred by the compiler only when needed.
+    if (getStmtClass() == BoundsCastExprClass)
+      return child_range(&SubExprs[OP], &SubExprs[END_EXPR]);
+    else
+      return child_range(&SubExprs[OP], &SubExprs[OP] + 1);
+  }
 
   // Checked C bounds information
 
-  /// \brief Return true if the subexpression of the cast has inferred
-  /// bounds.  It has inferred bounds when this is a cast to _Ptr
-  /// type.  The bound must be provably large enough at compile-time
-  /// to contain a value of the _Ptr type.
-  bool hasBoundsExpr() const { return Bounds != nullptr; }
+  /// \brief Return true if the cast expression has a bounds expression
+  /// associated with it.  Depending on the type of the cast expression,
+  /// the bounds expression may be declared as part of the program or inferred
+  /// by the compiler.
+  bool hasBoundsExpr() const { return SubExprs[BOUNDS] != nullptr; }
 
-  /// \brief The inferred bounds for the subexpression (source operand) of
-  /// this cast expression..
-  const BoundsExpr *getBoundsExpr() const {
-    return const_cast<BoundsExpr*>(Bounds);
+  /// \brief Returns the bounds associated with the cast expression.
+  /// * If the cast expression is a BoundsCast expression, it is the bounds
+  /// declared in the program.
+  /// * If the cast expression is a cast to Ptr, it is the compiler-inferred
+  /// bounds of the subexpression of the cast expression.   The bounds must be
+  /// provably large enough at compile-time to contain a value of the _Ptr type.
+  BoundsExpr *getBoundsExpr() {
+    return cast_or_null<BoundsExpr>(SubExprs[BOUNDS]);
   }
 
-  /// \brief The inferred bounds for the subexpression (source operand) of
-  /// this cast expression.
-  BoundsExpr *getBoundsExpr() { return Bounds; }
+  const BoundsExpr *getBoundsExpr() const {
+    return const_cast<BoundsExpr*>(cast_or_null<BoundsExpr>(SubExprs[BOUNDS]));
+  }
 
-  /// \brief Set the inferred bounds for the subexpression (source operand)
-  /// of this cast expression.
-  void setBoundsExpr(BoundsExpr *E) { Bounds = E; }
+  void setBoundsExpr(BoundsExpr *E) {
+    SubExprs[BOUNDS] = E;
+  }
 };
 
 /// ImplicitCastExpr - Allows us to explicitly represent implicit type
@@ -3012,11 +3134,6 @@ public:
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == BoundsCastExprClass;
-  }
-
-  child_range children(){
-    Stmt *bounds = dyn_cast<Stmt>(this->getBoundsExpr());
-    return child_range(&bounds, &bounds+1);
   }
 
   friend TrailingObjects;
@@ -4652,108 +4769,6 @@ public:
   friend class ASTStmtReader;
 };
 
-/// \brief Represents a Checked C bounds expression.
-class BoundsExpr : public Expr {
-private:
-  SourceLocation StartLoc, EndLoc;
-  friend class ASTStmtReader;
-
-public:
-  enum Kind {
-    // Invalid bounds expressions are used to flag invalid bounds
-    // expressions and prevent spurious downstream error messages
-    // in bounds declaration checking.
-    Invalid = 0,
-    // bounds(none)
-    None = 1,
-    // bounds(any)
-    Any = 2,
-    // count(e)
-    ElementCount = 3,
-    // byte_count(e)
-    ByteCount = 4,
-    // bounds(e1, e2)
-    Range = 5,
-    // ptr interop annotation.  This isn't really a bounds expression.
-    // To save space and for programmng convenience, we store the 
-    // ": ptr" interop annotation as a bounds expression.
-    InteropTypeAnnotation = 6,
-
-    // Sentinel marker for maximum bounds kind.
-    MaxBoundsKind = InteropTypeAnnotation
-  };
-
-  static_assert(MaxBoundsKind < (1 << NumBoundsExprKindBits), "kind field too small");
-
-  BoundsExpr(StmtClass StmtClass, QualType Ty, Kind BoundsKind, SourceLocation StartLoc,
-             SourceLocation EndLoc)
-    : Expr(StmtClass, Ty, VK_RValue, OK_Ordinary, false,
-           false, false, false), StartLoc(StartLoc), EndLoc(EndLoc) {
-    setKind(BoundsKind);
-  }
-
-  BoundsExpr(StmtClass StmtClass, Kind BoundsKind, SourceLocation StartLoc,
-             SourceLocation EndLoc)
-    : BoundsExpr(StmtClass, QualType(), BoundsKind, StartLoc, EndLoc) {
-  }
-
-  explicit BoundsExpr(StmtClass StmtClass, EmptyShell Empty) :
-    Expr(StmtClass, Empty) {
-    setKind(Invalid);
-  }
-
-
-  SourceLocation getStartLoc() const { return StartLoc; }
-  SourceLocation getEndLoc() const { return EndLoc; }
-  SourceLocation getRParenLoc() const { return EndLoc; }
-
-  SourceLocation getLocStart() const LLVM_READONLY { return StartLoc; }
-  SourceLocation getLocEnd() const LLVM_READONLY { return EndLoc; }
-
-  Kind getKind() const { return (Kind)BoundsExprBits.Kind; }
-  void setKind(Kind Kind) {
-    assert(validateKind(Kind));
-    BoundsExprBits.Kind = Kind;
-  }
-
-  bool isInvalid() const {
-    return getKind() == Invalid;
-  }
-
-  bool isNone() const {
-    return getKind() == None;
-  }
-
-  bool isAny() const {
-    return getKind() == Any;
-  }
-
-  bool isElementCount() const {
-    return getKind() == ElementCount;
-  }
-
-  bool isByteCount() const {
-    return getKind() == ByteCount;
-  }
-
-  bool isRange() const {
-    return getKind() == Range;
-  }
-
-  bool isInteropTypeAnnotation() const {
-    return getKind() == InteropTypeAnnotation;
-  }
-
-  static bool classof(const Stmt *T) {
-    return T->getStmtClass() >= firstBoundsExprConstant &&
-           T->getStmtClass() <= lastBoundsExprConstant;
-  }
-
-private:
-  /// \brief: check that the kind is valid for the type
-  /// of bounds expression.
-  bool validateKind(Kind kind);
-};
 
 /// \brief Represents a Checked C nullary bounds expression.
 class NullaryBoundsExpr : public BoundsExpr {


### PR DESCRIPTION
The new pointer_bounds_cast.c test failed with an internal compiler assertion
during automated compiler testing on Windows x86.  The problem is  the children 
method in the BoundsCastExpr class. The methods returns an iterator. The iterator was
being built by taking the address of local variable. When the method returned, the
iterator structure pointed to a stack location that had been deallocated.  This commit 
addresses issue #261 and part of issue #260.

The fix is to have the iterator structure point to heap-allocated memory that is
part of the AST.  This required refactoring the way bounds expressions are stored
in cast expressions. Both the bounds expression and the op expression need to be
stored in an array of Stmt *, following the pattern used elsewhere in the
AST for children of AST nodes.  I moved the BoundsExpr class earlier in
the file to avoid a forward reference to the BoundsExpr type, which would have
required a reinterpret_cast.

Testing:
- Passed Checked C regression tests.
- Pass Clang regression tests.