### PR TITLE
Fix up bugs related to #302

### DIFF
--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -3370,13 +3370,35 @@ public:
               (const FunctionProtoType *)CallArgTypeInfo;
           if (FPT && FPT->hasParamBounds()) {
             const BoundsExpr *Bounds = FPT->getParamBounds(N);
-            // if it has interop type, check interop type as well as the type
-            if (Bounds &&
-                Bounds->getKind() == BoundsExpr::Kind::InteropTypeAnnotation) {
-              const InteropTypeBoundsAnnotation *annot =
-                  dyn_cast<InteropTypeBoundsAnnotation>(Bounds);
-              interop_ty1 =
-                  getContext().getCanonicalType(annot->getType()).getTypePtr();
+            if (Bounds) {
+              switch (Bounds->getKind()) {
+              case BoundsExpr::Kind::InteropTypeAnnotation: {
+                const InteropTypeBoundsAnnotation *Annot =
+                    dyn_cast<InteropTypeBoundsAnnotation>(Bounds);
+                interop_ty1 = getContext()
+                                  .getCanonicalType(Annot->getType())
+                                  .getTypePtr();
+                break;
+              }
+              case BoundsExpr::Kind::ByteCount:
+              case BoundsExpr::Kind::ElementCount:
+              case BoundsExpr::Kind::Range: {
+                QualType Ty = FPT->getParamType(N);
+                if (const PointerType *PtrType = Ty->getAs<PointerType>()) {
+                  if (PtrType->isUnchecked()) {
+                    interop_ty1 =
+                        getContext()
+                            .getCanonicalType(getContext().getPointerType(
+                                PtrType->getPointeeType(),
+                                CheckedPointerKind::Array))
+                            .getTypePtr();
+                  }
+                }
+                break;
+              }
+              default:
+                break;
+              }
             }
           }
         }

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -10652,6 +10652,9 @@ bool Sema::DiagnoseCheckedDecl(const ValueDecl *Decl, SourceLocation UseLoc) {
     DeclKind = 3; // member
     Ty = Field->getType();
   }
+  else {
+    Ty = Decl->getType();
+  }
 
   bool Result = true;
   unsigned TypeKind = 0;

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -772,10 +772,7 @@ ExprResult Sema::CallExprUnaryConversions(Expr *E) {
   // Only do implicit cast for a function type, but not for a pointer
   // to function type.
   if (Ty->isFunctionType()) {
-    CheckedPointerKind kind = CheckedPointerKind::Unchecked;
-    if (getCurScope()->isCheckedScope())
-      kind = CheckedPointerKind::Ptr;
-    Res = ImpCastExprToType(E, Context.getPointerType(Ty, kind),
+    Res = ImpCastExprToType(E, Context.getPointerType(Ty),
                             CK_FunctionToPointerDecay).get();
     if (Res.isInvalid())
       return ExprError();

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -3638,6 +3638,8 @@ QualType Sema::GetCheckedCInteropType(const ValueDecl *Decl) {
         // become checked array types too.
         if (const ParmVarDecl *ParmVar = dyn_cast<ParmVarDecl>(TargetDecl))
           Ty = ParmVar->getOriginalType();
+        else if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(TargetDecl))
+          Ty = FD->getReturnType();
         else
           Ty = Decl->getType();
 


### PR DESCRIPTION
+ fix up bugs related to #302
  + if function return type is unchecked pointer type with bounds-safe interface, it is not checked properly
  For function declaration, it SHOULD consider its return type not function type itself