### PR TITLE
Removes some Clang Build Warnings

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2559,7 +2559,6 @@ void ASTDumper::dumpBoundsKind(BoundsExpr::Kind K) {
     case BoundsExpr::Kind::ByteCount: OS << " Byte"; break;
     case BoundsExpr::Kind::Range: OS << " Range"; break;
     case BoundsExpr::Kind::InteropTypeAnnotation: OS << " InteropTypeAnnotation"; break;
-    default: OS << " <<err>>"; break;
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3215,8 +3215,6 @@ ExprResult Parser::ParseBoundsCastExpression() {
         RAngleBracketLoc, RelativeClause, LParenLoc, RParenLoc, E1.get(),
         E2.get(), E3.get());
     break;
-  default:
-    llvm_unreachable("unexpected expression kind");
   }
 
   return Result;

--- a/lib/Parse/ParsePragma.cpp
+++ b/lib/Parse/ParsePragma.cpp
@@ -183,12 +183,9 @@ private:
 };
 
 struct PragmaCheckedScopeHandler : public PragmaHandler {
-  PragmaCheckedScopeHandler(Sema &S)
-      : PragmaHandler("BOUNDS_CHECKED"), Actions(S) {}
+  PragmaCheckedScopeHandler() : PragmaHandler("BOUNDS_CHECKED") {}
   void HandlePragma(Preprocessor &PP, PragmaIntroducerKind Introducer,
                     Token &FirstToken) override;
-private:
-  Sema &Actions;
 };
 
 /// PragmaAttributeHandler - "\#pragma clang attribute ...".
@@ -298,7 +295,7 @@ void Parser::initializePragmaHandlers() {
   AttributePragmaHandler.reset(new PragmaAttributeHandler(AttrFactory));
   PP.AddPragmaHandler("clang", AttributePragmaHandler.get());
 
-  CheckedScopeHandler.reset(new PragmaCheckedScopeHandler(Actions));
+  CheckedScopeHandler.reset(new PragmaCheckedScopeHandler());
   PP.AddPragmaHandler(CheckedScopeHandler.get());
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -859,7 +859,7 @@ StmtResult Parser::ParseCheckedScopeStatement() {
   else if (Tok.is(tok::kw__Unchecked))
     Kind = CSK_Unchecked;
 
-  SourceLocation CheckedLoc = ConsumeToken();
+  ConsumeToken();
   // expects checked/unchecked '{'
   if (Tok.is(tok::l_brace)) {
     return ParseCompoundStatement(false, Scope::DeclScope, Kind);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -859,7 +859,7 @@ StmtResult Parser::ParseCheckedScopeStatement() {
   else if (Tok.is(tok::kw__Unchecked))
     Kind = CSK_Unchecked;
 
-  ConsumeToken();
+  SourceLocation CheckedLoc = ConsumeToken();
   // expects checked/unchecked '{'
   if (Tok.is(tok::l_brace)) {
     return ParseCompoundStatement(false, Scope::DeclScope, Kind);

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -8563,6 +8563,7 @@ QualType Sema::GetCheckedCInteropType(const InitializedEntity &Entity) {
     case InitializedEntity::EK_Temporary:
     case InitializedEntity::EK_VectorElement:
     case InitializedEntity::EK_Parameter_CF_Audited:
+    case InitializedEntity::EK_LambdaToBlockConversionBlockElement:
       break;
   }
   return QualType();

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -3686,14 +3686,14 @@ QualType Sema::MakeCheckedArrayType(QualType T, bool Diagnose,
                                               true);
       }
       case Type::DependentSizedArray:
-      case Type::VariableArray: 
+      case Type::VariableArray:
         // Checked versions of these arrays cannot be created. An error
         // message is produced by BuildArrayType for the outer error type
         // because these result in the outer array type being
         // dependently-typed or variably-sized.
         break;
       default:
-          assert("unexpected array type");
+          llvm_unreachable("unexpected array type");
           break;
     }
   } else if (const TypedefType *TD = dyn_cast<TypedefType>(T)) {

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -94,6 +94,8 @@ public:
   bool isConstrained(uint32_t K) { 
     return ConstrainedVars.find(K) != ConstrainedVars.end(); 
   }
+
+  virtual ~ConstraintVariable() {};
 };
 
 class PointerVariableConstraint;
@@ -158,6 +160,8 @@ public:
   void dump() const { print(llvm::errs()); }
   void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);
   bool anyChanges(Constraints::EnvironmentMap &E);
+
+  virtual ~PointerVariableConstraint() {};
 };
 
 typedef PointerVariableConstraint PVConstraint;
@@ -206,6 +210,8 @@ public:
   void dump() const { print(llvm::errs()); }
   void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);
   bool anyChanges(Constraints::EnvironmentMap &E);
+
+  virtual ~FunctionVariableConstraint() {};
 };
 
 typedef FunctionVariableConstraint FVConstraint;


### PR DESCRIPTION
I had warnings for several things, which were annoying me.

- in `ASTDumper.cpp` clang has deduced the default branch is unneeded. We'll get warnings if we introduce another value to this enum, which is better than missing this case and printing "<<err>>".
- In `ParsePragma.cpp`, the `Actions` field of `PragmaCheckedScopeHandler` is currently totally unused, so I deleted it. If we want it for an `ActOnCheckedScopePragma` function we can reintroduce it.
- in `ParseStmt.cpp` `CheckedLoc` is unused. 
- in `SemaType.cpp`, assert much prefers a boolean to a string. Used llvm_unreachable which is semantically what we want here.
- in `ProgramInfo.h`, as these constraint classes all have virtual functions, clang wants them to have virtual destructors, so i just declare them as virtual. I haven't worked out if they need custom destruction behaviour.