### PR TITLE
Fix typo in Windows automation script.

### DIFF
--- a/automation/Windows/setup-files.bat
+++ b/automation/Windows/setup-files.bat
@@ -59,7 +59,7 @@ cd %BUILD_SOURCESDIRECTORY%\llvm\tools\clang
 if ERRORLEVEL 1 (goto cmdfailed)
 git fetch origin
 if ERRORLEVEL 1 (goto cmdfailed)
-git checkout -f %CHECKEDC_BRANCH%
+git checkout -f %CLANG_BRANCH%
 if ERRORLEVEL 1 (goto cmdfailed)
 git pull -f origin %CLANG_BRANCH%
 if ERRORLEVEL 1 (goto cmdfailed)


### PR DESCRIPTION
For each Checked C repo, we have a variable that controls which branch is used during an automated test run.   This allows us to test changes that span repos.  We can point the automation at specific combinations of branches.  

We were using the wrong branch name for the checkedc-clang repo in the Windows test scripts.  We were using CHECKEDC_BRANCH when we should have been using CLANG_BRANCH. I checked and this bug did not exist in the Linux bash scripts.