### PR TITLE
Avoid duplicate error messages when T * is cast to ptr<T>. 

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -312,6 +312,7 @@ public:
 
   bool VisitPositionalParameterExpr(PositionalParameterExpr *PE) {
     Used.set(PE->getIndex());
+    return true;
   }
 
   bool IsUsed(unsigned Index) {

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -721,11 +721,18 @@ namespace {
       if (Ty->isCheckedPointerPtrType()) {
         if (Ty->isFunctionPointerType())
           return CreateBoundsEmpty();
-        ImplicitCastExpr *Base = CreateImplicitCast(Ty, CastKind::CK_LValueToRValue, E);
-        Base->setBoundsSafeInterface(IsBoundsSafeInterface);
+        Expr *Base;
+        if (E->isLValue()) {
+          ImplicitCastExpr *ICE = CreateImplicitCast(Ty, CastKind::CK_LValueToRValue, E);
+          ICE->setBoundsSafeInterface(IsBoundsSafeInterface);
+          Base = ICE;
+        } else
+          Base = E;
         return CreateSingleElementBounds(Base);
+
       } else if (Ty->isCheckedArrayType() && IsParam) {
         assert(IsBoundsSafeInterface && "unexpected checked array type for parameter");
+        assert(E->isLValue());
         BoundsExpr *BE = CreateBoundsForArrayType(Ty);
         ImplicitCastExpr *Base = CreateImplicitCast(Ty, CastKind::CK_LValueToRValue, E);
         Base->setBoundsSafeInterface(IsBoundsSafeInterface);
@@ -905,6 +912,10 @@ namespace {
             llvm_unreachable("unexpected cast failure");
             return CreateBoundsInferenceError();
           }
+          // Casts to _Ptr narrow the bounds.  If the cast to
+          // _Ptr is invalid, that will be diagnosed separately.
+          if (E->getType()->isCheckedPointerPtrType())
+            return CreateTypeBasedBounds(E, E->getType(), false, false);
           return RValueCastBounds(CE->getCastKind(), CE->getSubExpr());
         }
         case Expr::UnaryOperatorClass: {

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -817,7 +817,7 @@ ExprResult Sema::CallExprUnaryConversions(Expr *E) {
     if (getCurScope()->isCheckedScope()) {
       kind = CheckedPointerKind::Ptr;
       if (auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenCasts()))
-        if (auto *FD = dyn_cast<FunctionDecl>(DRE->getDecl()))
+        if (isa<FunctionDecl>(DRE->getDecl()))
           if (Ty->hasUncheckedType()) {
             isBoundsSafeInterfaceCast = true;
             Ty = RewriteBoundsSafeInterfaceTypes(E->getType());

--- a/test/CheckedC/regression-cases/ptr_cast_bug_242.c
+++ b/test/CheckedC/regression-cases/ptr_cast_bug_242.c
@@ -1,5 +1,5 @@
 //
-// These are regression tests case for 
+// These are regression tests cases for 
 // https://github.com/Microsoft/checkedc-clang/issues/242.
 //
 // The tests check that there are not duplicate error messages when a cast to _Ptr

--- a/test/CheckedC/regression-cases/ptr_cast_bug_242.c
+++ b/test/CheckedC/regression-cases/ptr_cast_bug_242.c
@@ -1,0 +1,25 @@
+//
+// These are regression tests case for 
+// https://github.com/Microsoft/checkedc-clang/issues/242.
+//
+// The tests check that there are not duplicate error messages when a cast to _Ptr
+// is incorrect. The incorrect bounds should not propagate through the cast to _Ptr.
+//
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+
+// Test explicit cast.
+void f(int *p) {
+  // Test explicit cast where bounds are expected for the entire initializing expression.
+  _Array_ptr<int> q : count(1) = (_Ptr<int>)(p); // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  // Test explicit cast.
+  _Ptr<int> r = (_Ptr<int>)(p);    // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  // Test implicit cast.
+  _Ptr<int> s = p;                 // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  _Array_ptr<int> t : count(1) = 0; 
+  // Test explicit cast involving assignment;
+  t = (_Ptr<int>)(p);              // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  _Ptr<int> u = 0;
+  // Test implicit cast involving assignment.
+  u = p;                           // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+}
+


### PR DESCRIPTION
This addresses issue #242.  There were duplicate messages when
a value of T * is cast to a ptr variable.  One error message
was generated for the cast.  Another one was generated for the
consumer of the cast.

The fix is to determine the bounds of the cast expression by using
bounds inferred from the target type of the cast, when the target
type is a _Ptr.     This is the correct fix because we should be 
narrowing bounds anyway.

Testing:
- Added regression test case that checks that only one error message
  is issued.
