### PR TITLE
Allow re-writer to work with allocator patterns

### DIFF
--- a/test/CheckedCRewriter/allocator.c
+++ b/test/CheckedCRewriter/allocator.c
@@ -1,0 +1,22 @@
+// Tests for Checked C rewriter tool.
+//
+// Tests for malloc and friends. 
+//
+// RUN: checked-c-convert %s -- | FileCheck -match-full-lines %s
+// RUN: checked-c-convert %s -- | %clang_cc1 -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+//
+#include <stdlib.h>
+
+void dosomething(void) {
+  int a = 0;
+  int *b = &a;
+  *b = 1;
+  return;
+}
+
+void foo(void) {
+  int *a = (int *) malloc(sizeof(int));
+  *a = 0;
+  return;
+}

--- a/test/CheckedCRewriter/allocator.c
+++ b/test/CheckedCRewriter/allocator.c
@@ -20,11 +20,13 @@ void dosomething(void) {
 void foo(void) {
   int *a = (int *) malloc(sizeof(int));
   *a = 0;
-  free((void*)a);
+  free(a);
   return;
 }
 //CHECK: void foo(void) {
 //CHECK-NEXT: _Ptr<int>  a = (int *) malloc(sizeof(int));
+//CHECK-NEXT: *a = 0;
+//CHECK-NEXT: free((void *)a);
 
 typedef struct _listelt {
   struct _listelt *next;

--- a/test/CheckedCRewriter/allocator.c
+++ b/test/CheckedCRewriter/allocator.c
@@ -6,7 +6,7 @@
 // RUN: checked-c-convert %s -- | %clang_cc1 -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 //
-#include <stdlib.h>
+extern void *malloc(unsigned long);
 
 void dosomething(void) {
   int a = 0;
@@ -20,3 +20,5 @@ void foo(void) {
   *a = 0;
   return;
 }
+//CHECK: void foo(void) {
+//CHECK-NEXT: _Ptr<int> a = (int *) malloc(sizeof(int));

--- a/test/CheckedCRewriter/allocator.c
+++ b/test/CheckedCRewriter/allocator.c
@@ -48,3 +48,5 @@ void add_some_stuff(listhead *hd) {
   cur->next = l1;
   return;
 }
+//CHECK: void add_some_stuff(_Ptr<listhead>  hd) {
+//CHECK-NEXT: _Ptr<listelt>  l1 = (listelt *) malloc(sizeof(listelt));

--- a/test/CheckedCRewriter/function_tests.c
+++ b/test/CheckedCRewriter/function_tests.c
@@ -33,7 +33,7 @@ void *xyzzy(int *a, int b) {
 
   return 0;
 }
-//CHECK: void *xyzzy(_Ptr<int>  a, int b) {
+//CHECK: void* xyzzy(_Ptr<int>  a, int b) {
 //CHECK-NEXT: *a = b;
 
 void xyzzy_driver(void) {

--- a/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/tools/checked-c-convert/CheckedCConvert.cpp
@@ -292,6 +292,7 @@ void rewrite(Rewriter &R, std::set<DAndReplace> &toRewrite, SourceManager &S,
       //       Additionally, a source range can be (mis) identified as 
       //       spanning multiple files. We don't know how to re-write that,
       //       so don't.
+    
       SourceRange SR = UD->getReturnTypeSourceRange();
       if (canRewrite(R, SR))
         R.ReplaceText(SR, N.second);

--- a/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/tools/checked-c-convert/CheckedCConvert.cpp
@@ -440,6 +440,9 @@ std::set<unsigned int> CastPlacementVisitor::getParamsForExtern(std::string E) {
     .Default(std::set<unsigned int>());
 }
 
+// Checks the bindings in the environment for all of the constraints
+// associated with C and returns true if any of those constraints 
+// are WILD. 
 bool CastPlacementVisitor::anyTop(std::set<ConstraintVariable*> C) {
   bool anyTopFound = false;
   Constraints &CS = Info.getConstraints();

--- a/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/tools/checked-c-convert/CheckedCConvert.cpp
@@ -100,8 +100,6 @@ void rewrite(Rewriter &R, std::set<DAndReplace> &toRewrite, SourceManager &S,
   std::set<DAndReplace> skip;
 
   for (const auto &N : toRewrite) {
-    //if (N->anyChanges() == false)
-      //continue;
     DeclNStmt DN = N.first;
     Decl *D = DN.first;
     DeclStmt *Where = DN.second;

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -184,6 +184,7 @@ public:
   // an expression which might produce constraint variables, or, it might 
   // be some expression like NULL, an integer constant or a cast.
   void constrainAssign( std::set<ConstraintVariable*> V, 
+                        QualType lhsType,
                         Expr *RHS) {
     if (!RHS)
       return;
@@ -220,7 +221,8 @@ public:
         else if (CStyleCastExpr *C = dyn_cast<CStyleCastExpr>(RHS)) {
           // Case 4.
           W = Info.getVariable(C->getSubExpr(), Context);
-          if (Info.checkStructuralEquality(V, W)) {
+          QualType rhsTy = RHS->getType();
+          if (Info.checkStructuralEquality(V, W, lhsType, rhsTy)) {
             // This has become a little stickier to think about. 
             // What do you do here if we determine that two things with
             // very different arity are structurally equal? Is that even 
@@ -251,12 +253,12 @@ public:
 
   void constrainAssign(Expr *LHS, Expr *RHS) {
     std::set<ConstraintVariable*> V = Info.getVariable(LHS, Context);
-    constrainAssign(V, RHS);
+    constrainAssign(V, LHS->getType(), RHS);
   }
 
   void constrainAssign(DeclaratorDecl *D, Expr *RHS) {
     std::set<ConstraintVariable*> V = Info.getVariable(D, Context);
-    constrainAssign(V, RHS);
+    constrainAssign(V, D->getType(), RHS);
   }
 
   bool VisitDeclStmt(DeclStmt *S) {

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -222,13 +222,53 @@ public:
           // Case 4.
           W = Info.getVariable(C->getSubExpr(), Context);
           QualType rhsTy = RHS->getType();
+          bool rulesFired = false;
           if (Info.checkStructuralEquality(V, W, lhsType, rhsTy)) {
             // This has become a little stickier to think about. 
             // What do you do here if we determine that two things with
             // very different arity are structurally equal? Is that even 
             // possible? 
-            llvm_unreachable("TODO");
-          } else {
+            
+            // We apply a few rules here to determine if there are any
+            // finer-grained constraints we can add. One of them is if the 
+            // value being cast from on the RHS is a call to malloc, and if
+            // the type passed to malloc is equal to both lhsType and rhsTy. 
+            // If it is, we can do something less conservative. 
+            if (CallExpr *CA = dyn_cast<CallExpr>(C->getSubExpr())) {
+              // Is this a call to malloc? Can we coerce the callee 
+              // to a NamedDecl?
+              FunctionDecl *calleeDecl = 
+                dyn_cast<FunctionDecl>(CA->getCalleeDecl());
+              if (calleeDecl && calleeDecl->getName() == "malloc") {
+                // It's a call to malloc. What about the parameter to the call?
+                if (CA->getNumArgs() > 0) {
+                  UnaryExprOrTypeTraitExpr *arg = 
+                    dyn_cast<UnaryExprOrTypeTraitExpr>(CA->getArg(0));
+                  if (arg && arg->isArgumentType()) {
+                    QualType argTy = arg->getArgumentType();
+                    // argTy should be made a pointer, then compared for 
+                    // equality to lhsType and rhsTy. 
+                    QualType argPTy = Context->getPointerType(argTy); 
+
+                    if (Info.checkStructuralEquality(V, W, argPTy, lhsType) && 
+                        Info.checkStructuralEquality(V, W, argPTy, rhsTy)) 
+                    {
+                      rulesFired = true;
+                      // At present, I don't think we need to add an 
+                      // implication based constraint since this rule
+                      // only fires if there is a cast from a call to malloc.
+                      // Since malloc is an external, there's no point in 
+                      // adding constraints to it. 
+                    }
+                  }
+                }
+              }
+            }
+          } 
+
+          // If none of the above rules for cast behavior fired, then 
+          // we need to fall back to doing something conservative. 
+          if (rulesFired == false) {
             // Constrain everything in both to top.
             // Remove the casts from RHS and try again to get a variable
             // from it. We want to constrain that side to wild as well.

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -245,20 +245,23 @@ public:
                   UnaryExprOrTypeTraitExpr *arg = 
                     dyn_cast<UnaryExprOrTypeTraitExpr>(CA->getArg(0));
                   if (arg && arg->isArgumentType()) {
-                    QualType argTy = arg->getArgumentType();
-                    // argTy should be made a pointer, then compared for 
-                    // equality to lhsType and rhsTy. 
-                    QualType argPTy = Context->getPointerType(argTy); 
+                    // Check that the argument is a sizeof. 
+                    if (arg->getKind() == UETT_SizeOf) {
+                      QualType argTy = arg->getArgumentType();
+                      // argTy should be made a pointer, then compared for 
+                      // equality to lhsType and rhsTy. 
+                      QualType argPTy = Context->getPointerType(argTy); 
 
-                    if (Info.checkStructuralEquality(V, W, argPTy, lhsType) && 
-                        Info.checkStructuralEquality(V, W, argPTy, rhsTy)) 
-                    {
-                      rulesFired = true;
-                      // At present, I don't think we need to add an 
-                      // implication based constraint since this rule
-                      // only fires if there is a cast from a call to malloc.
-                      // Since malloc is an external, there's no point in 
-                      // adding constraints to it. 
+                      if (Info.checkStructuralEquality(V, W, argPTy, lhsType) && 
+                          Info.checkStructuralEquality(V, W, argPTy, rhsTy)) 
+                      {
+                        rulesFired = true;
+                        // At present, I don't think we need to add an 
+                        // implication based constraint since this rule
+                        // only fires if there is a cast from a call to malloc.
+                        // Since malloc is an external, there's no point in 
+                        // adding constraints to it. 
+                      }
                     }
                   }
                 }

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -484,9 +484,12 @@ void ProgramInfo::print_stats(std::set<std::string> &F, raw_ostream &O) {
   }
 }
 
+// Check the equality of 
 bool ProgramInfo::checkStructuralEquality(std::set<ConstraintVariable*> V, 
-                                          std::set<ConstraintVariable*> U) {
-  // TODO: implement structural equality checking.
+                                          std::set<ConstraintVariable*> U,
+                                          QualType VTy,
+                                          QualType UTy) 
+{
   return false;
 }
 

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -130,7 +130,12 @@ PointerVariableConstraint::mkString(Constraints::EnvironmentMap &E) {
     assert(C != nullptr);
 
     std::map<uint32_t, Qualification>::iterator q;
-    switch (C->getKind()) {
+    Atom::AtomKind K = C->getKind();
+
+    if (BaseType == "void")
+      K = Atom::A_Wild;
+
+    switch (K) {
     case Atom::A_Ptr:
       q = QualMap.find(V);
       if (q != QualMap.end())

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -484,13 +484,20 @@ void ProgramInfo::print_stats(std::set<std::string> &F, raw_ostream &O) {
   }
 }
 
-// Check the equality of 
+// Check the equality of VTy and UTy. There are some specific rules that
+// fire, and a general check is yet to be implemented. 
 bool ProgramInfo::checkStructuralEquality(std::set<ConstraintVariable*> V, 
                                           std::set<ConstraintVariable*> U,
                                           QualType VTy,
                                           QualType UTy) 
 {
-  return false;
+  // First specific rule: Are these types directly equal? 
+  if (VTy == UTy) {
+    return true;
+  } else {
+    // Further structural checking is TODO.
+    return false;
+  } 
 }
 
 bool ProgramInfo::link() {

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -220,7 +220,9 @@ public:
   // safe to add an implication that if U is wild, then V is wild. However,
   // if this returns false, then both U and V must be constrained to wild.
   bool checkStructuralEquality( std::set<ConstraintVariable*> V, 
-                                std::set<ConstraintVariable*> U);
+                                std::set<ConstraintVariable*> U,
+                                clang::QualType VTy,
+                                clang::QualType UTy);
 
   // Called when we are done adding constraints and visiting ASTs. 
   // Links information about global symbols together and adds 

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -263,6 +263,10 @@ public:
   VariableMap &getVarMap() { return Variables;  }
 
 private:
+  // Function to check if an external symbol is okay to leave 
+  // constrained. 
+  bool isExternOkay(std::string ext);
+
   std::list<clang::RecordDecl*> Records;
   // Next available integer to assign to a variable.
   uint32_t freeKey;


### PR DESCRIPTION
This implements a very simple heuristic for allowing the converter to constrain allocations to `_Ptr<T>`. It also allows for a limited form of cast placement in the event of a conflict during unification. 