### PR TITLE
Implementation-specific definitions of NULL in checked scopes.

### DIFF
--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2565,7 +2565,15 @@ void CastOperation::CheckCStyleCast() {
     unsigned TypeKind = 0;
     bool HasUncheckedType = DestType->hasUncheckedType(TypeKind);
     bool HasVariadicType = DestType->hasVariadicType();
-    if (HasUncheckedType || HasVariadicType) {
+    bool ConstructsNullPointer = false;
+    if (HasUncheckedType)
+      if (DestType->isVoidPointerType() &&
+          !SrcExpr.isInvalid()) {
+        const IntegerLiteral *Lit = dyn_cast<IntegerLiteral>(SrcExpr.get());
+        if (Lit && !Lit->getValue())
+         ConstructsNullPointer = true;
+      }
+    if ((HasUncheckedType && !ConstructsNullPointer) || HasVariadicType) {
       if (HasUncheckedType) {
         Self.Diag(OpRange.getBegin(), diag::err_checked_scope_type_for_casting)
             << TypeKind;

--- a/test/CheckedC/checked-scope-null.c
+++ b/test/CheckedC/checked-scope-null.c
@@ -1,0 +1,11 @@
+// Tests that implementation-specific definitions of NULL can be used
+// in checked scopes.
+
+// RUN: %clang_cc1 -verify -fcheckedc-extension -Wno-unused-value %s
+// expected-no-diagnostics
+
+_Checked _Ptr<int> f(void) {
+  _Ptr<int> p = ((void *)0);
+  *((void *) 0);  // TODO: this should not be allowed in a checked scope.
+  return p;
+}


### PR DESCRIPTION
The C standard allows NULL to be an implementation-defined null pointer
constant.  The clang implementation of C allows NULL to be defined as
((void *) 0).   This is rejected by the static checking of checked scopes
currently because it is a cast to an unchecked pointer.   However, we would
like to allow NULL to be used in checked scopes.

The solution is to allow null pointer constants to appear in checked scopes,
however an implementation defines them.  This changes modifies the checking
of casts in checked scopes to allow ((void *) 0).  We may need to do some
extra work to preserve the safety property of checked scopes. You can't
do pointer arithmetic because void is an incomplete type or convert it some
other unchecked pointer type in a checked scope.  You may be able to try
to dereference it.  This could lead to undefined behavior, which could
lead to safety problems given how C compilers optimize in the presence
of undefined behavior.

Testing:
- Add a new clang-specific test for its implementation defined null pointer
  constants.
- Passes existing Checked C tests.