### PR TITLE
Clean up naming and formatting issues.

### DIFF
--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1857,11 +1857,11 @@ public:
   bool hasUnnamedOrLocalType() const;
 
   /// \brief Whether this type is or contains a checked type
-  bool hasCheckedType() const;
+  bool isOrContainsCheckedType() const;
 
   /// \brief Whether this type is or contains an unchecked type.
   /// This ignores the presence of bounds-safe interface types.
-  bool hasUncheckedType() const;
+  bool isOrContainsUncheckedType() const;
 
   /// \brief Whether this type is or contains a variadic type
   bool hasVariadicType() const;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4496,26 +4496,27 @@ public:
   // \#pragma BOUNDS_CHECKED.
   void ActOnPragmaBoundsChecked(Scope *S, tok::OnOffSwitch OOS);
 
-  // Represents where the requirement that the checked expression is non-modifying
-  // comes from.
-  enum NonModifiyingExprRequirement {
-    NMER_Unknown,
-    NMER_Dynamic_Check,
-    NMER_Bounds_Count,
-    NMER_Bounds_Byte_Count,
-    NMER_Bounds_Range,
-    NMER_Bounds_Function_Return,
-    NMER_Bounds_Function_Parameter
+  // Represents the context where an expression must be non-modifying.
+  enum NonModifyingContext {
+    NMC_Unknown,
+    NMC_Dynamic_Check,
+    NMC_Count,                   // Bounds count expression.
+    NMC_Byte_Count,              // Bounds byte count expression.
+    NMC_Range,                   // Bounds range expression.
+    NMC_Function_Return,         // Argument for parameter used in function
+                                 // return bounds.
+    NMC_Function_Parameter       // Argument for parameter used in function
+                                 // parameter bounds.
   };
 
   BoundsExpr *CreateInvalidBoundsExpr();
   BoundsExpr *CreateCountForArrayType(QualType QT);
 
-  /// CheckNonModifyingExpr - checks whether an expression is non-modifying
+  /// CheckNonModifying - checks whether an expression is non-modifying
   /// (see Checked C Spec, 3.6.1).  Returns true if the expression is non-modifying,
   /// false otherwise.
-  bool CheckIsNonModifyingExpr(Expr *E, NonModifiyingExprRequirement Req =
-                               NonModifiyingExprRequirement::NMER_Unknown,
+  bool CheckIsNonModifying(Expr *E, NonModifyingContext Req =
+                               NonModifyingContext::NMC_Unknown,
                                bool ReportError = true);
 
   BoundsExpr *AbstractForFunctionType(BoundsExpr *Expr,
@@ -4525,7 +4526,7 @@ public:
   BoundsExpr *MakeMemberBoundsConcrete(Expr *MemberBase, bool IsArrow,
                                        BoundsExpr *Bounds);
   BoundsExpr *ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args,
-                                                 NonModifiyingExprRequirement ErrorKind);
+                                                 NonModifyingContext ErrorKind);
 
   /// ConvertToFullyCheckedType: convert an expression E to a fully checked type. This
   /// is used to retype declrefs and member exprs in checked scopes with bounds-safe

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3839,9 +3839,9 @@ bool Type::hasSizedVLAType() const {
   return false;
 }
 
-// hasCheckedType - check whether a type is a checked type or is a constructed
-//  type (array, pointer, function) that uses a checked type.
-bool Type::hasCheckedType() const {
+// isOrContainsCheckedType - check whether a type is a checked type or is a
+// constructed type (array, pointer, function) that uses a checked type.
+bool Type::isOrContainsCheckedType() const {
   const Type *current = CanonicalType.getTypePtr();
   switch (current->getTypeClass()) {
     case Type::Pointer: {
@@ -3849,7 +3849,7 @@ bool Type::hasCheckedType() const {
       if (ptr->isCheckedPointerType()) {
         return true;
       }
-      return ptr->getPointeeType()->hasCheckedType();
+      return ptr->getPointeeType()->isOrContainsCheckedType();
     }
     case Type::ConstantArray:
     case Type::DependentSizedArray:
@@ -3858,15 +3858,15 @@ bool Type::hasCheckedType() const {
      const ArrayType *arr = cast<ArrayType>(current);
       if (arr->isChecked())
         return true;
-      return arr->getElementType()->hasCheckedType();
+      return arr->getElementType()->isOrContainsCheckedType();
     }
     case Type::FunctionProto: {
       const FunctionProtoType *fpt =  cast<FunctionProtoType>(current);
-      if (fpt->getReturnType()->hasCheckedType())
+      if (fpt->getReturnType()->isOrContainsCheckedType())
         return true;
       unsigned int paramCount = fpt->getNumParams();
       for (unsigned int i = 0; i < paramCount; i++) {
-        if (fpt->getParamType(i)->hasCheckedType())
+        if (fpt->getParamType(i)->isOrContainsCheckedType())
           return true;
       }
       return false;
@@ -3876,16 +3876,16 @@ bool Type::hasCheckedType() const {
   }
 }
 
-// hasUncheckedType - check whether a type is a unchecked type or is a
+// isOrContainsUncheckedType - check whether a type is a unchecked type or is a
 // constructed type (array, pointer, function) that uses a unchecked type.
-bool Type::hasUncheckedType() const {
+bool Type::isOrContainsUncheckedType() const {
   const Type *current = CanonicalType.getTypePtr();
   switch (current->getTypeClass()) {
     case Type::Pointer: {
       const PointerType *ptr = cast<PointerType>(current);
       if (ptr->isUncheckedPointerType())
         return true;
-      return ptr->getPointeeType()->hasUncheckedType();
+      return ptr->getPointeeType()->isOrContainsUncheckedType();
     }
     case Type::ConstantArray:
     case Type::DependentSizedArray:
@@ -3894,15 +3894,15 @@ bool Type::hasUncheckedType() const {
      const ArrayType *arr = cast<ArrayType>(current);
       if (!arr->isChecked())
         return true;
-      return arr->getElementType()->hasUncheckedType();
+      return arr->getElementType()->isOrContainsUncheckedType();
     }
     case Type::FunctionProto: {
       const FunctionProtoType *fpt =  cast<FunctionProtoType>(current);
-      if (fpt->getReturnType()->hasUncheckedType())
+      if (fpt->getReturnType()->isOrContainsUncheckedType())
         return true;
       unsigned int paramCount = fpt->getNumParams();
       for (unsigned int i = 0; i < paramCount; i++) {
-        if (fpt->getParamType(i)->hasUncheckedType())
+        if (fpt->getParamType(i)->isOrContainsUncheckedType())
           return true;
       }
       return false;

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2574,18 +2574,18 @@ void CastOperation::CheckCStyleCast() {
   // Checked C - No C-style casts to unchecked pointer/array type or variadic
   // type in a checked block.
   if (Self.getCurScope()->isCheckedScope()) {
-    bool HasUncheckedType = DestType->hasUncheckedType();
+    bool IsUnchecked = DestType->isOrContainsUncheckedType();
     bool HasVariadicType = DestType->hasVariadicType();
     bool ConstructsNullPointer = false;
-    if (HasUncheckedType)
+    if (IsUnchecked)
       if (DestType->isVoidPointerType() &&
           !SrcExpr.isInvalid()) {
         const IntegerLiteral *Lit = dyn_cast<IntegerLiteral>(SrcExpr.get());
         if (Lit && !Lit->getValue())
          ConstructsNullPointer = true;
       }
-    if ((HasUncheckedType && !ConstructsNullPointer) || HasVariadicType) {
-      if (HasUncheckedType) {
+    if ((IsUnchecked && !ConstructsNullPointer) || HasVariadicType) {
+      if (IsUnchecked) {
         Self.Diag(OpRange.getBegin(), diag::err_checked_scope_type_for_casting)
           << DestType;
       } else {
@@ -2644,15 +2644,15 @@ void CastOperation::CheckBoundsCast(tok::TokenKind kind) {
   // Checked C - No C-style casts to unchecked pointer/array type or variadic
   // type in a checked block.
   if (Self.getCurScope()->isCheckedScope()) {
-    bool HasUncheckedType = DestType->hasUncheckedType();
+    bool IsUnchecked = DestType->isOrContainsUncheckedType();
     bool HasVariadicType = DestType->hasVariadicType();
     if (Kind == CK_AssumePtrBounds) {
       Self.Diag(OpRange.getBegin(),
                 diag::err_checked_scope_no_assume_bounds_casting);
       SrcExpr = ExprError();
       return;
-    } else if (HasUncheckedType || HasVariadicType) {
-      if (HasUncheckedType) {
+    } else if (IsUnchecked || HasVariadicType) {
+      if (IsUnchecked) {
         Self.Diag(OpRange.getBegin(), diag::err_checked_scope_type_for_casting)
           << DestType;
       } else {

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -1098,7 +1098,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
 
     Expr *Conditional = TheCall->getArg(0);
 
-    if (!CheckIsNonModifyingExpr(Conditional, NMER_Dynamic_Check))
+    if (!CheckIsNonModifying(Conditional, NMC_Dynamic_Check))
       return ExprError();
 
     WarnDynamicCheckAlwaysFails(Conditional);

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -12177,7 +12177,7 @@ static bool checkBoundsDeclWithTypeAnnotation(Sema &S, QualType DeclaredTy,
   }
 
   // Make sure that the annotation type is a checked type.
-  if (!(Errors & Annot_Illegal_Type) && !AnnotTy->hasCheckedType()) {
+  if (!(Errors & Annot_Illegal_Type) && !AnnotTy->isOrContainsCheckedType()) {
     S.Diag(AnnotTyLoc,
            diag::err_typecheck_bounds_type_annotation_must_be_checked_type);
     Errors |= Annot_Unchecked;
@@ -12370,15 +12370,15 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr) {
     return;
 
   if (Expr) {
-    NonModifiyingExprRequirement req = NMER_Unknown;
+    NonModifyingContext req = NMC_Unknown;
     if (isa<RangeBoundsExpr>(Expr)) {
-      req = NMER_Bounds_Range;
+      req = NMC_Range;
     }
     else if (const CountBoundsExpr *CountBounds = dyn_cast<CountBoundsExpr>(Expr)) {
-      req = CountBounds->isByteCount() ? NMER_Bounds_Byte_Count : NMER_Bounds_Count;
+      req = CountBounds->isByteCount() ? NMC_Byte_Count : NMC_Count;
     }
 
-    if (!CheckIsNonModifyingExpr(Expr, req)) {
+    if (!CheckIsNonModifying(Expr, req)) {
       ActOnInvalidBoundsDecl(D);
       return;
     }

--- a/lib/Sema/SemaExprMember.cpp
+++ b/lib/Sema/SemaExprMember.cpp
@@ -1863,7 +1863,7 @@ Sema::BuildFieldReferenceExpr(Expr *BaseExpr, bool IsArrow,
   // We skip uses of array types here.  They are handled later as part of
   // array-to-pointer decay.
   if (getCurScope()->isCheckedScope() && !MemberType->isArrayType() && 
-      MemberType->hasUncheckedType()) {
+      MemberType->isOrContainsUncheckedType()) {
     assert(!MemberType->isFunctionType());
     return ConvertToFullyCheckedType(ME, Field->getBoundsExpr(), false, VK);
   }


### PR DESCRIPTION
- Rename hasUncheckedType and hasCheckedType to isOrContainsUncheckedType
  and isOrContainsCheckedType.
- Shorten the name for the enum used for error messages involving
  non-modifing expressions.  Also shorten the name of the function
CheckNonModifyingExpr to CheckNonModifying.   The enum name
was inordinately long.
- Fix some line length and extra white space issues.