### PR TITLE
Create lexicographic ordering of C expressions (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ out-of-bounds memory accesses.  The Checked C specification is available  at the
 |Debug X64 Linux  | Checked C and clang regression tests| ![Debug X64 Linux status](https://msresearch.visualstudio.com/_apis/public/build/definitions/f6454e27-a46c-49d9-8453-29d89d53d2f9/217/badge)|
 |Release X64 Linux| Checked C, clang, and LLVM nightly tests|![Release X64 Linux status](https://msresearch.visualstudio.com/_apis/public/build/definitions/f6454e27-a46c-49d9-8453-29d89d53d2f9/238/badge)|
 
+## News
+
+We updated the LLVM/clang sources that we are using on June 20th, 2017.  If you have built your own copy
+of the compiler, you will need to delete your cmake build directory and re-run cmake after you sync.
 
 ## Trying out Checked C
 
@@ -32,61 +36,9 @@ command-line to enable the Checked C extension.
 
 ## Compiler development status
 
-### Summary
 We are implementing a subset of the Checked C extension that can be used to add bounds
-checking to real-world C programs.  After that, we will expand the implementation to include
-additional Checked C features. The subset includes the new `ptr`, `array_ptr`, and `checked` 
-array types. It also includes in-line bounds declarations, bounds-safe
-interface annotations, the new cast operators, and checked blocks.
-The implementation of the subset will be end-to-end within the
-compiler: it will include parsing, typechecking, other static
-semantic analysis, and code generation.
-
-We have completed most of the parsing and typechecking work
-for the subset. We are working on the insertion of runtime bounds checks.
-We have yet to start on implementing checked blocks, the new cast operators, 
-and checking the correctness of bounds declarations at compile time.
-
-### Details
-
-This table summarizes the implementation status for the
-features of the subset.  The columns are the major phases of the compiler
-and the rows list the language features.    A '-' indicates that that a compiler
-phase is not applicable to the language feature.
-
-|Feature                     | Parsing     | Type checking | Other semantic analysis| Code generation |
-|----                        | ---         | ---           | ---                    | ----            |
-|`ptr` type                  | Done        | Done          | -                      | Done             |
-|`array_ptr` type           | Done        | Done          | -                      | Done (excluding checks) |
-|`checked` array type       | Done        | Done          | -                      | Done (excluding checks) |
-|In-line bounds declarations | Done        | Done          | In-progress            | -            |
-|Bounds-safe interfaces      | Done        | Done          | Done                   | -            |
-|Function types with bounds-safe interfaces|Done | Done    | -                      | -             |
-|Checking of redeclarations  | -           | -             | Done                   |              | 
-|Expression bounds inference | -           | -             | In-progress            | -             |
-|Insertion of bounds checks  | -           | -             | -                      | In-progress   |
-|Insertion of null checks    | -           | -             | -                      | Not started   |
-|Checking correctness of bounds declarations | -   | -     | Not started            | -             |
-|Relative alignment of bounds declarations | Done  | Done  | Not started            | -             |
-|Checked blocks              | In progress | -             | Not started            | -             |
-|New cast operators          | Not started | Not started   | Not started            | -             |
-
-This table describes features _not_ in the subset, in approximate order of priority of implementation.
-
-|Feature                  | Comments                             |
-|-----                    |-----                                 |
-|Null-terminated arrays   |                                      |
-|Restrict taking addresses of variables used in bounds       |   |
-|Restrict taking addresses of members used in member bounds  |   |
-|Flow-sensitive bounds declarations                        |   |
-|Where clauses                                             |   |
-|Checking correctness of where clauses                     |   |
-|Bundled blocks                                            |   |
-|Holds/suspend state of member bounds                      | Depends on flow-sensitive bounds declarations. |
-|Check for undefined order of evaluation issues            |   |
-|Overflow checking of `array_ptr` pointer arithmetic      |   |
-|Span types                                                |Lower priority|
-|Pointers directly to `array_ptr`s                       |Design is tentative.|
+checking to real-world C programs.   The implementation roadmap and status are on the
+[Checked C Wiki](https://github.com/Microsoft/checkedc-clang/wiki/Implementation-roadmap-and-status).
 
 ## Contributing
 

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -42,7 +42,7 @@ namespace clang {
      virtual VarDecl *getRepresentative(VarDecl *V);
   };
 
-  class LexicographicCompare {
+  class Lexicographic {
   public:
     enum class Result {
       LessThan,
@@ -60,11 +60,11 @@ namespace clang {
     Result CompareDeclRefExpr(const Expr *E1, const Expr *E2);
     Result CompareIntegerLiteral(const Expr *E1, const Expr *E2);
     Result CompareFloatingLiteral(const Expr *E1, const Expr *E2);
-    Result CompareImaginaryLiteral(const Expr *E1, const Expr *E2);
     Result CompareStringLiteral(const Expr *E1, const Expr *E2);
     Result CompareCharacterLiteral(const Expr *E1, const Expr *E2);
     Result CompareUnaryOperator(const Expr *E1, const Expr *E2);
     Result CompareOffsetOfExpr(const Expr *E1, const Expr *E2);
+    Result CompareUnaryExprOrTypeTraitExpr(const Expr *E1, const Expr *E2);
     Result CompareMemberExpr(const Expr *E1, const Expr *E2);
     Result CompareBinaryOperator(const Expr *E1, const Expr *E2);
     Result CompareCompoundAssignOperator(const Expr *E1, const Expr *E2);
@@ -74,20 +74,29 @@ namespace clang {
     Result CompareGenericSelectionExpr(const Expr *E1, const Expr *E2);
     Result CompareNullaryBoundsExpr(const Expr *E1, const Expr *E2);
     Result CompareCountBoundsExpr(const Expr *E1, const Expr *E2);
+    Result CompareRangeBoundsExpr(const Expr *E1, const Expr *E2);
     Result CompareInteropTypeBoundsAnnotation(const Expr *E1, const Expr *E2);
     Result ComparePositionalParameterExpr(const Expr *E1, const Expr *E2);
+    Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
+                                       const RelativeBoundsClause *RC2);
     Result CompareBoundsCastExpr(const Expr *E1, const Expr *E2);
+    Result CompareAtomicExpr(const Expr *E1, const Expr *E2);
     Result CompareBlockExpr(const Expr *E1, const Expr *E2);
+    Result CompareScope(const DeclContext *DC1, const DeclContext *DC2);
 
   public:
-    LexicographicCompare(ASTContext &Ctx, EqualityRelation *EV) : 
+    Lexicographic(ASTContext &Ctx, EqualityRelation *EV) : 
       Context(Ctx), EqualVars(EV) {
     }
 
     /// \brief Lexicographic comparison of expressions that can occur in
     /// bounds expressions.
     Result CompareExpr(const Expr *E1, const Expr *E2);
-    Result CompareDecl(const ValueDecl *D1, const ValueDecl *D2);
+
+    /// \brief Compare declarations that may be used by expressions or
+    /// or types.
+    Result CompareDecl(const NamedDecl *D1, const NamedDecl *D2);
+    Result CompareType(QualType T1, QualType T2);
   };
 }  // end namespace clang
 

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -53,6 +53,7 @@ namespace clang {
   private:
     EqualityRelation *EqualVars;
     ASTContext &Context;
+    bool Trace;
 
     Result CompareInteger(signed I1, signed I2);
     Result CompareInteger(unsigned I1, unsigned I2);
@@ -85,9 +86,7 @@ namespace clang {
     Result CompareScope(const DeclContext *DC1, const DeclContext *DC2);
 
   public:
-    Lexicographic(ASTContext &Ctx, EqualityRelation *EV) : 
-      Context(Ctx), EqualVars(EV) {
-    }
+    Lexicographic(ASTContext &Ctx, EqualityRelation *EV);
 
     /// \brief Lexicographic comparison of expressions that can occur in
     /// bounds expressions.

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -55,35 +55,55 @@ namespace clang {
     ASTContext &Context;
     bool Trace;
 
+    template <typename T>
+    Lexicographic::Result Compare(const Expr *Raw1, const Expr *Raw2) {
+      const T *E1 = dyn_cast<T>(Raw1);
+      const T *E2 = dyn_cast<T>(Raw2);
+      if (!E1 || !E2) {
+        llvm_unreachable("dyn_cast failed");
+        return Result::LessThan;
+      }
+      return Lexicographic::CompareImpl(E1, E2);
+    }
+
     Result CompareInteger(signed I1, signed I2);
     Result CompareInteger(unsigned I1, unsigned I2);
-    Result ComparePredefinedExpr(const Expr *E1, const Expr *E2);
-    Result CompareDeclRefExpr(const Expr *E1, const Expr *E2);
-    Result CompareIntegerLiteral(const Expr *E1, const Expr *E2);
-    Result CompareFloatingLiteral(const Expr *E1, const Expr *E2);
-    Result CompareStringLiteral(const Expr *E1, const Expr *E2);
-    Result CompareCharacterLiteral(const Expr *E1, const Expr *E2);
-    Result CompareUnaryOperator(const Expr *E1, const Expr *E2);
-    Result CompareOffsetOfExpr(const Expr *E1, const Expr *E2);
-    Result CompareUnaryExprOrTypeTraitExpr(const Expr *E1, const Expr *E2);
-    Result CompareMemberExpr(const Expr *E1, const Expr *E2);
-    Result CompareBinaryOperator(const Expr *E1, const Expr *E2);
-    Result CompareCompoundAssignOperator(const Expr *E1, const Expr *E2);
-    Result CompareImplicitCastExpr(const Expr *E1, const Expr *E2);
-    Result CompareCStyleCastExpr(const Expr *E1, const Expr *E2);
-    Result CompareCompoundLiteralExpr(const Expr *E1, const Expr *E2);
-    Result CompareGenericSelectionExpr(const Expr *E1, const Expr *E2);
-    Result CompareNullaryBoundsExpr(const Expr *E1, const Expr *E2);
-    Result CompareCountBoundsExpr(const Expr *E1, const Expr *E2);
-    Result CompareRangeBoundsExpr(const Expr *E1, const Expr *E2);
-    Result CompareInteropTypeBoundsAnnotation(const Expr *E1, const Expr *E2);
-    Result ComparePositionalParameterExpr(const Expr *E1, const Expr *E2);
     Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
                                        const RelativeBoundsClause *RC2);
-    Result CompareBoundsCastExpr(const Expr *E1, const Expr *E2);
-    Result CompareAtomicExpr(const Expr *E1, const Expr *E2);
-    Result CompareBlockExpr(const Expr *E1, const Expr *E2);
     Result CompareScope(const DeclContext *DC1, const DeclContext *DC2);
+
+    Result CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2);
+    Result CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2);
+    Result CompareImpl(const IntegerLiteral *E1, const IntegerLiteral *E2);
+    Result CompareImpl(const FloatingLiteral *E1, const FloatingLiteral *E2);
+    Result CompareImpl(const StringLiteral *E1, const StringLiteral *E2);
+    Result CompareImpl(const CharacterLiteral *E1, const CharacterLiteral *E2);
+    Result CompareImpl(const UnaryOperator *E1, const UnaryOperator *E2);
+    Result CompareImpl(const OffsetOfExpr *E1, const OffsetOfExpr *E2);
+    Result CompareImpl(const UnaryExprOrTypeTraitExpr *E1,
+                   const UnaryExprOrTypeTraitExpr *E2);
+    Result CompareImpl(const MemberExpr *E1, const MemberExpr *E2);
+    Result CompareImpl(const BinaryOperator *E1, const BinaryOperator *E2);
+    Result CompareImpl(const CompoundAssignOperator *E1,
+                   const CompoundAssignOperator *E2);
+    Result CompareImpl(const ImplicitCastExpr *E1, const ImplicitCastExpr *E2);
+    Result CompareImpl(const CStyleCastExpr *E1, const CStyleCastExpr *E2);
+    Result CompareImpl(const CompoundLiteralExpr *E1,
+                   const CompoundLiteralExpr *E2);
+    Result CompareImpl(const GenericSelectionExpr *E1,
+                   const GenericSelectionExpr *E2);
+    Result CompareImpl(const NullaryBoundsExpr *E1,
+                       const NullaryBoundsExpr *E2);
+    Result CompareImpl(const CountBoundsExpr *E1, const CountBoundsExpr *E2);
+    Result CompareImpl(const RangeBoundsExpr *E1, const RangeBoundsExpr *E2);
+    Result CompareImpl(const InteropTypeBoundsAnnotation *E1,
+                   const InteropTypeBoundsAnnotation *E2);
+    Result CompareImpl(const PositionalParameterExpr *E1,
+                   const PositionalParameterExpr *E2);
+    Result CompareImpl(const BoundsCastExpr *E1, const BoundsCastExpr *E2);
+    Result CompareImpl(const AtomicExpr *E1, const AtomicExpr *E2);
+    Result CompareImpl(const BlockExpr *E1, const BlockExpr *E2);
+
 
   public:
     Lexicographic(ASTContext &Ctx, EqualityRelation *EV);

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -1,0 +1,94 @@
+//===-- CanonBounds.h - compare and canonicalize bounds exprs --*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the interface for comparing and canonicalizing
+//  bounds expressions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CANON_BOUNDS_H
+#define LLVM_CLANG_CANON_BOUNDS_H
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/AttrKinds.h"
+#include "clang/Basic/LLVM.h"
+#include "clang/Basic/OpenMPKinds.h"
+#include "clang/Basic/Sanitizers.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/VersionTuple.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <cassert>
+
+namespace clang {
+  class ASTContext;
+  class Expr;
+  class VarDecl;
+
+  // Abstract base class that provides information what variables
+  // currently are equal to each other.
+  class EqualityRelation {
+  public:
+     virtual VarDecl *getRepresentative(VarDecl *V);
+  };
+
+  class LexicographicCompare {
+  public:
+    enum class Result {
+      LessThan,
+      Equal,
+      GreaterThan
+    };
+
+  private:
+    EqualityRelation *EqualVars;
+    ASTContext &Context;
+
+    Result CompareInteger(signed I1, signed I2);
+    Result CompareInteger(unsigned I1, unsigned I2);
+    Result ComparePredefinedExpr(const Expr *E1, const Expr *E2);
+    Result CompareDeclRefExpr(const Expr *E1, const Expr *E2);
+    Result CompareIntegerLiteral(const Expr *E1, const Expr *E2);
+    Result CompareFloatingLiteral(const Expr *E1, const Expr *E2);
+    Result CompareImaginaryLiteral(const Expr *E1, const Expr *E2);
+    Result CompareStringLiteral(const Expr *E1, const Expr *E2);
+    Result CompareCharacterLiteral(const Expr *E1, const Expr *E2);
+    Result CompareUnaryOperator(const Expr *E1, const Expr *E2);
+    Result CompareOffsetOfExpr(const Expr *E1, const Expr *E2);
+    Result CompareMemberExpr(const Expr *E1, const Expr *E2);
+    Result CompareBinaryOperator(const Expr *E1, const Expr *E2);
+    Result CompareCompoundAssignOperator(const Expr *E1, const Expr *E2);
+    Result CompareImplicitCastExpr(const Expr *E1, const Expr *E2);
+    Result CompareCStyleCastExpr(const Expr *E1, const Expr *E2);
+    Result CompareCompoundLiteralExpr(const Expr *E1, const Expr *E2);
+    Result CompareGenericSelectionExpr(const Expr *E1, const Expr *E2);
+    Result CompareNullaryBoundsExpr(const Expr *E1, const Expr *E2);
+    Result CompareCountBoundsExpr(const Expr *E1, const Expr *E2);
+    Result CompareInteropTypeBoundsAnnotation(const Expr *E1, const Expr *E2);
+    Result ComparePositionalParameterExpr(const Expr *E1, const Expr *E2);
+    Result CompareBoundsCastExpr(const Expr *E1, const Expr *E2);
+    Result CompareBlockExpr(const Expr *E1, const Expr *E2);
+
+  public:
+    LexicographicCompare(ASTContext &Ctx, EqualityRelation *EV) : 
+      Context(Ctx), EqualVars(EV) {
+    }
+
+    /// \brief Lexicographic comparison of expressions that can occur in
+    /// bounds expressions.
+    Result CompareExpr(const Expr *E1, const Expr *E2);
+    Result CompareDecl(const ValueDecl *D1, const ValueDecl *D2);
+  };
+}  // end namespace clang
+
+#endif

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -15,6 +15,7 @@
 #include "CXXABI.h"
 #include "clang/AST/ASTMutationListener.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/CanonBounds.h"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/Comment.h"
 #include "clang/AST/CommentCommandTraits.h"
@@ -8868,11 +8869,8 @@ bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
 }
 
 bool ASTContext::EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2) {
-  llvm::FoldingSetNodeID ID1;
-  llvm::FoldingSetNodeID ID2;
-  Expr1->Profile(ID1, *this, true);
-  Expr2->Profile(ID2, *this, true);
-  return ID1 == ID2;
+  Lexicographic::Result Cmp = Lexicographic(*this, nullptr).CompareExpr(Expr1, Expr2);
+  return Cmp == Lexicographic::Result::Equal;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -10,6 +10,7 @@ add_clang_library(clangAST
   ASTStructuralEquivalence.cpp
   ASTTypeTraits.cpp
   AttrImpl.cpp
+  CanonBounds.cpp
   CXXInheritance.cpp
   Comment.cpp
   CommentBriefParser.cpp

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -1,0 +1,250 @@
+//===- CanonBounds.cpp: comparison and canonicalization for bounds exprs -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements methods to canoncialize expressions used in bounds
+//  expressions and determine if they should be considered semantically
+//  equivalent.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/CanonBounds.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
+
+using namespace clang;
+
+LexicographicCompare::Result LexicographicCompare::CompareInteger(signed I1, signed I2) {
+  if (I1 < I2)
+    return Result::LessThan;
+  else if (I1 > I2)
+    return Result::GreaterThan;
+  else
+    return Result::Equal;
+}
+
+LexicographicCompare::Result LexicographicCompare::CompareInteger(unsigned I1, unsigned I2) {
+  if (I1 < I2)
+    return Result::LessThan;
+  else if (I1 > I2)
+    return Result::GreaterThan;
+  else
+    return Result::Equal;
+}
+
+LexicographicCompare::Result LexicographicCompare::CompareExpr(const Expr *E1, const Expr *E2) {
+   Stmt::StmtClass E1Kind = E1->getStmtClass();
+   Stmt::StmtClass E2Kind = E2->getStmtClass();
+   Result Cmp = CompareInteger(E1Kind, E2Kind);
+   if (Cmp != Result::Equal)
+     return Cmp;
+
+   Cmp = Result::Equal; 
+   switch (E1Kind) {
+     case Stmt::NoStmtClass:
+#define ABSTRACT_STMT(Kind)
+#define STMT(Kind, Base) case Expr::Kind##Class:
+#define EXPR(Kind, Base)
+#include "clang/AST/StmtNodes.inc"
+       llvm_unreachable("cannot compare a statement");  
+     case Expr::PredefinedExprClass: Cmp = ComparePredefinedExpr(E1, E2); break;
+     case Expr::DeclRefExprClass: return CompareDeclRefExpr(E1, E2);
+     case Expr::IntegerLiteralClass: return CompareIntegerLiteral(E1, E2);
+     case Expr::FloatingLiteralClass: return CompareFloatingLiteral(E1, E2);
+     case Expr::ImaginaryLiteralClass: return CompareImaginaryLiteral(E1, E2);
+     case Expr::StringLiteralClass: return CompareStringLiteral(E1, E2);
+     case Expr::CharacterLiteralClass: return CompareCharacterLiteral(E1, E2);
+     case Expr::ParenExprClass: break;
+     case Expr::UnaryOperatorClass:Cmp = CompareUnaryOperator(E1, E2); break;
+     case Expr::OffsetOfExprClass: Cmp = CompareOffsetOfExpr(E1, E2); break;
+     case Expr::ArraySubscriptExprClass: break;
+     case Expr::CallExprClass: break;
+     case Expr::MemberExprClass: Cmp = CompareMemberExpr(E1, E2); break;
+     case Expr::BinaryOperatorClass: Cmp = CompareBinaryOperator(E1, E2); break;
+     case Expr::CompoundAssignOperatorClass:
+       Cmp = CompareCompoundAssignOperator(E1, E2); break;
+     case Expr::BinaryConditionalOperatorClass: break;
+     case Expr::ImplicitCastExprClass: Cmp = CompareImplicitCastExpr(E1, E2); break;
+     case Expr::CStyleCastExprClass: Cmp = CompareCStyleCastExpr(E1, E2); break;
+     case Expr::CompoundLiteralExprClass: Cmp = CompareCompoundLiteralExpr(E1, E2); break;
+     // TODO:
+     // case: ExtVectorElementExpr
+     case Expr::VAArgExprClass: break;
+     case Expr::GenericSelectionExprClass: Cmp = CompareGenericSelectionExpr(E1, E2); break;
+
+     // Atomic expressions.
+     case Expr::AtomicExprClass: break;
+
+     // GNU Extensions.
+     case Expr::AddrLabelExprClass: break;
+     case Expr::StmtExprClass: break;
+     case Expr::ChooseExprClass: break;
+     case Expr::GNUNullExprClass: break;
+
+     // Bounds expressions
+     case Expr::NullaryBoundsExprClass: Cmp = CompareNullaryBoundsExpr(E1, E2); break;
+     case Expr::CountBoundsExprClass: Cmp = CompareCountBoundsExpr(E1, E2); break;
+     case Expr::RangeBoundsExprClass: break;
+     case Expr::InteropTypeBoundsAnnotationClass: Cmp = CompareInteropTypeBoundsAnnotation(E1, E2); break;
+     case Expr::PositionalParameterExprClass: Cmp = ComparePositionalParameterExpr(E1, E2); break;
+     case Expr::BoundsCastExprClass: Cmp = CompareBoundsCastExpr(E1, E2); break;
+
+     // Clang extensions
+     case Expr::ShuffleVectorExprClass: break;
+     case Expr::ConvertVectorExprClass: break;
+     case Expr::BlockExprClass: Cmp = CompareBlockExpr(E1, E2); break;
+     case Expr::OpaqueValueExprClass: break;
+     case Expr::TypoExprClass: break;
+     // TODO:
+     // case Expr::MSPropertyRefExprClass:
+     // case Expr::MSPropertySubscriptExprClass:
+
+     default:
+       llvm_unreachable("unexpected expression kind");         
+   }
+
+   if (Cmp != Result::Equal)
+     return Cmp;
+
+   // Check children
+   auto I1 = E1->child_begin();
+   auto I2 = E2->child_begin();
+   for ( ;  I1 != E1->child_end() && I2 != E2->child_end(); ++I1, ++I2) {
+     const Stmt *E1Child = *I1;
+     const Stmt *E2Child = *I2;
+     if (E1Child == nullptr && E2Child != nullptr)
+       return Result::LessThan;
+     if (E1Child != nullptr && E2Child == nullptr)
+       return Result::GreaterThan;
+     if (E1Child == nullptr && E2Child == nullptr)
+       continue;
+
+     const Expr *E1ChildExpr = dyn_cast<Expr>(E1Child);
+     const Expr *E2ChildExpr = dyn_cast<Expr>(E2Child);
+     assert(E1ChildExpr && E2ChildExpr && "expected subexpression");
+     if (E1ChildExpr && E2ChildExpr) {
+       Result Cmp = CompareExpr(E1ChildExpr, E2ChildExpr);
+       if (Cmp != Result::Equal)
+         return Cmp;
+     } else
+       return Result::LessThan;
+   }
+
+   // Make sure the number of children was equal.  If E1 has
+   // fewer children than E2, make it less than.  If it has more
+   // children, make it greater than.
+   if (I1 == E1->child_end() && I2 != E2->child_end())
+     return Result::LessThan;
+
+   if (I1 != E1->child_end() && I2 == E2->child_end())
+     return Result::GreaterThan;
+
+   return LexicographicCompare::Result::Equal;
+}
+
+LexicographicCompare::Result 
+LexicographicCompare::CompareDecl(const ValueDecl *D1, const ValueDecl *D2) {
+  return Result::Equal;
+}
+
+#define CHECK_WRAPPER(N) \
+LexicographicCompare::Result \
+LexicographicCompare::Compare##N(const Expr *Raw1, const Expr *Raw2) { \
+  const N *E1 = dyn_cast<N>(Raw1); \
+  const N *E2 = dyn_cast<N>(Raw2); \
+  if (!E1 || !E2)  { \
+    llvm_unreachable("dyn_cast failed"); \
+    return Result::LessThan; \
+  } 
+
+CHECK_WRAPPER(PredefinedExpr)
+  return CompareInteger(E1->getIdentType(), E2->getIdentType());
+}
+
+CHECK_WRAPPER(DeclRefExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(IntegerLiteral)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(FloatingLiteral)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(ImaginaryLiteral)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(StringLiteral)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(CharacterLiteral)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(UnaryOperator)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(OffsetOfExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(MemberExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(BinaryOperator)
+  return Result::Equal;
+}
+
+
+CHECK_WRAPPER(CompoundAssignOperator)
+  return Result::Equal;
+}
+
+
+CHECK_WRAPPER(ImplicitCastExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(CompoundLiteralExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(GenericSelectionExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(NullaryBoundsExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(CountBoundsExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(InteropTypeBoundsAnnotation)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(PositionalParameterExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(BoundsCastExpr)
+  return Result::Equal;
+}
+
+CHECK_WRAPPER(BlockExpr)
+  return Result::Equal;
+}
+

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/APInt.h"
-#include "llvm/support/raw_ostream.h"
+#include "llvm/Support/raw_ostream.h"
 #include "clang/AST/CanonBounds.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -327,6 +327,8 @@ Lexicographic::Compare##N(const Expr *Raw1, const Expr *Raw2) { \
 
 Lexicographic::Result
 Lexicographic::CompareType(QualType QT1, QualType QT2) {
+  QT1 = QT1.getCanonicalType();
+  QT2 = QT2.getCanonicalType();
   if (QT1 == QT2)
     return Result::Equal;
   else

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -11,15 +11,18 @@
 //  expressions and determine if they should be considered semantically
 //  equivalent.
 //
+//
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/APInt.h"
 #include "clang/AST/CanonBounds.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/Stmt.h"
 
 using namespace clang;
 
-LexicographicCompare::Result LexicographicCompare::CompareInteger(signed I1, signed I2) {
+Lexicographic::Result Lexicographic::CompareInteger(signed I1, signed I2) {
   if (I1 < I2)
     return Result::LessThan;
   else if (I1 > I2)
@@ -28,7 +31,7 @@ LexicographicCompare::Result LexicographicCompare::CompareInteger(signed I1, sig
     return Result::Equal;
 }
 
-LexicographicCompare::Result LexicographicCompare::CompareInteger(unsigned I1, unsigned I2) {
+Lexicographic::Result Lexicographic::CompareInteger(unsigned I1, unsigned I2) {
   if (I1 < I2)
     return Result::LessThan;
   else if (I1 > I2)
@@ -37,7 +40,132 @@ LexicographicCompare::Result LexicographicCompare::CompareInteger(unsigned I1, u
     return Result::Equal;
 }
 
-LexicographicCompare::Result LexicographicCompare::CompareExpr(const Expr *E1, const Expr *E2) {
+static Lexicographic::Result CompareAPInt(const llvm::APInt &I1, const llvm::APInt &I2) {
+  if (I1.slt(I2))
+    return Lexicographic::Result::LessThan;
+  else if (I1.eq(I2))
+    return Lexicographic::Result::Equal;
+  else
+    return Lexicographic::Result::GreaterThan;
+}
+
+static Lexicographic::Result TranslateInt(int i) {
+  if (i == 0) 
+    return Lexicographic::Result::Equal;
+  else if  (i > 0)
+    return Lexicographic::Result::GreaterThan;
+  else
+    return Lexicographic::Result::LessThan;
+}
+
+// \brief See if two pointers can be ordered based on nullness or
+// pointer equality.   Set the parameter 'ordered' based on whether
+// they can be.  If they can be ordered, return the ordering.
+template<typename T> 
+static Lexicographic::Result ComparePointers(T *P1, T *P2, bool &ordered) {
+  ordered = true;
+  if (P1 == P2)
+    return Lexicographic::Result::Equal;
+  if (P1 == nullptr && P2 != nullptr)
+    return Lexicographic::Result::LessThan;
+  if (P1 != nullptr && P2 == nullptr)
+    return Lexicographic::Result::GreaterThan;
+  ordered = false;
+  return Lexicographic::Result::LessThan;
+}
+
+Lexicographic::Result 
+Lexicographic::CompareScope(const DeclContext *DC1, const DeclContext *DC2) {
+   DC1 = DC1->getPrimaryContext();
+   DC2 = DC2->getPrimaryContext();
+
+  if (DC1 == DC2)
+    return Result::Equal;
+
+  Result Cmp = CompareInteger(DC1->getDeclKind(), DC2->getDeclKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+
+  switch (DC1->getDeclKind()) {
+    case Decl::TranslationUnit: return Result::Equal;
+    case Decl::Function: 
+    case Decl::Enum:
+    case Decl::Record: {
+      const NamedDecl *ND1 = dyn_cast<NamedDecl>(DC1);
+      const NamedDecl *ND2 = dyn_cast<NamedDecl>(DC2);
+      return CompareDecl(ND1, ND2);
+    }
+    default:
+      llvm_unreachable("unexpected scope type");
+      return Result::LessThan;
+  }
+}
+
+Lexicographic::Result 
+Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) {
+  const NamedDecl *D1 = dyn_cast<NamedDecl>(D1Arg->getCanonicalDecl());
+  const NamedDecl *D2 = dyn_cast<NamedDecl>(D2Arg->getCanonicalDecl());
+  if (D1 == D2) 
+    return Result::Equal;
+
+  if (!D1 || !D2) {
+    assert("unexpected cast failure");
+    return Result::LessThan;
+  }
+
+  Result Cmp = CompareInteger(D1->getKind(), D2->getKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+
+  const IdentifierInfo *Name1 = D1->getIdentifier();
+  const IdentifierInfo *Name2 = D2->getIdentifier();
+
+  bool ordered;
+  Cmp = ComparePointers(D1, D2, ordered);
+  if (ordered && Cmp != Result::Equal)
+    return Cmp;
+  assert(Name1 && Name2);
+
+  Cmp = TranslateInt(Name1->getName().compare(Name2->getName()));
+  if (Cmp != Result::Equal)
+    return Cmp;
+
+  // They are canonical declarations that have the same kind and the same name, but are not 
+  // the same declaration.
+  // - If they are in the same semantic scope, one declaration must hide the other.  Order the
+  //   earlier declaration as less than the later declaration.
+  // - Otherwise order them by scope
+
+  const DeclContext *DC1 = D1->getDeclContext();
+  const DeclContext *DC2 = D2->getDeclContext();
+
+  if (!(DC1->Equals(DC2)))
+    return CompareScope(DC1, DC2);
+
+  // see if D2 occurs after D1 in the context
+  
+  const Decl *Current = D1->getNextDeclInContext();
+  while (Current != nullptr) {
+    if (Current == D2)
+      return Result::LessThan;
+    Current = Current->getNextDeclInContext();
+  }
+
+  // make sure D1 occurs after D2 then
+  Current = D2->getNextDeclInContext();
+  while (Current != nullptr) {
+    if (Current == D1)
+      return Result::LessThan;
+    Current = Current->getNextDeclInContext();
+  }
+  llvm_unreachable("unable to order declarations in same context");
+  return Result::LessThan;
+}
+
+Lexicographic::Result Lexicographic::CompareExpr(const Expr *E1, const Expr *E2) {
+   if (E1 == E2)
+     return Result::Equal;
+
    Stmt::StmtClass E1Kind = E1->getStmtClass();
    Stmt::StmtClass E2Kind = E2->getStmtClass();
    Result Cmp = CompareInteger(E1Kind, E2Kind);
@@ -56,12 +184,14 @@ LexicographicCompare::Result LexicographicCompare::CompareExpr(const Expr *E1, c
      case Expr::DeclRefExprClass: return CompareDeclRefExpr(E1, E2);
      case Expr::IntegerLiteralClass: return CompareIntegerLiteral(E1, E2);
      case Expr::FloatingLiteralClass: return CompareFloatingLiteral(E1, E2);
-     case Expr::ImaginaryLiteralClass: return CompareImaginaryLiteral(E1, E2);
+     case Expr::ImaginaryLiteralClass: break;
      case Expr::StringLiteralClass: return CompareStringLiteral(E1, E2);
      case Expr::CharacterLiteralClass: return CompareCharacterLiteral(E1, E2);
      case Expr::ParenExprClass: break;
-     case Expr::UnaryOperatorClass:Cmp = CompareUnaryOperator(E1, E2); break;
+     case Expr::UnaryOperatorClass: Cmp = CompareUnaryOperator(E1, E2); break;
      case Expr::OffsetOfExprClass: Cmp = CompareOffsetOfExpr(E1, E2); break;
+     case Expr::UnaryExprOrTypeTraitExprClass:
+       Cmp = CompareUnaryExprOrTypeTraitExpr(E1, E2); break;
      case Expr::ArraySubscriptExprClass: break;
      case Expr::CallExprClass: break;
      case Expr::MemberExprClass: Cmp = CompareMemberExpr(E1, E2); break;
@@ -78,7 +208,7 @@ LexicographicCompare::Result LexicographicCompare::CompareExpr(const Expr *E1, c
      case Expr::GenericSelectionExprClass: Cmp = CompareGenericSelectionExpr(E1, E2); break;
 
      // Atomic expressions.
-     case Expr::AtomicExprClass: break;
+     case Expr::AtomicExprClass: CompareAtomicExpr(E1, E2); break;
 
      // GNU Extensions.
      case Expr::AddrLabelExprClass: break;
@@ -89,7 +219,7 @@ LexicographicCompare::Result LexicographicCompare::CompareExpr(const Expr *E1, c
      // Bounds expressions
      case Expr::NullaryBoundsExprClass: Cmp = CompareNullaryBoundsExpr(E1, E2); break;
      case Expr::CountBoundsExprClass: Cmp = CompareCountBoundsExpr(E1, E2); break;
-     case Expr::RangeBoundsExprClass: break;
+     case Expr::RangeBoundsExprClass:  Cmp = CompareRangeBoundsExpr(E1, E2); break; break;
      case Expr::InteropTypeBoundsAnnotationClass: Cmp = CompareInteropTypeBoundsAnnotation(E1, E2); break;
      case Expr::PositionalParameterExprClass: Cmp = ComparePositionalParameterExpr(E1, E2); break;
      case Expr::BoundsCastExprClass: Cmp = CompareBoundsCastExpr(E1, E2); break;
@@ -117,44 +247,43 @@ LexicographicCompare::Result LexicographicCompare::CompareExpr(const Expr *E1, c
    for ( ;  I1 != E1->child_end() && I2 != E2->child_end(); ++I1, ++I2) {
      const Stmt *E1Child = *I1;
      const Stmt *E2Child = *I2;
-     if (E1Child == nullptr && E2Child != nullptr)
-       return Result::LessThan;
-     if (E1Child != nullptr && E2Child == nullptr)
-       return Result::GreaterThan;
-     if (E1Child == nullptr && E2Child == nullptr)
-       continue;
-
+     bool ordered = false;
+     Cmp = ComparePointers(E1Child, E2Child, ordered);
+     if (ordered) {
+       if (Cmp == Result::Equal)
+         continue;
+       return Cmp;
+      }
+     assert(E1Child && E2Child);
      const Expr *E1ChildExpr = dyn_cast<Expr>(E1Child);
      const Expr *E2ChildExpr = dyn_cast<Expr>(E2Child);
-     assert(E1ChildExpr && E2ChildExpr && "expected subexpression");
+     assert(E1ChildExpr && E2ChildExpr && "dyn_cast failed");
      if (E1ChildExpr && E2ChildExpr) {
-       Result Cmp = CompareExpr(E1ChildExpr, E2ChildExpr);
+       Cmp = CompareExpr(E1ChildExpr, E2ChildExpr);
        if (Cmp != Result::Equal)
          return Cmp;
      } else
+       // assert fired - return something
        return Result::LessThan;
    }
 
    // Make sure the number of children was equal.  If E1 has
-   // fewer children than E2, make it less than.  If it has more
-   // children, make it greater than.
+   // fewer children than E2, make it less than E2.  If it has more
+   // children, make it greater than E2.
    if (I1 == E1->child_end() && I2 != E2->child_end())
      return Result::LessThan;
 
    if (I1 != E1->child_end() && I2 == E2->child_end())
      return Result::GreaterThan;
 
-   return LexicographicCompare::Result::Equal;
+   return Lexicographic::Result::Equal;
 }
 
-LexicographicCompare::Result 
-LexicographicCompare::CompareDecl(const ValueDecl *D1, const ValueDecl *D2) {
-  return Result::Equal;
-}
-
+// Lexicogrpahic comparion of properties specific to each expression type. 
+// Does not check children of expressions.
 #define CHECK_WRAPPER(N) \
-LexicographicCompare::Result \
-LexicographicCompare::Compare##N(const Expr *Raw1, const Expr *Raw2) { \
+Lexicographic::Result \
+Lexicographic::Compare##N(const Expr *Raw1, const Expr *Raw2) { \
   const N *E1 = dyn_cast<N>(Raw1); \
   const N *E2 = dyn_cast<N>(Raw2); \
   if (!E1 || !E2)  { \
@@ -162,89 +291,207 @@ LexicographicCompare::Compare##N(const Expr *Raw1, const Expr *Raw2) { \
     return Result::LessThan; \
   } 
 
+Lexicographic::Result
+Lexicographic::CompareType(QualType QT1, QualType QT2) {
+  if (QT1 == QT2)
+    return Result::Equal;
+  else
+    // TODO: fill this in
+    return Result::LessThan;
+}
+
 CHECK_WRAPPER(PredefinedExpr)
   return CompareInteger(E1->getIdentType(), E2->getIdentType());
 }
 
 CHECK_WRAPPER(DeclRefExpr)
-  return Result::Equal;
+  return CompareDecl(E1->getDecl(), E2->getDecl());
 }
 
 CHECK_WRAPPER(IntegerLiteral)
-  return Result::Equal;
+  BuiltinType::Kind Kind1 = E1->getType()->castAs<BuiltinType>()->getKind();
+  BuiltinType::Kind Kind2 = E2->getType()->castAs<BuiltinType>()->getKind();
+  Result Cmp = CompareInteger(Kind1, Kind2);
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return CompareAPInt(E1->getValue(), E2->getValue());
 }
 
 CHECK_WRAPPER(FloatingLiteral)
-  return Result::Equal;
-}
-
-CHECK_WRAPPER(ImaginaryLiteral)
-  return Result::Equal;
+  BuiltinType::Kind Kind1 = E1->getType()->castAs<BuiltinType>()->getKind();
+  BuiltinType::Kind Kind2 = E2->getType()->castAs<BuiltinType>()->getKind();
+  Result Cmp = CompareInteger(Kind1, Kind2);
+  if (Cmp != Result::Equal)
+    return Cmp;
+  Cmp = CompareInteger(E1->isExact(), E2->isExact());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  llvm::APInt E1BitPattern = E1->getValue().bitcastToAPInt();
+  llvm::APInt E2BitPattern = E2->getValue().bitcastToAPInt();
+  return CompareAPInt(E1BitPattern, E2BitPattern);
 }
 
 CHECK_WRAPPER(StringLiteral)
-  return Result::Equal;
+  Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return TranslateInt(E1->getBytes().compare(E2->getBytes()));
 }
 
 CHECK_WRAPPER(CharacterLiteral)
-  return Result::Equal;
+  Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return CompareInteger(E1->getValue(), E2->getValue());
 }
 
 CHECK_WRAPPER(UnaryOperator)
-  return Result::Equal;
+  return CompareInteger(E1->getOpcode(), E2->getOpcode());
+}
+
+CHECK_WRAPPER(UnaryExprOrTypeTraitExpr)
+  Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+
+  Cmp = CompareInteger(E1->isArgumentType(), E2->isArgumentType());
+  if (Cmp != Result::Equal)
+    return Cmp;
+
+  if (E1->isArgumentType())
+    return CompareType(E1->getArgumentType(), E2->getArgumentType());
+  else
+    return CompareExpr(E1->getArgumentExpr(), E2->getArgumentExpr());
 }
 
 CHECK_WRAPPER(OffsetOfExpr)
+  // TODO: fill this in 
   return Result::Equal;
 }
 
 CHECK_WRAPPER(MemberExpr)
-  return Result::Equal;
+  Result Cmp = CompareInteger(E1->isArrow(), E2->isArrow());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return CompareDecl(E1->getMemberDecl(), E2->getMemberDecl());
 }
 
 CHECK_WRAPPER(BinaryOperator)
-  return Result::Equal;
+  return CompareInteger(E1->getOpcode(), E2->getOpcode());
 }
-
 
 CHECK_WRAPPER(CompoundAssignOperator)
-  return Result::Equal;
+  return CompareInteger(E1->getOpcode(), E2->getOpcode());
 }
 
-
 CHECK_WRAPPER(ImplicitCastExpr)
-  return Result::Equal;
+  return CompareInteger(E1->getValueKind(), E2->getValueKind());
+}
+
+CHECK_WRAPPER(CStyleCastExpr)
+  return CompareType(E1->getType(), E2->getType());
 }
 
 CHECK_WRAPPER(CompoundLiteralExpr)
-  return Result::Equal;
+  return CompareInteger(E1->isFileScope(), E2->isFileScope());
 }
 
 CHECK_WRAPPER(GenericSelectionExpr)
+  unsigned E1AssocCount = E1->getNumAssocs();
+  Result Cmp = CompareInteger(E1AssocCount, E2->getNumAssocs());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  for (unsigned i = 0; i != E1AssocCount; ++i) {
+    Cmp = CompareType(E1->getAssocType(i), E2->getAssocType(i));
+    if (Cmp != Result::Equal)
+      return Cmp;
+    Cmp = CompareExpr(E1->getAssocExpr(i), E2->getAssocExpr(i));
+    if (Cmp != Result::Equal)
+      return Cmp;
+    return Cmp;
+  }
   return Result::Equal;
+}
+
+CHECK_WRAPPER(AtomicExpr)
+  return CompareInteger(E1->getOp(), E2->getOp());
 }
 
 CHECK_WRAPPER(NullaryBoundsExpr)
-  return Result::Equal;
+  return CompareInteger(E1->getKind(), E2->getKind());
 }
 
 CHECK_WRAPPER(CountBoundsExpr)
-  return Result::Equal;
+  return CompareInteger(E1->getKind(), E2->getKind());
+}
+
+Lexicographic::Result
+Lexicographic::CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
+                                           const RelativeBoundsClause *RC2) {
+  bool ordered;
+  Result Cmp = ComparePointers(RC1, RC2, ordered);
+  if (ordered)
+    return Cmp;
+  assert(RC1 && RC2);
+
+  RelativeBoundsClause::Kind RC1Kind = RC1->getClauseKind();
+  Cmp = CompareInteger(RC1Kind, RC2->getClauseKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+
+  switch (RC1Kind) {
+    case RelativeBoundsClause::Type: {
+      const RelativeTypeBoundsClause *RT1 =
+        dyn_cast<RelativeTypeBoundsClause>(RC1);
+      const RelativeTypeBoundsClause *RT2 =
+        dyn_cast<RelativeTypeBoundsClause>(RC2);
+      return CompareType(RT1->getType(), RT2->getType());
+    }
+    case RelativeBoundsClause::Const: {
+      const RelativeConstExprBoundsClause *CC1 = 
+        dyn_cast<RelativeConstExprBoundsClause>(RC1);
+      const RelativeConstExprBoundsClause *CC2 = 
+        dyn_cast<RelativeConstExprBoundsClause>(RC2);
+      return CompareExpr(CC1->getConstExpr(), CC2->getConstExpr());
+    }
+    default:
+      llvm_unreachable("unexpected relative bounds clause kind");
+      return Result::LessThan;
+  }
+}
+
+CHECK_WRAPPER(RangeBoundsExpr)
+  Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  RelativeBoundsClause *RB1 = E1->getRelativeBoundsClause();
+  RelativeBoundsClause *RB2 = E2->getRelativeBoundsClause();
+
+  return CompareRelativeBoundsClause(RB1, RB2);
 }
 
 CHECK_WRAPPER(InteropTypeBoundsAnnotation)
-  return Result::Equal;
+  Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return CompareType(E1->getType(), E2->getType());
 }
 
 CHECK_WRAPPER(PositionalParameterExpr)
+  Result Cmp = CompareInteger(E1->getIndex(), E2->getIndex());
+  if (Cmp != Result::Equal)
+    return Cmp;
   return Result::Equal;
+  // return CompareType(E1->getType(), E2->getType());
 }
 
 CHECK_WRAPPER(BoundsCastExpr)
-  return Result::Equal;
+  Result Cmp = CompareExpr(E1->getBoundsExpr(), E2->getBoundsExpr());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return CompareType(E1->getType(), E2->getType());
 }
 
 CHECK_WRAPPER(BlockExpr)
   return Result::Equal;
 }
-

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -995,6 +995,9 @@ void ASTStmtReader::VisitRangeBoundsExpr(RangeBoundsExpr *E) {
   E->setUpperExpr(Record.readSubExpr());
   E->StartLoc = ReadSourceLocation();
   E->EndLoc = ReadSourceLocation();
+  // TODO: Github issue #332.  RelativeBoundsClause expressions are
+  // not being serialized.
+  E->setRelativeBoundsClause(nullptr);
 }
 
 void ASTStmtReader::VisitInteropTypeBoundsAnnotation(


### PR DESCRIPTION
This implements a lexicographic ordering of C expressions and switches comparison of bounds expressions to use it.  The lexicographic ordering provides a total order on C expressions.

We order by expression kind first  We then order by properties of expressions after that.  For expressions that have an identical kind and properties, we use the lexicographic order of their subexpressions.
-  The ordering is modulo parameter names and typedefs.  For parameters, we use the positional index of the parameter and its type in the ordering, and ignore the names.  For typedef type names, we use the canonical type name, where typedef'ed have been replaced with their underlying type.
- For non-parameter variables, we use their name, type, kind of scope, and order of declaration within a scope for the order.
- For constants, we use the value and type of the constant.

Some aspects of the lexicographic order have yet to be implemented.  The main one that is missing is a lexicographic order on types.   We determine equality/inequality properly for types by deferring to the clang type system APIs for that, but do not order types properly.   There are a few operators that have not been implemented - these are marked with TODOs.

This means that the lexicographic ordering can only be used reliably for equality/inequality of expressions at this point.

Testing:
- Adding a new test of lexical expression equality/inequality indirectly using redeclarations of bounds expressions to the Checked C repo.
- Passed existing Checked C and clang tests.
- Passed LNT test automation for Checked C, which includes benchmarks modified to use Checked C.



