### PR TITLE
Better error checking for generic and no-prototype functions.

### DIFF
--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1194,9 +1194,9 @@ def err_type_function_comma_or_greater_expected : Error<
   "expected , or >">;
 
 def err_type_list_and_type_variable_num_mismatch : Error<
-  "Mismatch between the number of types listed and number of type variables">;
+  "mismatch between the number of types listed and number of type variables">;
 
 def note_type_variables_declared_at : Note<
-  "Type variable(s) declared here">;
+  "type variable(s) declared here">;
 
 } // end of Parser diagnostics

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9362,6 +9362,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def note_inferred_bounds_for_expr : Note<
     "inferred bounds for right-hand side are '%0'">;
 
+  def no_prototype_generic_function : Error<
+    "expected prototype for a generic function">;
+
 } // end of Checked C Category
 
 } // end of sema component.


### PR DESCRIPTION
This change contains a bunch of fixes for checking functions in
Checked C.
- Don't allow declarations of generic no-prototype functions.  The compiler
 asserted when it saw a declaration of a no-prototype generic function.  Now
 check for this case and issue an error message.  This fixes issue #353.
- Don't allow generic old-style K&R function definitions.  Also issue an
  error message for this case.
- Issue an error message for a generic function applied to an empty
  type argument list, when the generic function expects type
  arguments.  The compiler silently allowed this.  Type checking still failed
  because the generic function was not instantiated.
- Don't allow old-style K&R function definitions in checked blocks.  The
  existing code was using the wrong test for whether a function definition
  is a K&R function definition. As a side-benefit, the code got easier
  to understand.
- Don't capitalize the first word of some error messages for generic
  functions.  In general, clang error message use lowercase even for the
  first word.

Testing:
- Added new test cases to the Checked C regression suite.
- Passes existing Checked C and clang test suites.