### PR TITLE
Fix usage of member bounds with the arrow operator. 

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -180,9 +180,13 @@ namespace {
           // For now, return nothing if we see an rvalue base.
           return ExprResult();
         ASTContext &Context = SemaRef.getASTContext();
-        ExprValueKind ResultKind = Base->isLValue() ? VK_LValue : VK_RValue;
+        ExprValueKind ResultKind;
+        if (IsArrow)
+          ResultKind = VK_LValue;
+        else
+          ResultKind = Base->isLValue() ? VK_LValue : VK_RValue;
         MemberExpr *ME =
-          new (Context) MemberExpr(Base, /*IsArrow=*/false,
+          new (Context) MemberExpr(Base, IsArrow,
                                    SourceLocation(), FD, SourceLocation(),
                                    E->getType(), ResultKind, OK_Ordinary);
         return ME;

--- a/test/CheckedC/ast-dump-struct-bounds.c
+++ b/test/CheckedC/ast-dump-struct-bounds.c
@@ -24,10 +24,10 @@ struct S2 {
 //CHECK: |-RecordDecl {{.*}} struct S2 definition
 //CHECK: | `-FieldDecl {{.*}} f '_Array_ptr<int>'
 //CHECK: |   `-CountBoundsExpr {{.*}} 'NULL TYPE' Byte
-//CHECK: |     `-BinaryOperator {{.*}} 'unsigned int' '*'
-//CHECK: |       |-ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+//CHECK: |     `-BinaryOperator {{.*}} 'unsigned {{.*}}' '*'
+//CHECK: |       |-ImplicitCastExpr {{.*}} 'unsigned {{.*}}' <IntegralCast>
 //CHECK: |       | `-IntegerLiteral {{.*}} 'int' 5
-//CHECK: |       `-UnaryExprOrTypeTraitExpr {{.*}} 'unsigned int' sizeof 'int'
+//CHECK: |       `-UnaryExprOrTypeTraitExpr {{.*}} 'unsigned {{.*}}' sizeof 'int'
 
 struct S3 {
   _Array_ptr<int> f : bounds(f, f + 5);
@@ -56,18 +56,18 @@ struct S4 {
 //CHECK: | `-FieldDecl {{.*}} referenced len 'int'
 
 struct S5 {
-  _Array_ptr<int> f: count(len * sizeof(int));
+  _Array_ptr<int> f: byte_count(len * sizeof(int));
   int len;
 };
 
 //CHECK: |-RecordDecl {{.*}} struct S5 definition
 //CHECK: | |-FieldDecl {{.*}} f '_Array_ptr<int>'
-//CHECK: | | `-CountBoundsExpr {{.*}} 'NULL TYPE' Element
-//CHECK: | |   `-BinaryOperator {{.*}} 'unsigned int' '*'
-//CHECK: | |     |-ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+//CHECK: | | `-CountBoundsExpr {{.*}} 'NULL TYPE' Byte
+//CHECK: | |   `-BinaryOperator {{.*}} 'unsigned {{.*}}' '*'
+//CHECK: | |     |-ImplicitCastExpr {{.*}} 'unsigned {{.*}}' <IntegralCast>
 //CHECK: | |     | `-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
 //CHECK: | |     |   `-DeclRefExpr {{.*}} 'int' lvalue Field {{0x[0-9a-f]+}} 'len' 'int'
-//CHECK: | |     `-UnaryExprOrTypeTraitExpr {{.*}} 'unsigned int' sizeof 'int'
+//CHECK: | |     `-UnaryExprOrTypeTraitExpr {{.*}} 'unsigned {{.*}}' sizeof 'int'
 //CHECK: | `-FieldDecl {{.*}} referenced len 'int'
 
 struct S6 {

--- a/test/CheckedC/ast-dump-struct-bounds.c
+++ b/test/CheckedC/ast-dump-struct-bounds.c
@@ -1,0 +1,89 @@
+// Tests for dumping of ASTS with Checked C extensions.
+// This makes sure that additional information appears as
+// expected.
+//
+// RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
+
+//===================================================================
+// Dumps of different kinds of member bounds expressions
+//===================================================================
+
+struct S1 {
+  _Array_ptr<int> f : count(5);
+};
+
+//CHECK: |-RecordDecl {{.*}} struct S1 definition
+//CHECK: | `-FieldDecl {{.*}} f '_Array_ptr<int>'
+//CHECK: |   `-CountBoundsExpr {{.*}} 'NULL TYPE' Element
+//CHECK: |     `-IntegerLiteral {{.*}} 'int' 5
+
+struct S2 {
+  _Array_ptr<int> f : byte_count(5 * sizeof(int));
+};
+
+//CHECK: |-RecordDecl {{.*}} struct S2 definition
+//CHECK: | `-FieldDecl {{.*}} f '_Array_ptr<int>'
+//CHECK: |   `-CountBoundsExpr {{.*}} 'NULL TYPE' Byte
+//CHECK: |     `-BinaryOperator {{.*}} 'unsigned int' '*'
+//CHECK: |       |-ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+//CHECK: |       | `-IntegerLiteral {{.*}} 'int' 5
+//CHECK: |       `-UnaryExprOrTypeTraitExpr {{.*}} 'unsigned int' sizeof 'int'
+
+struct S3 {
+  _Array_ptr<int> f : bounds(f, f + 5);
+};
+
+//CHECK: |-RecordDecl {{.*}} struct S3 definition
+//CHECK: | `-FieldDecl {{.*}} referenced f '_Array_ptr<int>'
+//CHECK: |   `-RangeBoundsExpr {{.*}} 'NULL TYPE'
+//CHECK: |     |-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <LValueToRValue>
+//CHECK: |     | `-DeclRefExpr {{.*}} '_Array_ptr<int>' lvalue Field {{0x[0-9a-f]+}} 'f' '_Array_ptr<int>'
+//CHECK: |     `-BinaryOperator {{.*}} '_Array_ptr<int>' '+'
+//CHECK: |       |-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <LValueToRValue>
+//CHECK: |       | `-DeclRefExpr {{.*}} '_Array_ptr<int>' lvalue Field {{0x[0-9a-f]+}} 'f' '_Array_ptr<int>'
+//CHECK: |       `-IntegerLiteral {{.*}} 'int' 5
+
+struct S4 {
+  _Array_ptr<int> f : count(len);
+  int len;
+};
+
+//CHECK: |-RecordDecl {{.*}} struct S4 definition
+//CHECK: | |-FieldDecl {{.*}} f '_Array_ptr<int>'
+//CHECK: | | `-CountBoundsExpr {{.*}} 'NULL TYPE' Element
+//CHECK: | |   `-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+//CHECK: | |     `-DeclRefExpr {{.*}} 'int' lvalue Field {{0x[0-9a-f]+}} 'len' 'int'
+//CHECK: | `-FieldDecl {{.*}} referenced len 'int'
+
+struct S5 {
+  _Array_ptr<int> f: count(len * sizeof(int));
+  int len;
+};
+
+//CHECK: |-RecordDecl {{.*}} struct S5 definition
+//CHECK: | |-FieldDecl {{.*}} f '_Array_ptr<int>'
+//CHECK: | | `-CountBoundsExpr {{.*}} 'NULL TYPE' Element
+//CHECK: | |   `-BinaryOperator {{.*}} 'unsigned int' '*'
+//CHECK: | |     |-ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+//CHECK: | |     | `-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+//CHECK: | |     |   `-DeclRefExpr {{.*}} 'int' lvalue Field {{0x[0-9a-f]+}} 'len' 'int'
+//CHECK: | |     `-UnaryExprOrTypeTraitExpr {{.*}} 'unsigned int' sizeof 'int'
+//CHECK: | `-FieldDecl {{.*}} referenced len 'int'
+
+struct S6 {
+  _Array_ptr<int> f : bounds(f, f + len);
+  int len;
+};
+
+//CHECK: `-RecordDecl {{.*}} struct S6 definition
+//CHECK: |-FieldDecl {{.*}} referenced f '_Array_ptr<int>'
+//CHECK: | `-RangeBoundsExpr {{.*}} 'NULL TYPE'
+//CHECK: |   |-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <LValueToRValue>
+//CHECK: |   | `-DeclRefExpr {{.*}} '_Array_ptr<int>' lvalue Field {{0x[0-9a-f]+}} 'f' '_Array_ptr<int>'
+//CHECK: |   `-BinaryOperator {{.*}} '_Array_ptr<int>' '+'
+//CHECK: |     |-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <LValueToRValue>
+//CHECK: |     | `-DeclRefExpr {{.*}} '_Array_ptr<int>' lvalue Field {{0x[0-9a-f]+}} 'f' '_Array_ptr<int>'
+//CHECK: |     `-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+//CHECK: |       `-DeclRefExpr {{.*}} 'int' lvalue Field {{0x[0-9a-f]+}} 'len' 'int'
+//CHECK: `-FieldDecl {{.*}} referenced len 'int'
+

--- a/test/CheckedC/inferred-bounds/member-arrow-reference.c
+++ b/test/CheckedC/inferred-bounds/member-arrow-reference.c
@@ -1,0 +1,195 @@
+// Tests of inferred bounds for references of members of structures or
+// union, using arrow operations.
+//
+// The tests have the general form:
+// 1. Some C code.
+// 2. A description of the inferred bounds for that C code:
+//  a. The expression
+//  b. The inferred bounds.
+// The description uses AST dumps.
+//
+// This line is for the clang test infrastructure:
+// RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
+// expected-no-diagnostics
+
+struct S1 {
+  _Array_ptr<int> p : count(len);
+  int len;
+};
+
+struct S2 {
+  int arr _Checked[5];
+};
+
+struct S3 {
+  int f;
+};
+
+//-------------------------------------------------------------------------//
+// Test reading a member of a parameter                                    //
+//-------------------------------------------------------------------------//
+
+void f1(struct S1 *a1, struct S2 *b2) {
+  _Array_ptr<int> ap : count(a1->len) = a1->p;
+
+// CHECK: VarDecl {{.*}} ap '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{.*}} 'NULL TYPE' Element
+// CHECK: | `-ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+// CHECK: |   `-MemberExpr {{.*}} 'int' lvalue ->len {{0x[0-9a-f]+}}
+// CHECK: |     `-ImplicitCastExpr {{.*}} 'struct S1 *' <LValueToRValue>
+// CHECK: |       `-DeclRefExpr {{.*}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct S1 *'
+// CHECK: `-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   `-MemberExpr {{.*}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}
+// CHECK:     `-ImplicitCastExpr {{.*}} 'struct S1 *' <LValueToRValue>
+// CHECK:       `-DeclRefExpr {{.*}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct S1 *'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:   `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->len {{0x[0-9a-f]+}}
+// CHECK:     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct S1 *'
+// CHECK: Initializer Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct S1 *'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}
+// CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct S1 *'
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->len {{0x[0-9a-f]+}}
+// CHECK:       `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK:         `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct S1 *'
+
+  _Array_ptr<int> bp : count(5) = b2->arr;
+
+// CHECK: VarDecl {{.*}} bp '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{.*}} 'NULL TYPE' Element
+// CHECK: | `-IntegerLiteral {{.*}} 'int' 5
+// CHECK: `-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   `-MemberExpr {{.*}} 'int checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
+// CHECK:     `-ImplicitCastExpr {{.*}} 'struct S2 *' <LValueToRValue>
+// CHECK:       `-DeclRefExpr {{.*}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: Initializer Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S2 *' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
+// CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S2 *' <LValueToRValue>
+// CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 5
+}
+
+//-------------------------------------------------------------------------//
+// Test writing a member of a parameter                                    //
+//-------------------------------------------------------------------------//
+
+void f2(struct S1 *a3) {
+  int local_arr1[5];
+  // TODO: need bundled block.
+  a3->p = local_arr1;
+
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a3' 'struct S1 *'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <ArrayToPointerDecay>
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a3' 'struct S1 *'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}
+// CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a3' 'struct S1 *'
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->len {{0x[0-9a-f]+}}
+// CHECK:       `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S1 *' <LValueToRValue>
+// CHECK:         `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1 *' lvalue ParmVar {{0x[0-9a-f]+}} 'a3' 'struct S1 *'
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *':'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 5
+
+  a3->len = 5;
+
+  // Ignore the bounds on this assignment, which is here to avoid having a program
+  // with undefined behavior.
+  a3->p = 0;
+  a3->len = 0;
+}
+
+//-------------------------------------------------------------------------//
+// Test taking the address of a member of a parameter                      //
+//-------------------------------------------------------------------------//
+
+void f3(struct S3 *c1) {
+  _Array_ptr<int> cp : bounds(&(c1->f), &(c1->f) + 1) = &(c1->f);
+
+// CHECK: VarDecl {{.*}} cp '_Array_ptr<int>' cinit
+// CHECK: |-RangeBoundsExpr {{.*}} 'NULL TYPE'
+// CHECK: | |-UnaryOperator {{.*}} 'int *' prefix '&'
+// CHECK: | | `-ParenExpr {{.*}} 'int' lvalue
+// CHECK: | |   `-MemberExpr {{.*}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: | |     `-ImplicitCastExpr {{.*}} 'struct S3 *' <LValueToRValue>
+// CHECK: | |       `-DeclRefExpr {{.*}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK: | `-BinaryOperator {{.*}} 'int *' '+'
+// CHECK: |   |-UnaryOperator {{.*}} 'int *' prefix '&'
+// CHECK: |   | `-ParenExpr {{.*}} 'int' lvalue
+// CHECK: |   |   `-MemberExpr {{.*}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   |     `-ImplicitCastExpr {{.*}} 'struct S3 *' <LValueToRValue>
+// CHECK: |   |       `-DeclRefExpr {{.*}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK: |   `-IntegerLiteral {{.*}} 'int' 1
+// CHECK: `-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK:   `-UnaryOperator {{.*}} 'int *' prefix '&'
+// CHECK:     `-ParenExpr {{.*}} 'int' lvalue
+// CHECK:       `-MemberExpr {{.*}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK:         `-ImplicitCastExpr {{.*}} 'struct S3 *' <LValueToRValue>
+// CHECK:           `-DeclRefExpr {{.*}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK: Declared Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK: | `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: |   `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S3 *' <LValueToRValue>
+// CHECK: |       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK:   | `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK:   |   `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK:   |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S3 *' <LValueToRValue>
+// CHECK:   |       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S3 *' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S3 *' <LValueToRValue>
+// CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
+
+}


### PR DESCRIPTION
This addresses issue #280, found when converting some benchmarks in LNT
to use Checked C.  Two benchmarks that used the arrow operator to
access members with bounds failed to compile because they caused
internal compiler asserts.   The problem was that the conversion of
member bounds to concrete instances of bounds on variables and expressions
was incorrect.  The concretization function neglected to take into account the
arrow operator, even though the the kind of member access operator had been
passed in to it.

Testing:
Added several small tests to make sure that the feature works in some
cases so that others blocked on this bug can make forward progress.
Additional tests need to be written.

New tests in the checkedc-clang repo are:
- Add a test of dumping bounds for structures in the AST
(ast-dump-struct-bounds.c), so that we can be sure that the input
to the concretization function is reasonable.
- Add tests of the inferred bounds for members with member bounds,
where the members are accessed using the arrow operator
(member-arrow-reference.c).

Also added runtimes test to the Checked C repo in
tests\dynamic_checking\read-member-arrow-ponter-check.c.
This is the read-member-pointer-check.c adapted to
use pointers to structures.