### PR TITLE
Check that call arguments have bounds when expected.

### DIFF
--- a/include/clang/Basic/DiagnosticGroups.td
+++ b/include/clang/Basic/DiagnosticGroups.td
@@ -825,6 +825,10 @@ def MicrosoftVoidPseudoDtor : DiagGroup<"microsoft-void-pseudo-dtor">;
 def MicrosoftAnonTag : DiagGroup<"microsoft-anon-tag">;
 def MicrosoftCommentPaste : DiagGroup<"microsoft-comment-paste">;
 def MicrosoftEndOfFile : DiagGroup<"microsoft-end-of-file">;
+
+// Checked C warnings for bounds declaration checking.
+def CheckBoundsDecls : DiagGroup<"check-bounds-decls">;
+
 // Aliases.
 def : DiagGroup<"msvc-include", [MicrosoftInclude]>;
                 // -Wmsvc-include = -Wmicrosoft-include

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9286,6 +9286,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     "expression has no bounds"
     ", initializer expected to have bounds because the variable being declared has bounds">;
 
+  def err_expected_bounds_for_argument : Error<
+    "argument has no bounds, bounds expected because the "
+    "%ordinal0 parameter has bounds">;
+
   def err_initializer_expected_with_bounds : Error<
     "automatic variable %0 with bounds must have initializer">;
 
@@ -9313,8 +9317,11 @@ def err_bounds_type_annotation_lost_checking : Error<
 	InGroup<CheckedC>;
 
   def err_not_non_modifying_expr : Error<
-	"%select{assignment|increment|decrement|call|volatile}0 expression not allowed in "
-	"%select{expression|dynamic check expression|count expression|byte count expression|bounds expression|argument mentioned in function return bounds expression}1">;
+	"%select{assignment|increment|decrement|call|volatile}0 expression not "
+    "allowed in %select{expression|dynamic check expression|count expression"
+    "|byte count expression|bounds expression"
+    "|argument for parameter used in function return bounds expression"
+    "|argument for parameter used in function parameter bounds expression}1">;
 
   def err_checked_scope_type: Error<
     "%select{parameter|return|local variable|global variable|member}0 %select{|used }1in a checked scope must have "
@@ -9359,13 +9366,25 @@ def err_bounds_type_annotation_lost_checking : Error<
     "declared bounds for %1 may be invalid after "
     " %select{assignment|initialization}0">,
     DefaultIgnore,
-    InGroup<DiagGroup<"check-bounds-decls">>;
+    InGroup<CheckBoundsDecls>;
 
   def note_declared_bounds : Note<
     "(expanded) declared bounds are '%0'">;
 
   def note_inferred_bounds : Note<
     "(expanded) inferred bounds are '%0'">;
+
+  def err_modifying_expr_not_supported : Error<
+   "argument must be a non-modifying expression because %ordinal0 parameter "
+   "is used in a bounds expression">;
+
+  def warn_argument_bounds_invalid : Warning<
+    "argument may not meet declared bounds for %ordinal0 parameter">,
+    DefaultIgnore,
+    InGroup<CheckBoundsDecls>;
+
+  def note_expected_argument_bounds : Note<
+    "(expanded) expected argument bounds are '%0'">;
 
   def no_prototype_generic_function : Error<
     "expected prototype for a generic function">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4496,8 +4496,27 @@ public:
   // \#pragma BOUNDS_CHECKED.
   void ActOnPragmaBoundsChecked(Scope *S, tok::OnOffSwitch OOS);
 
+  // Represents where the requirement that the checked expression is non-modifying
+  // comes from.
+  enum NonModifiyingExprRequirement {
+    NMER_Unknown,
+    NMER_Dynamic_Check,
+    NMER_Bounds_Count,
+    NMER_Bounds_Byte_Count,
+    NMER_Bounds_Range,
+    NMER_Bounds_Function_Return,
+    NMER_Bounds_Function_Parameter
+  };
+
   BoundsExpr *CreateInvalidBoundsExpr();
   BoundsExpr *CreateCountForArrayType(QualType QT);
+
+  /// CheckNonModifyingExpr - checks whether an expression is non-modifying
+  /// (see Checked C Spec, 3.6.1).  Returns true if the expression is non-modifying,
+  /// false otherwise.
+  bool CheckIsNonModifyingExpr(Expr *E, NonModifiyingExprRequirement Req =
+                               NonModifiyingExprRequirement::NMER_Unknown,
+                               bool ReportError = true);
 
   BoundsExpr *AbstractForFunctionType(BoundsExpr *Expr,
                                       ArrayRef<DeclaratorChunk::ParamInfo> Params);
@@ -4505,7 +4524,8 @@ public:
                                          ArrayRef<ParmVarDecl *> Params);
   BoundsExpr *MakeMemberBoundsConcrete(Expr *MemberBase, bool IsArrow,
                                        BoundsExpr *Bounds);
-  BoundsExpr *ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args);
+  BoundsExpr *ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args,
+                                                 NonModifiyingExprRequirement ErrorKind);
 
   /// GetArrayPtrDereference - determine if an lvalue expression is
   /// a dereference of an Array_ptr (via '*" or an array subscript operator).
@@ -4543,22 +4563,6 @@ public:
   /// not within a function body.
   void CheckTopLevelBoundsDecls(VarDecl *VD);
 
-  // Represents where the requirement that the checked expression is non-modifying
-  // comes from.
-  enum NonModifiyingExprRequirement {
-    NMER_Unknown,
-    NMER_Dynamic_Check,
-    NMER_Bounds_Count,
-    NMER_Bounds_Byte_Count,
-    NMER_Bounds_Range,
-    NMER_Bounds_Function_Args,
-  };
-
-  /// CheckNonModifyingExpr - checks whether an expression is non-modifying
-  /// (see Checked C Spec, 3.6.1)
-  bool CheckIsNonModifyingExpr(Expr *E, NonModifiyingExprRequirement Req =
-                               NonModifiyingExprRequirement::NMER_Unknown,
-                               bool ReportError = true);
 
   // WarnDynamicCheckAlwaysFails - Adds a warning if an explicit dynamic check
   // will always fail.

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1355,13 +1355,18 @@ namespace {
           continue;
 
         // TODO: Github issue #334.  As part of addressing that,
-        // we should be able to remove this check.
+        // we should be able to remove these checks.
         // An itype(array_ptr<T>) has bounds(none), so skip checking
-        // it.
+        // it.   itype(ptr<... function type>) has bounds(none) also,
+        // so skip that too.
         if (const InteropTypeBoundsAnnotation *ITA =
-            dyn_cast<InteropTypeBoundsAnnotation>(ParamBounds))
+            dyn_cast<InteropTypeBoundsAnnotation>(ParamBounds)) {
           if (ITA->getType()->isCheckedPointerArrayType())
             continue;
+          if (ITA->getType()->isCheckedPointerPtrType() &&
+              ITA->getType()->getPointeeType()->isFunctionType())
+            continue;
+        }
 
         Expr *Arg = CE->getArg(i);
         BoundsExpr *ArgBounds = S.InferRValueBounds(Arg);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -175,13 +175,17 @@ namespace {
     // This stores whether we've emitted an error for a particular substitution
     // so that we don't duplicate error messages.
     llvm::SmallBitVector ErroredForArgument;
+    Sema::NonModifiyingExprRequirement ErrorKind;
     bool SubstitutedModifyingExpression;
 
+
   public:
-    ConcretizeBoundsExprWithArgs(Sema &SemaRef, ArrayRef<Expr *> Args) :
+    ConcretizeBoundsExprWithArgs(Sema &SemaRef, ArrayRef<Expr *> Args,
+                                 Sema::NonModifiyingExprRequirement ErrorKind) :
       BaseTransform(SemaRef),
       Arguments(Args),
       ErroredForArgument(Args.size()),
+      ErrorKind(ErrorKind),
       SubstitutedModifyingExpression(false) { }
 
     bool substitutedModifyingExpression() {
@@ -196,8 +200,7 @@ namespace {
 
         // We may only substitute if this argument expression is
         // a non-modifying expression.
-        if (!SemaRef.CheckIsNonModifyingExpr(AE,
-                                             Sema::NonModifiyingExprRequirement::NMER_Bounds_Function_Args,
+        if (!SemaRef.CheckIsNonModifyingExpr(AE, ErrorKind,
                                              ShouldReportError)) {
           SubstitutedModifyingExpression = true;
           ErroredForArgument.set(index);
@@ -212,12 +215,14 @@ namespace {
   };
 }
 
-BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args) {
+BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
+  BoundsExpr *Bounds, ArrayRef<Expr *> Args,
+  NonModifiyingExprRequirement ErrorKind) {
   if (!Bounds)
     return Bounds;
 
   BoundsExpr *Result;
-  auto Concretizer = ConcretizeBoundsExprWithArgs(*this, Args);
+  auto Concretizer = ConcretizeBoundsExprWithArgs(*this, Args, ErrorKind);
   ExprResult ConcreteBounds = Concretizer.TransformExpr(Bounds);
   if (Concretizer.substitutedModifyingExpression()) {
       return nullptr;
@@ -293,6 +298,26 @@ BoundsExpr *Sema::MakeMemberBoundsConcrete(
     BoundsExpr *Result = dyn_cast<BoundsExpr>(ConcreteBounds.get());
     return Result;
   }
+}
+
+namespace {
+// Compute what positional parameters are used by an expression.
+class CollectPositionalParameters : public RecursiveASTVisitor<CollectPositionalParameters> {
+
+private:
+  llvm::SmallBitVector Used;
+
+public:
+  CollectPositionalParameters(unsigned ParamCount) : Used(ParamCount) {}
+
+  bool VisitPositionalParameterExpr(PositionalParameterExpr *PE) {
+    Used.set(PE->getIndex());
+  }
+
+  bool IsUsed(unsigned Index) {
+    return Used.test(Index);
+  }
+};
 }
 
 namespace {
@@ -941,7 +966,9 @@ namespace {
 
             // Concretize Call Bounds with argument expressions.
             // We can only do this if the argument expressions are non-modifying
-            ReturnBounds = SemaRef.ConcretizeFromFunctionTypeWithArgs(FunBounds, ArgExprs);
+            ReturnBounds =
+              SemaRef.ConcretizeFromFunctionTypeWithArgs(FunBounds, ArgExprs,
+                                Sema::NonModifiyingExprRequirement::NMER_Bounds_Function_Return);
             // If concretization failed, this means we tried to substitute with a non-modifying
             // expression, which is not allowed by the specification.
             if (!ReturnBounds)
@@ -1150,8 +1177,8 @@ namespace {
 
     // Check that SrcBounds implies that DeclaredBounds are provably
     // true.
-    bool CheckBoundsDeclIsProvable(BoundsExpr *DeclaredBounds,
-                                   BoundsExpr *SrcBounds) {
+    bool CheckBoundsDeclIsProvable(const BoundsExpr *DeclaredBounds,
+                                   const BoundsExpr *SrcBounds) {
       // source bounds(any) implies that any other bounds is valid.
       if (SrcBounds->isAny())
         return true;
@@ -1180,6 +1207,26 @@ namespace {
           << DeclaredBounds << DeclaredBounds->getSourceRange();
         S.Diag(Src->getExprLoc(), diag::note_inferred_bounds)
           << SrcBounds << Src->getSourceRange();
+      }
+    }
+
+    // Check that the bounds for an argument imply the expected
+    // bounds for the argument.   The expected bounds are computed
+    // by substituting the arguments into the bounds expression for
+    // the corresponding parameter.
+    void CheckBoundsDeclAtCallArg(unsigned ParamNum,
+                                  BoundsExpr *ExpectedArgBounds, Expr *Arg,
+                                  BoundsExpr *ArgBounds) {
+      SourceLocation ArgLoc = Arg->getLocStart();
+      if (S.Diags.isIgnored(diag::warn_bounds_declaration_invalid, ArgLoc))
+        return;
+
+      if (!CheckBoundsDeclIsProvable(ExpectedArgBounds, ArgBounds)) {
+        S.Diag(ArgLoc, diag::warn_argument_bounds_invalid) << (ParamNum + 1)
+          << Arg->getSourceRange();
+        S.Diag(ArgLoc, diag::note_expected_argument_bounds) << ExpectedArgBounds;
+        S.Diag(Arg->getExprLoc(), diag::note_inferred_bounds)
+          << ArgBounds << Arg->getSourceRange();
       }
     }
 
@@ -1255,6 +1302,78 @@ namespace {
         DumpAssignmentBounds(llvm::outs(), E, LHSTargetBounds, RHSBounds);
       return true;
     }
+
+    bool VisitCallExpr(CallExpr *CE) {
+      const PointerType *FuncPtrTy = CE->getCallee()->getType()->getAs<PointerType>();
+      assert(FuncPtrTy);
+      const FunctionType *FuncTy =
+        FuncPtrTy->getPointeeType()->getAs<FunctionType>();
+      assert(FuncTy);
+      const FunctionProtoType *FuncProtoTy = FuncTy->getAs<FunctionProtoType>();
+      if (!FuncProtoTy)
+        return true;
+      if (!FuncProtoTy->hasParamBounds())
+        return true;
+      unsigned NumParams = FuncProtoTy->getNumParams();
+      unsigned NumArgs = CE->getNumArgs();
+      unsigned Count = (NumParams < NumArgs) ? NumParams : NumArgs;
+      if (false) {
+        // TODO: need RecursiveASTVisitor.h to visit bounds expressions
+        // in functions for this to work.
+        CollectPositionalParameters Uses(NumParams);
+        Uses.VisitFunctionProtoType(const_cast<FunctionProtoType *>(FuncProtoTy));
+
+        // If arguments are used in bounds expressions and are modifying expressions, issue
+        // an error.  TODO: If an argument expression has side-effects, but we can represent
+        // the value of the expression in terms of the values of variables before the call,
+        // we should use that instead and not issue an error.
+        for (unsigned i = 0; i < NumParams; i++)
+          if (Uses.IsUsed(i) && i < NumArgs &&
+              !S.CheckIsNonModifyingExpr(CE->getArg(i),
+                 Sema::NonModifiyingExprRequirement::NMER_Bounds_Function_Parameter,
+                                        false)) {
+            S.Diag(CE->getArg(i)->getLocStart(), diag::err_modifying_expr_not_supported) <<
+              (i + 1) << CE->getArg(i)->getSourceRange();
+          }
+      }
+
+      ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
+                                                     CE->getNumArgs());
+      for (unsigned i = 0; i < Count; i++) {
+        if (FuncProtoTy->getParamType(i)->isUncheckedPointerType()) {
+          // skip checking bounds, unless this is a bounds-safe interface cast.
+          ImplicitCastExpr *ICE = dyn_cast<ImplicitCastExpr>(CE->getArg(i));
+          if (!(ICE && ICE->getCastKind() == CK_BitCast &&
+                ICE->getSubExpr()->getType()->isCheckedPointerType()))
+            continue;
+        }
+
+        const BoundsExpr *ParamBounds = FuncProtoTy->getParamBounds(i);
+        if (!ParamBounds)
+          continue;
+        Expr *Arg = CE->getArg(i);
+        BoundsExpr *ArgBounds = S.InferRValueBounds(Arg);
+        if (ArgBounds->isNone()) {
+          S.Diag(Arg->getLocStart(),
+                 diag::err_expected_bounds_for_argument) << (i + 1) <<
+            Arg->getSourceRange();
+          ArgBounds = S.CreateInvalidBoundsExpr();
+        }
+        else {
+          // Concretize parameter bounds with argument expressions. This fails
+          // and return null if an argument expression is a modifying
+          // expression, but we've already issued an error about about that.
+          BoundsExpr *SubstParamBounds =
+            S.ConcretizeFromFunctionTypeWithArgs(
+              const_cast<BoundsExpr *>(ParamBounds),
+              ArgExprs,
+           Sema::NonModifiyingExprRequirement::NMER_Bounds_Function_Parameter);
+          if (SubstParamBounds)
+            CheckBoundsDeclAtCallArg(i, SubstParamBounds, Arg, ArgBounds);
+        }
+      }
+      return true;
+   }
 
     // This includes both ImplicitCastExprs and CStyleCastExprs
     bool VisitCastExpr(CastExpr *E) {

--- a/test/CheckedC/bounds-decl-checking.c
+++ b/test/CheckedC/bounds-decl-checking.c
@@ -46,3 +46,22 @@ void f6(_Array_ptr<int> p : count(x), int x) {
               // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
 }
+
+// Parameter passing
+
+void test_f1(_Array_ptr<int> arg : bounds(arg, arg + 1));
+
+void test_f2(_Array_ptr<int> arg : count(1)) {
+}
+
+void test_calls(_Array_ptr<int> arg1 : count(1)) {
+  // Passing null, no warning
+  test_f1(0);
+
+  _Array_ptr<int> t1 : bounds(t1, t1 + 1) = 0;
+  // Syntactically identical bounds
+  test_f1(t1);
+
+  // Syntactically identical after expanding count
+  test_f2(t1);
+}

--- a/test/CheckedC/inferred-bounds/calls.c
+++ b/test/CheckedC/inferred-bounds/calls.c
@@ -154,7 +154,7 @@ void f10(_Array_ptr<int> a, _Array_ptr<int> b) {
 
 void f11(_Array_ptr<int> a, _Array_ptr<int> b) {
     _Array_ptr<int> c : bounds(a, a+1) = f_bounds(b++, a); // \
-    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -208,7 +208,7 @@ void f12(int i, int j) {
 
 void f13(int i, int j) {
     _Array_ptr<int> b : count(i) = f_count(j++, i); // \
-    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -254,7 +254,7 @@ void f14(int i, int j) {
 
 void f15(int i, int j) {
     _Array_ptr<int> b : byte_count(i) = f_byte(j++, i); // \
-    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -317,7 +317,7 @@ void f20(int* a, int* b) {
 
 void f21(int* a, int* b) {
     _Array_ptr<int> c : bounds(a, a+1) = f_boundsi(b++, a); // \
-    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -373,7 +373,7 @@ void f22(int i, int j) {
 
 void f23(int i, int j) {
     _Array_ptr<int> b : count(i) = f_counti(j++, i); // \
-    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -421,7 +421,7 @@ void f24(int i, int j) {
 
 void f25(int i, int j) {
     _Array_ptr<int> b : byte_count(i) = f_bytei(j++, i); // \
-    // expected-error {{expression not allowed in argument mentioned in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 


### PR DESCRIPTION
 If a function parameter has a bounds declaration, check that the corresponding argument at a call has known bounds.   This addresses issue #373.

Also plumb in support for checking declared bounds at function calls.  We take the declared parameter bounds for a parameter and substitute the actual arguments to create an expected bounds for the argument.   For arguments for parameters used in bounds expressions, we can't handle modifying (side-effecting) expression. We will issue an error if we see this.   We then try to check that the inferred bounds for each argument expression imply the actual bounds.

Testing:
 - Add a new test file bounds_decl_checking.c to the Checked C repo  tests\static_checking directory.  This checks that expressions  have bounds when expected.
- Add tests to the clang\tests\CheckedC\bounds-decl-checking.c file (for -Wcheck-bounds-decl) that check that warnings are not issued for simple cases such as passing null or an argument whose expected bounds exactly match the bounds for the argument. 
- Update one of the convert LNT benchmarks to add a missing bounds declaration found by this checking.
- Pass automated testing for x64 Linux for the clang regression suite and LNT.
