### PR TITLE
Extend -Wcheck-bounds-decls to variable declarations with initializers

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9351,16 +9351,17 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_bounds_cast_error_with_array_syntax
       : Error<"invalid bounds cast: expected _Array_ptr type">;
 
-  def warn_bounds_declaration_not_true : Warning<
-    "bounds declaration for '%0' may not be true after assignment">,
+  def warn_bounds_declaration_invalid : Warning<
+    "declared bounds for %1 may be invalid after "
+    " %select{assignment|initialization}0">,
     DefaultIgnore,
     InGroup<DiagGroup<"check-bounds-decls">>;
 
-  def note_declared_bounds_for_expr : Note<
-    "declared bounds for '%0' are '%1'">;
+  def note_declared_bounds : Note<
+    "declared bounds are '%0'">;
 
-  def note_inferred_bounds_for_expr : Note<
-    "inferred bounds for right-hand side are '%0'">;
+  def note_inferred_bounds : Note<
+    "inferred bounds are '%0'">;
 
   def no_prototype_generic_function : Error<
     "expected prototype for a generic function">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9358,10 +9358,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     InGroup<DiagGroup<"check-bounds-decls">>;
 
   def note_declared_bounds : Note<
-    "declared bounds are '%0'">;
+    "(expanded) declared bounds are '%0'">;
 
   def note_inferred_bounds : Note<
-    "inferred bounds are '%0'">;
+    "(expanded) inferred bounds are '%0'">;
 
   def no_prototype_generic_function : Error<
     "expected prototype for a generic function">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4500,6 +4500,11 @@ public:
   /// expression evaluates is in range.
   BoundsExpr *InferRValueBounds(Expr *E);
 
+  enum BoundsDeclarationCheck {
+      BDC_Assignment,
+      BDC_Initialization
+  };
+
   /// CheckFunctionBodyBoundsDecls - check bounds declarations within a function
   /// body.
   void CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4495,10 +4495,13 @@ public:
   /// target of an lvalue.
   BoundsExpr *InferLValueTargetBounds(Expr *E);
 
-  /// InferRVa;ieBounds - infer a bounds expression for an rvalue.
+  /// InferRValueBounds - infer a bounds expression for an rvalue.
   /// The bounds determine whether the rvalue to which an
   /// expression evaluates is in range.
   BoundsExpr *InferRValueBounds(Expr *E);
+
+  BoundsExpr *ExpandToRange(Expr *Base, BoundsExpr *B);
+  BoundsExpr *ExpandToRange(VarDecl *D, BoundsExpr *B);
 
   enum BoundsDeclarationCheck {
       BDC_Assignment,

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1379,7 +1379,7 @@ namespace {
         // Make sure that automatic variables that are not arrays are
         // initialized.
         if (D->hasLocalStorage() && !D->getType()->isArrayType())
-          S.Diag(D->getInitializerStartLoc(),
+          S.Diag(D->getLocation(),
                  diag::err_initializer_expected_with_bounds) << D;
         // Static variables are always initialized to a valid initialization
         // value for bounds, if there is no initializer.  See the prior comment

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1097,8 +1097,7 @@ namespace {
         } else if (ArraySubscriptExpr *AS = dyn_cast<ArraySubscriptExpr>(Deref)) {
           assert(!AS->hasBoundsExpr());
           AS->setBoundsExpr(LValueBounds);
-        }
-        else
+        } else
           llvm_unreachable("unexpected expression kind");
       }
       return NeedsBoundsCheck;
@@ -1376,8 +1375,7 @@ namespace {
        if (DumpBounds)
          DumpInitializerBounds(llvm::outs(), D, DeclaredBounds, InitBounds);
        // TODO: check that it meets the bounds requirements for the variable.
-      }
-      else {
+      } else {
         // Make sure that automatic variables that are not arrays are
         // initialized.
         if (D->hasLocalStorage() && !D->getType()->isArrayType())

--- a/test/CheckedC/bounds-decl-checking.c
+++ b/test/CheckedC/bounds-decl-checking.c
@@ -13,7 +13,7 @@ void f1(_Array_ptr<int> p : bounds(p, p + x), int x) {
 // Initialization by expression with syntactically identical
 // normalized bounds - no warning.
 void f2(_Array_ptr<int> p : bounds(p, p + x), int x) {
-  _Array_ptr<int> r : bounds(p, p + x) = 0;
+  _Array_ptr<int> r : bounds(p, p + x) = p;
 }
 
 // Initialization by expression without syntactically identical
@@ -34,7 +34,7 @@ void f4(_Array_ptr<int> p : count(x), int x) {
 // Assignment of expression with syntactically identical normalized bounds -
 //- no warning.
 void f5(_Array_ptr<int> p : count(x), int x) {
-  _Array_ptr<int> r : bounds(p, p + x) = 0;
+  _Array_ptr<int> r : bounds(p, p + x) = p;
   r = p;
 }
 

--- a/test/CheckedC/bounds-decl-checking.c
+++ b/test/CheckedC/bounds-decl-checking.c
@@ -10,13 +10,13 @@ void f1(_Array_ptr<int> p : bounds(p, p + x), int x) {
     _Array_ptr<int> r : bounds(p, p + x) = 0;
 }
 
-// Initialization by expression with syntactically identical 
+// Initialization by expression with syntactically identical
 // normalized bounds - no warning.
 void f2(_Array_ptr<int> p : bounds(p, p + x), int x) {
   _Array_ptr<int> r : bounds(p, p + x) = 0;
 }
 
-// Initialization by expression without syntactically identical 
+// Initialization by expression without syntactically identical
 // normalized bounds - warning expected.
 void f3(_Array_ptr<int> p : bounds(p, p + x), int x) {
   _Array_ptr<int> r : count(x) = p;     // expected-warning {{may be invalid}} \

--- a/test/CheckedC/bounds-decl-checking.c
+++ b/test/CheckedC/bounds-decl-checking.c
@@ -5,12 +5,40 @@
 //
 // RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify -verify-ignore-unexpected=note %s
 
+// Initialization by null - no warning.
 void f1(_Array_ptr<int> p : bounds(p, p + x), int x) {
     _Array_ptr<int> r : bounds(p, p + x) = 0;
-    r = p;
 }
 
-void f2(_Array_ptr<int> p : count(x), int x) {
+// Initialization by expression with syntactically identical 
+// normalized bounds - no warning.
+void f2(_Array_ptr<int> p : bounds(p, p + x), int x) {
+  _Array_ptr<int> r : bounds(p, p + x) = 0;
+}
+
+// Initialization by expression without syntactically identical 
+// normalized bounds - warning expected.
+void f3(_Array_ptr<int> p : bounds(p, p + x), int x) {
+  _Array_ptr<int> r : count(x) = p;     // expected-warning {{may be invalid}}
+}
+
+
+// Assignment of null - no warning.
+void f4(_Array_ptr<int> p : count(x), int x) {
+  _Array_ptr<int> r : bounds(p, p + x) = 0;
+  r = 0;
+}
+
+// Assignment of expression with syntactically identical normalized bounds -
+//- no warning.
+void f5(_Array_ptr<int> p : count(x), int x) {
+  _Array_ptr<int> r : bounds(p, p + x) = 0;
+  r = p;
+}
+
+// Assignment of expression without syntactically identical normalized bounds -
+// no warning.
+void f6(_Array_ptr<int> p : count(x), int x) {
   _Array_ptr<int> r : count(x) = 0;
-  r = p;  // expected-warning {{may not be true}}
+  r = p;      // expected-warning {{may be invalid}}
 }

--- a/test/CheckedC/bounds-decl-checking.c
+++ b/test/CheckedC/bounds-decl-checking.c
@@ -3,7 +3,7 @@
 // mostly unimplemented, we only issue warnings when bounds declarations
 // cannot be provided to hold.
 //
-// RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify -verify-ignore-unexpected=note %s
+// RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
 
 // Initialization by null - no warning.
 void f1(_Array_ptr<int> p : bounds(p, p + x), int x) {
@@ -19,7 +19,9 @@ void f2(_Array_ptr<int> p : bounds(p, p + x), int x) {
 // Initialization by expression without syntactically identical 
 // normalized bounds - warning expected.
 void f3(_Array_ptr<int> p : bounds(p, p + x), int x) {
-  _Array_ptr<int> r : count(x) = p;     // expected-warning {{may be invalid}}
+  _Array_ptr<int> r : count(x) = p;     // expected-warning {{may be invalid}} \
+                                        // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
+                                        // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
 }
 
 
@@ -40,5 +42,7 @@ void f5(_Array_ptr<int> p : count(x), int x) {
 // no warning.
 void f6(_Array_ptr<int> p : count(x), int x) {
   _Array_ptr<int> r : count(x) = 0;
-  r = p;      // expected-warning {{may be invalid}}
+  r = p;      // expected-warning {{may be invalid}} \
+              // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
+              // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
 }


### PR DESCRIPTION
Checking the correctness of bounds declarations is currently under a warning flag that is off by default (-Wcheck-bounds-decls).    This is because the checking that declared bounds are implied by inferred bounds is not very powerful.  It is limited to just syntactically identical bounds declarations and special cases for bounds(none) and bounds(any).    There'd be lots of spurious warnings if it was on by default.

The checking of bounds declarations is done only for assignments.  This extends it to variable declarations with initializers.   Most of the work went into producing good warning messages that have notes explaining what is going on.   Assignments were using expanded bounds declarations (where count/byte_count have been expanded into their underlying range expressions).   I implemented new logic to create expanded bounds declarations for variable declarations with bounds.   This is so that the contents of notes match up.  I had to make some methods public on BoundsInference.  It isn't clear that the methods are in the right place, but I've left that code refactoring for another day.

Other than that, I refactored the logic for checking bounds declarations for assignments so that we could re-use it for declarations with initializers.

Testing:
- Passes existing Checked C tests.
- Clang test run in progress.
- Added a new clang-specific tests that checks bounds inference for initializers.  Also check the notes generated with warnings.

