### PR TITLE
Correct CL_MPCount variable in documention.

### DIFF
--- a/docs/checkedc/Setup-and-Build.md
+++ b/docs/checkedc/Setup-and-Build.md
@@ -205,11 +205,11 @@ To build
 
 Follow the earlier instruction to set up the build system.  Form the build directory, use the following comamnd to build clang only:
 
-	msbuild tools\clang\tools\driver\clang.vcxproj /p:CL_CPUCount=6 /m
+	msbuild tools\clang\tools\driver\clang.vcxproj /p:CL_MPCount=6 /m
 
 To build everything:
 
-	msbuild LLVM.sln /p:CL_CPUCount=6 /m
+	msbuild LLVM.sln /p:CL_MPCount=6 /m
 
 To clean the build directory:
 

--- a/docs/checkedc/Testing.md
+++ b/docs/checkedc/Testing.md
@@ -28,9 +28,9 @@ Load the solution and the open it using the Solution explorer (View->Solution Ex
 ### From a command shell using msbuild
 Set up the build system and then change to your new object directory.  Use the following commands to run tests:
 
-- Checked C tests: `msbuild projects\checkedc-wrapper\check-checkedc.vcxproj /p:CL_CPUCount=6 /m`
-- Clang tests: `msbuild tools\clang\test\check-clang.vcxproj /p:CL_CPUCount=6 /m`
-- All LLVM and clang tests: `msbuild check-all.vcxproj /p:CL_CPUCount=6 /m`
+- Checked C tests: `msbuild projects\checkedc-wrapper\check-checkedc.vcxproj /p:CL_MPCount=6 /m`
+- Clang tests: `msbuild tools\clang\test\check-clang.vcxproj /p:CL_MPCount=6 /m`
+- All LLVM and clang tests: `msbuild check-all.vcxproj /p:CL_MPCount=6 /m`
 
 ### Using make
 In your build directory,


### PR DESCRIPTION
We accidentally used the name CL_CPUCount for a build environment variable that controls the number of parallel C compiles that will be forked by the C compiler driver.  The correct name is CL_MPCount.   CL_CPUCount has no effect, which leads machines to suffer from VM thrashing when msbuild is invoked by hand following directions in the documentation.

