### PR TITLE
Checked pointer types display incorrectly in aka clauses in diagnostics.

### DIFF
--- a/lib/AST/ASTDiagnostic.cpp
+++ b/lib/AST/ASTDiagnostic.cpp
@@ -177,7 +177,7 @@ break; \
   // FIXME: Handle other pointer-like types.
   if (const PointerType *Ty = QT->getAs<PointerType>()) {
     QT = Context.getPointerType(Desugar(Context, Ty->getPointeeType(),
-                                        ShouldAKA));
+                                        ShouldAKA), Ty->getKind());
   } else if (const auto *Ty = QT->getAs<ObjCObjectPointerType>()) {
     QT = Context.getObjCObjectPointerType(Desugar(Context, Ty->getPointeeType(),
                                                   ShouldAKA));

--- a/test/CheckedC/regression-cases/bug_254_aka_type.c
+++ b/test/CheckedC/regression-cases/bug_254_aka_type.c
@@ -1,0 +1,21 @@
+//
+// These is a regression test case for 
+// https://github.com/Microsoft/checkedc-clang/issues/254
+//
+// This test checks that checked pointers and arrays display
+// properly in "aka" (also known as) clauses printed in clang diagnostics.
+//
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+
+typedef _Ptr<int> DefTy;
+typedef _Ptr<int _Checked[10]> DefArrTy;
+
+void test(DefArrTy arr); // expected-note {{passing argument to parameter 'arr' here}}
+
+void f(void) {
+  int i = 0;
+  DefTy p = i; // expected-error {{initializing 'DefTy' (aka '_Ptr<int>') with an expression of incompatible type 'int'}}
+  test(i);     // expected-error {{passing 'int' to parameter of incompatible type 'DefArrTy' (aka '_Ptr<int checked[10]>')}}
+}
+
+


### PR DESCRIPTION
Checked pointer types were being displayed as unchecked pointer types
in "aka" clauses for types named by typedefs that are printed in
diagnostics.  The "aka" clause displays the underlying type that was
typedef'ed.

The fix is a one-line change in to pass the pointer type kind through
in the Desugar routine in ASTDiagnostics.  This change addresses issue #254.

Testing:
- Add regression test  that checks that checked types display
  properly in "aka" clauses.