### PR TITLE
Fix Return value of ParseRelativeBoundsForDecl not being used (#282)

### DIFF
--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1072,9 +1072,6 @@ def err_expected_range_bounds_expr : Error<
 def err_expected_relative_bounds_clause
     : Error<"expected rel_align or rel_align_value">;
 
-def err_invalid_relative_bounds_clause
-    : Error<"invalid rel_align or rel_align_value">;
-
 def err_unexpected_bounds_expr_after_declarator: Error<
   "unexpected bounds expression after declarator">;
 

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1072,6 +1072,9 @@ def err_expected_range_bounds_expr : Error<
 def err_expected_relative_bounds_clause
     : Error<"expected rel_align or rel_align_value">;
 
+def err_invalid_relative_bounds_clause
+    : Error<"invalid rel_align or rel_align_value">;
+
 def err_unexpected_bounds_expr_after_declarator: Error<
   "unexpected bounds expression after declarator">;
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2841,7 +2841,10 @@ ExprResult Parser::ParseBoundsExpressionOrInteropType(const Declarator &D,
 
   TempTok = Tok;
   if (StartsRelativeBoundsClause(Tok))
-    ParseRelativeBoundsClauseForDecl(Result);
+    if (ParseRelativeBoundsClauseForDecl(Result)) {
+      Diag(Tok, diag::err_invalid_relative_bounds_clause);
+      Result = ExprError();
+    }
 
   return Result;
 }
@@ -2977,7 +2980,6 @@ bool Parser::ParseRelativeBoundsClauseForDecl(ExprResult &Expr) {
       ParseRelativeBoundsClause(isError, Ident, BoundsKWLoc);
 
   if (Expr.isInvalid()) {
-    isError = true;
     return isError;
   }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2842,7 +2842,6 @@ ExprResult Parser::ParseBoundsExpressionOrInteropType(const Declarator &D,
   TempTok = Tok;
   if (StartsRelativeBoundsClause(Tok))
     if (ParseRelativeBoundsClauseForDecl(Result)) {
-      Diag(Tok, diag::err_invalid_relative_bounds_clause);
       Result = ExprError();
     }
 


### PR DESCRIPTION
.According to the return value of ParseRelativeBoundsForDecl, it generates "invalid rel_align or rel_align_value" error message.