### PR TITLE
Check types of operands of *_bounds_cast operators (#286)

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -3089,11 +3089,7 @@ class BoundsCastExpr final
   SourceLocation RParenLoc;
   SourceRange AngleBrackets;
 public:
-  enum SyntaxType {
-    Single = 0,
-    Count = 1,
-    Range = 2
-  };
+  enum SyntaxType { Bounds = 0, Single = 1, Count = 2, Range = 3 };
 
   BoundsCastExpr(QualType exprTy, ExprValueKind vk, CastKind kind, Expr *op,
                  unsigned PathSize, TypeSourceInfo *writtenTy, SourceLocation l,

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4288,6 +4288,16 @@ public:
                                                     SourceLocation BoundsKWLoc,
                                                     SourceLocation RParenLoc);
 
+  bool CheckBoundsCastBaseType(Expr *E1);
+
+  ExprResult
+  ActOnBoundsCastExprBounds(Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
+                            SourceLocation LAnagleBracketLoc, ParsedType D,
+                            SourceLocation RAngleBracketLoc,
+                            RelativeBoundsClause *RelativeClause,
+                            SourceLocation LParenLoc, SourceLocation RParenLoc,
+                            Expr *E1, Expr *ParsedBounds);
+
   ExprResult ActOnBoundsCastExprSingle(
       Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
       SourceLocation LAnagleBracketLoc, ParsedType D,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3098,11 +3098,6 @@ ExprResult Parser::ParseBoundsCastExpression() {
   if (Tok.is(tok::comma)) {
     ConsumeToken();
     if (StartsBoundsExpression(Tok)) {
-      IdentifierInfo *Ident = Tok.getIdentifierInfo();
-
-      if (Ident == Ident_byte_count)
-        return ExprError();
-
       syntax = BoundsCastExpr::SyntaxType::Bounds;
       ParsedBounds = ParseBoundsExpression();
       if (ParsedBounds.isInvalid())

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12469,8 +12469,6 @@ ExprResult Sema::CreatePositionalParameterExpr(unsigned Index, QualType QT) {
 bool Sema::CheckBoundsCastBaseType(Expr *E1) {
   bool Result = false;
   QualType SrcTy = E1->getType();
-  if (SrcTy->isFunctionType())
-    SrcTy = dyn_cast<FunctionType>(SrcTy)->getReturnType();
   if (!SrcTy->isPointerType() && !SrcTy->isIntegralType(Context) &&
       !SrcTy->isArrayType()) {
     Diag(E1->getLocStart(), diag::err_typecheck_non_count_bounds_decl) << E1;
@@ -12536,8 +12534,8 @@ ExprResult Sema::ActOnBoundsCastExprSingle(
   QualType DestTy = GetTypeFromParser(D, &castTInfo);
   SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();
 
-  if(CheckBoundsCastBaseType(E1))
-    return ExprError();  
+  if (CheckBoundsCastBaseType(E1))
+    return ExprError();
 
   if (DestTy->isCheckedPointerPtrType() || DestTy->isUncheckedPointerType()) {
     llvm::APInt I = llvm::APInt(1, 1, false);
@@ -12586,9 +12584,9 @@ ExprResult Sema::ActOnBoundsCastExprCount(
   ExprResult ResE2 = CorrectDelayedTyposInExpr(E2);
   SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();
 
-  if(CheckBoundsCastBaseType(E1))
+  if (CheckBoundsCastBaseType(E1))
     return ExprError();
-  
+
   if (!DestTy->isCheckedPointerArrayType()) {
     Diag(TypeLoc, diag::err_bounds_cast_error_with_array_syntax);
     return ExprError();
@@ -12632,7 +12630,7 @@ ExprResult Sema::ActOnBoundsCastExprRange(
   TypeSourceInfo *castTInfo;
   ExprResult bounds(true);
 
-  if(CheckBoundsCastBaseType(E1))
+  if (CheckBoundsCastBaseType(E1))
     return ExprError();
 
   QualType DestTy = GetTypeFromParser(D, &castTInfo);

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -12466,6 +12466,63 @@ ExprResult Sema::CreatePositionalParameterExpr(unsigned Index, QualType QT) {
   return new (Context) PositionalParameterExpr(Index, QT);
 }
 
+bool Sema::CheckBoundsCastBaseType(Expr *E1) {
+  bool Result = false;
+  QualType SrcTy = E1->getType();
+  if (SrcTy->isFunctionType())
+    SrcTy = dyn_cast<FunctionType>(SrcTy)->getReturnType();
+  if (!SrcTy->isPointerType() && !SrcTy->isIntegralType(Context) &&
+      !SrcTy->isArrayType()) {
+    Diag(E1->getLocStart(), diag::err_typecheck_non_count_bounds_decl) << E1;
+    Result = true;
+  }
+  return Result;
+}
+
+ExprResult Sema::ActOnBoundsCastExprBounds(
+    Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
+    SourceLocation LAngleBracketLoc, ParsedType D,
+    SourceLocation RAngleBracketLoc, RelativeBoundsClause *RelativeClause,
+    SourceLocation LParenLoc, SourceLocation RParenLoc, Expr *E1,
+    Expr *bounds) {
+
+  RangeBoundsExpr *Range = nullptr;
+  TypeSourceInfo *castTInfo;
+
+  QualType DestTy = GetTypeFromParser(D, &castTInfo);
+  ExprResult ParsedBounds = CorrectDelayedTyposInExpr(bounds);
+  SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();
+
+  if (CheckBoundsCastBaseType(E1))
+    return ExprError();
+
+  if (!DestTy->isCheckedPointerArrayType()) {
+    Diag(TypeLoc, diag::err_bounds_cast_error_with_array_syntax);
+    return ExprError();
+  } else if ((E1->getType())->isVoidPointerType()) {
+    Diag(E1->getLocStart(),
+         diag::err_typecheck_void_pointer_count_return_bounds);
+    return ExprError();
+  }
+
+  if (ParsedBounds.isInvalid())
+    return ExprError();
+
+  if (RelativeClause != nullptr) {
+    RelativeBoundsClause::Kind kind = RelativeClause->getClauseKind();
+    if (((kind == RelativeBoundsClause::Kind::Type) ||
+         (kind == RelativeBoundsClause::Kind::Const)) &&
+        (Range = dyn_cast<RangeBoundsExpr>(ParsedBounds.get()))) {
+      Range->setRelativeBoundsClause(RelativeClause);
+    }
+  }
+
+  return BuildBoundsCastExpr(OpLoc, Kind, castTInfo,
+                             SourceRange(LAngleBracketLoc, RAngleBracketLoc),
+                             SourceRange(LParenLoc, RParenLoc), E1,
+                             dyn_cast<BoundsExpr>(ParsedBounds.get()));
+}
+
 ExprResult Sema::ActOnBoundsCastExprSingle(
     Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
     SourceLocation LAngleBracketLoc, ParsedType D,
@@ -12478,6 +12535,9 @@ ExprResult Sema::ActOnBoundsCastExprSingle(
 
   QualType DestTy = GetTypeFromParser(D, &castTInfo);
   SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();
+
+  if(CheckBoundsCastBaseType(E1))
+    return ExprError();  
 
   if (DestTy->isCheckedPointerPtrType() || DestTy->isUncheckedPointerType()) {
     llvm::APInt I = llvm::APInt(1, 1, false);
@@ -12526,6 +12586,9 @@ ExprResult Sema::ActOnBoundsCastExprCount(
   ExprResult ResE2 = CorrectDelayedTyposInExpr(E2);
   SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();
 
+  if(CheckBoundsCastBaseType(E1))
+    return ExprError();
+  
   if (!DestTy->isCheckedPointerArrayType()) {
     Diag(TypeLoc, diag::err_bounds_cast_error_with_array_syntax);
     return ExprError();
@@ -12568,6 +12631,9 @@ ExprResult Sema::ActOnBoundsCastExprRange(
   RangeBoundsExpr *Range = nullptr;
   TypeSourceInfo *castTInfo;
   ExprResult bounds(true);
+
+  if(CheckBoundsCastBaseType(E1))
+    return ExprError();
 
   QualType DestTy = GetTypeFromParser(D, &castTInfo);
   SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();


### PR DESCRIPTION
 . Add check whether E1 is a pointer type or and integral type. If E1 is
   functional type, it checks the return type of E1.

 . Add parsing bounds expression for bounds cast expression.
   - Add check whether the second argument of bounds cast expression is bounds
     expression such as count(10) or bounds(a, b) and it parses them except
     byte_count expression. If it is byte_count then it return ExprError().