### PR TITLE
Add missing cast for bounds-safe interfaces

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -9466,13 +9466,6 @@ public:
   QualType MakeCheckedArrayType(QualType T, bool Diagnose = false,
                                 SourceLocation Loc = SourceLocation());
 
-  /// \brief Helper function for type checking an assignment whose LHS has a
-  /// Checked C bounds-safe interface.  This function chooses which type to
-  /// use for the LHS of the assignment.
-  QualType ResolveSingleAssignmentType(QualType LHSType, 
-                                       QualType LHSInteropType, 
-                                       ExprResult &RHS);
-
   // \brief If the lhs type is a transparent union, check whether we
   // can initialize the transparent union with the given expression.
   AssignConvertType CheckTransparentUnionArgumentConstraints(QualType ArgType,

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -9445,7 +9445,8 @@ public:
   ///        \p Diagnose must also be \c false.
   AssignConvertType CheckSingleAssignmentConstraints(
       QualType LHSType, ExprResult &RHS, bool Diagnose = true,
-      bool DiagnoseCFAudited = false, bool ConvertRHS = true);
+      bool DiagnoseCFAudited = false, bool ConvertRHS = true,
+      QualType LHSInteropType = QualType());
 
 public:
   /// \brief Given a value with type Ty and bounds Bounds,

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -3699,13 +3699,6 @@ public:
 
   template<typename T>
   static bool isObjCMethodWithTypeParams(const T *) { return false; }
-
-  // Determine whether the given argument is FunctionProtoType
-  // that have parameter bounds information within it
-  static bool isFunctionProtoType(const FunctionProtoType* FPT) { return true; }
-
-  template<typename T>
-  static bool isFunctionProtoType(const T *) { return false; }
 #endif
 
   enum class EvaluationOrder {
@@ -3732,73 +3725,22 @@ public:
     if (CallArgTypeInfo) {
 #ifndef NDEBUG
       bool isGenericMethod = isObjCMethodWithTypeParams(CallArgTypeInfo);
-      bool isFunctionProto= isFunctionProtoType(CallArgTypeInfo);
 #endif
 
       // First, use the argument types that the type info knows about
-      int N = 0;
       for (auto I = CallArgTypeInfo->param_type_begin() + ParamsToSkip,
                 E = CallArgTypeInfo->param_type_end();
-           I != E; ++I, ++Arg, ++N) {
+           I != E; ++I, ++Arg) {
         assert(Arg != ArgRange.end() && "Running over edge of argument list!");
-#ifndef NDEBUG
-        const Type *ty1 = getContext()
-                              .getCanonicalType((*I).getNonReferenceType())
-                              .getTypePtr();
-        const Type *ty2 =
-            getContext().getCanonicalType((*Arg)->getType()).getTypePtr();
-        const Type *interop_ty1 = ty1;
-
-        // Checked C consideration
-        // In case of function prototype, it has parameter type information
-        // that involves also itype as bounds information
-        // To check interop type properly, it SHOULD consider additional bounds
-        // info likely Sema (semantic)
-        if (isFunctionProto) {
-          const FunctionProtoType *FPT =
-              (const FunctionProtoType *)CallArgTypeInfo;
-          if (FPT && FPT->hasParamBounds()) {
-            const BoundsExpr *Bounds = FPT->getParamBounds(N);
-            if (Bounds) {
-              switch (Bounds->getKind()) {
-              case BoundsExpr::Kind::InteropTypeAnnotation: {
-                const InteropTypeBoundsAnnotation *Annot =
-                    dyn_cast<InteropTypeBoundsAnnotation>(Bounds);
-                interop_ty1 = getContext()
-                                  .getCanonicalType(Annot->getType())
-                                  .getTypePtr();
-                break;
-              }
-              case BoundsExpr::Kind::ByteCount:
-              case BoundsExpr::Kind::ElementCount:
-              case BoundsExpr::Kind::Range: {
-                QualType Ty = FPT->getParamType(N);
-                if (const PointerType *PtrType = Ty->getAs<PointerType>()) {
-                  if (PtrType->isUnchecked()) {
-                    interop_ty1 =
-                        getContext()
-                            .getCanonicalType(getContext().getPointerType(
-                                PtrType->getPointeeType(),
-                                CheckedPointerKind::Array))
-                            .getTypePtr();
-                  }
-                }
-                break;
-              }
-              default:
-                break;
-              }
-            }
-          }
-        }
-#endif
-
         assert((isGenericMethod ||
                 ((*I)->isVariablyModifiedType() ||
                  (*I).getNonReferenceType()->isObjCRetainableType() ||
-                 (ty1 == ty2) ||
-                 // interopType checking as well as original type checking is done
-                 (interop_ty1 == ty2))) &&
+                 getContext()
+                         .getCanonicalType((*I).getNonReferenceType())
+                         .getTypePtr() ==
+                     getContext()
+                         .getCanonicalType((*Arg)->getType())
+                         .getTypePtr())) &&
                "type mismatch in call argument!");
         ArgTypes.push_back(*I);
       }

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8179,8 +8179,6 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
   Sema::AssignConvertType result =
     CheckAssignmentConstraints(LHSType, RHS, Kind, ConvertRHS);
 
-
-
   // C99 6.5.16.1p2: The value of the right operand is converted to the
   // type of the assignment expression.
   // CheckAssignmentConstraints allows the left-hand side to be a reference,

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8217,7 +8217,7 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
   }
 
   // If we can't convert to the LHS type, try the LHS interop type instead.
-  // Note that we have to insert a a cast that "downgrades" the checkedness.
+  // Note that we have to insert a cast that "downgrades" the checkedness.
   if (result == Incompatible && !LHSInteropType.isNull()) {
     result = CheckAssignmentConstraints(LHSInteropType, RHS, Kind, ConvertRHS);
     assert(!LHSType->isReferenceType());
@@ -8255,31 +8255,6 @@ QualType Sema::GetCheckedCInteropType(ExprResult LHS) {
     }
   }
   return QualType();
-}
-
-/// Helper function for type checking an assignment whose left-hande side has a
-/// Checked C bounds-safe interface.  This function chooses which type to use
-/// for the LHS of the assignment: the type computed via normal C type checking
-/// (LHSType) or the Checked C interoperation type for the LHS.  It tries type
-/// checking the assignment using LHSType. If that does not work, it tries
-/// LHSInteropType.  It returns the first type that works.  If neither type
-/// works, it returns the LHSType (this will cause any diagnostic messages for
-/// the type checking failure to refer to the LHSType).
-QualType Sema::ResolveSingleAssignmentType(QualType LHSType,
-                                           QualType LHSInteropType,
-                                           ExprResult &RHS) {
-  assert(!LHSType.isNull() && !LHSInteropType.isNull());
-  QualType Result = LHSType;
-  Sema::AssignConvertType TrialConvTy =
-    CheckSingleAssignmentConstraints(LHSType, RHS, false, false, false);
-  if (TrialConvTy == Sema::AssignConvertType::Incompatible) {
-    TrialConvTy = 
-      CheckSingleAssignmentConstraints(LHSInteropType, RHS,
-                                       false, false, false);
-    if (TrialConvTy != Sema::AssignConvertType::Incompatible)
-      Result = LHSInteropType;
-  }
-  return Result;
 }
 
 QualType Sema::InvalidOperands(SourceLocation Loc, ExprResult &LHS,

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -7060,24 +7060,17 @@ InitializationSequence::Perform(Sema &S,
       ExprResult Result = CurInit;
 
       QualType LHSType = Step->Type;
+      QualType LHSInteropType;
       if (S.getLangOpts().CheckedC && LHSType->isUncheckedPointerType()) {
-        // Tap-dance around the side-effecting behavior of
-        // CheckSingleAssignmentConstraints.  The call to
-        // CheckSingleAssignmentConstraints below can have side-effects where
-        // it modifies the RHS or produces diagnostic messages.  We want the
-        // side-effects to happen exactly once, so we carefully compute the
-        // right type and pass it to the call.
         const BoundsExpr *Bounds = Entity.getBounds();
         bool isParam = Entity.isParameterKind();
-        QualType LHSInteropType = S.GetCheckedCInteropType(LHSType, Bounds, isParam);
-        if (!LHSInteropType.isNull())
-            LHSType = S.ResolveSingleAssignmentType(LHSType, LHSInteropType,
-                                                    Result);
+        LHSInteropType = S.GetCheckedCInteropType(LHSType, Bounds, isParam);
       }
 
       Sema::AssignConvertType ConvTy =
         S.CheckSingleAssignmentConstraints(LHSType, Result, true,
-           Entity.getKind() == InitializedEntity::EK_Parameter_CF_Audited);
+           Entity.getKind() == InitializedEntity::EK_Parameter_CF_Audited,
+                                           true, LHSInteropType);
 
       if (Result.isInvalid())
         return ExprError();

--- a/test/CheckedC/regression-cases/interop_bug_143.c
+++ b/test/CheckedC/regression-cases/interop_bug_143.c
@@ -1,0 +1,11 @@
+//
+// This example is from https://github.com/Microsoft/checkedc-clang/issues/143
+//
+// RUN: %clang -c -fcheckedc-extension %s -o %t
+
+void f1(int *p : itype(_Ptr<int>)) {
+}
+
+void g1(_Ptr<int> p) {
+  f1(p);
+}


### PR DESCRIPTION
At bounds-safe interfaces, we allow values with checked pointer types to be assigned to lvalues with unchecked pointer types.  We also allow values with checked pointer types to be passed to arguments with unchecked pointer types.

We were missing a cast from the checked type to the unchecked type in the AST.  This triggered an assert during code generation for parameter passing because the type of the argument was incompatible with the type of the parameter.   We had a workaround that modified the assert to allow special behavior at a bounds-safe interface.

This change adds the missing cast and removes the workaround.   It modifies CheckSingleAssignmentConstraints to take the interop type as an additional argument.  If the match fails with the original LHS type, we try the initerop type.   There are a lot of special cases in CheckSingleAssignmentConstraints.  I was concerned that some of them would apply to the LHSInteropType.  However, in examining the special cases it seems that they all apply to non-C languages.   So the logic in CheckSingleAssignmentConstraints for handling the interop type can be simple.  We just need to check at the end of the function that the interop type works if the LHS type didn't work. 

If we use the interop type, we insert a downcast to the unchecked type. For now, I use a bitcast operator.   This should be changed to use a new cast operator for clarity in the AST.  I plan to make that change separately.

Testing:
- Added new test case from issue #143 that triggered the assert in the unmodified code.
- Passes automated testing on Windows and Linux.
