### PR TITLE
Type-checking error leads to compiler crash

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -399,7 +399,11 @@ namespace {
     // should be the range of an object in memory or a subrange of
     // an object.
     BoundsExpr *LValueBounds(Expr *E) {
-      assert(E->isLValue());
+			// When type-checking errors, the resulting AST may not have 
+			// lvalue attribute to a node when it should. Then, if we use 
+			// assert, the compiler crashes. This should be okay, because 
+			// this will only occur when compiler has an error.
+			if (!E->isLValue()) return CreateBoundsNone();
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       switch (E->getStmtClass()) {

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -924,8 +924,12 @@ namespace {
         DumpAssignmentBounds(llvm::outs(), E, LHSTargetBounds, RHSBounds);
       return true;
     }
-
-    // This includes both ImplicitCastExprs and CStyleCastExprs
+	    
+    // If inferred bounds of e1 are bounds(none), compile-time error. 
+    // If inferred bounds of e1 are bounds(any), no runtime checks. 
+    // Otherwise, the inferred bounds is bounds(lb, ub). 
+    // bounds of cast operation is bounds(e2, e3). 
+    // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub). 
     bool VisitCastExpr(CastExpr *E) {
       CheckDisallowedFunctionPtrCasts(E);
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -399,8 +399,8 @@ namespace {
     // should be the range of an object in memory or a subrange of
     // an object.
     BoundsExpr *LValueBounds(Expr *E) {
-      // E may not be lvalue if there is a typechecking error
-      // when struct accesses member array incorrectly.
+      // E may not be an lvalue if there is a typechecking error when struct 
+      // accesses member array incorrectly.
       if (!E->isLValue()) return CreateBoundsNone();
       // TODO: handle side effects within E
       E = E->IgnoreParens();

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -399,7 +399,7 @@ namespace {
     // should be the range of an object in memory or a subrange of
     // an object.
     BoundsExpr *LValueBounds(Expr *E) {
-      assert(E->isLValue());
+      if (!E->isLValue()) return CreateBoundsNone();
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       switch (E->getStmtClass()) {

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -399,7 +399,11 @@ namespace {
     // should be the range of an object in memory or a subrange of
     // an object.
     BoundsExpr *LValueBounds(Expr *E) {
-      if (!E->isLValue()) return CreateBoundsNone();
+			// When type-checking errors, the resulting AST may not have 
+			// lvalue attribute to a node when it should. Then, if we use 
+			// assert, the compiler crashes. This should be okay, because 
+			// this will only occur when compiler has an error.
+			if (!E->isLValue()) return CreateBoundsNone();
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       switch (E->getStmtClass()) {
@@ -934,11 +938,6 @@ namespace {
         return true;
       }
 
-      // If inferred bounds of e1 are bounds(none), compile-time error.
-      // If inferred bounds of e1 are bounds(any), no runtime checks.
-      // Otherwise, the inferred bounds is bounds(lb, ub).
-      // bounds of cast operation is bounds(e2, e3).
-      // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub).
       if (CK == CK_DynamicPtrBounds) {
         Expr *subExpr = E->getSubExpr();
         BoundsExpr *subExprBounds = S.InferRValueBounds(subExpr);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -399,11 +399,9 @@ namespace {
     // should be the range of an object in memory or a subrange of
     // an object.
     BoundsExpr *LValueBounds(Expr *E) {
-			// When type-checking errors, the resulting AST may not have 
-			// lvalue attribute to a node when it should. Then, if we use 
-			// assert, the compiler crashes. This should be okay, because 
-			// this will only occur when compiler has an error.
-			if (!E->isLValue()) return CreateBoundsNone();
+      // E may not be lvalue if there is a typechecking error
+      // when struct accesses member array incorrectly.
+      if (!E->isLValue()) return CreateBoundsNone();
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       switch (E->getStmtClass()) {

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -399,11 +399,7 @@ namespace {
     // should be the range of an object in memory or a subrange of
     // an object.
     BoundsExpr *LValueBounds(Expr *E) {
-			// When type-checking errors, the resulting AST may not have 
-			// lvalue attribute to a node when it should. Then, if we use 
-			// assert, the compiler crashes. This should be okay, because 
-			// this will only occur when compiler has an error.
-			if (!E->isLValue()) return CreateBoundsNone();
+      assert(E->isLValue());
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       switch (E->getStmtClass()) {
@@ -924,12 +920,8 @@ namespace {
         DumpAssignmentBounds(llvm::outs(), E, LHSTargetBounds, RHSBounds);
       return true;
     }
-	    
-    // If inferred bounds of e1 are bounds(none), compile-time error. 
-    // If inferred bounds of e1 are bounds(any), no runtime checks. 
-    // Otherwise, the inferred bounds is bounds(lb, ub). 
-    // bounds of cast operation is bounds(e2, e3). 
-    // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub). 
+
+    // This includes both ImplicitCastExprs and CStyleCastExprs
     bool VisitCastExpr(CastExpr *E) {
       CheckDisallowedFunctionPtrCasts(E);
 
@@ -942,6 +934,11 @@ namespace {
         return true;
       }
 
+      // If inferred bounds of e1 are bounds(none), compile-time error.
+      // If inferred bounds of e1 are bounds(any), no runtime checks.
+      // Otherwise, the inferred bounds is bounds(lb, ub).
+      // bounds of cast operation is bounds(e2, e3).
+      // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub).
       if (CK == CK_DynamicPtrBounds) {
         Expr *subExpr = E->getSubExpr();
         BoundsExpr *subExprBounds = S.InferRValueBounds(subExpr);

--- a/test/CheckedC/type-checking-crash.c
+++ b/test/CheckedC/type-checking-crash.c
@@ -1,23 +1,20 @@
-// Tests to make sure the checked c code does not crash the compiler
-// when it encounters an incorrectly constructed AST caused by type
-// checking error.
+// Tests to make sure the Checked C code does not crash the compiler when it 
+// encounters an incorrectly constructed AST caused by type checking error.
 //
-// More specifically, take a look at the four test cases below.
-// First of all, even when clang encounters a type checking error,
-// it does its best to create the entire AST, before it exits with
-// an error message.
-// struct_int_array_type_checking_crash_test_1 creates an invalid AST,
-// where "arr" is not an lvalue, although it should be an lvalue.
-// Interestingly, for the other three test cases, the constructed AST
-// has "arr" to be an lvalue.
-// This test makes sure that no matter the case, the checked c code will
-// not exit the program with an exception.
+// More specifically, take a look at the four test cases below. First of all, 
+// even when clang encounters a type checking error, it does its best to create 
+// the entire AST, before it exits with an error message. 
+// Struct_int_array_type_checking_crash_test_1 creates an invalid AST, where 
+// "arr" is not an lvalue, although it should be an lvalue. Interestingly, for 
+// the other three test cases, the constructed AST has "arr" to be an lvalue. 
+// This test makes sure that no matter the case, the Checked C code will not 
+// exit the program with an exception.
 //
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 
 struct S {
-	char arr _Checked[10];
-	int data;
+  char arr _Checked[10];
+  int data;
 };
 
 //====================================================================
@@ -25,8 +22,8 @@ struct S {
 //====================================================================
 
 void struct_int_array_type_checking_crash_test_1(int i) {
-	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-	s->arr[i] = 1; //expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} //expected-error{{expression has no bounds}}
+  struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+  s->arr[i] = 1; //expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} //expected-error{{expression has no bounds}}
 }
 
 //====================================================================
@@ -34,8 +31,8 @@ void struct_int_array_type_checking_crash_test_1(int i) {
 //====================================================================
 
 void struct_int_array_type_checking_crash_test_2(int i) {
-	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-	s.arr[i] = 1;
+  struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+  s.arr[i] = 1;
 }
 
 //====================================================================
@@ -43,8 +40,8 @@ void struct_int_array_type_checking_crash_test_2(int i) {
 //====================================================================
 
 void struct_int_array_type_checking_crash_test_3(int i) {
-	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-	(&s)->arr[i] = 1;
+  struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+  (&s)->arr[i] = 1;
 }
 
 //====================================================================
@@ -52,6 +49,6 @@ void struct_int_array_type_checking_crash_test_3(int i) {
 //====================================================================
 
 void struct_int_array_type_checking_crash_test_4(int i) {
-	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-	(&s).arr[i] = 1;//expected-error{{member reference type 'struct S *' is a pointer; did you mean to use '->'?}}
+  struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+  (&s).arr[i] = 1;//expected-error{{member reference type 'struct S *' is a pointer; did you mean to use '->'?}}
 }

--- a/test/CheckedC/type-checking-crash.c
+++ b/test/CheckedC/type-checking-crash.c
@@ -1,12 +1,18 @@
-// Checks for crashes during type-checking error.
-// This was caused by an lvalue assert in SemaBounds.cpp
-// The goal of this test is to make sure we're seeing 
-// type-checking errors, but not get any crashes.
-// The llvm-lit test will fail the test if the compiler
-// crashes because of assert failure (This has been tested)
-// I wanted to use FileCheck to specifically look for
-// "assert failed" output but for some reason FileCheck 
-// refuses to work. So I had to use this method.
+// Tests to make sure the checked c code does not crash the compiler
+// when it encounters an incorrectly constructed AST caused by type
+// checking error.
+//
+// More specifically, take a look at the four test cases below.
+// First of all, even when clang encounters a type checking error,
+// it does its best to create the entire AST, before it exits with
+// an error message.
+// struct_int_array_type_checking_crash_test_1 creates an invalid AST,
+// where "arr" is not an lvalue, although it should be an lvalue.
+// Interestingly, for the other three test cases, the constructed AST
+// has "arr" to be an lvalue.
+// This test makes sure that no matter the case, the checked c code will
+// not exit the program with an exception.
+//
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 
 struct S {
@@ -14,22 +20,38 @@ struct S {
 	int data;
 };
 
+//====================================================================
+// Accessing struct with "->" causes error and wrongly eliminates lvalue
+//====================================================================
+
 void struct_int_array_type_checking_crash_test_1(int i) {
 	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-	s->arr[i] = 1; // expected-error{{expression has no bounds}}	// expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} 
+	s->arr[i] = 1; //expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} //expected-error{{expression has no bounds}}
 }
+
+//====================================================================
+// Correctly accessing struct.
+//====================================================================
 
 void struct_int_array_type_checking_crash_test_2(int i) {
 	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
 	s.arr[i] = 1;
 }
 
+//====================================================================
+// Correctly accessing struct pointer.
+//====================================================================
+
 void struct_int_array_type_checking_crash_test_3(int i) {
 	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
 	(&s)->arr[i] = 1;
 }
 
+//====================================================================
+// Accessing struct pointer with "." causes error but keeps lvalue
+//====================================================================
+
 void struct_int_array_type_checking_crash_test_4(int i) {
 	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-	(&s).arr[i] = 1;// expected-error{{member reference type 'struct S *' is a pointer; did you mean to use '->'?}}
+	(&s).arr[i] = 1;//expected-error{{member reference type 'struct S *' is a pointer; did you mean to use '->'?}}
 }

--- a/test/CheckedC/type-checking-crash.c
+++ b/test/CheckedC/type-checking-crash.c
@@ -1,0 +1,35 @@
+// Checks for crashes during type-checking error.
+// This was caused by an lvalue assert in SemaBounds.cpp
+// The goal of this test is to make sure we're seeing 
+// type-checking errors, but not get any crashes.
+// The llvm-lit test will fail the test if the compiler
+// crashes because of assert failure (This has been tested)
+// I wanted to use FileCheck to specifically look for
+// "assert failed" output but for some reason FileCheck 
+// refuses to work. So I had to use this method.
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+
+struct S {
+	char arr _Checked[10];
+	int data;
+};
+
+void struct_int_array_type_checking_crash_test_1(int i) {
+	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+	s->arr[i] = 1; // expected-error{{expression has no bounds}}	// expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} 
+}
+
+void struct_int_array_type_checking_crash_test_2(int i) {
+	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+	s.arr[i] = 1;
+}
+
+void struct_int_array_type_checking_crash_test_3(int i) {
+	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+	(&s)->arr[i] = 1;
+}
+
+void struct_int_array_type_checking_crash_test_4(int i) {
+	struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
+	(&s).arr[i] = 1;// expected-error{{member reference type 'struct S *' is a pointer; did you mean to use '->'?}}
+}


### PR DESCRIPTION
Type-checking error removes lvalue attribute in MemberExpr. This causes assert to throw error. Changed assert to conditional. Although there are numerous lvalue assert checks, it looks like the assert in Line402 is the only assert that it comes across. Fixes #291 