### PR TITLE
Update documentation for parallel builds

### DIFF
--- a/docs/checkedc/Setup-and-Build.md
+++ b/docs/checkedc/Setup-and-Build.md
@@ -29,18 +29,18 @@ of parallelism that will be used during builds.  By default, the Visual Studio s
 for clang has [too much parallelism](https:/github.com/Microsoft/checkedc-clang/issues/268). 
 The parallelism will cause your build to use too much physical memory and cause your machine
 to start paging.  This will make your machine unresponsive and slow down your build too.
-In VS 2015, go to _Debug->Options->Projects and Solutions->VC++ Project Solutions_ and set
-the `Maximum Number of concurrent C++ compilations` to 4 or 6.
+See The Wiki page on [Parallel builds of clang on Windows](https://github.com/Microsoft/checkedc-clang/wiki/Parallel-builds-of-clang-on-Windows/)
+for more details.
+
+in VS 2015, go to _Debug->Options->Projects and Solutions->VC++ Project Solutions_ and set
+the `Maximum Number of concurrent C++ compilations` to 6, if your development machine has
+1 GByte of memor or more per core.  If not, see the 
+[Wiki page](https://github.com/Microsoft/checkedc-clang/wiki/Parallel-builds-of-clang-on-Windows/)
+to figure out what number to use.
 By default, 0 causes it to be the number of available CPU cores on your machine, which is too much.
 You may want to go to  _Debug->Options->Projects and Solutions ->Build and Run_ and 
 set the maximum number of parallel project builds to be 3/4 of the actual number of CPU cores on
 your machine.  
-
-In general, choose these numbers so that the build stays within physical
-memory.  We have found that having 256 MBytes of memory per compiler invocation given the
-maximum number of compiler invocations works well. In other words, we recommend
-that _total physical memory_/(_number of concurrent compilations_ *
-_number of parallel project builds_) is greater than 256 MBytes.
 
 LLVM/clang have some tests that depend on using Unix line ending conventions
 (line feeds only).  This means that the sources you will be working with
@@ -176,11 +176,15 @@ Subsequent builds during development will be much faster (minutes, not an hour).
 
 Change to your build directory and just run `make`:
 
-	make
+	make -j _nnn_
+
+where `nnn` is the number of CPU cores on your machine.
 
 For subsequent builds, you can just build `clang`:
 
-	make clang
+	make -j _nnn_ clang
+
+where `_nnn_` is the number of core CPU cores on your machine
 
 ### On Windows
 
@@ -201,11 +205,11 @@ To build
 
 Follow the earlier instruction to set up the build system.  Form the build directory, use the following comamnd to build clang only:
 
-	msbuild tools\clang\tools\driver\clang.vcxproj /maxcpucount:number of processors/3
+	msbuild tools\clang\tools\driver\clang.vcxproj /p:CL_CPUCount=6 /m
 
 To build everything:
 
-	msbuild LLVM.sln //maxcpucount:number of processors/3
+	msbuild LLVM.sln /p:CL_CPUCount=6 /m
 
 To clean the build directory:
 

--- a/docs/checkedc/Setup-and-Build.md
+++ b/docs/checkedc/Setup-and-Build.md
@@ -178,13 +178,13 @@ Change to your build directory and just run `make`:
 
 	make -j nnn
 
-where `nnn` is replaced by the number of CPU cores on your machine.
+where `nnn` is replaced by the number of CPU cores that your computer has.
 
 For subsequent builds, you can just build `clang`:
 
 	make -j nnn clang
 
-where `nnn` is replaced by the number of core CPU cores on your machine
+where `nnn` is replaced by the number of CPU cores that your computer has.
 
 ### On Windows
 

--- a/docs/checkedc/Setup-and-Build.md
+++ b/docs/checkedc/Setup-and-Build.md
@@ -29,12 +29,12 @@ of parallelism that will be used during builds.  By default, the Visual Studio s
 for clang has [too much parallelism](https:/github.com/Microsoft/checkedc-clang/issues/268). 
 The parallelism will cause your build to use too much physical memory and cause your machine
 to start paging.  This will make your machine unresponsive and slow down your build too.
-See The Wiki page on [Parallel builds of clang on Windows](https://github.com/Microsoft/checkedc-clang/wiki/Parallel-builds-of-clang-on-Windows/)
+See the Wiki page on [Parallel builds of clang on Windows](https://github.com/Microsoft/checkedc-clang/wiki/Parallel-builds-of-clang-on-Windows/)
 for more details.
 
 in VS 2015, go to _Debug->Options->Projects and Solutions->VC++ Project Solutions_ and set
 the `Maximum Number of concurrent C++ compilations` to 6, if your development machine has
-1 GByte of memor or more per core.  If not, see the 
+1 GByte of memory or more per core.  If not, see the
 [Wiki page](https://github.com/Microsoft/checkedc-clang/wiki/Parallel-builds-of-clang-on-Windows/)
 to figure out what number to use.
 By default, 0 causes it to be the number of available CPU cores on your machine, which is too much.
@@ -176,15 +176,15 @@ Subsequent builds during development will be much faster (minutes, not an hour).
 
 Change to your build directory and just run `make`:
 
-	make -j _nnn_
+	make -j nnn
 
-where `nnn` is the number of CPU cores on your machine.
+where `nnn` is replaced by the number of CPU cores on your machine.
 
 For subsequent builds, you can just build `clang`:
 
-	make -j _nnn_ clang
+	make -j nnn clang
 
-where `_nnn_` is the number of core CPU cores on your machine
+where `nnn` is replaced by the number of core CPU cores on your machine
 
 ### On Windows
 

--- a/docs/checkedc/Testing.md
+++ b/docs/checkedc/Testing.md
@@ -28,16 +28,18 @@ Load the solution and the open it using the Solution explorer (View->Solution Ex
 ### From a command shell using msbuild
 Set up the build system and then change to your new object directory.  Use the following commands to run tests:
 
-- Checked C tests: `msbuild projects\checkedc-wrapper\check-checkedc.vcxproj /maxcpucount:`_number of processors_/3
-- Clang tests: `msbuild tools\clang\test\check-clang.vcxproj /maxcpucount:`_number of processors_/3
-- All LLVM and clang tests: `msbuild check-all.vcxproj /maxcpucount:`_number of processors_/3
+- Checked C tests: `msbuild projects\checkedc-wrapper\check-checkedc.vcxproj /p:CL_CPUCount=6 /m`
+- Clang tests: `msbuild tools\clang\test\check-clang.vcxproj /p:CL_CPUCount=6 /m`
+- All LLVM and clang tests: `msbuild check-all.vcxproj /p:CL_CPUCount=6 /m`
 
 ### Using make
 In your build directory,
 
-- Checked C tests: `make check-checkedc`
-- clang tests: `make check-clang`
-- All tests: `make check-all`
+- Checked C tests: `make -j _nnn_ check-checkedc`
+- clang tests: `make -j _nnn_ check-clang`
+- All tests: `make -j _nnn_ check-all`
+
+where `_nnn` is the number of CPU cores on your machine.
 
 ### From a command shell using the testing harness
 You can use the testing harness to run individual tests or sets of tests.

--- a/docs/checkedc/Testing.md
+++ b/docs/checkedc/Testing.md
@@ -39,7 +39,7 @@ In your build directory,
 - clang tests: `make -j nnn check-clang`
 - All tests: `make -j nnn check-all`
 
-where `nnn` is replaced by the number of CPU cores on your machine.
+where `nnn` is replaced by the number of CPU cores that your computer has.
 
 ### From a command shell using the testing harness
 You can use the testing harness to run individual tests or sets of tests.

--- a/docs/checkedc/Testing.md
+++ b/docs/checkedc/Testing.md
@@ -35,11 +35,11 @@ Set up the build system and then change to your new object directory.  Use the f
 ### Using make
 In your build directory,
 
-- Checked C tests: `make -j _nnn_ check-checkedc`
-- clang tests: `make -j _nnn_ check-clang`
-- All tests: `make -j _nnn_ check-all`
+- Checked C tests: `make -j nnn check-checkedc`
+- clang tests: `make -j nnn check-clang`
+- All tests: `make -j nnn check-all`
 
-where `_nnn` is the number of CPU cores on your machine.
+where `nnn` is replaced by the number of CPU cores on your machine.
 
 ### From a command shell using the testing harness
 You can use the testing harness to run individual tests or sets of tests.


### PR DESCRIPTION
Update the documentation md files to agree with recommended settings for parallel builds on Windows.
