### PR TITLE
Implement runtime check insertion for bounds_cast operator (#256)

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2798,8 +2798,9 @@ private:
 /// classes).
 class CastExpr : public Expr {
 private:
-  // CASTBOUNDS - for expanded bounds of cast expression
-  // SUBEXPRBOUNDS - for bounds of subexpression
+  // BOUNDS - declared bounds of the result of the cast expression
+  // CASTBOUNDS - inferred bounds of cast expression
+  // SUBEXPRBOUNDS - inferred bounds of subexpression
   enum { OP, BOUNDS, CASTBOUNDS, SUBEXPRBOUNDS, END_EXPR = 4 };
   Stmt* SubExprs[END_EXPR];
 

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2798,9 +2798,9 @@ private:
 /// classes).
 class CastExpr : public Expr {
 private:
-  // BOUNDS - enum value for bounds of cast expression
-  // SUBBOUNDS - enum value for bounds of subexpression
-  enum { OP, BOUNDS, SUBBOUNDS, END_EXPR = 3 };
+  // CASTBOUNDS - for expanded bounds of cast expression
+  // SUBEXPRBOUNDS - for bounds of subexpression
+  enum { OP, BOUNDS, CASTBOUNDS, SUBEXPRBOUNDS, END_EXPR = 4 };
   Stmt* SubExprs[END_EXPR];
 
   bool CastConsistency() const;
@@ -2836,7 +2836,8 @@ protected:
     assert(kind != CK_Invalid && "creating cast with invalid cast kind");
     SubExprs[OP] = op;
     SubExprs[BOUNDS] = nullptr;
-    SubExprs[SUBBOUNDS] = nullptr;
+    SubExprs[CASTBOUNDS] = nullptr;
+    SubExprs[SUBEXPRBOUNDS] = nullptr;
     CastExprBits.Kind = kind;
     setBasePathSize(BasePathSize);
     assert(CastConsistency());
@@ -2847,7 +2848,8 @@ protected:
     : Expr(SC, Empty) {
     SubExprs[OP] = nullptr;
     SubExprs[BOUNDS] = nullptr;
-    SubExprs[SUBBOUNDS] = nullptr;
+    SubExprs[CASTBOUNDS] = nullptr;
+    SubExprs[SUBEXPRBOUNDS] = nullptr;
     setBasePathSize(BasePathSize);
   }
 
@@ -2920,15 +2922,26 @@ public:
     SubExprs[BOUNDS] = E;
   }
 
-  bool hasSubBoundsExpr() const { return SubExprs[SUBBOUNDS] != nullptr; }
-  BoundsExpr *getSubBoundsExpr() {
-    return cast_or_null<BoundsExpr>(SubExprs[SUBBOUNDS]);
+  bool hasCastBoundsExpr() const { return SubExprs[CASTBOUNDS] != nullptr; }
+  BoundsExpr *getCastBoundsExpr() {
+    return cast_or_null<BoundsExpr>(SubExprs[CASTBOUNDS]);
   }
-  const BoundsExpr *getSubBoundsExpr() const {
-    return const_cast<BoundsExpr*>(cast_or_null<BoundsExpr>(SubExprs[SUBBOUNDS]));
+  const BoundsExpr *getCastBoundsExpr() const {
+    return const_cast<BoundsExpr*>(cast_or_null<BoundsExpr>(SubExprs[CASTBOUNDS]));
   }
-  void setSubBoundsExpr(BoundsExpr *E) {
-    SubExprs[SUBBOUNDS] = E;
+  void setCastBoundsExpr(BoundsExpr *E) {
+    SubExprs[CASTBOUNDS] = E;
+  }
+
+  bool hasSubExprBoundsExpr() const { return SubExprs[SUBEXPRBOUNDS] != nullptr; }
+  BoundsExpr *getSubExprBoundsExpr() {
+    return cast_or_null<BoundsExpr>(SubExprs[SUBEXPRBOUNDS]);
+  }
+  const BoundsExpr *getSubExprBoundsExpr() const {
+    return const_cast<BoundsExpr*>(cast_or_null<BoundsExpr>(SubExprs[SUBEXPRBOUNDS]));
+  }
+  void setSubExprBoundsExpr(BoundsExpr *E) {
+    SubExprs[SUBEXPRBOUNDS] = E;
   }
 };
 

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2799,7 +2799,7 @@ private:
 class CastExpr : public Expr {
 private:
   // BOUNDS - declared bounds of the result of the cast expression
-  // CASTBOUNDS - inferred bounds of cast expression
+  // CASTBOUNDS - normalized version of BOUNDS
   // SUBEXPRBOUNDS - inferred bounds of subexpression
   enum { OP, BOUNDS, CASTBOUNDS, SUBEXPRBOUNDS, END_EXPR = 4 };
   Stmt* SubExprs[END_EXPR];

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2798,7 +2798,9 @@ private:
 /// classes).
 class CastExpr : public Expr {
 private:
-  enum { OP, BOUNDS, END_EXPR = 2 };
+  // BOUNDS - enum value for bounds of cast expression
+  // SUBBOUNDS - enum value for bounds of subexpression
+  enum { OP, BOUNDS, SUBBOUNDS, END_EXPR = 3 };
   Stmt* SubExprs[END_EXPR];
 
   bool CastConsistency() const;
@@ -2834,6 +2836,7 @@ protected:
     assert(kind != CK_Invalid && "creating cast with invalid cast kind");
     SubExprs[OP] = op;
     SubExprs[BOUNDS] = nullptr;
+    SubExprs[SUBBOUNDS] = nullptr;
     CastExprBits.Kind = kind;
     setBasePathSize(BasePathSize);
     assert(CastConsistency());
@@ -2844,6 +2847,7 @@ protected:
     : Expr(SC, Empty) {
     SubExprs[OP] = nullptr;
     SubExprs[BOUNDS] = nullptr;
+    SubExprs[SUBBOUNDS] = nullptr;
     setBasePathSize(BasePathSize);
   }
 
@@ -2914,6 +2918,17 @@ public:
 
   void setBoundsExpr(BoundsExpr *E) {
     SubExprs[BOUNDS] = E;
+  }
+
+  bool hasSubBoundsExpr() const { return SubExprs[SUBBOUNDS] != nullptr; }
+  BoundsExpr *getSubBoundsExpr() {
+    return cast_or_null<BoundsExpr>(SubExprs[SUBBOUNDS]);
+  }
+  const BoundsExpr *getSubBoundsExpr() const {
+    return const_cast<BoundsExpr*>(cast_or_null<BoundsExpr>(SubExprs[SUBBOUNDS]));
+  }
+  void setSubBoundsExpr(BoundsExpr *E) {
+    SubExprs[SUBBOUNDS] = E;
   }
 };
 

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -4315,11 +4315,13 @@ llvm::Value *CodeGenFunction::EmitBoundsCast(CastExpr *CE) {
   Expr *E = CE->getSubExpr();
   QualType DestTy = CE->getType();
   CastKind Kind = CE->getCastKind();
-  // Bounds casting has two functionalities
+  // Bounds casting has two functionalities.
   // - code generation for explicit type casting
-  // - code generation for dynamic check, dynamic_bounds_cast only
-  //  - dynamic_check(e1 != NULL)
-  //  - dynamic_check(lb <= e2 && e3 <= ub)
+  // - code generation for dynamic check for only dynamic_bounds_cast
+  // : bounds_cast<T>(e1, e2, e3) with e1 : bounds(lb, ub)
+  //  - dynamic_check(e1 == NULL || (lb <= e2 && e3 <= ub))
+  //  if e1 is NULL, it skips checking range bounds.
+  //  otherwise, it checks range bounds.
   Address Addr = Address::invalid();
   // For count bounds, source can be a pointer/array type (ArrayToPointerDecay)
   // For range bounds, source can be a pointer/array/integer

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -3668,7 +3668,7 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
   case CK_DynamicPtrBounds:
   case CK_AssumePtrBounds:
     return MakeNaturalAlignAddrLValue(
-        EmitDynamicBoundsCast(const_cast<CastExpr *>(E)), E->getType());
+        EmitBoundsCast(const_cast<CastExpr *>(E)), E->getType());
 
   case CK_ConstructorConversion:
   case CK_UserDefinedConversion:
@@ -4311,7 +4311,7 @@ LValue CodeGenFunction::EmitPseudoObjectLValue(const PseudoObjectExpr *E) {
   return emitPseudoObjectExpr(*this, E, true, AggValueSlot::ignored()).LV;
 }
 
-llvm::Value *CodeGenFunction::EmitDynamicBoundsCast(CastExpr *CE) {
+llvm::Value *CodeGenFunction::EmitBoundsCast(CastExpr *CE) {
   Expr *E = CE->getSubExpr();
   QualType DestTy = CE->getType();
   CastKind Kind = CE->getCastKind();
@@ -4342,8 +4342,8 @@ llvm::Value *CodeGenFunction::EmitDynamicBoundsCast(CastExpr *CE) {
   }
   if (Kind == CK_DynamicPtrBounds) {
     BoundsCastExpr *BCE = cast<BoundsCastExpr>(CE);
-    EmitDynamicNonNullCheck(Addr, E->getType());
-    EmitDynamicBoundsCheck(BCE->getBoundsExpr(), BCE->getSubBoundsExpr());
+    EmitDynamicBoundsCheck(Addr, BCE->getCastBoundsExpr(),
+                           BCE->getSubExprBoundsExpr());
   }
   return Addr.getPointer();
 }

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1074,6 +1074,7 @@ LValue CodeGenFunction::EmitLValue(const Expr *E) {
   case Expr::CXXReinterpretCastExprClass:
   case Expr::CXXConstCastExprClass:
   case Expr::ObjCBridgedCastExprClass:
+  case Expr::BoundsCastExprClass:
     return EmitCastLValue(cast<CastExpr>(E));
 
   case Expr::MaterializeTemporaryExprClass:
@@ -3664,13 +3665,16 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
     return MakeNaturalAlignAddrLValue(EmitDynamicCast(V, DCE), E->getType());
   }
 
+  case CK_DynamicPtrBounds:
+  case CK_AssumePtrBounds:
+    return MakeNaturalAlignAddrLValue(
+        EmitDynamicBoundsCast(const_cast<CastExpr *>(E)), E->getType());
+
   case CK_ConstructorConversion:
   case CK_UserDefinedConversion:
   case CK_CPointerToObjCPointerCast:
   case CK_BlockPointerToObjCPointerCast:
   case CK_NoOp:
-  case CK_DynamicPtrBounds:
-  case CK_AssumePtrBounds:
   case CK_LValueToRValue:
     return EmitLValue(E->getSubExpr());
 
@@ -4306,3 +4310,41 @@ RValue CodeGenFunction::EmitPseudoObjectRValue(const PseudoObjectExpr *E,
 LValue CodeGenFunction::EmitPseudoObjectLValue(const PseudoObjectExpr *E) {
   return emitPseudoObjectExpr(*this, E, true, AggValueSlot::ignored()).LV;
 }
+
+llvm::Value *CodeGenFunction::EmitDynamicBoundsCast(CastExpr *CE) {
+  Expr *E = CE->getSubExpr();
+  QualType DestTy = CE->getType();
+  CastKind Kind = CE->getCastKind();
+  // Bounds casting has two functionalities
+  // - code generation for explicit type casting
+  // - code generation for dynamic check, dynamic_bounds_cast only
+  //  - dynamic_check(e1 != NULL)
+  //  - dynamic_check(lb <= e2 && e3 <= ub)
+  Address Addr = Address::invalid();
+  // For count bounds, source can be a pointer/array type (ArrayToPointerDecay)
+  // For range bounds, source can be a pointer/array/integer
+  // For integer type,
+  if (E->getType()->isPointerType()) {
+    Addr = EmitPointerWithAlignment(E);
+    // explicit type casting for destination type
+    Addr = Builder.CreateBitCast(Addr, ConvertType(DestTy));
+  } else {
+    // CK_IntegralToPointer (IntToPtr) casts integer to pointer type
+    llvm::Value *Src = EmitScalarExpr(const_cast<Expr *>(E));
+    llvm::Type *DestLLVMTy = ConvertType(DestTy);
+    llvm::Type *MiddleTy = CGM.getDataLayout().getIntPtrType(DestLLVMTy);
+    bool InputSigned = E->getType()->isSignedIntegerOrEnumerationType();
+    llvm::Value* IntResult =
+      Builder.CreateIntCast(Src, MiddleTy, InputSigned, "conv");
+    llvm::Value *Result = Builder.CreateIntToPtr(IntResult, DestLLVMTy);
+    CharUnits Align = getContext().getTypeAlignInChars(DestTy);
+    Addr = Address(Result, Align);
+  }
+  if (Kind == CK_DynamicPtrBounds) {
+    BoundsCastExpr *BCE = cast<BoundsCastExpr>(CE);
+    EmitDynamicNonNullCheck(Addr, E->getType());
+    EmitDynamicBoundsCheck(BCE->getBoundsExpr(), BCE->getSubBoundsExpr());
+  }
+  return Addr.getPointer();
+}
+

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -1446,7 +1446,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
 
   case CK_DynamicPtrBounds:
   case CK_AssumePtrBounds:
-    return CGF.EmitDynamicBoundsCast(CE);
+    return CGF.EmitBoundsCast(CE);
 
   case CK_ArrayToPointerDecay:
     return CGF.EmitArrayToPointerDecay(E).getPointer();

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -1444,6 +1444,10 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     return CGF.EmitDynamicCast(V, DCE);
   }
 
+  case CK_DynamicPtrBounds:
+  case CK_AssumePtrBounds:
+    return CGF.EmitDynamicBoundsCast(CE);
+
   case CK_ArrayToPointerDecay:
     return CGF.EmitArrayToPointerDecay(E).getPointer();
   case CK_FunctionToPointerDecay:
@@ -1500,8 +1504,6 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
   case CK_ToUnion:
     llvm_unreachable("scalar cast to non-scalar value");
 
-  case CK_DynamicPtrBounds:
-  case CK_AssumePtrBounds:
   case CK_LValueToRValue:
     assert(CGF.getContext().hasSameUnqualifiedType(E->getType(), DestTy));
     assert(E->isGLValue() && "lvalue-to-rvalue applied to r-value!");

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2294,8 +2294,6 @@ public:
   /// \brief Create a basic block that will call the trap intrinsic, and emit
   /// a conditional branch to it, for Checked C's dynamic checks.
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
-  /// Emit code blocks for dynamic_check(cond1 || cond2)
-  void EmitDynamicCheckBlocks(llvm::Value *Cond1, llvm::Value *Cond2);
 
   llvm::Value *EmitBoundsCast(CastExpr *CE);
 

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2288,12 +2288,16 @@ public:
   void EmitDynamicNonNullCheck(const Address BaseAddr, const QualType BaseTy);
   void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy, const Address PtrAddr);
   void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds);
-  void EmitDynamicBoundsCheck(const BoundsExpr* DynamicBounds, const BoundsExpr *SrcBounds);
+  void EmitDynamicBoundsCheck(const Address BaseAddr,
+                              const BoundsExpr *CastBounds,
+                              const BoundsExpr *SubExprBounds);
   /// \brief Create a basic block that will call the trap intrinsic, and emit
   /// a conditional branch to it, for Checked C's dynamic checks.
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
+  /// Emit code blocks for dynamic_check(cond1 || cond2)
+  void EmitDynamicCheckBlocks(llvm::Value *Cond1, llvm::Value *Cond2);
 
-  llvm::Value *EmitDynamicBoundsCast(CastExpr *CE);
+  llvm::Value *EmitBoundsCast(CastExpr *CE);
 
   void EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S);
   void EmitObjCAtTryStmt(const ObjCAtTryStmt &S);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2288,9 +2288,12 @@ public:
   void EmitDynamicNonNullCheck(const Address BaseAddr, const QualType BaseTy);
   void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy, const Address PtrAddr);
   void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds);
+  void EmitDynamicBoundsCheck(const BoundsExpr* DynamicBounds, const BoundsExpr *SrcBounds);
   /// \brief Create a basic block that will call the trap intrinsic, and emit
   /// a conditional branch to it, for Checked C's dynamic checks.
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
+
+  llvm::Value *EmitDynamicBoundsCast(CastExpr *CE);
 
   void EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S);
   void EmitObjCAtTryStmt(const ObjCAtTryStmt &S);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -942,17 +942,17 @@ namespace {
       // bounds of cast operation is bounds(e2, e3).
       // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub).
       if (CK == CK_DynamicPtrBounds) {
-        Expr *subExpr = E->getSubExpr();
-        BoundsExpr *subExprBounds = S.InferRValueBounds(subExpr);
-        BoundsExpr *SrcBounds = S.InferRValueBounds(E);
+        Expr *SubExpr = E->getSubExpr();
+        BoundsExpr *SubExprBounds = S.InferRValueBounds(SubExpr);
+        BoundsExpr *CastBounds = S.InferRValueBounds(E);
 
-        if (subExprBounds->isNone()) {
-          S.Diag(subExpr->getLocStart(), diag::err_expected_bounds);
+        if (SubExprBounds->isNone()) {
+          S.Diag(SubExpr->getLocStart(), diag::err_expected_bounds);
         }
 
-        assert(SrcBounds);
-        E->setBoundsExpr(SrcBounds);
-        E->setSubBoundsExpr(subExprBounds);
+        assert(CastBounds);
+        E->setCastBoundsExpr(CastBounds);
+        E->setSubExprBoundsExpr(SubExprBounds);
       }
 
       // Casts to _Ptr type must have a source for which we can infer bounds.

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -946,6 +946,7 @@ namespace {
 
         assert(SrcBounds);
         E->setBoundsExpr(SrcBounds);
+        E->setSubBoundsExpr(subExprBounds);
       }
 
       // Casts to _Ptr type must have a source for which we can infer bounds.

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -942,6 +942,7 @@ namespace {
       if (CK == CK_DynamicPtrBounds) {
         Expr *subExpr = E->getSubExpr();
         BoundsExpr *subExprBounds = S.InferRValueBounds(subExpr);
+        BoundsExpr *SrcBounds = S.InferRValueBounds(E);
 
         if (subExprBounds->isNone()) {
           S.Diag(subExpr->getLocStart(), diag::err_expected_bounds);

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -682,9 +682,13 @@ void ASTStmtReader::VisitCastExpr(CastExpr *E) {
   if (hasBoundsExpr) {
     E->setBoundsExpr(Reader.ReadBoundsExpr(F));
   }
-  bool hasSubBoundsExpr = Record[Idx++];
-  if (hasSubBoundsExpr) {
-    E->setSubBoundsExpr(Reader.ReadBoundsExpr(F));
+  bool hasCastBoundsExpr = Record[Idx++];
+  if (hasCastBoundsExpr) {
+    E->setCastBoundsExpr(Reader.ReadBoundsExpr(F));
+  }
+  bool hasSubExprBoundsExpr = Record[Idx++];
+  if (hasSubExprBoundsExpr) {
+    E->setSubExprBoundsExpr(Reader.ReadBoundsExpr(F));
   }
   CastExpr::path_iterator BaseI = E->path_begin();
   while (NumBaseSpecs--) {

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -682,6 +682,10 @@ void ASTStmtReader::VisitCastExpr(CastExpr *E) {
   if (hasBoundsExpr) {
     E->setBoundsExpr(Reader.ReadBoundsExpr(F));
   }
+  bool hasSubBoundsExpr = Record[Idx++];
+  if (hasSubBoundsExpr) {
+    E->setSubBoundsExpr(Reader.ReadBoundsExpr(F));
+  }
   CastExpr::path_iterator BaseI = E->path_begin();
   while (NumBaseSpecs--) {
     CXXBaseSpecifier *BaseSpec = new (Reader.getContext()) CXXBaseSpecifier;

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -2125,7 +2125,8 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(0)); // PathSize
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 6)); // CastKind
   Abv->Add(BitCodeAbbrevOp(0)); // hasBoundsExpr
-  Abv->Add(BitCodeAbbrevOp(0)); // hasSubBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0)); // hasCastBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0)); // hasSubExprBoundsExpr
   // ImplicitCastExpr
   ExprImplicitCastAbbrev = Stream.EmitAbbrev(Abv);
 

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -2125,6 +2125,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(0)); // PathSize
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 6)); // CastKind
   Abv->Add(BitCodeAbbrevOp(0)); // hasBoundsExpr
+  Abv->Add(BitCodeAbbrevOp(0)); // hasSubBoundsExpr
   // ImplicitCastExpr
   ExprImplicitCastAbbrev = Stream.EmitAbbrev(Abv);
 

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -649,11 +649,15 @@ void ASTStmtWriter::VisitCastExpr(CastExpr *E) {
   if (E->hasBoundsExpr()) {
     Record.AddStmt(E->getBoundsExpr());
   }
-  Record.push_back(E->hasSubBoundsExpr());
-  if (E->hasSubBoundsExpr()) {
-    Record.AddStmt(E->getSubBoundsExpr());
+  Record.push_back(E->hasCastBoundsExpr());
+  if (E->hasCastBoundsExpr()) {
+    Record.AddStmt(E->getCastBoundsExpr());
   }
 
+  Record.push_back(E->hasSubExprBoundsExpr());
+  if (E->hasSubExprBoundsExpr()) {
+    Record.AddStmt(E->getSubExprBoundsExpr());
+  }
 
   for (CastExpr::path_iterator
          PI = E->path_begin(), PE = E->path_end(); PI != PE; ++PI)

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -649,6 +649,11 @@ void ASTStmtWriter::VisitCastExpr(CastExpr *E) {
   if (E->hasBoundsExpr()) {
     Record.AddStmt(E->getBoundsExpr());
   }
+  Record.push_back(E->hasSubBoundsExpr());
+  if (E->hasSubBoundsExpr()) {
+    Record.AddStmt(E->getSubBoundsExpr());
+  }
+
 
   for (CastExpr::path_iterator
          PI = E->path_begin(), PE = E->path_end(); PI != PE; ++PI)


### PR DESCRIPTION
+ Implement runtime checking for bounds_cast (#256)
      + implement emission of dynamic checking for bounds_cast
      it does two things as follows:
      it generates codes for explicit type casting
      since subexpression can be non-pointer type, it SHOULD take care about it
      it also generates dynamic_check for bounds casting by using both bounds of cast and bounds of subexpression
      : bounds (castlb, castub), bounds of cast operation
      : bounds(lb, ub), bounds of subexpression of cast operation
      -> emits non-null check for subexpression (dynamic_check(base != NULL))
      -> emits dynamic check (dynamic_check(lb <= castlb && castub <= ub)
      + add inferred bounds of subexpression since code generation requires source bounds
      when inferring bounds of subexpression, it also binds inferred source bounds to cast operation