### PR TITLE
Adding incomplete type to type variable. 

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1913,8 +1913,8 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
   }    
   
   case Type::TypeVariable:
-    Width = Target->getPointerWidth(0);
-    Align = Target->getPointerAlign(0);
+    Width = 0;
+    Align = 8;
     break;
 
   case Type::Elaborated:

--- a/lib/AST/ASTStructuralEquivalence.cpp
+++ b/lib/AST/ASTStructuralEquivalence.cpp
@@ -711,6 +711,15 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
     break;
   }
 
+  case Type::TypeVariable: {
+    const TypeVariableType *Tv1 = cast<TypeVariableType>(T1);
+    const TypeVariableType *Tv2 = cast<TypeVariableType>(T2);
+    if ((Tv1->GetDepth() != Tv2->GetDepth()) ||
+      (Tv1->GetIndex() != Tv2->GetIndex()))
+      return false;
+    break;
+  }
+
   } // end switch
 
   return true;

--- a/lib/AST/ItaniumMangle.cpp
+++ b/lib/AST/ItaniumMangle.cpp
@@ -1884,6 +1884,7 @@ bool CXXNameMangler::mangleUnresolvedTypeOrSimpleId(QualType Ty,
   case Type::ObjCTypeParam:
   case Type::Atomic:
   case Type::Pipe:
+  case Type::TypeVariable:
     llvm_unreachable("type is illegal as a nested name specifier");
 
   case Type::SubstTemplateTypeParmPack:

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1939,6 +1939,9 @@ bool Type::isIncompleteType(NamedDecl **Def) const {
     // Void is the only incomplete builtin type.  Per C99 6.2.5p19, it can never
     // be completed.
     return isVoidType();
+  case TypeVariable:
+    // Type Variables are treated like Void type - An incomplete type.
+    return true;
   case Enum: {
     EnumDecl *EnumD = cast<EnumType>(CanonicalType)->getDecl();
     if (Def)
@@ -3432,6 +3435,8 @@ static CachedProperties computeCachedProperties(const Type *T) {
     return Cache::get(cast<AtomicType>(T)->getValueType());
   case Type::Pipe:
     return Cache::get(cast<PipeType>(T)->getElementType());
+  case Type::TypeVariable:
+    return CachedProperties(ExternalLinkage, false);
   }
 
   llvm_unreachable("unhandled type class");
@@ -3517,6 +3522,8 @@ static LinkageInfo computeLinkageInfo(const Type *T) {
     return computeLinkageInfo(cast<AtomicType>(T)->getValueType());
   case Type::Pipe:
     return computeLinkageInfo(cast<PipeType>(T)->getElementType());
+  case Type::TypeVariable:
+    return LinkageInfo::external();
   }
 
   llvm_unreachable("unhandled type class");

--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -219,6 +219,7 @@ TypeEvaluationKind CodeGenFunction::getEvaluationKind(QualType type) {
     case Type::Enum:
     case Type::ObjCObjectPointer:
     case Type::Pipe:
+    case Type::TypeVariable:
       return TEK_Scalar;
 
     // Complexes.

--- a/lib/CodeGen/CodeGenTypes.cpp
+++ b/lib/CodeGen/CodeGenTypes.cpp
@@ -512,6 +512,11 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     ResultType = llvm::PointerType::get(PointeeType, AS);
     break;
   }
+  case Type::TypeVariable: {
+    // Type Variables work just like void type.
+    ResultType = llvm::Type::getInt8Ty(getLLVMContext());
+    break;
+  }
 
   case Type::VariableArray: {
     const VariableArrayType *A = cast<VariableArrayType>(Ty);

--- a/test/CheckedC/generic-function/generic-func-call-info.c
+++ b/test/CheckedC/generic-function/generic-func-call-info.c
@@ -4,31 +4,38 @@
 // by replacing all type variable types with specified type names in the list
 // of type names provided when calling generic function.
 //
+// Also of important is to check that the resulting LLVM IR correctly shows
+// the representation of pointer to type variables. Type variables are treated
+// similar to void, as an incomplete type, so the representation of pointer to
+// type variables should be the same as void* (i8*).
 //
-// RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
+//
+// RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s --check-prefix=CHECK-AST
+// RUN: %clang_cc1 -fcheckedc-extension %s -emit-llvm -O0 -o - | FileCheck %s --check-prefix=CHECK-IR
 
 _For_any(T) _Ptr<T> ptrGenericTest(_Ptr<T> test, int num) {
   return test;
 }
 
+// Check the LLVM IR types of the paramters are correct.
+// CHECK-IR: define i8* @ptrGenericTest(i8* %test, i32 %num) #0 {
+
 _For_any(T) void arrayPtrGenericTest(_Array_ptr<T> test, int num) {
   return;
 }
+
+// Check the LLVM IR types of the paramters are correct.
+// CHECK-IR: define void @arrayPtrGenericTest(i8* %test, i32 %num) #0 {
 
 _For_any(T) int funcPtrGenericTest(_Ptr<T> a, _Ptr<T> b, int (*comparator)(_Ptr<T>, _Ptr<T>)) {
   return 0;
 }
 
+// Check the LLVM IR types of the paramters are correct.
+// CHECK-IR: define i32 @funcPtrGenericTest(i8* %a, i8* %b, i32 (i8*, i8*)* %comparator) #0 {
+
 int compareFunction(_Ptr<int> a, _Ptr<int> b) {
   return 0;
-}
-
-_For_any(T) void incompleteArrayTest(T test[]) {
-  return;
-}
-
-_For_any(T) void completeArrayTest(T test[10]) {
-  return;
 }
 
 void callPolymorphicTypes(void) {
@@ -39,41 +46,25 @@ void callPolymorphicTypes(void) {
   _Ptr<int> pt = &t;
   ptrGenericTest<int>(pt, t);
 
-  // CHECK: CallExpr {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> '_Ptr<int>'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> '_Ptr<int> (*)(_Ptr<int>, int)' <FunctionToPointerDecay>
-  // CHECK-NEXT: -DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> '_Ptr<int> (_Ptr<int>, int)' instantiated Function {{0x[0-9a-f]+}}  'ptrGenericTest' '_For_any(1) _Ptr<T> (_Ptr<T>, int)'
-  // CHECK-NEXT: -BuiltinType {{0x[0-9a-f]+}} 'int'
+  // Check the type of DeclRefExpr is correctly instantiated.
+  // CHECK-AST: CallExpr {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> '_Ptr<int>'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> '_Ptr<int> (*)(_Ptr<int>, int)' <FunctionToPointerDecay>
+  // CHECK-AST-NEXT: -DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> '_Ptr<int> (_Ptr<int>, int)' instantiated Function {{0x[0-9a-f]+}}  'ptrGenericTest' '_For_any(1) _Ptr<T> (_Ptr<T>, int)'
+  // CHECK-AST-NEXT: -BuiltinType {{0x[0-9a-f]+}} 'int'
 
   _Array_ptr<int> a : count(5) = 0;
   arrayPtrGenericTest<int>(a, 5);
 
-  // CHECK: CallExpr {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> 'void'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (*)(_Array_ptr<int>, int)' <FunctionToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (_Array_ptr<int>, int)' instantiated Function {{0x[0-9a-f]+}} 'arrayPtrGenericTest' '_For_any(1) void (_Array_ptr<T>, int)'
+  // Check the type of DeclRefExpr is correctly instantiated.
+  // CHECK-AST: CallExpr {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> 'void'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (*)(_Array_ptr<int>, int)' <FunctionToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (_Array_ptr<int>, int)' instantiated Function {{0x[0-9a-f]+}} 'arrayPtrGenericTest' '_For_any(1) void (_Array_ptr<T>, int)'
 
   int result = funcPtrGenericTest<int>(pt, pt, &compareFunction);
 
-  // CHECK: CallExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'int'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int (*)(_Ptr<int>, _Ptr<int>, int (*)(_Ptr<int>, _Ptr<int>))' <FunctionToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int (_Ptr<int>, _Ptr<int>, int (*)(_Ptr<int>, _Ptr<int>))' instantiated Function {{0x[0-9a-f]+}} 'funcPtrGenericTest' '_For_any(1) int (_Ptr<T>, _Ptr<T>, int (*)(_Ptr<T>, _Ptr<T>))'
-  // CHECK-NEXT: BuiltinType {{0x[0-9a-f]+}} 'int'
-
-  int myArray[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-  incompleteArrayTest<int>(myArray);
-
-  // CHECK: CallExpr {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> 'void'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (*)(int *)' <FunctionToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (int *)' instantiated Function {{0x[0-9a-f]+}} 'incompleteArrayTest' '_For_any(1) void (T *)'
-  // CHECK-NEXT: BuiltinType {{0x[0-9a-f]+}}  'int'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int *' <ArrayToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int [10]' lvalue Var {{0x[0-9a-f]+}} 'myArray' 'int [10]'
-
-  completeArrayTest<int>(myArray);
-
-  // CHECK: CallExpr {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}> 'void'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (*)(int *)' <FunctionToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'void (int *)' instantiated Function {{0x[0-9a-f]+}} 'completeArrayTest' '_For_any(1) void (T *)'
-  // CHECK-NEXT: BuiltinType {{0x[0-9a-f]+}}  'int'
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int *' <ArrayToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int [10]' lvalue Var {{0x[0-9a-f]+}} 'myArray' 'int [10]'
+  // Check the type of DeclRefExpr is correctly instantiated.
+  // CHECK-AST: CallExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> 'int'
+  // CHECK-AST-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int (*)(_Ptr<int>, _Ptr<int>, int (*)(_Ptr<int>, _Ptr<int>))' <FunctionToPointerDecay>
+  // CHECK-AST-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'int (_Ptr<int>, _Ptr<int>, int (*)(_Ptr<int>, _Ptr<int>))' instantiated Function {{0x[0-9a-f]+}} 'funcPtrGenericTest' '_For_any(1) int (_Ptr<T>, _Ptr<T>, int (*)(_Ptr<T>, _Ptr<T>))'
+  // CHECK-AST-NEXT: BuiltinType {{0x[0-9a-f]+}} 'int'
 }

--- a/test/CheckedC/generic-function/type-variable-type.c
+++ b/test/CheckedC/generic-function/type-variable-type.c
@@ -11,30 +11,28 @@
 //
 // RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
 
-_For_any(T, S, R) T foo(T test, S steve, R ray) {
+_For_any(T, S, R) _Ptr<T> foo(_Ptr<T> test, _Ptr<S> steve, _Ptr<R> ray) {
   // CHECK: TypedefDecl {{0x[0-9a-f]+}} <{{.+}}.c:{{[0-9]+}}:{{[0-9]+}}, col:[[TPOS:[0-9]+]]> col:[[TPOS]] referenced T '(0, 0)'
   // CHECK-NEXT: TypeVariableType {{0x[0-9a-f]+}} '(0, 0)'
   // CHECK-NEXT: TypedefDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[SPOS:[0-9]+]]> col:[[SPOS]] referenced S '(0, 1)'
   // CHECK-NEXT: TypeVariableType {{0x[0-9a-f]+}} '(0, 1)'
   // CHECK-NEXT: TypedefDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[RPOS:[0-9]+]]> col:[[RPOS]] referenced R '(0, 2)'
   // CHECK-NEXT: TypeVariableType {{0x[0-9a-f]+}} '(0, 2)'
-  // CHECK-NEXT: FunctionDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, line:{{[0-9]+}}:{{[0-9]+}}> line:{{[0-9]+}}:{{[0-9]+}} used foo '_For_any(3) T (T, S, R)'
+  // CHECK-NEXT: FunctionDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, line:{{[0-9]+}}:{{[0-9]+}}> line:{{[0-9]+}}:{{[0-9]+}} used foo '_For_any(3) _Ptr<T> (_Ptr<T>, _Ptr<S>, _Ptr<R>)'
   // CHECK-NEXT: TypeVariable {{0x[0-9a-f]+}} col:[[TPOS]] T '(0, 0)'
   // CHECK-NEXT: TypeVariable {{0x[0-9a-f]+}} col:[[SPOS]] S '(0, 1)'
   // CHECK-NEXT: TypeVariable {{0x[0-9a-f]+}} col:[[RPOS]] R '(0, 2)'
-  // CHECK-NEXT: ParmVarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[TESTPOS:[0-9]+]]> col:[[TESTPOS]] test 'T':'(0, 0)'
-  // CHECK-NEXT: ParmVarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[STEVEPOS:[0-9]+]]> col:[[STEVEPOS]] steve 'S':'(0, 1)'
-  // CHECK-NEXT: ParmVarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[RAYPOS:[0-9]+]]> col:[[RAYPOS]] ray 'R':'(0, 2)'
-  T returnVal;
-  return returnVal;
-  // CHECK: DeclStmt {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}>
-  // CHECK-NEXT: VarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:{{[0-9]+}}> col:{{[0-9]+}} used returnVal 'T':'(0, 0)'
-  // CHECK-NEXT: ReturnStmt {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}>
-  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'T':'(0, 0)'
-  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> 'T':'(0, 0)' lvalue Var {{0x[0-9a-f]+}} 'returnVal' 'T':'(0, 0)'
+  // CHECK-NEXT: ParmVarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[TESTPOS:[0-9]+]]> col:[[TESTPOS]] used test '_Ptr<T>'
+  // CHECK-NEXT: ParmVarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[STEVEPOS:[0-9]+]]> col:[[STEVEPOS]] steve '_Ptr<S>'
+  // CHECK-NEXT: ParmVarDecl {{0x[0-9a-f]+}} <col:{{[0-9]+}}, col:[[RAYPOS:[0-9]+]]> col:[[RAYPOS]] ray '_Ptr<R>'
+  return test;
+  // CHECK: ReturnStmt {{0x[0-9a-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}>
+  // CHECK-NEXT: ImplicitCastExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> '_Ptr<T>' <LValueToRValue>
+  // CHECK-NEXT: DeclRefExpr {{0x[0-9a-f]+}} <col:{{[0-9]+}}> '_Ptr<T>' lvalue ParmVar {{0x[0-9a-f]+}} 'test' '_Ptr<T>'
 }
 
 void callPolymorphicTypes() {
-  void *t, *s, *r;
-  foo<void*, void*, void*>(t, s, r);
+  int i = 0;
+  _Ptr<int> ip = &i;
+  foo<int, int, int>(ip, ip, ip);
 }

--- a/test/CheckedC/parsing/generic_func_parsing_error.c
+++ b/test/CheckedC/parsing/generic_func_parsing_error.c
@@ -7,8 +7,7 @@
 //
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 
-_For_any(T) T Foo(T a, T b) {
-  T a;
+_For_any(T) T *Foo(T *a, T *b) {
   return a;
 }
 
@@ -19,7 +18,7 @@ void Bar() {
   // saying you cannot do isa<> on NULL pointer, crashing compiler. I fixed the
   // code to check whether the Expr* is NULL or not.
   void* x, y; //expected-error{{variable has incomplete type 'void'}}
-  Foo<void*>(x, y);
+  Foo<void>(x, y);
   return;
 }
 


### PR DESCRIPTION
This pull request does 3 things.
1) Changes the type of Type Variable to incomplete type.
2) Removes some of the easily noticeable warnings, where the switch statement of Types did not include Type Variables
3) Changed Test cases accordingly so that Type Variable being incomplete type will not fail previously created test cases.