### PR TITLE
Follow-up on issues from pull request #269 (#287)

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1965,7 +1965,7 @@ void ASTDumper::VisitCastExpr(const CastExpr *Node) {
   dumpBasePath(OS, Node);
   OS << ">";
 
-  if(Node->getStmtClass() != Expr::BoundsCastExprClass)
+  if (Node->getStmtClass() != Expr::BoundsCastExprClass)
     if (const BoundsExpr *Bounds = Node->getBoundsExpr()) {
       dumpChild([=] {
         OS << "Inferred Bounds";

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -935,17 +935,12 @@ namespace {
       }
 
       if (CK == CK_DynamicPtrBounds) {
-        BoundsExpr *SrcBounds = S.InferRValueBounds(E);
         Expr *subExpr = E->getSubExpr();
         BoundsExpr *subExprBounds = S.InferRValueBounds(subExpr);
 
         if (subExprBounds->isNone()) {
           S.Diag(subExpr->getLocStart(), diag::err_expected_bounds);
-          SrcBounds = S.CreateInvalidBoundsExpr();
         }
-
-        assert(SrcBounds);
-        E->setBoundsExpr(SrcBounds);
       }
 
       // Casts to _Ptr type must have a source for which we can infer bounds.


### PR DESCRIPTION
 Delete inferring the rvalue bounds for the entire cast expression in SemaBounds.