### PR TITLE
Do not allow some bounds_cast in checked scope (#277)

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8946,6 +8946,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_checked_scope_no_variadic_func_for_expression : Error<
     "cannot use a variable arguments function in a checked scope or function">;
 
+  def err_checked_scope_no_assume_bounds_casting : Error<
+    "invalid _Assume_bounds_cast in a checked scope or function">;
+
   def err_bounds_cast_error_with_single_syntax
       : Error<"invalid bounds cast: expected _Ptr or * type">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8947,7 +8947,7 @@ def err_bounds_type_annotation_lost_checking : Error<
     "cannot use a variable arguments function in a checked scope or function">;
 
   def err_checked_scope_no_assume_bounds_casting : Error<
-    "invalid _Assume_bounds_cast in a checked scope or function">;
+    "_Assume_bounds_cast not allowed in a checked scope or function">;
 
   def err_bounds_cast_error_with_single_syntax
       : Error<"invalid bounds cast: expected _Ptr or * type">;

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -937,7 +937,8 @@ namespace {
       // If inferred bounds of e1 are bounds(none), compile-time error.
       // If inferred bounds of e1 are bounds(any), no runtime checks.
       // Otherwise, the inferred bounds is bounds(lb, ub).
-      // In code geneartion, it inserts dynamic check(lb <= e2 && e3 <= ub)
+      // bounds of cast operation is bounds(e2, e3).
+      // In code geneartion, it inserts dynamic_check(lb <= e2 && e3 <= ub).
       if (CK == CK_DynamicPtrBounds) {
         BoundsExpr *SrcBounds = S.InferRValueBounds(E);
         Expr *subExpr = E->getSubExpr();
@@ -946,8 +947,6 @@ namespace {
         if (subExprBounds->isNone()) {
           S.Diag(subExpr->getLocStart(), diag::err_expected_bounds);
           SrcBounds = S.CreateInvalidBoundsExpr();
-        } else if (subExprBounds->isAny()) {
-          E->setCastKind(CK_AssumePtrBounds);
         }
 
         assert(SrcBounds);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -934,6 +934,10 @@ namespace {
         return true;
       }
 
+      // If inferred bounds of e1 are bounds(none), compile-time error.
+      // If inferred bounds of e1 are bounds(any), no runtime checks.
+      // Otherwise, the inferred bounds is bounds(lb, ub).
+      // In code geneartion, it inserts dynamic check(lb <= e2 && e3 <= ub)
       if (CK == CK_DynamicPtrBounds) {
         BoundsExpr *SrcBounds = S.InferRValueBounds(E);
         Expr *subExpr = E->getSubExpr();
@@ -942,6 +946,8 @@ namespace {
         if (subExprBounds->isNone()) {
           S.Diag(subExpr->getLocStart(), diag::err_expected_bounds);
           SrcBounds = S.CreateInvalidBoundsExpr();
+        } else if (subExprBounds->isAny()) {
+          E->setCastKind(CK_AssumePtrBounds);
         }
 
         assert(SrcBounds);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -938,7 +938,7 @@ namespace {
       // If inferred bounds of e1 are bounds(any), no runtime checks.
       // Otherwise, the inferred bounds is bounds(lb, ub).
       // bounds of cast operation is bounds(e2, e3).
-      // In code geneartion, it inserts dynamic_check(lb <= e2 && e3 <= ub).
+      // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub).
       if (CK == CK_DynamicPtrBounds) {
         BoundsExpr *SrcBounds = S.InferRValueBounds(E);
         Expr *subExpr = E->getSubExpr();


### PR DESCRIPTION
+ Do not allow some bounds_cast in checked scope (#277)
  + prevent all _Assume_bounds_cast operations in checked scope
  + prevent _Dynamic_bounds_cast to unchecked or variadic type in a checked scope
  it is same as constraints of C-style explicit casting in a checked scope
+ bounds cast operation
  + if source bounds is bounds(any), no runtime checks are neeeded