### PR TITLE
Fix incorrect logic for inserting implicit casts at bounds-safe interfaces.

### DIFF
--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8218,16 +8218,15 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
   // Note that we have to insert a cast that "downgrades" the checkedness.
   if (result == Incompatible && !LHSInteropType.isNull()) {
     result = CheckAssignmentConstraints(LHSInteropType, RHS, Kind, ConvertRHS);
-    assert(!LHSType->isReferenceType());
-    assert(!LHSInteropType->isReferenceType());
-    Expr *E = RHS.get();
-    if (ConvertRHS) {
-      if (Kind != Compatible) {
-        RHS = ImpCastExprToType(E, LHSInteropType, Kind);
-        E = RHS.get();
+    if (result != Incompatible) {
+      assert(!LHSType->isReferenceType());
+      assert(!LHSInteropType->isReferenceType());
+      if (ConvertRHS) {
+        if (RHS.get()->getType() != LHSInteropType)
+          RHS = ImpCastExprToType(RHS.get(), LHSInteropType, Kind);
+        // Downgrade checked pointer to unchecked LHSType
+        RHS = ImpCastExprToType(RHS.get(), LHSType, CK_BitCast);
       }
-      // Downgrade checked pointer to unchecked LHSType
-      RHS = ImpCastExprToType(E, LHSType, CK_BitCast);
     }
   }
   return result;


### PR DESCRIPTION
This addresses Github issue #369.   We were incorrectly comparing values of different enum types when deciding whether to insert implicit casts at bounds-safe interfaces.  Change the comparison to be correct.
Rework the logic to follow the earlier code in the function for inserting casts. The earlier code has a logic twisted up like a pretzel, so we follow it exactly to avoid subtle problems.

If we are able to type check using the LHSInteropType, we insert a cast to the LHSInteropType, if necessary (CheckAssignmentConstraints takes the RHS by reference and may already have altered it).  Then we always insert a  bitcast from the LHSInteropType to the LHSType.

Testing:
- Passed local testing of Checked C repo and clang Checked C tests on Windows on x64.
- Passed automated testing for X64 Linux for clang tests and LNT.