### PR TITLE
Revert "Try enabling using cmake for LNT automation testing. (#315)"

### DIFF
--- a/automation/UNIX/test-lnt.sh
+++ b/automation/UNIX/test-lnt.sh
@@ -18,22 +18,21 @@ if [ ! -e "$CLANG" ]; then
   exit 1
 fi
 
-# "$LNT_SCRIPT" runtest nt --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
-#   --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
+"$LNT_SCRIPT" runtest nt --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
+   --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
+   --cflags -fcheckedc-extension \
+   --make-param=ExtraHeaders=${BUILD_SOURCESDIRECTORY}/llvm/projects/checkedc-wrapper/checkedc/include \
+   -v --output=${RESULT_DATA} -j${BUILD_CPU_COUNT} | tee ${RESULT_SUMMARY}
+
+# Code for running tests using cmake.  Needs further testing before enabling.
+#
+# "$LNT_SCRIPT" runtest test-suite --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
+# --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
 #   --cflags -fcheckedc-extension \
-#   --make-param=ExtraHeaders=${BUILD_SOURCESDIRECTORY}/llvm/projects/checkedc-wrapper/checkedc/include \
-#   -v --output=${RESULT_DATA} -j${BUILD_CPU_COUNT} | tee ${RESULT_SUMMARY}
-
-# Code for running tests using cmake.
-
-"$LNT_SCRIPT" runtest test-suite --sandbox "$LNT_RESULTS_DIR" --no-timestamp \
-  --cc "$CLANG" --test-suite ${BUILD_SOURCESDIRECTORY}/llvm-test-suite \
-  --cflags -fcheckedc-extension \
-  --use-cmake=/usr/local/bin/cmake \
-  --cmake-cache ${BUILDCONFIGURATION} \
-  --use-lit=${BUILD_SOURCESDIRECTORY}/llvm/utils/lit/lit.py \
-  --cmake-define "CHECKEDC_SPEC_DIR=${BUILD_SOURCESDIRECTORY}/llvm/projects/checkedc-wrapper/checkedc"  \
-  -v | tee ${RESULT_SUMMARY}
+#  --use-cmake=/usr/local/bin/cmake \
+#   --cmake-cache ${BUILDCONFIGURATION} \
+#   --use-lit=${BUILD_SOURCESDIRECTORY}/llvm/utilkkvs/lit/lit.py \
+#   -v | tee ${RESULT_SUMMARY}
 
 if grep FAIL ${RESULT_SUMMARY}; then
   echo "LNT testing failed."


### PR DESCRIPTION
This reverts commit eefccde031c4feb5aef2b7c3a53c85cc43a34914.

It turns out that using cmake for LNT automation testing is more complex than I thought.  It apparently requires the LLVM gold plugin to be built too.   Revert this for now until this is sorted out.
