### PR TITLE
Allow K&R style function definitions preceded by prototypes in a checked scope.

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1670,9 +1670,9 @@ private:
   unsigned HasImplicitReturnZero : 1;
   unsigned IsLateTemplateParsed : 1;
   unsigned IsConstexpr : 1;
-  unsigned IsGenericFunction : 1; 
+  unsigned IsGenericFunction : 1;
   // indicate the function declared with an _Checked or _Unchecked specifier
-  unsigned CheckedSpecifier : 2; 
+  unsigned CheckedSpecifier : 2;
 
   /// \brief Indicates if the function uses __try.
   unsigned UsesSEHTry : 1;
@@ -1769,7 +1769,7 @@ protected:
         IsDeleted(false), IsTrivial(false), IsDefaulted(false),
         IsExplicitlyDefaulted(false), HasImplicitReturnZero(false),
         IsLateTemplateParsed(false), IsConstexpr(isConstexprSpecified),
-        IsGenericFunction(false), 
+        IsGenericFunction(false),
         CheckedSpecifier(CheckedFunctionSpecifiers::CFS_None),
         UsesSEHTry(false), HasSkippedBody(false), WillHaveBody(false),
         EndRangeLoc(NameInfo.getEndLoc()), TemplateOrSpecialization(),

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1670,7 +1670,9 @@ private:
   unsigned HasImplicitReturnZero : 1;
   unsigned IsLateTemplateParsed : 1;
   unsigned IsConstexpr : 1;
-  unsigned genericFunction : 1;
+  unsigned IsGenericFunction : 1; 
+  // indicate the function declared with an _Checked or _Unchecked specifier
+  unsigned CheckedSpecifier : 2; 
 
   /// \brief Indicates if the function uses __try.
   unsigned UsesSEHTry : 1;
@@ -1767,7 +1769,8 @@ protected:
         IsDeleted(false), IsTrivial(false), IsDefaulted(false),
         IsExplicitlyDefaulted(false), HasImplicitReturnZero(false),
         IsLateTemplateParsed(false), IsConstexpr(isConstexprSpecified),
-        genericFunction(false),
+        IsGenericFunction(false), 
+        CheckedSpecifier(CheckedFunctionSpecifiers::CFS_None),
         UsesSEHTry(false), HasSkippedBody(false), WillHaveBody(false),
         EndRangeLoc(NameInfo.getEndLoc()), TemplateOrSpecialization(),
         DNLoc(NameInfo.getInfo()) {}
@@ -1830,8 +1833,13 @@ public:
 
   SourceRange getSourceRange() const override LLVM_READONLY;
 
-  void setGenericFunctionFlag(bool f) { genericFunction = f; }
-  bool IsGenericFunction() const { return genericFunction; }
+  void setGenericFunctionFlag(bool f) { IsGenericFunction = f; }
+  bool isGenericFunction() const { return IsGenericFunction; }
+
+  void setCheckedSpecifier(CheckedFunctionSpecifiers CS) { CheckedSpecifier = CS; }
+  CheckedFunctionSpecifiers getCheckedSpecifier() {
+    return (CheckedFunctionSpecifiers) CheckedSpecifier;
+  }
 
   /// \brief Returns true if the function has a body (definition). The
   /// function body might be in any of the (re-)declarations of this

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1671,7 +1671,8 @@ private:
   unsigned IsLateTemplateParsed : 1;
   unsigned IsConstexpr : 1;
   unsigned IsGenericFunction : 1;
-  // indicate the function declared with an _Checked or _Unchecked specifier
+  // Indicates whether the function is declared with a _Checked or
+  // _Unchecked specifier.
   unsigned CheckedSpecifier : 2;
 
   /// \brief Indicates if the function uses __try.

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -279,6 +279,7 @@ namespace clang {
     SD_Dynamic         ///< Dynamic storage duration.
   };
 
+
   /// Describes the nullability of a particular type.
   enum class NullabilityKind : uint8_t {
     /// Values of this type can never be null.
@@ -317,6 +318,13 @@ namespace clang {
   };
 
   llvm::StringRef getParameterABISpelling(ParameterABI kind);
+
+  /// Checked C - checked function specifiers
+  enum CheckedFunctionSpecifiers {
+    CFS_None = 0,
+    CFS_Checked = 1,
+    CFS_Unchecked = 2
+  };
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_SPECIFIERS_H

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -279,7 +279,6 @@ namespace clang {
     SD_Dynamic         ///< Dynamic storage duration.
   };
 
-
   /// Describes the nullability of a particular type.
   enum class NullabilityKind : uint8_t {
     /// Values of this type can never be null.

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -329,12 +329,10 @@ public:
     PQ_FunctionSpecifier     = 8
   };
 
-  /// Checked C - checked function specifiers
-  enum CheckedFunctionSpecifiers {
-    CFS_None       = 0,
-    CFS_Checked    = 1,
-    CFS_Unchecked  = 2
-  };
+  typedef CheckedFunctionSpecifiers CFS;
+  static const CFS CFS_None = clang::CFS_None;
+  static const CFS CFS_Checked = clang::CFS_Checked;
+  static const CFS CFS_Unchecked = clang::CFS_Unchecked;
 
 private:
   // storage-class-specifier

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1195,7 +1195,7 @@ void ASTDumper::VisitFunctionDecl(const FunctionDecl *D) {
 
   // If the function is generic function, dump information about type variable.
   // Type variable is stored as a TypedefDecl.
-  if (D->IsGenericFunction() && D->getNumTypeVars() > 0) {
+  if (D->isGenericFunction() && D->getNumTypeVars() > 0) {
     for (const TypedefDecl* Typevar : D->typeVariables()) {
       dumpChild([=] {
         OS << "TypeVariable";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2854,7 +2854,6 @@ unsigned FunctionDecl::getNumTypeVars() const {
 void FunctionDecl::setTypeVars(ASTContext &C, 
                                ArrayRef<TypedefDecl *> NewTypeVarInfo) {
   assert(!TypeVarInfo && "Already has type variable info!");
-  assert(NewTypeVarInfo.size() == getNumTypeVars() && "Type variable count mismatch!");
 
   // Zero params -> null pointer.
   if (!NewTypeVarInfo.empty()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2854,6 +2854,7 @@ unsigned FunctionDecl::getNumTypeVars() const {
 void FunctionDecl::setTypeVars(ASTContext &C, 
                                ArrayRef<TypedefDecl *> NewTypeVarInfo) {
   assert(!TypeVarInfo && "Already has type variable info!");
+  assert(NewTypeVarInfo.size() == getNumTypeVars() && "Type variable count mismatch!");
 
   // Zero params -> null pointer.
   if (!NewTypeVarInfo.empty()) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3177,8 +3177,8 @@ bool Parser::ParseGenericFunctionExpression(ExprResult &Res) {
   ValueDecl *resDecl = declRef->getDecl();
   if (!resDecl || !isa<FunctionDecl>(resDecl)) return false;
   FunctionDecl* funDecl = dyn_cast<FunctionDecl>(resDecl);
-  // Only parse for a list of type specifiers if it's a generic function.
-  if (!funDecl->IsGenericFunction()) return false;
+  // Only parse the list of type arguments if it's a generic function.
+  if (!funDecl->isGenericFunction()) return false;
 
   // Expect a '<' to denote that a list of type specifiers are incoming.
   SourceLocation lessLoc = Tok.getLocation();

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -8327,11 +8327,11 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
   if (!NewFD) return nullptr;
 
   if (D.getDeclSpec().isForanySpecified()) {
-    NewFD->setGenericFunctionFlag(true);
-    NewFD->setTypeVars(D.getDeclSpec().typeVariables());
-
-    // Diagnose generic no-prototype function declarator
-    if (!NewFD->hasPrototype()) {
+    if (NewFD->hasPrototype()) {
+      NewFD->setGenericFunctionFlag(true);
+      NewFD->setTypeVars(D.getDeclSpec().typeVariables());
+    } else {
+      // Diagnose generic no-prototype function declarator
       Diag(NewFD->getLocation(), diag::no_prototype_generic_function);
       NewFD->setInvalidDecl();
     }

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -8965,9 +8965,9 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
       (CFS != CheckedFunctionSpecifiers::CFS_Unchecked && S->isCheckedScope())) {
       // Disallow no prototype function declarators within a checked scope.
       //
-      // We also disallow K&R style definitions of functions in checked scopes
+      // This includes K&R style definitions of functions in checked scopes
       // that aren't preceded by a prototype. clang gives K&R style
-      // definitions prototypes, even though the C11 standard does not say
+      // definitions prototype types, even though the C11 standard does not say
       // that K&R definitions create prototypes.
       if (isa<FunctionNoProtoType>(FT) ||
           (D.isFunctionDefinition() && isKNRDeclarationOnly(NewFD))) {

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -12816,8 +12816,6 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   if (FD) {
     FD->setBody(Body);
 
-
-
     if (getLangOpts().CPlusPlus14) {
       if (!FD->isInvalidDecl() && Body && !FD->isDependentContext() &&
           FD->getReturnType()->isUndeducedType()) {


### PR DESCRIPTION
We disallow function declarators that have no prototypes in checked scopes because calls to them may not be typechecked.  We were being too strict in the checking and  just looking at whether a function declarator provided a prototype. 

We need to take into account that according to the C11 specification, type information from prior declarations of a function is merged with a function declarator to determine whether a function has a  prototype.    This change moves checking to later in ActOnFunctionDeclarator after type merging, which addresses issue #355.  If a no-prototype function declarator is preceded by a prototype, the declarator is considered to have a prototype.  

However, we need to add some special-case handling for the case of K&R style function definitions. 
This is where the function declarator for a function definition is followed by a list of declarations for parameters, for example:
```
int f(a, b)
int a;
int b;
{ }
```
clang assigns a prototype function type to this definition, even though the C11 standard does not say that such a definition creates a prototype for a function.  We could have issues with other C compilers in the future, which may not type check succeeding uses of the function. We specifically check that there is a prior declaration with a prototype.  There may be an easier way in clang to determine that a K&R function definition has a prototype in a standard-compliant way (because of a prior declaration),  but I couldn't find it.

Even though K&R-style function definition are obsolete, we care about this because we are trying to minimize code changes required to use Checked C.  We don't want to force someone to modify a K&R-style function definition when they have done their homework and provided a prototype.

This change also includes some minor clean up and improvements:
- We now record whether a function declarator has a checked/unchecked specifier.
- There were some identifiers that started with lowercase letters  that needed to start with uppercase letters (and vice versa) to match the coding convention.
- Make some comments more accurate.

Testing:
- I added a new test case to the Checked C tests for a K&R function definition preceded by a prototype.  This will be covered by a separate pull request for the Checked C repo.
