### PR TITLE
Removing warning signs from linux build

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1757,11 +1757,12 @@ protected:
         DeclContext(DK), redeclarable_base(C), ParamInfo(nullptr), Body(),
         SClass(S), IsInline(isInlineSpecified),
         IsInlineSpecified(isInlineSpecified), IsExplicitSpecified(false),
-        IsVirtualAsWritten(false), IsPure(false), genericFunction(false),
+        IsVirtualAsWritten(false), IsPure(false),
         HasInheritedPrototype(false), HasWrittenPrototype(true),
         IsDeleted(false), IsTrivial(false), IsDefaulted(false),
         IsExplicitlyDefaulted(false), HasImplicitReturnZero(false),
         IsLateTemplateParsed(false), IsConstexpr(isConstexprSpecified),
+        genericFunction(false),
         UsesSEHTry(false), HasSkippedBody(false), WillHaveBody(false),
         EndRangeLoc(NameInfo.getEndLoc()), TemplateOrSpecialization(),
         DNLoc(NameInfo.getInfo()) {}


### PR DESCRIPTION
During the Linux build, it looks like they pass '-Wreorder' which shows all the cases where the initialization is in a different order than variable declaration in the class constructor.
I have reordered which variables are getting initialized when, in order to remove the warning.
