### PR TITLE
Add automation support for skipping Checked C tests.

### DIFF
--- a/automation/UNIX/config-vars.sh
+++ b/automation/UNIX/config-vars.sh
@@ -46,12 +46,12 @@ elif [ "$TEST_TARGET_ARCH" != "X86" -a "$TEST_TARGET_ARCH" != "AMD64" ]; then
 fi
 
 if [ -z $BUILD_BINARIESDIRECTORY ]; then
-  echo "BUILD_BINARIESDIRECTORY not set.  Set it the directory that will contain the object directory."
+  echo "BUILD_BINARIESDIRECTORY not set.  Set it to the directory that will contain the object directory."
   CHECKEDC_CONFIG_STATUS="error" 
 fi
 
 if [ -z $BUILD_SOURCESDIRECTORY ]; then
-  echo "BUILD_SOURCESDIRECTORY not set.  Set it the directory that will contain the sources directory."
+  echo "BUILD_SOURCESDIRECTORY not set.  Set it to the directory that will contain the sources directory."
   CHECKEDC_CONFIG_STATUS="error" 
 fi
 
@@ -66,6 +66,17 @@ elif [ "$TEST_SUITE" != "CheckedC" -a "$TEST_SUITE" != "CheckedC_clang" -a \
        "$TEST_SUITE" != "CheckedC_LLVM" ]; then
   echo "Unknown TEST_SUITE value $TEST_SUITE: must be one of CheckedC, CheckedC_clang, or CheckedC_LLVM"
   CHECKEDC_CONFIG_STATUS="error" 
+fi
+
+# SKIP_CHECKEDC_TESTS controls whether to skip the Checked C repo tests
+# entirely. This is useful for building/testing a stock (unmodified)
+# version of clang/LLVM that does not support Checked C.
+
+if [ -z "$SKIP_CHECKEDC_TESTS" ]; then
+  export SKIP_CHECKEDC_TESTS="No"
+elif [ "$SKIP_CHECKEDC_TESTS" != "Yes" -a "$SKIP_CHECKEDC_TESTS" != "No" ]; then
+  echo Unknown SKIP_CHECKEDC_TESTS value: must be one of Yes or No
+  CHECKEDC_CONFIG_STATUS="error"
 fi
 
 # set up branch names
@@ -128,8 +139,9 @@ if [ "$CHECKEDC_CONFIG_STATUS" == "passed" ]; then
   echo " BUILDOS: $BUILDOS"
   echo " TEST_TARGET_ARCH: $TEST_TARGET_ARCH"
   echo " TEST_SUITE: $TEST_SUITE"
+  echo " SKIP_CHECKEDC_TESTS: $SKIP_CHECKEDC_TESTS"
   echo " LNT: $LNT"
-  echo "  LNT_SCRIPT: $LNT_SCRIPT"
+  echo " LNT_SCRIPT: $LNT_SCRIPT"
   echo
   echo " Directories:"
   echo "  BUILD_SOURCESDIRECTORY: $BUILD_SOURCESDIRECTORY"
@@ -151,4 +163,3 @@ if [ "$CHECKEDC_CONFIG_STATUS" == "passed" ]; then
 else
   echo "Configuration of environment variables failed"
 fi
-

--- a/automation/UNIX/test-clang.sh
+++ b/automation/UNIX/test-clang.sh
@@ -5,7 +5,10 @@ set -o pipefail
 set -x
 
 cd ${LLVM_OBJ_DIR}
-make -j${BUILD_CPU_COUNT} check-checkedc
+
+if [ "${SKIP_CHECKEDC_TESTS}" != "Yes" ]; then
+  make -j${BUILD_CPU_COUNT} check-checkedc
+fi
 
 if [ "${TEST_SUITE}" == "CheckedC_clang" ]; then
   make -j${BUILD_CPU_COUNT} check-clang

--- a/automation/UNIX/test-lnt.sh
+++ b/automation/UNIX/test-lnt.sh
@@ -19,16 +19,27 @@ if [ ! -e "$CLANG" ]; then
 fi
 
 "$LNT_SCRIPT" runtest nt --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
-   --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
-   --cflags -fcheckedc-extension \
-   -v --output=${RESULT_DATA} -j${BUILD_CPU_COUNT} | tee ${RESULT_SUMMARY}
+    --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
+    --cflags -fcheckedc-extension \
+    --make-param=ExtraHeaders=${BUILD_SOURCESDIRECTORY}/llvm/projects/checkedc-wrapper/checkedc/include \
+    -v --output=${RESULT_DATA} -j${BUILD_CPU_COUNT} | tee ${RESULT_SUMMARY}
+
+# Code for runnint tests using cmake.  Needs further testing before enabling.
+#
+# "$LNT_SCRIPT" runtest test-suite --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
+# --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
+#   --cflags -fcheckedc-extension \
+#  --use-cmake=/usr/local/bin/cmake \
+#   --cmake-cache ${BUILDCONFIGURATION} \
+#   --use-lit=${BUILD_SOURCESDIRECTORY}/llvm/utilkkvs/lit/lit.py \
+#   -v | tee ${RESULT_SUMMARY}
 
 if grep FAIL ${RESULT_SUMMARY}; then
   echo "LNT testing failed."
   exit 1
 else
   if [ $? -eq 2 ]; then
-    echo "Grep of LNT result log unexepectedly failed."
+    echo "Grep of LNT result log unexpectedly failed."
     exit 1
   fi
 fi

--- a/automation/UNIX/test-lnt.sh
+++ b/automation/UNIX/test-lnt.sh
@@ -19,12 +19,12 @@ if [ ! -e "$CLANG" ]; then
 fi
 
 "$LNT_SCRIPT" runtest nt --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
-    --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
-    --cflags -fcheckedc-extension \
-    --make-param=ExtraHeaders=${BUILD_SOURCESDIRECTORY}/llvm/projects/checkedc-wrapper/checkedc/include \
-    -v --output=${RESULT_DATA} -j${BUILD_CPU_COUNT} | tee ${RESULT_SUMMARY}
+   --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
+   --cflags -fcheckedc-extension \
+   --make-param=ExtraHeaders=${BUILD_SOURCESDIRECTORY}/llvm/projects/checkedc-wrapper/checkedc/include \
+   -v --output=${RESULT_DATA} -j${BUILD_CPU_COUNT} | tee ${RESULT_SUMMARY}
 
-# Code for runnint tests using cmake.  Needs further testing before enabling.
+# Code for running tests using cmake.  Needs further testing before enabling.
 #
 # "$LNT_SCRIPT" runtest test-suite --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
 # --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \

--- a/automation/Windows/config-vars.bat
+++ b/automation/Windows/config-vars.bat
@@ -1,4 +1,4 @@
-rem 
+rem
 rem Validate and set configuration variables.   Other scripts should only 
 rem depend on variables printed at the end of this script.
 rem
@@ -98,6 +98,21 @@ if NOT DEFINED TEST_SUITE (
   exit /b 1
 )
 
+rem SKIP_CHECKEDC_TESTS controls whether to skip the Checked C repo tests
+rem entirely. This is useful for building/testing a stock (unmodified)
+rem version of clang/LLVM that does not support Checked C.
+
+if NOT DEFINED SKIP_CHECKEDC_TESTS (
+  set SKIP_CHECKEDC_TESTS=No
+) else if "%SKIP_CHECKEDC_TESTS%"=="Yes" (
+  rem
+) else if "%SKIP_CHECKEDC_TESTS%"=="No" (
+  rem
+) else (
+  echo Unknown SKIP_CHECKEDC_TESTS value: must be one of Yes or No
+  exit /b 1
+)
+
 rem set up branch names
 if not defined LLVM_BRANCH (
   set LLVM_BRANCH=master
@@ -157,6 +172,7 @@ echo.  BUILDCONFIGURATION: %BUILDCONFIGURATION%
 echo.  BUILDOS: %BUILDOS%
 echo.  TEST_TARGET_ARCH: %TEST_TARGET_ARCH%
 echo.  TEST_SUITE: %TEST_SUITE%
+echo.  SKIP_CHECKEDC_TESTS: %SKIP_CHECKEDC_TESTS%
 echo.  BUILD_CHECKEDC_CLEAN: %BUILD_CHECKEDC_CLEAN%
 echo.
 echo.  Directories:

--- a/automation/Windows/test-clang.bat
+++ b/automation/Windows/test-clang.bat
@@ -9,8 +9,12 @@ set OLD_DIR=%CD%
 
 cd %LLVM_OBJ_DIR%
 
-"%MSBUILD_BIN%" projects\checkedc-wrapper\check-checkedc.vcxproj /v:%MSBUILD_VERBOSITY% /maxcpucount:%MSBUILD_CPU_COUNT% /p:CL_MPCount=%CL_CPU_COUNT%
-if ERRORLEVEL 1 (goto cmdfailed)
+if "%SKIP_CHECKEDC_TESTS%"=="Yes" (
+  rem
+) else (
+  "%MSBUILD_BIN%" projects\checkedc-wrapper\check-checkedc.vcxproj /v:%MSBUILD_VERBOSITY% /maxcpucount:%MSBUILD_CPU_COUNT% /p:CL_MPCount=%CL_CPU_COUNT%
+  if ERRORLEVEL 1 (goto cmdfailed)
+)
 
 if "%TEST_SUITE%"=="CheckedC" (
   rem


### PR DESCRIPTION
- Add support for skipping the Checked C tests.  We are planning to move to
a newer version of the clang/LLVM sources and this enables us to run
automation testing on a stock (unchanged) LLVM/clang version.  We can use
that to make sure that the newer sources are in good shape before merging
our changes into them.

- For LNT testing, add the Checked C headers in the enlistment to the list of
  header directories, using the --make-param flag.  There is a makefile
  variable ExtraHeaders that can hold extra include directories.  This is
  in preparation for deleting the extra copy of the Checked C headers in the
  repo.

- Fix typos in error messages and some spacing issues.

Testing:
- Ran automation scripts locally.