### PR TITLE
Copy Checked C headers to clang system header directory.

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 add_dependencies(clang clang-headers)
 
 if (DEFINED CHECKEDC_IN_TREE)
-  add_dependencies(checkedc-headers)
+  add_dependencies(clang checkedc-headers)
 endif()
 
 if(NOT CLANG_LINKS_TO_CREATE)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -51,6 +51,10 @@ endif()
 
 add_dependencies(clang clang-headers)
 
+if (DEFINED CHECKEDC_IN_TREE)
+  add_dependencies(checkedc-headers)
+endif()
+
 if(NOT CLANG_LINKS_TO_CREATE)
   set(CLANG_LINKS_TO_CREATE clang++ clang-cl)
 

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 add_dependencies(clang clang-headers)
 
-if (DEFINED CHECKEDC_IN_TREE)
+if (CHECKEDC_IN_TREE)
   add_dependencies(clang checkedc-headers)
 endif()
 


### PR DESCRIPTION
The Checked C header files are stored in the Checked C repo.  If the Checked C repo is in the tree, add a dependency on the target that copies the Checked C headers.   The target is conditionally added by the LLVM cmake files and a variable is set for use by the clang build system.

