### PR TITLE
Allow returning a checked pointer from a function with an interop type.

### DIFF
--- a/include/clang/Sema/Initialization.h
+++ b/include/clang/Sema/Initialization.h
@@ -187,9 +187,9 @@ private:
   /// function, throwing an object, performing an explicit cast, or
   /// initializing a parameter for which there is no declaration.
   InitializedEntity(EntityKind Kind, SourceLocation Loc, QualType Type,
-                    bool NRVO = false)
+                    bool NRVO = false, const BoundsExpr *Bounds = nullptr)
     : Kind(Kind), Parent(nullptr), Type(Type), ManglingNumber(0),
-      Bounds(nullptr)
+      Bounds(Bounds)
 
   {
     LocAndNRVO.Location = Loc.getRawEncoding();
@@ -266,8 +266,9 @@ public:
 
   /// \brief Create the initialization entity for the result of a function.
   static InitializedEntity InitializeResult(SourceLocation ReturnLoc,
-                                            QualType Type, bool NRVO) {
-    return InitializedEntity(EK_Result, ReturnLoc, Type, NRVO);
+                                            QualType Type, bool NRVO,
+                                          const BoundsExpr *Bounds = nullptr) {
+    return InitializedEntity(EK_Result, ReturnLoc, Type, NRVO, Bounds);
   }
 
   static InitializedEntity InitializeBlock(SourceLocation BlockVarLoc,


### PR DESCRIPTION
Add support for returning checked pointers from functions with bounds-safe interface for their return values.   This addresses issue #366. The problem was that information about return bounds was not being propagated.  Modify SemaInit to propagate the return bounds information for the function to the EK_Result entities, which are used to typecheck return statements.   The existing machinery in SemaInit for handling C assignments takes care of the rest of the checking.

Testing:
- Added tests to the Checked C repo for returning checked values in  bodies of functions with bounds-safe interfaces for their return.  Modified  an existing test to allow this behavior.
- Passes existing Checked C repo and clang Checked C tests.
- Passes  automated testing for debug Windows x64 and Linux x64.