### PR TITLE
Refine and Improve Bounds Inference Code

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9310,7 +9310,7 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def err_not_non_modifying_expr : Error<
 	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "
-	"%select{expression|dynamic check expression|count expression|byte count expression|bounds expression|function argument mentioned in return bounds expression}1">;
+	"%select{expression|dynamic check expression|count expression|byte count expression|bounds expression|argument mentioned in function return bounds expression}1">;
 
   def err_checked_scope_type_for_declaration : Error<
     "%select{parameter|return|variable|member}0 cannot have an unchecked "

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9310,7 +9310,7 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def err_not_non_modifying_expr : Error<
 	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "
-	"%select{expression|dynamic check expression|count expression|byte count expression|bounds expression}1">;
+	"%select{expression|dynamic check expression|count expression|byte count expression|bounds expression|function argument mentioned in return bounds expression}1">;
 
   def err_checked_scope_type_for_declaration : Error<
     "%select{parameter|return|variable|member}0 cannot have an unchecked "

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4515,7 +4515,8 @@ public:
     NMER_Dynamic_Check,
     NMER_Bounds_Count,
     NMER_Bounds_Byte_Count,
-    NMER_Bounds_Range
+    NMER_Bounds_Range,
+    NMER_Bounds_Function_Args,
   };
 
   /// CheckNonModifyingExpr - checks whether an expression is non-modifying

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4478,6 +4478,7 @@ public:
                                          ArrayRef<ParmVarDecl *> Params);
   BoundsExpr *MakeMemberBoundsConcrete(Expr *MemberBase, bool IsArrow,
                                        BoundsExpr *Bounds);
+  BoundsExpr *ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args);
 
   /// GetArrayPtrDereference - determine if an lvalue expression is
   /// a dereference of an Array_ptr (via '*" or an array subscript operator).

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2554,7 +2554,7 @@ void ASTDumper::dumpBoundsKind(BoundsExpr::Kind K) {
   switch (K) {
     case BoundsExpr::Kind::Invalid: OS << " Invalid"; break;
     case BoundsExpr::Kind::None: OS << " None"; break;
-    case BoundsExpr::Kind::Any: OS << "Any"; break;
+    case BoundsExpr::Kind::Any: OS << " Any"; break;
     case BoundsExpr::Kind::ElementCount: OS << " Element"; break;
     case BoundsExpr::Kind::ByteCount: OS << " Byte"; break;
     case BoundsExpr::Kind::Range: OS << " Range"; break;

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -871,7 +871,7 @@ namespace {
             return CreateBoundsEmpty();
 
           if (FunBounds->isInteropTypeAnnotation())
-            return CreateBoundsInferenceError();
+            return CreateBoundsAllowedButUncomputable();
 
           ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
                                                          CE->getNumArgs());

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -871,7 +871,7 @@ namespace {
             return CreateBoundsEmpty();
 
           if (FunBounds->isInteropTypeAnnotation())
-            return CreateBoundsAllowedButUncomputable();
+            return FunBounds;
 
           ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
                                                          CE->getNumArgs());

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -831,7 +831,7 @@ namespace {
             if (!LHSBounds->isNone() && !RHSBounds->isNone()) {
               // TODO: Check if LHSBounds and RHSBounds are equal.
               // if so, return one of them. If not, return bounds(none)
-              return CreateBoundsAllowedButUncomputable();
+              return CreateBoundsUnknown();
             }
             if (LHSBounds->isNone() && RHSBounds->isNone())
               return CreateBoundsEmpty();

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -709,13 +709,18 @@ namespace {
             return CreateBoundsInferenceError();
           }
           UnaryOperatorKind Op = UO->getOpcode();
-          Expr *SubExpr = UO->getSubExpr();
 
           // `*e` is not an r-value.
           if (Op == UnaryOperatorKind::UO_Deref) {
             llvm_unreachable("unexpected dereference expression in RValue Bounds inference");
             return CreateBoundsInferenceError();
           }
+
+          // `!e` has empty bounds
+          if (Op == UnaryOperatorKind::UO_LNot)
+            return CreateBoundsEmpty();
+
+          Expr *SubExpr = UO->getSubExpr();
 
           // `&e` has the bounds of `e`.
           // `e` is an lvalue, so its bounds are its lvalue bounds.
@@ -738,10 +743,6 @@ namespace {
               Op == UnaryOperatorKind::UO_Minus ||
               Op == UnaryOperatorKind::UO_Not)
             return RValueBounds(SubExpr);
-
-          // `!e` has empty bounds
-          if (Op == UnaryOperatorKind::UO_LNot)
-            return CreateBoundsEmpty();
 
           // We cannot infer the bounds of other unary operators
           return CreateBoundsUnknown();

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -330,8 +330,14 @@ namespace {
                                              SourceLocation());
     }
 
-    // This describes a bounds of empty range. We use this
-    // for example for function pointers.
+    // This describes an empty range. We use this where semantically the value
+    // can never point to any range of memory, and statically understanding this
+    // is useful.
+    // We use this for example for function pointers or float-typed expressions.
+    //
+    // This is better than represenging the empty range as bounds(e, e), or even
+    // bounds(e1, e2), because in these cases we need to do further analysis to
+    // understand that the upper and lower bounds of the range are equal.
     BoundsExpr *CreateBoundsEmpty() {
       return CreateBoundsNone();
     }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -871,7 +871,7 @@ namespace {
             return CreateBoundsEmpty();
 
           if (FunBounds->isInteropTypeAnnotation())
-            return CreateBoundsAllowedButUncomputable();
+            return CreateBoundsInferenceError();
 
           ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
                                                          CE->getNumArgs());

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -888,8 +888,8 @@ namespace {
             return CreateBoundsInferenceError();
           }
 
-          // Get function prototype.
-          // The Callee is a function *pointer*, almost always.
+          // Get the function prototype, where the abstract function return bounds are kept.
+          // The callee is always a function pointer.
           const FunctionProtoType *CalleeTy = dyn_cast<FunctionProtoType>(CE->getCallee()->getType()->getPointeeType());
           if (!CalleeTy)
             // K&R functions have no prototype, and we cannot perform inference on them,

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -140,7 +140,56 @@ BoundsExpr *Sema::ConcretizeFromFunctionType(BoundsExpr *Expr,
   ExprResult ConcreteBounds = ConcretizeBoundsExpr(*this, Params).TransformExpr(Expr);
   if (ConcreteBounds.isInvalid()) {
     llvm_unreachable("unexpected failure in making bounds concrete");
-    Result = nullptr;
+    return nullptr;
+  }
+  else {
+    Result = dyn_cast<BoundsExpr>(ConcreteBounds.get());
+    assert(Result && "unexpected dyn_cast failure");
+    return Result;
+  }
+}
+
+namespace {
+  class ConcretizeBoundsExprWithArgs : public TreeTransform<ConcretizeBoundsExprWithArgs> {
+    typedef TreeTransform<ConcretizeBoundsExprWithArgs> BaseTransform;
+
+  private:
+    const ArrayRef<Expr *> Arguments;
+
+  public:
+    ConcretizeBoundsExprWithArgs(Sema &SemaRef, ArrayRef<Expr *> Args) :
+      BaseTransform(SemaRef),
+      Arguments(Args) { }
+
+    ExprResult TransformPositionalParameterExpr(PositionalParameterExpr *E) {
+      unsigned index = E->getIndex();
+      if (index < Arguments.size()) {
+        Expr *AE = Arguments[index];
+
+        // We may only substitute if this argument expression is
+        // a non-modifying expression.
+        if (!SemaRef.CheckIsNonModifyingExpr(AE,
+                                             Sema::NonModifiyingExprRequirement::NMER_Unknown,
+                                             /*ReportError=*/false))
+          return ExprResult();
+
+        return AE;
+      } else {
+        llvm_unreachable("out of range index for positional argument");
+        return ExprResult();
+      }
+    }
+  };
+}
+
+BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args) {
+  if (!Bounds)
+    return Bounds;
+
+  BoundsExpr *Result;
+  ExprResult ConcreteBounds = ConcretizeBoundsExprWithArgs(*this, Args).TransformExpr(Bounds);
+  if (ConcreteBounds.isInvalid()) {
+    return nullptr;
   }
   else {
     Result = dyn_cast<BoundsExpr>(ConcreteBounds.get());
@@ -262,10 +311,37 @@ namespace {
                                              SourceLocation());
     }
 
+    // This describes a bounds of empty range. We use this
+    // for example for function pointers.
+    BoundsExpr *CreateBoundsEmpty() {
+      return CreateBoundsNone();
+    }
+
+    // This describes that this is an expression we will never
+    // be able to infer bounds for.
+    BoundsExpr *CreateBoundsUnknown() {
+      return CreateBoundsNone();
+    }
+
+    // If we have an error in our bounds inference that we can't
+    // recover from, bounds(none) is our error value
+    BoundsExpr *CreateBoundsInferenceError() {
+      return CreateBoundsNone();
+    }
+
+    // This describes the bounds of null, which is compatible with every
+    // other bounds annotation.
     BoundsExpr *CreateBoundsAny() {
       return new (Context) NullaryBoundsExpr(BoundsExpr::Kind::Any,
                                              SourceLocation(),
                                              SourceLocation());
+    }
+
+    // Currently our inference algorithm has some limitations,
+    // where we cannot compute bounds for things that we want to be able
+    // to compute bounds for.
+    BoundsExpr *CreateBoundsAllowedButUncomputable() {
+      return CreateBoundsAny();
     }
 
     BoundsExpr *CreateSingleElementBounds(Expr *LowerBounds) {
@@ -314,7 +390,7 @@ namespace {
     BoundsExpr *CreateBoundsForArrayType(QualType QT) {
       const ConstantArrayType *CAT = Context.getAsConstantArrayType(QT);
       if (!CAT)
-        return CreateBoundsNone();
+        return CreateBoundsUnknown();
 
       IntegerLiteral *Size = CreateIntegerLiteral(CAT->getSize());
 
@@ -339,7 +415,7 @@ namespace {
           CountBoundsExpr *BC = dyn_cast<CountBoundsExpr>(B);
           if (!BC) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
           Expr *Count = BC->getCountExpr();
           QualType ResultTy;
@@ -369,7 +445,7 @@ namespace {
                                                SourceLocation());
         }
         case BoundsExpr::Kind::InteropTypeAnnotation:
-          return CreateBoundsNone();
+          return CreateBoundsAllowedButUncomputable();
         default:
           return B;
       }
@@ -401,7 +477,7 @@ namespace {
     BoundsExpr *LValueBounds(Expr *E) {
       // E may not be an lvalue if there is a typechecking error when struct 
       // accesses member array incorrectly.
-      if (!E->isLValue()) return CreateBoundsNone();
+      if (!E->isLValue()) return CreateBoundsInferenceError();
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       switch (E->getStmtClass()) {
@@ -409,7 +485,7 @@ namespace {
         DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
         if (!DR) {
           llvm_unreachable("unexpected cast failure");
-          return CreateBoundsNone();
+          return CreateBoundsInferenceError();
         }
 
         if (DR->getType()->isArrayType())
@@ -419,7 +495,7 @@ namespace {
         // references.  This should only apply to function
         // references.
         if (DR->getType()->isFunctionType())
-          return CreateBoundsNone();
+          return CreateBoundsEmpty();
 
         Expr *AddrOf = CreateAddressOfOperator(DR);
         return CreateSingleElementBounds(AddrOf);
@@ -428,13 +504,13 @@ namespace {
         UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
         if (!UO) {
           llvm_unreachable("unexpected cast failure");
-          return CreateBoundsNone();
+          return CreateBoundsInferenceError();
         }
         if (UO->getOpcode() == UnaryOperatorKind::UO_Deref)
           return RValueBounds(UO->getSubExpr());
         else {
           llvm_unreachable("unexpected lvalue unary operator");
-          return CreateBoundsNone();
+          return CreateBoundsInferenceError();
         }
       }
       case Expr::ArraySubscriptExprClass: {
@@ -444,7 +520,7 @@ namespace {
         ArraySubscriptExpr *AS = dyn_cast<ArraySubscriptExpr>(E);
         if (!AS) {
           llvm_unreachable("unexpected cast failure");
-          return CreateBoundsNone();
+          return CreateBoundsInferenceError();
         }
         // getBase returns the pointer-typed expression.
         return RValueBounds(AS->getBase());
@@ -453,31 +529,33 @@ namespace {
         MemberExpr *ME = dyn_cast<MemberExpr>(E);
         FieldDecl *FD = dyn_cast<FieldDecl>(ME->getMemberDecl());
         if (!FD)
-          return CreateBoundsNone();
+          return CreateBoundsInferenceError();
         if (!SemaRef.CheckIsNonModifyingExpr(ME->getBase(),
                              Sema::NonModifiyingExprRequirement::NMER_Unknown,
                                            /*ReportError=*/false))
-          return CreateBoundsNone();
+          return CreateBoundsAllowedButUncomputable();
 
         if (ME->getType()->isArrayType())
           return ArrayExprBounds(ME);
 
-        // TODO: can a member have a function type, or is it adjusted
-        // to be a pointer function type?
+        // It is an error for a member to have function type
         if (ME->getType()->isFunctionType())
-          return CreateBoundsNone();
+          return CreateBoundsInferenceError();
 
-        if (ME->isRValue())
-          return CreateBoundsNone();
+        // If E is an L-value, the ME must be an L-value too.
+        if (ME->isRValue()) {
+          llvm_unreachable("unexpected MemberExpr r-value");
+          return CreateBoundsInferenceError();
+        }
 
         Expr *AddrOf = CreateAddressOfOperator(ME);
         return CreateSingleElementBounds(AddrOf);
       }
       // TODO: fill in these cases.
       case Expr::CompoundLiteralExprClass:
-        return CreateBoundsAny();
+        return CreateBoundsAllowedButUncomputable();
       default:
-        return CreateBoundsNone();
+        return CreateBoundsUnknown();
       }
     }
 
@@ -485,17 +563,23 @@ namespace {
     // the lvalue must satisfy these bounds.   Values read through the
     // lvalue will meet these bounds.
     BoundsExpr *LValueTargetBounds(Expr *E) {
-      assert(E->isLValue());
+      if (!E->isLValue()) return CreateBoundsInferenceError();
       // TODO: handle side effects within E
       E = E->IgnoreParens();
       QualType QT = E->getType();
+
+      // The type here cannot ever be an array type, as these are dealt with
+      // by an array conversion, not an lvalue conversion. The bounds for an
+      // array conversion are the same as the lvalue bounds of the
+      // array-typed expression.
+      assert(!QT->isArrayType() && "Unexpected Array-typed lvalue in LValueTargetBounds");
 
       // If the target value v is a Ptr type, it has bounds(v, v + 1), unless
       // it is a function pointer type, in which case it has no required
       // bounds.
       if (QT->isCheckedPointerPtrType()) {
          if (QT->isFunctionPointerType())
-           return CreateBoundsNone();
+           return CreateBoundsEmpty();
 
         Expr *Base = CreateImplicitCast(E->getType(),
                                         CastKind::CK_LValueToRValue, E);
@@ -507,15 +591,15 @@ namespace {
           DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
           if (!DR) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
           VarDecl *D = dyn_cast<VarDecl>(DR->getDecl());
           if (!D)
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
 
           BoundsExpr *B = D->getBoundsExpr();
           if (!B || B->isNone())
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
 
            Expr *Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, E);
            return ExpandToRange(Base, B);
@@ -524,25 +608,25 @@ namespace {
           MemberExpr *M = dyn_cast<MemberExpr>(E);
           if (!M) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
 
           FieldDecl *F = dyn_cast<FieldDecl>(M->getMemberDecl());
           if (!F)
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
 
           BoundsExpr *B = F->getBoundsExpr();
           if (!B || B->isNone() || B->isInteropTypeAnnotation())
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
 
           Expr *MemberBaseExpr = M->getBase();
           if (!SemaRef.CheckIsNonModifyingExpr(MemberBaseExpr,
               Sema::NonModifiyingExprRequirement::NMER_Unknown,
               /*ReportError=*/false))
-            return CreateBoundsNone();
+            return CreateBoundsAllowedButUncomputable();
           B = SemaRef.MakeMemberBoundsConcrete(MemberBaseExpr, M->isArrow(), B);
           if (!B)
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           if (B->isElementCount() || B->isByteCount()) {
              Expr *MemberRValue;
             if (M->isLValue())
@@ -554,7 +638,7 @@ namespace {
           return B;
         }
         default:
-          return CreateBoundsNone();
+          return CreateBoundsUnknown();
       }
     }
 
@@ -578,43 +662,29 @@ namespace {
         case CastKind::CK_ArrayToPointerDecay:
           return LValueBounds(E);
         default:
-          return CreateBoundsNone();
+          return CreateBoundsUnknown();
       }
     }
 
     // Compute the bounds of an expression that produces an rvalue.
     BoundsExpr *RValueBounds(Expr *E) {
-      assert(E->isRValue());
+      if (!E->isRValue()) return CreateBoundsInferenceError();
+
       E = E->IgnoreParens();
+
+      // Null Ptrs always have bounds(any)
+      // This is the correct way to detect all the different ways that
+      // C can make a null ptr.
+      if (E->isNullPointerConstant(Context, Expr::NPC_NeverValueDependent)) {
+        return CreateBoundsAny();
+      }
+
       switch (E->getStmtClass()) {
-        case Expr::IntegerLiteralClass: {
-         IntegerLiteral *Lit = dyn_cast<IntegerLiteral>(E);
-         if (!Lit) {
-           llvm_unreachable("unexpected cast failure");
-           return CreateBoundsNone();
-         }
-         if (Lit->getValue() == 0)
-           return CreateBoundsAny();
-
-         return CreateBoundsNone();
-        }
-        case Expr::DeclRefExprClass: {
-          DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
-          if (!DR) {
-            llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
-          }
-          EnumConstantDecl *ECD = dyn_cast<EnumConstantDecl>(DR->getDecl());
-          if (ECD->getInitVal() == 0)
-            return CreateBoundsAny();
-
-          return CreateBoundsNone();
-        }
         case Expr::BoundsCastExprClass: {
           CastExpr *CE = dyn_cast<CastExpr>(E);
           if (!E) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
 
           Expr *subExpr = CE->getSubExpr();
@@ -628,7 +698,7 @@ namespace {
           CastExpr *CE = dyn_cast<CastExpr>(E);
           if (!E) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
           return RValueCastBounds(CE->getCastKind(), CE->getSubExpr());
         }
@@ -636,85 +706,204 @@ namespace {
           UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
           if (!UO) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
           UnaryOperatorKind Op = UO->getOpcode();
+          Expr *SubExpr = UO->getSubExpr();
 
+          // `*e` is not an r-value.
+          if (Op == UnaryOperatorKind::UO_Deref) {
+            llvm_unreachable("unexpected dereference expression in RValue Bounds inference");
+            return CreateBoundsInferenceError();
+          }
+
+          // `&e` has the bounds of `e`.
+          // `e` is an lvalue, so its bounds are its lvalue bounds.
           if (Op == UnaryOperatorKind::UO_AddrOf) {
-            Expr *SubExpr = UO->getSubExpr();
+
+            // Functions have bounds corresponding to the empty range
             if (SubExpr->getType()->isFunctionType())
-              return CreateBoundsNone();
+              return CreateBoundsEmpty();
 
             return LValueBounds(SubExpr);
           }
 
+          // `++e`, `e++`, `--e`, `e--` all have bounds of `e`.
+          // `e` is an LValue, so its bounds are its lvalue target bounds.
           if (UnaryOperator::isIncrementDecrementOp(Op))
-            return LValueTargetBounds(UO->getSubExpr());
+            return LValueTargetBounds(SubExpr);
 
+          // `+e`, `-e`, `~e` all have bounds of `e`. `e` is an RValue.
           if (Op == UnaryOperatorKind::UO_Plus ||
               Op == UnaryOperatorKind::UO_Minus ||
               Op == UnaryOperatorKind::UO_Not)
-            return RValueBounds(UO->getSubExpr());
-          return CreateBoundsNone();
+            return RValueBounds(SubExpr);
+
+          // `!e` has empty bounds
+          if (Op == UnaryOperatorKind::UO_LNot)
+            return CreateBoundsEmpty();
+
+          // We cannot infer the bounds of other unary operators
+          return CreateBoundsUnknown();
         }
         case Expr::BinaryOperatorClass:
         case Expr::CompoundAssignOperatorClass: {
           BinaryOperator *BO = dyn_cast<BinaryOperator>(E);
           if (!BO) {
             llvm_unreachable("unexpected cast failure");
-            return CreateBoundsNone();
+            return CreateBoundsInferenceError();
           }
           Expr *LHS = BO->getLHS();
           Expr *RHS = BO->getRHS();
           BinaryOperatorKind Op = BO->getOpcode();
 
-          if (Op == BinaryOperatorKind::BO_Assign)
-            return RValueBounds(RHS);
+          BoundsExpr *RHSBounds = RValueBounds(RHS);
 
+          // Floating point expressions have empty bounds
+          if (BO->getType()->isFloatingType())
+            return CreateBoundsEmpty();
+
+          // `e1 = e2` has the bounds of `e2`. `e2` is an RValue.
+          if (Op == BinaryOperatorKind::BO_Assign)
+            return RHSBounds;
+
+          // `e1, e2` has the bounds of `e2`. Both `e1` and `e2`
+          // are RValues.
+          if (Op == BinaryOperatorKind::BO_Comma)
+            return RHSBounds;
+
+          // Compound Assignments function like assignments mostly,
+          // except the LHS is an L-Value, so we'll use its lvalue target bounds
           bool IsCompoundAssignment = false;
+          BoundsExpr *LHSBounds;
           if (BinaryOperator::isCompoundAssignmentOp(Op)) {
             Op = BinaryOperator::getOpForCompoundAssignment(Op);
             IsCompoundAssignment = true;
+            LHSBounds = LValueTargetBounds(LHS);
+          }
+          else {
+            LHSBounds = RValueBounds(LHS);
           }
 
           // Pointer arithmetic.
+          //
+          // `p + i` has the bounds of `p`. `p` is an RValue.
+          // `p += i` has the lvalue target bounds of `p`. `p` is an LValue.
+          // same applies for `-` and `-=` respectively
           if (LHS->getType()->isPointerType() &&
               RHS->getType()->isIntegerType() &&
               BinaryOperator::isAdditiveOp(Op)) {
-            return IsCompoundAssignment ?
-              LValueTargetBounds(LHS) : RValueBounds(LHS);
+            return LHSBounds;
           }
+          // `i + p` has the bounds of `p`. `p` is an RValue.
+          // `i += p` has the bounds of `p`. `p` is an RValue.
           if (LHS->getType()->isIntegerType() &&
               RHS->getType()->isPointerType() &&
-              BinaryOperator::isAdditiveOp(Op)) {
-            assert(!IsCompoundAssignment);
-            return RValueBounds(RHS);
+              Op == BinaryOperatorKind::BO_Add) {
+            return RHSBounds;
+          }
+          // `e - p` has empty bounds, regardless of the bounds of p.
+          // `e -= p` has empty bounds, regardless of the bounds of p.
+          if (RHS->getType()->isPointerType() &&
+              Op == BinaryOperatorKind::BO_Sub) {
+            return CreateBoundsEmpty();
           }
 
           // Arithmetic on integers with bounds.
+          //
+          // `e1 @ e2` has the bounds of whichever of `e1` or `e2` has bounds.
+          // if both `e1` and `e2` have bounds, then they must be equal.
+          // Both `e1` and `e2` are RValues
+          //
+          // `e1 @= e2` has the bounds of whichever of `e1` or `e2` has bounds.
+          // if both `e1` and `e2` have bounds, then they must be equal.
+          // `e1` is an LValue, its bounds are the lvalue target bounds.
+          // `e2` is an RValue
+          //
+          // @ can stand for: +, -, *, /, %, &, |, ^, >>, <<
           if (LHS->getType()->isIntegerType() &&
               RHS->getType()->isIntegerType() &&
               (BinaryOperator::isAdditiveOp(Op) ||
                BinaryOperator::isMultiplicativeOp(Op) ||
-               BinaryOperator::isBitwiseOp(Op))) {
-            BoundsExpr *LHSBounds = IsCompoundAssignment ?
-              LValueTargetBounds(LHS) : RValueBounds(LHS);
-            BoundsExpr *RHSBounds = RValueBounds(RHS);
+               BinaryOperator::isBitwiseOp(Op) ||
+               BinaryOperator::isShiftOp(Op))) {
             if (LHSBounds->isNone() && !RHSBounds->isNone())
               return RHSBounds;
             if (!LHSBounds->isNone() && RHSBounds->isNone())
               return LHSBounds;
-            // TODO: check if both LHS and RHS have bounds and
-            // indicate cause of failure to have bounds.
+            if (!LHSBounds->isNone() && !RHSBounds->isNone()) {
+              // TODO: Check if LHSBounds and RHSBounds are equal.
+              // if so, return one of them. If not, return bounds(none)
+              return CreateBoundsAllowedButUncomputable();
+            }
+            if (LHSBounds->isNone() && RHSBounds->isNone())
+              return CreateBoundsEmpty();
           }
-          return CreateBoundsNone();
+
+          // Comparisons and Logical Ops
+          //
+          // `e1 @ e2` have empty bounds if @ is:
+          // ==, !=, <=, <, >=, >, &&, ||
+          if (BinaryOperator::isComparisonOp(Op) ||
+              BinaryOperator::isLogicalOp(Op)) {
+            return CreateBoundsEmpty();
+          }
+
+          // All Other Binary Operators we don't know how to deal with
+          return CreateBoundsEmpty();
         }
-        case Expr::CallExprClass:
+        case Expr::CallExprClass: {
+          const CallExpr *CE = dyn_cast<CallExpr>(E);
+          if (!CE) {
+            llvm_unreachable("unexpected cast failure");
+            return CreateBoundsInferenceError();
+          }
+
+          // Get function prototype.
+          // The Callee is a function *pointer*, almost always.
+          const FunctionProtoType* CalleeTy = dyn_cast<FunctionProtoType>(CE->getCallee()->getType()->getPointeeType());
+          if (!CalleeTy)
+            // K&R functions have no prototype, and we cannot perform inference on them,
+            // so we return bounds(none) for their results.
+            return CreateBoundsEmpty();
+
+          BoundsExpr *FunBounds = const_cast<BoundsExpr *>(CalleeTy->getReturnBounds());
+          if (!FunBounds)
+            // This function has no return bounds
+            return CreateBoundsEmpty();
+
+          if (FunBounds->isInteropTypeAnnotation())
+            return CreateBoundsAllowedButUncomputable();
+
+          ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
+                                                         CE->getNumArgs());
+
+          // Concretize Call Bounds with argument expressions.
+          // We can only do this if the argument expressions are non-modifying
+          BoundsExpr *ReturnBounds = SemaRef.ConcretizeFromFunctionTypeWithArgs(FunBounds, ArgExprs);
+
+          // If concretization failed, we can't yet compute static bounds
+          // for the return type of this function.
+          if (!ReturnBounds)
+            return CreateBoundsAllowedButUncomputable();
+
+          // Currently we cannot yet concretize function bounds of the forms
+          // count(e) or byte_count(e) becuase we need a way of referring
+          // to the function's return value which we currently lack in the
+          // general case.
+          if (ReturnBounds->isElementCount() ||
+              ReturnBounds->isByteCount())
+            return CreateBoundsAllowedButUncomputable();
+
+          return ReturnBounds;
+        }
         case Expr::ConditionalOperatorClass:
         case Expr::BinaryConditionalOperatorClass:
-          return CreateBoundsAny();
+          // TODO: infer correct bounds for conditional operators
+          return CreateBoundsAllowedButUncomputable();
         default:
-          return CreateBoundsNone();
+          // All other cases are unknowable
+          return CreateBoundsUnknown();
       }
     }
   };

--- a/test/CheckedC/inferred-bounds/basic.c
+++ b/test/CheckedC/inferred-bounds/basic.c
@@ -224,26 +224,6 @@ void f10(float a) {
 // CHECK: Initializer Bounds:
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
 
-void f11(_Array_ptr<int> a, _Array_ptr<int> b) {
-  _Array_ptr<int> c : count(5) = (_Array_ptr<int>)(a - b); // expected-error {{expression has no bounds}}
-}
-
-// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} c '_Array_ptr<int>' cinit
-// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
-// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 5
-// CHECK: `-CStyleCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <IntegralToPointer>
-// CHECK: `-ParenExpr {{0x[0-9a-f]+}} {{.*}} 'long'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} {{.*}} 'long' '-'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>'
-// CHECK: Declared Bounds:
-// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
-// CHECK: Initializer Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
-
 //-------------------------------------------------------------------------//
 // Test assignment of variables to _Array_ptr variables.  This covers both //
 // variables with bounds and variables without bounds.                     //

--- a/test/CheckedC/inferred-bounds/basic.c
+++ b/test/CheckedC/inferred-bounds/basic.c
@@ -41,7 +41,7 @@ void f1(_Array_ptr<int> a : bounds(a, a + 5)) {
 // CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: RHS Bounds:
-// CHECK:  NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'Any
+// CHECK:  NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 void f2(_Array_ptr<int> b : count(5)) {
   b = 0;
@@ -60,7 +60,7 @@ void f2(_Array_ptr<int> b : count(5)) {
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: RHS Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'Any
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 void f3(_Array_ptr<int> c : byte_count(sizeof(int) * 5)) {
   c = 0;
@@ -84,7 +84,7 @@ void f3(_Array_ptr<int> c : byte_count(sizeof(int) * 5)) {
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'unsigned {{.*}}' <IntegralCast>
 // CHECK:       `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: RHS Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'Any
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 //  Test assignment of an integer constant expressed as
 // an enum constant.
@@ -110,7 +110,7 @@ void f4(_Array_ptr<int> d : count(5)) {
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'd' '_Array_ptr<int>'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: RHS Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'Any
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 void f5(void) {
   _Array_ptr<int> d : count(5) = 0;
@@ -128,7 +128,7 @@ void f5(void) {
 // CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: Initializer Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'Any
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 void f6(_Array_ptr<int> a : bounds(a, a + 5)) {
   a = (_Array_ptr<int>) 5; // expected-error {{expression has no bounds}}
@@ -218,6 +218,26 @@ void f10(float a) {
 // CHECK:   `-CStyleCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <FloatingToIntegral>
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'float' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'float' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'float'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
+
+void f11(_Array_ptr<int> a, _Array_ptr<int> b) {
+  _Array_ptr<int> c : count(5) = (_Array_ptr<int>)(a - b); // expected-error {{expression has no bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} c '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 5
+// CHECK: `-CStyleCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <IntegralToPointer>
+// CHECK: `-ParenExpr {{0x[0-9a-f]+}} {{.*}} 'long'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} {{.*}} 'long' '-'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>'
 // CHECK: Declared Bounds:
 // CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5

--- a/test/CheckedC/inferred-bounds/calls.c
+++ b/test/CheckedC/inferred-bounds/calls.c
@@ -1,0 +1,445 @@
+// Tests of inferred bounds for expressions in assignments and declarations.
+// The goal is to check that the bounds are being inferred correctly.  This
+// file covers:
+// - Function calls returning an _Array_ptr where arguments have to be
+//   substituted in the bounds.
+//
+// The tests have the general form:
+// 1. Some C code.
+// 2. A description of the inferred bounds for that C code:
+//  a. The source assignnment or declaration.
+//  b. The expected bounds.
+//  c. The inferred bounds.
+// The description uses AST dumps.
+//
+// This line is for the clang test infrastructure:
+// RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
+
+// In all these functions, though they take two arguments, the bounds
+// are only expressed in terms of the first of the two.
+// This means we can test that substitution is successful even if
+// a non-modifying-expression is used for the second argument.
+
+extern _Array_ptr<int> f_bounds(_Array_ptr<int> start, _Array_ptr<int> end) : bounds(start, start + 1);
+extern _Array_ptr<int> f_count(int i, int j) : count(i);
+extern _Array_ptr<int> f_byte(int i, int j) : count(i);
+
+extern int* f_boundsi(int* start, int* end) : bounds(start, start + 1);
+extern int* f_counti(int i, int j) : count(i);
+extern int* f_bytei(int i, int j) : count(i);
+
+//
+// Performing Substitution
+//
+
+void f0(_Array_ptr<int> a) {
+    _Array_ptr<int> b : bounds(a, a+1) = f_bounds(a, a);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)' Function {{0x[0-9a-f]+}} 'f_bounds' '_Array_ptr<int> (_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: Declared Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+
+void f1(int i) {
+    _Array_ptr<int> b : count(i) = f_count(i, i);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_count' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
+
+void f2(int i) {
+    _Array_ptr<int> b : byte_count(i) = f_byte(i, i);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
+
+//
+// Modifying Expressions
+//
+
+void f10(_Array_ptr<int> a, _Array_ptr<int> b) {
+    _Array_ptr<int> c : bounds(a, a+1) = f_bounds(a, b++);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} c '_Array_ptr<int>' cinit
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)' Function {{0x[0-9a-f]+}} 'f_bounds' '_Array_ptr<int> (_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>'
+// CHECK: Declared Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+
+void f11(_Array_ptr<int> a, _Array_ptr<int> b) {
+    _Array_ptr<int> c : bounds(a, a+1) = f_bounds(b++, a); // \
+    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{initializer expected to have bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} c '_Array_ptr<int>' cinit
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)' Function {{0x[0-9a-f]+}} 'f_bounds' '_Array_ptr<int> (_Array_ptr<int>, _Array_ptr<int>) : bounds(arg #0, arg #0 + 1)'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: Declared Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
+
+void f12(int i, int j) {
+    _Array_ptr<int> b : count(i) = f_count(i, j++);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_count' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
+
+void f13(int i, int j) {
+    _Array_ptr<int> b : count(i) = f_count(j++, i); // \
+    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{initializer expected to have bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_count' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
+
+void f14(int i, int j) {
+    _Array_ptr<int> b : byte_count(i) = f_byte(i, j++);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
+
+void f15(int i, int j) {
+    _Array_ptr<int> b : byte_count(i) = f_byte(j++, i); // \
+    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{initializer expected to have bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
+
+// Interoperation Types
+
+void f20(int* a, int* b) {
+    _Array_ptr<int> c : bounds(a, a+1) = f_boundsi(a, b++);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} c '_Array_ptr<int>' cinit
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int *, int *) : bounds(arg #0, arg #0 + 1)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int *, int *) : bounds(arg #0, arg #0 + 1)' Function {{0x[0-9a-f]+}} 'f_boundsi' 'int *(int *, int *) : bounds(arg #0, arg #0 + 1)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'b' 'int *'
+// CHECK: Declared Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+
+void f21(int* a, int* b) {
+    _Array_ptr<int> c : bounds(a, a+1) = f_boundsi(b++, a); // \
+    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{initializer expected to have bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} c '_Array_ptr<int>' cinit
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int *, int *) : bounds(arg #0, arg #0 + 1)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int *, int *) : bounds(arg #0, arg #0 + 1)' Function {{0x[0-9a-f]+}} 'f_boundsi' 'int *(int *, int *) : bounds(arg #0, arg #0 + 1)'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'b' 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: Declared Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int *' lvalue ParmVar {{0x[0-9a-f]+}} 'a' 'int *'
+// CHECK: IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
+
+void f22(int i, int j) {
+    _Array_ptr<int> b : count(i) = f_counti(i, j++);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_counti' 'int *(int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
+
+void f23(int i, int j) {
+    _Array_ptr<int> b : count(i) = f_counti(j++, i); // \
+    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{initializer expected to have bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_counti' 'int *(int, int) : count(arg #0)'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
+
+void f24(int i, int j) {
+    _Array_ptr<int> b : byte_count(i) = f_bytei(i, j++);
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_bytei' 'int *(int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
+
+void f25(int i, int j) {
+    _Array_ptr<int> b : byte_count(i) = f_bytei(j++, i); // \
+    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{initializer expected to have bounds}}
+}
+
+// CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_bytei' 'int *(int, int) : count(arg #0)'
+// CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Byte
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
+// CHECK: Initializer Bounds:
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid

--- a/test/CheckedC/inferred-bounds/calls.c
+++ b/test/CheckedC/inferred-bounds/calls.c
@@ -22,11 +22,11 @@
 
 extern _Array_ptr<int> f_bounds(_Array_ptr<int> start, _Array_ptr<int> end) : bounds(start, start + 1);
 extern _Array_ptr<int> f_count(int i, int j) : count(i);
-extern _Array_ptr<int> f_byte(int i, int j) : count(i);
+extern _Array_ptr<int> f_byte(int i, int j) : byte_count(i);
 
 extern int* f_boundsi(int* start, int* end) : bounds(start, start + 1);
 extern int* f_counti(int i, int j) : count(i);
-extern int* f_bytei(int i, int j) : count(i);
+extern int* f_bytei(int i, int j) : byte_count(i);
 
 //
 // Performing Substitution
@@ -99,8 +99,8 @@ void f2(int i) {
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : byte_count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : byte_count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : byte_count(arg #0)'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
@@ -239,8 +239,8 @@ void f14(int i, int j) {
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : byte_count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : byte_count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : byte_count(arg #0)'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
@@ -263,8 +263,8 @@ void f15(int i, int j) {
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: CallExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (*)(int, int) : byte_count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int> (int, int) : byte_count(arg #0)' Function {{0x[0-9a-f]+}} 'f_byte' '_Array_ptr<int> (int, int) : byte_count(arg #0)'
 // CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
@@ -406,8 +406,8 @@ void f24(int i, int j) {
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
 // CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_bytei' 'int *(int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : byte_count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : byte_count(arg #0)' Function {{0x[0-9a-f]+}} 'f_bytei' 'int *(int, int) : byte_count(arg #0)'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
@@ -431,8 +431,8 @@ void f25(int i, int j) {
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
 // CHECK: `-CallExpr {{0x[0-9a-f]+}} {{.*}} 'int *'
-// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : count(arg #0)' <FunctionToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : count(arg #0)' Function {{0x[0-9a-f]+}} 'f_bytei' 'int *(int, int) : count(arg #0)'
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int *(*)(int, int) : byte_count(arg #0)' <FunctionToPointerDecay>
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int *(int, int) : byte_count(arg #0)' Function {{0x[0-9a-f]+}} 'f_bytei' 'int *(int, int) : byte_count(arg #0)'
 // CHECK: UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int' postfix '++'
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} 'int' <LValueToRValue>

--- a/test/CheckedC/inferred-bounds/member-base.c
+++ b/test/CheckedC/inferred-bounds/member-base.c
@@ -145,35 +145,6 @@ void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
 
-// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '='
-// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
-// CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
-// CHECK: `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
-// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK: Target Bounds:
-// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '+'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-// CHECK: RHS Bounds:
-// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-
   *p = 1;
   p = &(a->f);
 
@@ -191,41 +162,6 @@ void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
 
   *p = 2;
   p = &(a[3].f);
-  
-// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '='
-// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
-// CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
-// CHECK: `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
-// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: Target Bounds:
-// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '+'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-// CHECK: RHS Bounds:
-// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
  // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
  // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
@@ -336,35 +272,6 @@ int f10(void) {
   *p = 10;
   p = &(arr->f);
 
-// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '='
-// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
-// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
-// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
-// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK:         `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
-// CHECK: Target Bounds:
-// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-// CHECK: RHS Bounds:
-// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
@@ -379,41 +286,6 @@ int f10(void) {
 
   *p = 11;
   p = &(arr[3].f);
-
-// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '='
-// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
-// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
-// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
-// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK:         `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
-// CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: Target Bounds:
-// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-// CHECK: RHS Bounds:
-// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
-// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
-// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
@@ -568,35 +440,6 @@ void f22(struct S b _Checked[9]) {
   *p = 1;
   p = &(b->f);
 
-// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '='
-// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
-// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
-// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
-// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK:         `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
-// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: Target Bounds:
-// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-// CHECK: RHS Bounds:
-// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
-// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
@@ -611,41 +454,6 @@ void f22(struct S b _Checked[9]) {
 
   *p = 2;
   p = &(b[3].f);
-
-// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '='
-// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
-// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
-// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
-// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK:         `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
-// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: Target Bounds:
-// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Ptr<int>' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Ptr<int>'
-// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
-// CHECK: RHS Bounds:
-// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
-// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue

--- a/test/CheckedC/inferred-bounds/member-base.c
+++ b/test/CheckedC/inferred-bounds/member-base.c
@@ -129,7 +129,7 @@ void f2(_Array_ptr<struct S> a : bounds(a, a + 6)) {
 //-------------------------------------------------------------------------//
 
 void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
-  _Ptr<int> p = &((*a).f);
+  _Array_ptr<int> p : count(1) = &((*a).f);
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
@@ -148,6 +148,35 @@ void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
   *p = 1;
   p = &(a->f);
 
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
+
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
@@ -163,19 +192,54 @@ void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
   *p = 2;
   p = &(a[3].f);
 
- // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
- // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
- // CHECK:   |-Bounds
- // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
- // CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
- // CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
- // CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>' '+'
- // CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
- // CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
- // CHECK:   |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 7
- // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
- // CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
- // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK: `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
+
+// CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK:   |-Bounds
+// CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>' '+'
+// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK:   |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 7
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
   *p = 3;
 }
 
@@ -253,7 +317,7 @@ int f10(void) {
 // CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
 
-  _Ptr<int> p = &((*arr).f);
+  _Array_ptr<int> p : count(1) = &((*arr).f);
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
@@ -272,6 +336,35 @@ int f10(void) {
   *p = 10;
   p = &(arr->f);
 
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK:         `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
+// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
+
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
@@ -286,6 +379,41 @@ int f10(void) {
 
   *p = 11;
   p = &(arr[3].f);
+
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK:         `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
+// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
@@ -421,7 +549,7 @@ void f21(struct S b _Checked[8]) {
 //-------------------------------------------------------------------------//
 
 void f22(struct S b _Checked[9]) {
-  _Ptr<int> p = &((*b).f);
+  _Array_ptr<int> p : count(1) = &((*b).f);
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ParenExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
@@ -440,6 +568,35 @@ void f22(struct S b _Checked[9]) {
   *p = 1;
   p = &(b->f);
 
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK:         `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
+
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
@@ -454,6 +611,41 @@ void f22(struct S b _Checked[9]) {
 
   *p = 2;
   p = &(b[3].f);
+
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   `-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
+// CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
+// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK:         `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
+// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
+// CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
+// CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue

--- a/test/CheckedCRewriter/allocator.c
+++ b/test/CheckedCRewriter/allocator.c
@@ -7,7 +7,7 @@
 // expected-no-diagnostics
 //
 typedef __SIZE_TYPE__ size_t;
-extern void *malloc(size_t);
+extern void *malloc(size_t n) : byte_count(n);
 extern void free(void *);
 
 void dosomething(void) {


### PR DESCRIPTION
There were a few places where the bounds inference algorithm could have been improved.

- I wanted to make our intent clearer with respect to where we intend to return `bounds(any)` and always will, and where we have to return `bounds(any)` because right now we can't fully model the exact bounds, but we know we will be able to infer bounds eventually (`CreateBoundsAllowedButUncomputable()`)
- I also wanted to make the intent clearer around `bounds(none)` which means one of 3 things:
  - the bounds cannot be described statically (`CreateBoundsUnknown()`)
  - the bounds is an explicitly empty range (`CreateBoundsEmpty()`)
  - We hit some state we're not expecting in the inference algorithm: (`CreateBoundsError()`)

- Now using `Expr::isNullPointerConstant` to detect null pointers, which is more fail-safe than hand-rolled implementations of the very same.
- Can now substitute within the bounds on a CallExpr. The substitution happens as long as the argument expressions are non-modifying-expressions. If the resulting bounds expression is a count or byte count bounds expression, we cannot compute the correct value, but we can at least perform substitution.
- Explicitly allowing/disallowing more mathematics expressions:
  - Float expressions now definitely have bounds(none)
  - Expressions which return ints that represent booleans have bounds(none)  (i.e. `e && e`, `e || e`, `e <= e` `e == e`, `!e` etc.).
  - Explicitly making sure `e - p` where p is a ptr with bounds returns bounds(none). Pointer difference gives you an offset, not a ptr-typed thing. You'll add this offset back to a pointer-like thing to get a pointer again, and in that case we'll require the pointer being added to to have bounds.