### PR TITLE
Remove Ptrtoint from Dynamic Check CG

### DIFF
--- a/lib/CodeGen/CGDynamicCheck.cpp
+++ b/lib/CodeGen/CGDynamicCheck.cpp
@@ -117,9 +117,9 @@ void CodeGenFunction::EmitDynamicBoundsCheck(const Address PtrAddr, const Bounds
   EmitDynamicCheckBlocks(Builder.CreateAnd(LowerChk, UpperChk, "_Dynamic_check.range"));
 }
 
-void CodeGenFunction::EmitDynamicBoundsCheck(const Address BaseAddr,
-                                             const BoundsExpr *CastBounds,
-                                             const BoundsExpr *SubExprBounds) {
+void CodeGenFunction::EmitDynamicBoundsCastCheck(const Address BaseAddr,
+                                                 const BoundsExpr *CastBounds,
+                                                 const BoundsExpr *SubExprBounds) {
   if (!getLangOpts().CheckedC)
     return;
 

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -4588,8 +4588,9 @@ llvm::Value *CodeGenFunction::EmitBoundsCast(CastExpr *CE) {
   }
   if (Kind == CK_DynamicPtrBounds) {
     BoundsCastExpr *BCE = cast<BoundsCastExpr>(CE);
-    EmitDynamicBoundsCheck(Addr, BCE->getCastBoundsExpr(),
-                           BCE->getSubExprBoundsExpr());
+    EmitDynamicBoundsCastCheck(Addr,
+                               BCE->getCastBoundsExpr(),
+                               BCE->getSubExprBoundsExpr());
   }
   return Addr.getPointer();
 }

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2548,9 +2548,9 @@ public:
   void EmitDynamicNonNullCheck(const Address BaseAddr, const QualType BaseTy);
   void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy, const Address PtrAddr);
   void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds);
-  void EmitDynamicBoundsCheck(const Address BaseAddr,
-                              const BoundsExpr *CastBounds,
-                              const BoundsExpr *SubExprBounds);
+  void EmitDynamicBoundsCastCheck(const Address BaseAddr,
+                                  const BoundsExpr *CastBounds,
+                                  const BoundsExpr *SubExprBounds);
   /// \brief Create a basic block that will call the trap intrinsic, and emit
   /// a conditional branch to it, for Checked C's dynamic checks.
   void EmitDynamicCheckBlocks(llvm::Value *Condition);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2554,6 +2554,7 @@ public:
   /// \brief Create a basic block that will call the trap intrinsic, and emit
   /// a conditional branch to it, for Checked C's dynamic checks.
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
+  llvm::BasicBlock *EmitDynamicCheckFailedBlock();
 
   llvm::Value *EmitBoundsCast(CastExpr *CE);
 

--- a/test/CheckedC/dynamic-checks/array-compound-assign-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-compound-assign-code-gen.c
@@ -48,12 +48,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -82,12 +79,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -118,12 +112,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -154,12 +145,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -189,12 +177,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -247,12 +232,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -282,12 +264,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -319,12 +298,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -356,12 +332,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -391,12 +364,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -443,10 +413,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -473,10 +444,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -504,10 +476,12 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -532,13 +506,13 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -564,10 +538,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -615,12 +590,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -649,12 +621,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -685,12 +654,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -721,12 +687,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -755,12 +718,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -811,10 +771,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -842,13 +803,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -877,13 +838,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -914,12 +875,15 @@ void f5() {
 
   // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 and (
+  // CHECK-IR-SAME:   i1 icmp ule (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:   i1 icmp ult (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:       i64 3, i32 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -947,10 +911,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -977,13 +942,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -1033,14 +998,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1076,14 +1040,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1120,14 +1083,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1165,14 +1127,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1205,14 +1166,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG3]] to i32*
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG6]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG4]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG7]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -1247,14 +1207,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]

--- a/test/CheckedC/dynamic-checks/array-compound-assign-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-compound-assign-code-gen.c
@@ -414,10 +414,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -445,10 +445,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -478,10 +478,10 @@ void f3(void) {
   // The following line of LLVM IR is very long
 
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -509,10 +509,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -539,10 +539,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -772,10 +772,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -806,10 +806,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -841,10 +841,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -877,13 +877,13 @@ void f5() {
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 and (
   // CHECK-IR-SAME:   i1 icmp ule (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2)),
   // CHECK-IR-SAME:   i1 icmp ult (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2),
   // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:       i64 3, i32 0))),
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:       {{i[0-9]+}} 3, {{i[0-9]+}} 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -912,10 +912,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -945,10 +945,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/array-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-increment-code-gen.c
@@ -48,12 +48,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -82,12 +79,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -118,12 +112,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -154,12 +145,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -189,12 +177,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -247,12 +232,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -282,12 +264,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -319,12 +298,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -356,12 +332,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -391,12 +364,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -443,10 +413,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -473,10 +444,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -504,10 +476,12 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -532,13 +506,13 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -564,10 +538,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -615,12 +590,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -649,12 +621,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -685,12 +654,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -721,12 +687,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -755,12 +718,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -811,10 +771,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -842,13 +803,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -877,13 +838,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -914,12 +875,15 @@ void f5() {
 
   // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 and (
+  // CHECK-IR-SAME:   i1 icmp ule (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:   i1 icmp ult (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:       i64 3, i32 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -947,10 +911,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -977,13 +942,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -1033,14 +998,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1076,14 +1040,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1120,14 +1083,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1165,14 +1127,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1205,14 +1166,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG3]] to i32*
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG6]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG4]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG7]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -1247,14 +1207,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]

--- a/test/CheckedC/dynamic-checks/array-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-increment-code-gen.c
@@ -414,10 +414,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -445,10 +445,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -478,10 +478,10 @@ void f3(void) {
   // The following line of LLVM IR is very long
 
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -509,10 +509,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -539,10 +539,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -772,10 +772,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -806,10 +806,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -841,10 +841,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -877,13 +877,13 @@ void f5() {
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 and (
   // CHECK-IR-SAME:   i1 icmp ule (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2)),
   // CHECK-IR-SAME:   i1 icmp ult (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2),
   // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:       i64 3, i32 0))),
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:       {{i[0-9]+}} 3, {{i[0-9]+}} 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -912,10 +912,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -945,10 +945,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/array-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-read-code-gen.c
@@ -46,12 +46,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -78,12 +75,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -110,12 +104,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -143,12 +134,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -174,12 +162,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -227,12 +212,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -258,12 +240,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -290,12 +269,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -322,12 +298,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -352,12 +325,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -399,10 +369,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -425,10 +396,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -451,10 +423,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -475,11 +448,13 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}), {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -502,10 +477,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -551,12 +527,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -581,12 +554,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -612,12 +582,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -644,12 +611,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -675,12 +639,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG1]]
@@ -727,10 +688,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -753,13 +715,13 @@ void f5() {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -783,13 +745,13 @@ void f5() {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -814,12 +776,15 @@ void f5() {
 
   // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 and (
+  // CHECK-IR-SAME:   i1 icmp ule (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:   i1 icmp ult (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:       i64 3, i32 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -844,10 +809,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -870,13 +836,13 @@ void f5() {
   // CHECK-AST-NEXT: ArraySubscriptExpr
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -921,14 +887,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -959,14 +924,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -998,14 +962,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1037,14 +1000,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]
@@ -1074,14 +1036,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG3]] to i32*
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG6]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG4]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG7]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG2]]
@@ -1112,14 +1073,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = load i32, i32* [[REG3]]

--- a/test/CheckedC/dynamic-checks/array-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-read-code-gen.c
@@ -370,10 +370,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -397,10 +397,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -424,10 +424,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -451,10 +451,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -478,10 +478,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -689,10 +689,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -718,10 +718,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -748,10 +748,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -778,13 +778,13 @@ void f5() {
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 and (
   // CHECK-IR-SAME:   i1 icmp ule (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2)),
   // CHECK-IR-SAME:   i1 icmp ult (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2),
   // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:       i64 3, i32 0))),
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:       {{i[0-9]+}} 3, {{i[0-9]+}} 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -810,10 +810,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -839,10 +839,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/array-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-write-code-gen.c
@@ -387,10 +387,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -415,10 +415,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -445,10 +445,10 @@ void f3(void) {
   // The following line of LLVM IR is very long
 
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -474,10 +474,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -502,10 +502,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -724,10 +724,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -756,10 +756,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -789,10 +789,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -823,13 +823,13 @@ void f5() {
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 and (
   // CHECK-IR-SAME:   i1 icmp ule (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2)),
   // CHECK-IR-SAME:   i1 icmp ult (
-  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2),
   // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:       i64 3, i32 0))),
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:       {{i[0-9]+}} 3, {{i[0-9]+}} 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -856,10 +856,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -887,10 +887,10 @@ void f5() {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
-  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3, i32 0)),
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3, {{i[0-9]+}} 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/array-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-write-code-gen.c
@@ -48,12 +48,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 1, i32* [[REG2]]
@@ -80,12 +77,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 2, i32* [[REG1]]
@@ -114,12 +108,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 3, i32* [[REG2]]
@@ -148,12 +139,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 4, i32* [[REG2]]
@@ -180,12 +168,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 5, i32* [[REG1]]
@@ -235,12 +220,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 1, i32* [[REG2]]
@@ -267,12 +249,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 2, i32* [[REG1]]
@@ -301,12 +280,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 3, i32* [[REG2]]
@@ -335,12 +311,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 4, i32* [[REG2]]
@@ -367,12 +340,9 @@ void f2(_Array_ptr<int> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 5, i32* [[REG1]]
@@ -416,10 +386,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -443,10 +414,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x i32]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([1 x i32], [1 x i32]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -471,10 +443,12 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -497,13 +471,13 @@ void f3(void) {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i64 0, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -527,10 +501,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x i32]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds
-  // CHECK-IR-SAME: (i32, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds (i32,
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32], [3 x i32]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -576,12 +551,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 1, i32* [[REG2]]
@@ -608,12 +580,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 2, i32* [[REG1]]
@@ -642,12 +611,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 3, i32* [[REG2]]
@@ -676,12 +642,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 4, i32* [[REG2]]
@@ -708,12 +671,9 @@ void f4(int la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load i32*, i32** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds i32, i32* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 5, i32* [[REG1]]
@@ -763,10 +723,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 0, i64 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -792,13 +753,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -825,13 +786,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 1, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 1, i64 2),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -860,12 +821,15 @@ void f5() {
 
   // NOTE: No Non-null check inserted
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} -2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 and (
+  // CHECK-IR-SAME:   i1 icmp ule (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2)),
+  // CHECK-IR-SAME:   i1 icmp ult (
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i64 -2),
+  // CHECK-IR-SAME:     i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:       [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:       i64 3, i32 0))),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -891,10 +855,11 @@ void f5() {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -919,13 +884,13 @@ void f5() {
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
   // NOTE: No Non-null check inserted
+  // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x [3 x i32]]* @gma to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 2, {{i[0-9]+}} 0) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint ([3 x i32]* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x i32], [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i64 0, i64 2, i32 0),
+  // CHECK-IR-SAME:   i32* getelementptr inbounds ([3 x i32],
+  // CHECK-IR-SAME:     [3 x i32]* getelementptr inbounds ([3 x [3 x i32]], [3 x [3 x i32]]* @gma, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3, i32 0)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -973,14 +938,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 1, i32* [[REG3]]
@@ -1014,14 +978,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 2, i32* [[REG3]]
@@ -1056,14 +1019,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 5
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 3, i32* [[REG3]]
@@ -1099,14 +1061,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} -2
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 4, i32* [[REG3]]
@@ -1137,14 +1098,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG3]] to i32*
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG6]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG4]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG2]], [[REG7]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 5, i32* [[REG2]]
@@ -1177,14 +1137,13 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-IR-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
-  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG5]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint i32* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint [3 x i32]* [[REG6]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG4]] to i32*
+  // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
+  // CHECK-IR-NEXT: [[REG7:%[a-zA-Z0-9.]*]] = getelementptr inbounds [3 x i32], [3 x i32]* [[REG6]], {{i[0-9]+}} 3
+  // CHECK-IR-NEXT: [[REG8:%[a-zA-Z0-9.]*]] = bitcast [3 x i32]* [[REG7]] to i32*
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule i32* [[REG5]], [[REG3]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult i32* [[REG3]], [[REG8]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: store i32 6, i32* [[REG3]]

--- a/test/CheckedC/dynamic-checks/struct-compound-assign-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-compound-assign-code-gen.c
@@ -47,12 +47,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -81,12 +78,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -120,12 +114,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -171,12 +162,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -206,12 +194,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -245,12 +230,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -292,11 +274,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -321,11 +303,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -353,12 +335,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -401,12 +382,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -435,12 +413,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -474,12 +449,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0

--- a/test/CheckedC/dynamic-checks/struct-compound-assign-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-compound-assign-code-gen.c
@@ -275,10 +275,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -304,10 +304,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -336,10 +336,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -282,10 +282,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -312,10 +312,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -345,10 +345,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -48,12 +48,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -83,12 +80,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -123,12 +117,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -175,12 +166,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -211,12 +199,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -251,12 +236,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -299,11 +281,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -329,11 +311,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -362,12 +344,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -411,12 +392,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -446,12 +424,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -486,12 +461,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -276,10 +276,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -305,10 +305,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -337,10 +337,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -48,12 +48,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -82,12 +79,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -121,12 +115,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -172,12 +163,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -207,12 +195,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -246,12 +231,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -293,11 +275,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -322,11 +304,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -354,12 +336,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -402,12 +383,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -436,12 +414,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -475,12 +450,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -263,10 +263,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 1)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -290,10 +290,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -320,10 +320,10 @@ void f3(void) {
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
   // CHECK-IR:      br i1 icmp ult (
-  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2),
   // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
-  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
-  // CHECK-IR-SAME:     i64 3)),
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
+  // CHECK-IR-SAME:     {{i[0-9]+}} 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -47,12 +47,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp1
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -79,12 +76,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -116,12 +110,9 @@ void f1(void) {
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** @gp3
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -165,12 +156,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -198,12 +186,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -235,12 +220,9 @@ void f2(_Array_ptr<S1> lp1 : count(1),
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %lp3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -280,11 +262,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([1 x %struct.S1]* @ga1 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([1 x %struct.S1], [1 x %struct.S1]* @ga1, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 1) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([1 x %struct.S1], [1 x %struct.S1]* @ga1, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 1)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -307,11 +289,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 icmp ult ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0),
-  // CHECK-IR-SAME: {{i[0-9]+}} 3) to {{i[0-9]+}})),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -337,12 +319,11 @@ void f3(void) {
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
   // The following line of LLVM IR is very long
-  // CHECK-IR: br i1 and
-  // CHECK-IR-SAME: (i1 icmp ule ({{i[0-9]+}} ptrtoint ([3 x %struct.S1]* @ga3 to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}})),
-  // CHECK-IR-SAME: i1 icmp ult ({{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 2) to {{i[0-9]+}}),
-  // CHECK-IR-SAME: {{i[0-9]+}} ptrtoint (%struct.S1* getelementptr inbounds
-  // CHECK-IR-SAME: (%struct.S1, %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, {{i[0-9]+}} 0, {{i[0-9]+}} 0), {{i[0-9]+}} 3) to {{i[0-9]+}}))),
+  // CHECK-IR:      br i1 icmp ult (
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i64 2),
+  // CHECK-IR-SAME:   %struct.S1* getelementptr inbounds (%struct.S1,
+  // CHECK-IR-SAME:     %struct.S1* getelementptr inbounds ([3 x %struct.S1], [3 x %struct.S1]* @ga3, i32 0, i32 0),
+  // CHECK-IR-SAME:     i64 3)),
   // CHECK-IR-SAME: label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]],
   // CHECK-IR-SAME: label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
@@ -383,12 +364,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la1.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 1
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -415,12 +393,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG2:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG3]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG1]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG4]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG2]], [[REG1]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG1]], [[REG4]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG1]], {{i[0-9]+}} 0, {{i[0-9]+}} 0
@@ -452,12 +427,9 @@ void f4(S1 la1 _Checked[1],
   // CHECK-IR-NEXT: [[REG3:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG4:%[a-zA-Z0-9.]*]] = load %struct.S1*, %struct.S1** %la3.addr
   // CHECK-IR-NEXT: [[REG5:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG4]], {{i[0-9]+}} 3
-  // CHECK-IR-NEXT: [[REG_DYADDR:%_Dynamic_check.addr[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG2]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG3]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYLOWC:%_Dynamic_check.lower_cmp[a-zA-Z0-9.]*]] = icmp ule {{i[0-9]+}} [[REG_DYLOW]], [[REG_DYADDR]]
-  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = ptrtoint %struct.S1* [[REG5]] to {{i[0-9]+}}
-  // CHECK-IR-NEXT: [[REG_DYUPPC:%_Dynamic_check.upper_cmp[a-zA-Z0-9.]*]] = icmp ult {{i[0-9]+}} [[REG_DYADDR]], [[REG_DYUPP]]
-  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOWC]], [[REG_DYUPPC]]
+  // CHECK-IR-NEXT: [[REG_DYLOW:%_Dynamic_check.lower[a-zA-Z0-9.]*]] = icmp ule %struct.S1* [[REG3]], [[REG2]]
+  // CHECK-IR-NEXT: [[REG_DYUPP:%_Dynamic_check.upper[a-zA-Z0-9.]*]] = icmp ult %struct.S1* [[REG2]], [[REG5]]
+  // CHECK-IR-NEXT: [[REG_DYRNG:%_Dynamic_check.range[a-zA-Z0-9.]*]] = and i1 [[REG_DYLOW]], [[REG_DYUPP]]
   // CHECK-IR-NEXT: br i1 [[REG_DYRNG]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %{{_Dynamic_check.failed[a-zA-Z0-9.]*}}
   // CHECK-IR: [[LAB_DYSUC]]:
   // CHECK-IR-NEXT: [[REG6:%[a-zA-Z0-9.]*]] = getelementptr inbounds %struct.S1, %struct.S1* [[REG2]], {{i[0-9]+}} 0, {{i[0-9]+}} 0


### PR DESCRIPTION
It turns out you can icmp pointer types in LLVM IR, without converting them to integers first. This pull request removes our generation of "ptrtoint" instructions.

However there is an issue in inference, ICMP needs both operandi to have the same type, and for complex reasons sometimes the type of the bounds doesn't match the types of the pointer we're comparing to. This means sometimes we have to insert a bitcast in the LLVM IR. Semantically this keeps the same value but changes the IR type to match what is needed. I need to add code comments to clarify how we use these casts. 

I also cleared up the method name used for generating dynamic_bounds_cast so it doesn't overload that of the dynamic bounds check, and split out statistics for dynamic checks from casts to be desperate to bounds checks. 

Tested:
- Windows 32bit
- Mac 64 bit. 

No tests failed when I cleaned up and clarified the dynamic bounds cast code, which worries me slightly. Do we not test the LLVM IR that's generated?