### PR TITLE
Conversions involving checked void pointers

### DIFF
--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7473,42 +7473,56 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType) {
   // incomplete type and the other is a pointer to a qualified or unqualified
   // version of void...
 
-  // Allow conversion from any unchecked pointer to any kind of void pointer,
-  // including void *.  In Checked C, also allow conversions from any checked
-  // pointer to any kind of checked void pointer.
-  if (lhptee->isVoidType() && (rhkind == CheckedPointerKind::Unchecked ||
-    (lhkind != CheckedPointerKind::Unchecked &&
-     rhkind != CheckedPointerKind::Unchecked))) {
-    if (rhptee->isIncompleteOrObjectType())
-      return ConvTy;
+  // Handle the plain C case (where both pointers unchecked).
+  if (lhkind == CheckedPointerKind::Unchecked &&
+      rhkind == CheckedPointerKind::Unchecked) {
 
-    if (lhkind == CheckedPointerKind::Unchecked &&
-        rhkind == CheckedPointerKind::Unchecked) {
+    if (lhptee->isVoidType()) {
+      if (rhptee->isIncompleteOrObjectType())
+        return ConvTy;
+
       // As an extension, we allow cast to/from void* to function pointer.
       assert(rhptee->isFunctionType());
       return Sema::FunctionVoidPointer;
     }
-  }
 
-  // Only void * can be converted implicitly to another pointer type. In
-  // Checked C, _Ptr<void> and _Array_ptr<void> cannot be converted implicitly
-  // to non-void checked pointer types. They can be converted implicitly to
-  // each other, though.
-  if (rhptee->isVoidType() && rhkind == CheckedPointerKind::Unchecked) {
-    if (lhptee->isIncompleteOrObjectType())
-      return ConvTy;
+    if (rhptee->isVoidType()) {
+      if (lhptee->isIncompleteOrObjectType())
+        return ConvTy;
 
-    if (lhkind == CheckedPointerKind::Unchecked &&
-        rhkind == CheckedPointerKind::Unchecked) {
       // As an extension, we allow cast to/from void* to function pointer.
       assert(lhptee->isFunctionType());
       return Sema::FunctionVoidPointer;
     }
   }
 
-  // Do not allow implicit conversions from checked pointers to
-  // unchecked pointers.  Implicit conversions between different kinds
-  // of checked pointers with compatible referent types are allowed.
+  // Handle Checked C cases (where one pointer is checked).
+  if (lhkind != CheckedPointerKind::Unchecked ||
+      rhkind != CheckedPointerKind::Unchecked) {
+    // Allow conversions from any pointer to any kind of checked void
+    // pointer. Do not have an extension allowing casts from checked void
+    // pointers to function pointers.
+    if (lhptee->isVoidType() && lhkind != CheckedPointerKind::Unchecked &&
+        rhptee->isIncompleteOrObjectType()) {
+      return ConvTy;
+    }
+
+    // Allow void * to be converted implicitly to a checked pointer type (it
+    // will still need to have the appropriate bounds).  Do not allow
+    // _Ptr<void> or _Array_ptr<void> to be converted implicitly to another
+    // checked pointer type.
+    if (rhptee->isVoidType() && rhkind == CheckedPointerKind::Unchecked &&
+       lhptee->isIncompleteOrObjectType())
+      return ConvTy;
+  }
+
+  // We are done handling pointers void. Now apply restrictions based on
+  // checkedness of pointers.
+  // - Disallow implicit conversions from checked pointers to unchecked
+  // pointers.
+  // - Allow:
+  // * Implicit conversions from unchecked pointers to checked pointers.
+  // * Implicit conversions between different kinds of checked pointers.
   if (rhkind != CheckedPointerKind::Unchecked &&
       lhkind == CheckedPointerKind::Unchecked)
     return Sema::Incompatible;


### PR DESCRIPTION
This addresses GitHub issue #364.   Allow any kind of checked pointer to be implicitly converted to any kind of checked void pointer.   Previously we required that the target and destination types be the same kind of checked pointer.  

Also disallow conversions between void pointers and checked function types.   In examining the code for conversions involving void pointers, I noticed that the code allowed conversions between void * and function pointers as an extension.   This would also allow conversions between checked void pointers and function pointers.  We do not want to allow this, even if the same static analysis for function pointers might disallow this.

Improve the comment about conversions between different checked pointers to the same referent type.

Testing:
- Update tests in the Checked C repo to allow the conversions to different kinds of checked void pointers.  This is covered by a separate pull request.
- Add  tests that conversions between void pointers and checked function pointers are not allowed.
- Passes existing Checked C and clang tests.
