### PR TITLE
Revisit function to pointer type decay in a checked scope (#304)

### DIFF
--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -772,7 +772,10 @@ ExprResult Sema::CallExprUnaryConversions(Expr *E) {
   // Only do implicit cast for a function type, but not for a pointer
   // to function type.
   if (Ty->isFunctionType()) {
-    Res = ImpCastExprToType(E, Context.getPointerType(Ty),
+    CheckedPointerKind kind = CheckedPointerKind::Unchecked;
+    if (getCurScope()->isCheckedScope())
+      kind = CheckedPointerKind::Ptr;
+    Res = ImpCastExprToType(E, Context.getPointerType(Ty, kind),
                             CK_FunctionToPointerDecay).get();
     if (Res.isInvalid())
       return ExprError();
@@ -1770,6 +1773,14 @@ Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
       if (!CheckCUDACall(NameInfo.getLoc(), Callee))
         return ExprError();
 
+  // Checked C - no-prototype function is not allowed in checked scope.
+  // KNR parameter function has no-prototype function proto type
+  if (getCurScope()->isCheckedScope()) {
+    if (Ty->isFunctionNoProtoType()) {
+      Diag(NameInfo.getLoc(), diag::err_checked_scope_no_prototype_func);
+      return ExprError();
+    }
+  }
   bool RefersToCapturedVariable =
       isa<VarDecl>(D) &&
       NeedToCaptureVariable(cast<VarDecl>(D), NameInfo.getLoc());


### PR DESCRIPTION
+ Revisit function to pointer type decay in a checked scope (#304)
  + In checked scope, it is not allowed to use or declare no-prototype function
  However, KNR parameter function is little bit exceptional
  KNR parameter has special form of function parameters which are defined outside of function
  KNR parameter function is not no-prototype function declaration
  However, it builds DeclRef expression at function call side
  if it calls KNR parameter function, it generates no-prototype function DeclRefExpr
  Shortly, it is declared as normal function declaration but is called as no-prototype function call
  In checked scope, this no-prototype function call SHOULD be prevented

  + In checked scope, all function call is implicitly casted to checked pointer type of function
  After fixing-up above problem, restore this conversion