### PR TITLE
Disallow Global Variable References in Parameter Bounds Expressions

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9263,6 +9263,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     "out-of-scope variable for bounds in a function type (a function type "
     "cannot reference local variables)">;
 
+  def err_out_of_scope_function_type_global : Error<
+    "out-of-scope variable for bounds in a function type (a function type "
+    "cannot reference global variables)">;
+
   def err_out_of_scope_function_type_parameter : Error<
     "out-of-scope variable for bounds in a function type (a function type can "
     "only reference parameters from its own parameter list)">;


### PR DESCRIPTION
This is preparation for a change we're thinking of making.

We cannot reason about how global variables change inside functions, which means our bounds static analysis may not be sound if global variables are allowed in parameter bounds. 

This adds some code to disallow global variables inside parameter bounds expressions. It guards it behind a flag that is currently false, because we're not 100% sold on needing this yet, and want to think about it more.

Testing:
- I set the variable `errorOnGlobals` to true, and ran the compiler on the YACR2 converted benchmark, and I got a lot of errors. 