### PR TITLE
Parsing and typechecking for new null-terminated array types.

### DIFF
--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -1141,8 +1141,12 @@ public:
 
   /// \brief Return the uniqued reference to the type for a pointer to
   /// the specified type.
-  QualType getPointerType(QualType T, CheckedPointerKind kind = CheckedPointerKind::Unchecked) const;
-  CanQualType getPointerType(CanQualType T, CheckedPointerKind kind = CheckedPointerKind::Unchecked) const {
+  QualType getPointerType(QualType T,
+                          CheckedPointerKind kind =
+                            CheckedPointerKind::Unchecked) const;
+  CanQualType getPointerType(CanQualType T,
+                             CheckedPointerKind kind =
+                               CheckedPointerKind::Unchecked) const {
     return CanQualType::CreateUnsafe(getPointerType((QualType) T, kind));
   }
 
@@ -1243,14 +1247,16 @@ public:
   QualType getIncompleteArrayType(QualType EltTy,
                                   ArrayType::ArraySizeModifier ASM,
                                   unsigned IndexTypeQuals,
-                                  bool isChecked) const;
+                                  CheckedArrayKind =
+                                    CheckedArrayKind::Unchecked) const;
 
   /// \brief Return the unique reference to the type for a constant array of
   /// the specified element type.
   QualType getConstantArrayType(QualType EltTy, const llvm::APInt &ArySize,
                                 ArrayType::ArraySizeModifier ASM,
                                 unsigned IndexTypeQuals,
-                                bool isChecked = false) const;
+                                CheckedArrayKind Kind =
+                                  CheckedArrayKind::Unchecked) const;
   
   /// \brief Returns a vla type where known sizes are replaced with [*].
   QualType getVariableArrayDecayedType(QualType Ty) const;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9110,6 +9110,15 @@ let CategoryName = "Checked C" in {
 def err_checked_vla : Error<
   "checked variable-length array not allowed">;
 
+def err_illegal_decl_nullterm_array_of_nonscalar : Error<
+  "'%0' declared as null-terminated array of type %1; only integer and pointer types allowed">;
+
+def err_illegal_decl_array_ptr_to_function : Error<
+  "'%0' declared as _Array_ptr to function of type %1; use _Ptr to function instead">;
+
+def err_illegal_decl_nt_array_ptr_of_nonscalar : Error<
+  "'%0' declared as _Nt_array_ptr of type %1; only integer and pointer types are allowed">;
+
 def err_checked_cplusplus : Error<
   "checked extension not supported for C++">;
 

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -76,6 +76,7 @@ namespace clang {
     TST_atomic,           // C11 _Atomic
     TST_plainPtr,     // Checked C _Ptr type
     TST_arrayPtr,     // Checked C _Array_ptr type
+    TST_ntarrayPtr ,  // Chcecked C _Nt_array_ptr type
 #define GENERIC_IMAGE_TYPE(ImgType, Id) TST_##ImgType##_t, // OpenCL image types
 #include "clang/Basic/OpenCLImageTypes.def"
     TST_error // erroneous type

--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -635,9 +635,11 @@ ALIAS("_declspec"        , __declspec , KEYMS)
 
 // Checked C Extension
 KEYWORD(_Array_ptr                 , KEYCHECKEDC)
+KEYWORD(_Nt_array_ptr              , KEYCHECKEDC)
 KEYWORD(_Ptr                       , KEYCHECKEDC)
 KEYWORD(_Where                     , KEYCHECKEDC)
 KEYWORD(_Checked                   , KEYCHECKEDC)
+KEYWORD(_Nt_checked                , KEYCHECKEDC)
 KEYWORD(_Unchecked                 , KEYCHECKEDC)
 KEYWORD(_Assume_bounds_cast        , KEYCHECKEDC)
 KEYWORD(_Dynamic_bounds_cast       , KEYCHECKEDC)

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -302,6 +302,7 @@ public:
   static const TST TST_atomic = clang::TST_atomic;
   static const TST TST_plainPtr = clang::TST_plainPtr;
   static const TST TST_arrayPtr = clang::TST_arrayPtr;
+  static const TST TST_nt_arrayPtr = clang::TST_ntarrayPtr;
 #define GENERIC_IMAGE_TYPE(ImgType, Id) \
   static const TST TST_##ImgType##_t = clang::TST_##ImgType##_t;
 #include "clang/Basic/OpenCLImageTypes.def"
@@ -419,7 +420,8 @@ private:
   static bool isTypeRep(TST T) {
     return (T == TST_typename || T == TST_typeofType ||
             T == TST_underlyingType || T == TST_atomic ||
-            T == TST_plainPtr || T == TST_arrayPtr);
+            T == TST_plainPtr || T == TST_arrayPtr ||
+            T == TST_nt_arrayPtr);
   }
   static bool isExprRep(TST T) {
     return (T == TST_typeofExpr || T == TST_decltype);
@@ -1242,8 +1244,8 @@ struct DeclaratorChunk {
     /// True if this dimension was [*].  In this case, NumElts is null.
     unsigned isStar : 1;
 
-    // Checked C - True if this is a checked array.
-    bool isChecked: 1;
+    // Checked C - the kind of checked array
+    unsigned kind: 2;
 
     /// This is the size of the array, or null if [] or [*] was specified.
     /// Since the parser is multi-purpose, and we don't want to impose a root
@@ -1630,7 +1632,7 @@ struct DeclaratorChunk {
   /// \brief Return a DeclaratorChunk for an array.
   static DeclaratorChunk getArray(unsigned TypeQuals,
                                   bool isStatic, bool isStar,
-                                  bool isChecked, Expr *NumElts,
+                                  CheckedArrayKind kind, Expr *NumElts,
                                   SourceLocation LBLoc, SourceLocation RBLoc) {
     DeclaratorChunk I;
     I.Kind          = Array;
@@ -1640,7 +1642,7 @@ struct DeclaratorChunk {
     I.Arr.TypeQuals = TypeQuals;
     I.Arr.hasStatic = isStatic;
     I.Arr.isStar    = isStar;
-    I.Arr.isChecked = (unsigned) isChecked;
+    I.Arr.kind = (unsigned) kind;
     I.Arr.NumElts   = NumElts;
     return I;
   }

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -1304,8 +1304,9 @@ public:
   QualType BuildReferenceType(QualType T, bool LValueRef,
                               SourceLocation Loc, DeclarationName Entity);
   QualType BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
-                          Expr *ArraySize, unsigned Quals, bool IsChecked,
-                          SourceRange Brackets, DeclarationName Entity);
+                          Expr *ArraySize, unsigned Quals,
+                          CheckedArrayKind Kind, SourceRange Brackets,
+                          DeclarationName Entity);
   QualType BuildExtVectorType(QualType T, Expr *ArraySize,
                               SourceLocation AttrLoc);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2708,7 +2708,7 @@ QualType ASTContext::getConstantArrayType(QualType EltTy,
                                           const llvm::APInt &ArySizeIn,
                                           ArrayType::ArraySizeModifier ASM,
                                           unsigned IndexTypeQuals,
-                                          bool IsChecked) const {
+                                          CheckedArrayKind Kind) const {
   assert((EltTy->isDependentType() ||
           EltTy->isIncompleteType() || EltTy->isConstantSizeType()) &&
          "Constant array of VLAs is illegal!");
@@ -2720,7 +2720,7 @@ QualType ASTContext::getConstantArrayType(QualType EltTy,
 
   llvm::FoldingSetNodeID ID;
   ConstantArrayType::Profile(ID, EltTy, ArySize, ASM, IndexTypeQuals,
-                             IsChecked);
+                             Kind);
 
   void *InsertPos = nullptr;
   if (ConstantArrayType *ATP =
@@ -2733,7 +2733,7 @@ QualType ASTContext::getConstantArrayType(QualType EltTy,
   if (!EltTy.isCanonical() || EltTy.hasLocalQualifiers()) {
     SplitQualType canonSplit = getCanonicalType(EltTy).split();
     Canon = getConstantArrayType(QualType(canonSplit.Ty, 0), ArySize,
-                                 ASM, IndexTypeQuals, IsChecked);
+                                 ASM, IndexTypeQuals, Kind);
     Canon = getQualifiedType(Canon, canonSplit.Quals);
 
     // Get the new insert position for the node we care about.
@@ -2744,7 +2744,7 @@ QualType ASTContext::getConstantArrayType(QualType EltTy,
 
   ConstantArrayType *New = new(*this,TypeAlignment)
     ConstantArrayType(EltTy, Canon, ArySize, ASM, IndexTypeQuals,
-                      IsChecked);
+                      Kind);
   ConstantArrayTypes.InsertNode(New, InsertPos);
   Types.push_back(New);
   return QualType(New, 0);
@@ -2842,7 +2842,7 @@ QualType ASTContext::getVariableArrayDecayedType(QualType type) const {
                                   cat->getSize(),
                                   cat->getSizeModifier(),
                                   cat->getIndexTypeCVRQualifiers(),
-                                  cat->isChecked());
+                                  cat->getKind());
     break;
   }
 
@@ -2987,10 +2987,10 @@ QualType ASTContext::getDependentSizedArrayType(QualType elementType,
 QualType ASTContext::getIncompleteArrayType(QualType elementType,
                                             ArrayType::ArraySizeModifier ASM,
                                             unsigned elementTypeQuals,
-                                            bool isChecked) const {
+                                            CheckedArrayKind Kind) const {
   llvm::FoldingSetNodeID ID;
   IncompleteArrayType::Profile(ID, elementType, ASM, elementTypeQuals,
-                               isChecked);
+                               Kind);
 
   void *insertPos = nullptr;
   if (IncompleteArrayType *iat =
@@ -3005,7 +3005,7 @@ QualType ASTContext::getIncompleteArrayType(QualType elementType,
   if (!elementType.isCanonical() || elementType.hasLocalQualifiers()) {
     SplitQualType canonSplit = getCanonicalType(elementType).split();
     canon = getIncompleteArrayType(QualType(canonSplit.Ty, 0),
-                                   ASM, elementTypeQuals, isChecked);
+                                   ASM, elementTypeQuals, Kind);
     canon = getQualifiedType(canon, canonSplit.Quals);
 
     // Get the new insert position for the node we care about.
@@ -3015,7 +3015,7 @@ QualType ASTContext::getIncompleteArrayType(QualType elementType,
   }
 
   IncompleteArrayType *newType = new (*this, TypeAlignment)
-    IncompleteArrayType(elementType, canon, ASM, elementTypeQuals, isChecked);
+    IncompleteArrayType(elementType, canon, ASM, elementTypeQuals, Kind);
 
   IncompleteArrayTypes.InsertNode(newType, insertPos);
   Types.push_back(newType);
@@ -4660,12 +4660,12 @@ QualType ASTContext::getUnqualifiedArrayType(QualType type,
 
   if (const ConstantArrayType *CAT = dyn_cast<ConstantArrayType>(AT)) {
     return getConstantArrayType(unqualElementType, CAT->getSize(),
-                                CAT->getSizeModifier(), 0, CAT->isChecked());
+                                CAT->getSizeModifier(), 0, CAT->getKind());
   }
 
   if (const IncompleteArrayType *IAT = dyn_cast<IncompleteArrayType>(AT)) {
     return getIncompleteArrayType(unqualElementType, IAT->getSizeModifier(), 0,
-                                  IAT->isChecked());
+                                  IAT->getKind());
   }
 
   if (const VariableArrayType *VAT = dyn_cast<VariableArrayType>(AT)) {
@@ -4966,12 +4966,12 @@ const ArrayType *ASTContext::getAsArrayType(QualType T) const {
     return cast<ArrayType>(getConstantArrayType(NewEltTy, CAT->getSize(),
                                                 CAT->getSizeModifier(),
                                            CAT->getIndexTypeCVRQualifiers(),
-                                                CAT->isChecked()));
+                                                CAT->getKind()));
   if (const IncompleteArrayType *IAT = dyn_cast<IncompleteArrayType>(ATy))
     return cast<ArrayType>(getIncompleteArrayType(NewEltTy,
                                                   IAT->getSizeModifier(),
                                            IAT->getIndexTypeCVRQualifiers(),
-                                                  IAT->isChecked()));
+                                                  IAT->getKind()));
 
   if (const DependentSizedArrayType *DSAT
         = dyn_cast<DependentSizedArrayType>(ATy))
@@ -5022,7 +5022,8 @@ QualType ASTContext::getExceptionObjectType(QualType T) const {
 ///
 /// See C99 6.7.5.3p7 and C99 6.3.2.1p3.
 ///
-/// For Checked C, a checked array type can decay to an _Array_ptr type.
+/// For Checked C, a checked array type can decay to an _Array_ptr type or
+/// an Nt_array_ptr type.
 QualType ASTContext::getArrayDecayedType(QualType Ty) const {
   // Get the element type with 'getAsArrayType' so that we don't lose any
   // typedefs in the element type of the array.  This also handles propagation
@@ -5031,9 +5032,18 @@ QualType ASTContext::getArrayDecayedType(QualType Ty) const {
   const ArrayType *PrettyArrayType = getAsArrayType(Ty);
   assert(PrettyArrayType && "Not an array type!");
 
-  CheckedPointerKind checkedKind = PrettyArrayType->isChecked() ?
-    CheckedPointerKind::Array : CheckedPointerKind::Unchecked;
-
+  CheckedArrayKind Kind = PrettyArrayType->getKind();
+  CheckedPointerKind checkedKind = CheckedPointerKind::Unchecked;
+  switch (Kind) {
+    case CheckedArrayKind::Unchecked:
+      checkedKind = CheckedPointerKind::Unchecked;
+      break;
+    case CheckedArrayKind::Checked:
+      checkedKind = CheckedPointerKind::Array;
+      break;
+    case CheckedArrayKind::NtChecked:
+      checkedKind = CheckedPointerKind::NtArray;
+  }
   QualType PtrTy = getPointerType(PrettyArrayType->getElementType(),
                                   checkedKind);
 
@@ -7909,13 +7919,14 @@ QualType ASTContext::matchArrayCheckedness(QualType LHS, QualType RHS) {
           const ConstantArrayType *rhsca = cast<ConstantArrayType>(rhsTy);
           QualType result = getConstantArrayType(elemTy, rhsca->getSize(),
                                                  rhsca->getSizeModifier(), RHS.getCVRQualifiers(),
-                                                 true);
+                                                 CheckedArrayKind::Checked);
           return result;
       }
       else if (rhsTypeClass == Type::IncompleteArray) {
           const IncompleteArrayType *rhsic = cast<IncompleteArrayType>(rhsTy);
           QualType result = getIncompleteArrayType(elemTy, rhsic->getSizeModifier(),
-                                                   RHS.getCVRQualifiers(), true);
+                                                   RHS.getCVRQualifiers(),
+                                                   CheckedArrayKind::Checked);
           return result;
       }
     }
@@ -8422,8 +8433,8 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS,
   {
     const ArrayType *LHSArrayType = getAsArrayType(LHS);
     const ArrayType *RHSArrayType = getAsArrayType(RHS);
-    bool isChecked = LHSArrayType->isChecked();
-    if (isChecked != RHSArrayType->isChecked()) {
+    CheckedArrayKind Kind = LHSArrayType->getKind();
+    if (Kind != RHSArrayType->getKind()) {
       return QualType();
     }
 
@@ -8448,10 +8459,10 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS,
       return RHS;
     if (LCAT) return getConstantArrayType(ResultType, LCAT->getSize(),
                                           ArrayType::ArraySizeModifier(), 0,
-                                          isChecked);
+                                          Kind);
     if (RCAT) return getConstantArrayType(ResultType, RCAT->getSize(),
                                           ArrayType::ArraySizeModifier(), 0,
-                                          isChecked);
+                                          Kind);
     const VariableArrayType* LVAT = getAsVariableArrayType(LHS);
     const VariableArrayType* RVAT = getAsVariableArrayType(RHS);
     if (LVAT && getCanonicalType(LHSElem) == getCanonicalType(ResultType))
@@ -8474,7 +8485,7 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS,
     if (getCanonicalType(RHSElem) == getCanonicalType(ResultType)) return RHS;
     return getIncompleteArrayType(ResultType,
                                   ArrayType::ArraySizeModifier(), 0,
-                                  isChecked);
+                                  Kind);
   }
   case Type::FunctionNoProto:
     return mergeFunctionTypes(LHS, RHS, OfBlockPointer, Unqualified,

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -460,7 +460,7 @@ QualType ASTNodeImporter::VisitConstantArrayType(const ConstantArrayType *T) {
                                                       T->getSize(),
                                                       T->getSizeModifier(),
                                                T->getIndexTypeCVRQualifiers(),
-                                                      T->isChecked());
+                                                      T->getKind());
 }
 
 QualType
@@ -472,7 +472,7 @@ ASTNodeImporter::VisitIncompleteArrayType(const IncompleteArrayType *T) {
   return Importer.getToContext().getIncompleteArrayType(ToElementType, 
                                                         T->getSizeModifier(),
                                                 T->getIndexTypeCVRQualifiers(),
-                                                      T->isChecked());
+                                                      T->getKind());
 }
 
 QualType ASTNodeImporter::VisitVariableArrayType(const VariableArrayType *T) {

--- a/lib/AST/MicrosoftMangle.cpp
+++ b/lib/AST/MicrosoftMangle.cpp
@@ -1545,7 +1545,7 @@ void MicrosoftCXXNameMangler::mangleArgumentType(QualType T,
       OriginalType = getASTContext().getIncompleteArrayType(
           AT->getElementType(), AT->getSizeModifier(),
           AT->getIndexTypeCVRQualifiers(),
-          AT->isChecked());
+          AT->getKind());
 
     TypePtr = OriginalType.getCanonicalType().getAsOpaquePtr();
     // If the original parameter was textually written as an array,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -127,10 +127,9 @@ DependentSizedArrayType::DependentSizedArrayType(const ASTContext &Context,
                                                  SourceRange brackets)
     : ArrayType(DependentSizedArray, et, can, sm, tq, 
                 (et->containsUnexpandedParameterPack() ||
-                 (e && e->containsUnexpandedParameterPack())), /*IsChecked=*/false),
-      Context(Context), SizeExpr((Stmt*) e), Brackets(brackets) 
-{
-}
+                 (e && e->containsUnexpandedParameterPack())),
+                CheckedArrayKind::Unchecked),
+      Context(Context), SizeExpr((Stmt*) e), Brackets(brackets) {}
 
 void DependentSizedArrayType::Profile(llvm::FoldingSetNodeID &ID,
                                       const ASTContext &Context,
@@ -768,7 +767,7 @@ public:
     return Ctx.getConstantArrayType(elementType, T->getSize(),
                                     T->getSizeModifier(),
                                     T->getIndexTypeCVRQualifiers(),
-                                    T->isChecked());
+                                    T->getKind());
   }
 
   QualType VisitVariableArrayType(const VariableArrayType *T) {
@@ -795,7 +794,7 @@ public:
 
     return Ctx.getIncompleteArrayType(elementType, T->getSizeModifier(),
                                       T->getIndexTypeCVRQualifiers(),
-                                      T->isChecked());
+                                      T->getKind());
   }
 
   QualType VisitVectorType(const VectorType *T) { 

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -346,11 +346,19 @@ void TypePrinter::printPointerBefore(const PointerType *T, raw_ostream &OS) {
     OS << '*';
   }
   else {
-    if (T->getKind() == CheckedPointerKind::Ptr) {
-      OS << "_Ptr<";
-    }
-    else {
-      OS << "_Array_ptr<";
+    switch (T->getKind()) {
+      case CheckedPointerKind::Unchecked:
+        llvm_unreachable("should have been handled already");
+        break;
+      case CheckedPointerKind::Ptr:
+        OS << "_Ptr<";
+        break;
+      case CheckedPointerKind::Array:
+        OS << "_Array_ptr<";
+        break;
+      case CheckedPointerKind::NtArray:
+        OS << "_Nt_array_ptr<";
+        break;
     }
     print(T->getPointeeType(), OS, StringRef());
     OS << '>';

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -475,8 +475,10 @@ void TypePrinter::printConstantArrayBefore(const ConstantArrayType *T,
 // printer that recursively calls itself with the state.
 void TypePrinter::printArrayAfter(const ArrayType *T, Qualifiers Quals, raw_ostream &OS,
                                   bool checkedOuterDimension) {
-  if (T->isChecked() && !checkedOuterDimension)
+  if (T->isExactlyChecked() && !checkedOuterDimension)
     OS << "checked";
+  else if (T->isNtChecked())
+      OS << "nt_checked";
   else if (checkedOuterDimension && !T->isChecked()) {
     // This case is never supposed to happen, but print an accurate type name if it does.
     OS << "unchecked";

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3047,9 +3047,9 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
     const llvm::APInt ArySize = caType->getSize();
     ArrayType::ArraySizeModifier ASM = caType->getSizeModifier();
     unsigned IndexTypeQuals = caType->getIndexTypeCVRQualifiers();
-    bool isChecked = caType->isChecked();
+    CheckedArrayKind Kind = caType->getKind();
     return Actions.getASTContext().getConstantArrayType(EltTy, ArySize, ASM, 
-                                                  IndexTypeQuals, isChecked);
+                                                  IndexTypeQuals, Kind);
   }
   case Type::VariableArray: {
     const VariableArrayType *vaType = dyn_cast<VariableArrayType>(T);
@@ -3074,9 +3074,9 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
     QualType EltTy = SubstituteTypeVariable(iaType->getElementType(), typeNames);
     ArrayType::ArraySizeModifier ASM = iaType->getSizeModifier();
     unsigned IndexTypeQuals = iaType->getIndexTypeCVRQualifiers();
-    bool isChecked = iaType->isChecked();
+    CheckedArrayKind Kind = iaType->getKind();
     return Actions.getASTContext().getIncompleteArrayType(EltTy, ASM, 
-                                                    IndexTypeQuals, isChecked);
+                                                    IndexTypeQuals, Kind);
   }
   case Type::DependentSizedArray: {
     const DependentSizedArrayType *dsaType = dyn_cast<DependentSizedArrayType>(T);

--- a/lib/Parse/ParseExprCXX.cpp
+++ b/lib/Parse/ParseExprCXX.cpp
@@ -2847,7 +2847,7 @@ void Parser::ParseDirectNewDeclarator(Declarator &D) {
 
     D.AddTypeInfo(DeclaratorChunk::getArray(0,
                                             /*static=*/false, /*star=*/false,
-                                            /*isChecked=*/false,
+                                            CheckedArrayKind::Unchecked,
                                             Size.get(),
                                             T.getOpenLocation(),
                                             T.getCloseLocation()),

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -356,6 +356,7 @@ bool Declarator::isDeclarationOfFunction() const {
     case TST_wchar:
     case TST_arrayPtr:
     case TST_plainPtr:
+    case TST_ntarrayPtr:
 #define GENERIC_IMAGE_TYPE(ImgType, Id) case TST_##ImgType##_t:
 #include "clang/Basic/OpenCLImageTypes.def"
       return false;
@@ -541,8 +542,9 @@ const char *DeclSpec::getSpecifierName(DeclSpec::TST T,
   case DeclSpec::TST_underlyingType: return "__underlying_type";
   case DeclSpec::TST_unknown_anytype: return "__unknown_anytype";
   case DeclSpec::TST_atomic: return "_Atomic";
-  case DeclSpec::TST_arrayPtr: return "_ArrayPtr";
+  case DeclSpec::TST_arrayPtr: return "_Array_ptr";
   case DeclSpec::TST_plainPtr: return "_Ptr";
+  case DeclSpec::TST_nt_arrayPtr: return "_Nt_array_ptr";
 #define GENERIC_IMAGE_TYPE(ImgType, Id) \
   case DeclSpec::TST_##ImgType##_t: \
     return #ImgType "_t";

--- a/lib/Sema/Sema.cpp
+++ b/lib/Sema/Sema.cpp
@@ -850,7 +850,7 @@ void Sema::ActOnEndOfTranslationUnit() {
       llvm::APInt One(Context.getTypeSize(Context.getSizeType()), true);
       QualType T = Context.getConstantArrayType(ArrayT->getElementType(),
                                                 One, ArrayType::Normal, 0,
-                                                ArrayT->isChecked());
+                                                ArrayT->getKind());
       VD->setType(T);
     } else if (RequireCompleteType(VD->getLocation(), VD->getType(),
                                    diag::err_tentative_def_incomplete_type))

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -12312,7 +12312,7 @@ static bool checkBoundsDeclWithBoundsExpr(Sema &S, QualType Ty,
 bool Sema::DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
                                   BoundsExpr *Expr, bool IsReturnBounds) {
   assert(D != nullptr || IsReturnBounds);
-  if (Expr->isInvalid())
+  if ((D != nullptr && D->isInvalidDecl()) || Expr->isInvalid())
     return false;
 
   bool result = true;
@@ -12361,7 +12361,7 @@ static void HandleVarDeclBounds(Sema &S, VarDecl *D, BoundsExpr *Expr) {
 // - For VarDecls, make sure that a bounds expression on a redeclaration
 // is valid.
 void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsExpr *Expr) {
-  if (!D)
+  if (!D || D->isInvalidDecl())
     return;
 
   assert(!isa<FunctionDecl>(D) && "unexpected function decl");

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -6621,8 +6621,8 @@ static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
      }
      else if (rhsKind == CheckedPointerKind::Unchecked) {
        // Same as above, but reversed.
-       resultKind = (rhsKind == CheckedPointerKind::NtArray) ?
-         CheckedPointerKind::Array : rhsKind;
+       resultKind = (lhsKind == CheckedPointerKind::NtArray) ?
+         CheckedPointerKind::Array : lhsKind;
        if (CompositeTy.isNull() && S.Context.pointeeTypesAreAssignable(lhptee, rhptee)) {
          CompositeTy = lhptee;
        }

--- a/lib/Sema/SemaExprCXX.cpp
+++ b/lib/Sema/SemaExprCXX.cpp
@@ -1991,7 +1991,8 @@ Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
           ArrayType::Normal, 0);
     else if (ArraySize)
       InitType =
-          Context.getIncompleteArrayType(AllocType, ArrayType::Normal, 0, false);
+          Context.getIncompleteArrayType(AllocType, ArrayType::Normal, 0,
+                                         CheckedArrayKind::Unchecked);
     else
       InitType = AllocType;
 

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -7164,7 +7164,7 @@ InitializationSequence::Perform(Sema &S,
                                              IncompleteDest->getElementType(),
                                              ConstantSource->getSize(),
                                              ArrayType::Normal, 0,
-                                             IncompleteDest->isChecked());
+                                             IncompleteDest->getKind());
           }
         }
       }

--- a/lib/Sema/SemaTemplateVariadic.cpp
+++ b/lib/Sema/SemaTemplateVariadic.cpp
@@ -702,7 +702,8 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
   case TST_underlyingType:
   case TST_atomic:
   case TST_plainPtr:
-  case TST_arrayPtr: {
+  case TST_arrayPtr:
+  case TST_ntarrayPtr: {
     QualType T = DS.getRepAsType().get();
     if (!T.isNull() && T->containsUnexpandedParameterPack())
       return true;

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -1483,20 +1483,36 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
     break;
   }
   case DeclSpec::TST_plainPtr:
-  case DeclSpec::TST_arrayPtr: {
+  case DeclSpec::TST_arrayPtr:
+  case DeclSpec::TST_nt_arrayPtr: {
       Result = S.GetTypeFromParser(DS.getRepAsType());
-      assert(!Result.isNull() && "Didn't get a type for _Ptr or _Array_ptr?");
+      assert(!Result.isNull() &&
+             "Didn't get a type for _Ptr, _Array_ptr, or _Nt_array_ptr?");
       // The name we're declaring, if any.
       DeclarationName Name;
       if (declarator.getIdentifier())
         Name = declarator.getIdentifier();
-      CheckedPointerKind kind;
-      if (DS.getTypeSpecType() == DeclSpec::TST_plainPtr) {
-        kind = CheckedPointerKind::Ptr;
-      } else {
-        kind = CheckedPointerKind::Array;
+      CheckedPointerKind Kind = CheckedPointerKind::Ptr;
+      TypeSpecifierType TS = DS.getTypeSpecType();
+      switch (TS) {
+        case DeclSpec::TST_plainPtr:
+          Kind = CheckedPointerKind::Ptr;
+          break;
+        case DeclSpec::TST_arrayPtr:
+          Kind = CheckedPointerKind::Array;
+          break;
+        case DeclSpec::TST_nt_arrayPtr:
+          Kind = CheckedPointerKind::NtArray;
+          break;
+        default:
+            llvm_unreachable("unexpected type spec type");
+            break;
       }
-      Result = S.BuildPointerType(Result, kind, DS.getTypeSpecTypeLoc(), Name);
+      Result = S.BuildPointerType(Result, Kind, DS.getTypeSpecTypeLoc(), Name);
+      if (Result.isNull()) {
+        Result = Context.IntTy;
+        declarator.setInvalidType(true);
+      }
       break;
   }
   case DeclSpec::TST_decltype: {
@@ -1910,6 +1926,23 @@ QualType Sema::BuildPointerType(QualType T, CheckedPointerKind kind,
   if (getLangOpts().ObjCAutoRefCount)
     T = inferARCLifetimeForPointee(*this, T, Loc, /*reference*/ false);
 
+  // In Checked C, _Array_ptr of functions is not allowed
+  if ((kind == CheckedPointerKind::Array ||
+       kind == CheckedPointerKind::NtArray) && T->isFunctionType()) {
+    Diag(Loc, diag::err_illegal_decl_array_ptr_to_function)
+      << getPrintableNameForEntity(Entity) << T;
+    return QualType();
+  }
+
+  // In Checked C, null-terminated array_ptr of non-integer/non-pointer are not
+  // allowed
+  if (kind == CheckedPointerKind::NtArray && !T->isIntegerType() &&
+      !T->isPointerType()) {
+    Diag(Loc, diag::err_illegal_decl_nt_array_ptr_of_nonscalar)
+      << getPrintableNameForEntity(Entity) << T;
+    return QualType();
+  }
+
   // Build the pointer type.
   return Context.getPointerType(T, kind);
 }
@@ -2039,7 +2072,7 @@ static bool isArraySizeVLA(Sema &S, Expr *ArraySize, llvm::APSInt &SizeVal) {
 /// returns a NULL type.
 QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
                               Expr *ArraySize, unsigned Quals,
-                              bool IsChecked, SourceRange Brackets,
+                              CheckedArrayKind Kind, SourceRange Brackets,
                               DeclarationName Entity) {
 
   SourceLocation Loc = Brackets.getBegin();
@@ -2091,6 +2124,13 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
     return QualType();
   }
 
+  if (Kind == CheckedArrayKind::NtChecked && !T->isIntegerType() &&
+      !T->isPointerType()) {
+    Diag(Loc, diag::err_illegal_decl_nullterm_array_of_nonscalar)
+      << getPrintableNameForEntity(Entity) << T;
+    return QualType();
+  }
+
   if (const RecordType *EltTy = T->getAs<RecordType>()) {
     // If the element type is a struct or union that contains a variadic
     // array, accept it as a GNU extension: C99 6.7.2.1p2.
@@ -2132,7 +2172,7 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
     if (ASM == ArrayType::Star)
       T = Context.getVariableArrayType(T, nullptr, ASM, Quals, Brackets);
     else
-      T = Context.getIncompleteArrayType(T, ASM, Quals, IsChecked);
+      T = Context.getIncompleteArrayType(T, ASM, Quals, Kind);
   } else if (ArraySize->isTypeDependent() || ArraySize->isValueDependent()) {
     T = Context.getDependentSizedArrayType(T, ArraySize, ASM, Quals, Brackets);
   } else if ((!T->isDependentType() && !T->isIncompleteType() &&
@@ -2190,8 +2230,7 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
       }
     }
 
-    T = Context.getConstantArrayType(T, ConstVal, ASM, Quals,
-                                     IsChecked);
+    T = Context.getConstantArrayType(T, ConstVal, ASM, Quals, Kind);
   }
 
   // OpenCL v1.2 s6.9.d: variable length arrays are not supported.
@@ -2204,7 +2243,7 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
   if (getLangOpts().CUDA && T->isVariableArrayType())
     CUDADiagIfDeviceCode(Loc, diag::err_cuda_vla) << CurrentCUDATarget();
 
-  if (getLangOpts().CheckedC && IsChecked) {
+  if (getLangOpts().CheckedC && Kind != CheckedArrayKind::Unchecked) {
     // checked extensions are not supported for variable length arrays.
     if (T->isVariableArrayType()) {
       Diag(Loc, diag::err_checked_vla);
@@ -3676,14 +3715,14 @@ QualType Sema::MakeCheckedArrayType(QualType T, bool Diagnose,
                                             constArrTy->getSize(),
                                             constArrTy->getSizeModifier(),
                                             T.getCVRQualifiers(),
-                                            true);
+                                            CheckedArrayKind::Checked);
       }
       case Type::IncompleteArray: {
         const IncompleteArrayType *incArrTy = cast<IncompleteArrayType>(ty);
         return Context.getIncompleteArrayType(elemTy,
                                               incArrTy->getSizeModifier(),
                                               T.getCVRQualifiers(),
-                                              true);
+                                              CheckedArrayKind::Checked);
       }
       case Type::DependentSizedArray:
       case Type::VariableArray:
@@ -4252,16 +4291,19 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         checkNullabilityConsistency(S, SimplePointerKind::Array, DeclType.Loc);
       }
 
-      bool isChecked = ATI.isChecked;
+      CheckedArrayKind Kind = (CheckedArrayKind) ATI.kind;
       // Handle multi-dimensional arrays for Checked C. A multi-dimensional
       // array is an array of arrays, so look for a nested type that is an array.
       // - Dimensions must either all be checked or all be unchecked.
       // - The checked property propagates to nested array types, if the array
       //   types are unchecked.  The nested array types must be declared as part
       //   of this declaration.
+      //
+      // Note that we can ignore null-termined arrays here.  Null-terminated
+      // arrays of arrays are not allowed.
       if (const ArrayType *AT = dyn_cast<ArrayType>(T.getCanonicalType())) {
-        if (isChecked != AT->isChecked()) {
-          if (isChecked) 
+        if (Kind != AT->getKind()) {
+          if (Kind == CheckedArrayKind::Checked)
             // The new array type is checked. Propagate this to nested array types
             // declared as part of this declaration.
             T = S.MakeCheckedArrayType(T, true, DeclType.Loc);
@@ -4275,7 +4317,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
               const DeclaratorChunk &DC = D.getTypeObject(x);
               if (DC.Kind == DeclaratorChunk::Array) {
                 const DeclaratorChunk::ArrayTypeInfo &ParentInfo = DC.Arr;
-                if (ParentInfo.isChecked) {
+                if ((CheckedArrayKind) ParentInfo.kind == CheckedArrayKind::Checked) {
                   parentIsChecked = true;
                   break;
                 }
@@ -4297,7 +4339,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         }
       }
 
-      T = S.BuildArrayType(T, ASM, ArraySize, ATI.TypeQuals, isChecked,
+      T = S.BuildArrayType(T, ASM, ArraySize, ATI.TypeQuals, Kind,
                            SourceRange(DeclType.Loc, DeclType.EndLoc), Name);
       break;
     }

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4307,8 +4307,10 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
             // types declared as part of this declaration.
             T = S.MakeCheckedArrayType(T, true, DeclType.Loc);
           else if (Kind == CheckedArrayKind::NtChecked) {
-            // Do not propagate - null-terminated arrays of arrays are not
-            // allowed and BuildArrayType will issue an error.
+            // Do not propagate. Null-terminated arrays of arrays are illegal to
+            // declare, so we don't care about the checkedness of arrays nested
+            // with them.  The call to BuildArrayType below will issue a
+            // diagnostic message about the illegal array type.
           } else {
             // The new array type is unchecked and the nested array type is checked,
             // See if an enclosing array type will eventually make the new array

--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -5753,20 +5753,20 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
     QualType ElementType = readType(*Loc.F, Record, Idx);
     ArrayType::ArraySizeModifier ASM = (ArrayType::ArraySizeModifier)Record[1];
     unsigned IndexTypeQuals = Record[2];
-    bool IsChecked = Record[3];
+    CheckedArrayKind Kind = (CheckedArrayKind) Record[3];
     unsigned Idx = 4;
     llvm::APInt Size = ReadAPInt(Record, Idx);
     return Context.getConstantArrayType(ElementType, Size,
-                                         ASM, IndexTypeQuals, IsChecked);
+                                         ASM, IndexTypeQuals, Kind);
   }
 
   case TYPE_INCOMPLETE_ARRAY: {
     QualType ElementType = readType(*Loc.F, Record, Idx);
     ArrayType::ArraySizeModifier ASM = (ArrayType::ArraySizeModifier)Record[1];
     unsigned IndexTypeQuals = Record[2];
-    bool isChecked = Record[3];
+    CheckedArrayKind Kind = (CheckedArrayKind) Record[3];
     return Context.getIncompleteArrayType(ElementType, ASM, IndexTypeQuals,
-                                          isChecked);
+                                          Kind);
   }
 
   case TYPE_VARIABLE_ARRAY: {

--- a/lib/Serialization/ASTWriter.cpp
+++ b/lib/Serialization/ASTWriter.cpp
@@ -214,7 +214,7 @@ void ASTTypeWriter::VisitArrayType(const ArrayType *T) {
   Record.AddTypeRef(T->getElementType());
   Record.push_back(T->getSizeModifier()); // FIXME: stable values
   Record.push_back(T->getIndexTypeCVRQualifiers()); // FIXME: stable values
-  Record.push_back(T->isChecked());
+  Record.push_back((unsigned)T->getKind());
 }
 
 void ASTTypeWriter::VisitConstantArrayType(const ConstantArrayType *T) {

--- a/test/CheckedC/typechecking.c
+++ b/test/CheckedC/typechecking.c
@@ -33,7 +33,7 @@ _Ptr<int> f100(a, b)
 ///////////////////////////////////////////////////////////////////////////////
 
 void f101(void) {
-  _Array_ptr<int> void a; // expected-error {{cannot combine with previous '_ArrayPtr' declaration specifier}}
+  _Array_ptr<int> void a; // expected-error {{cannot combine with previous '_Array_ptr' declaration specifier}}
   int _Array_ptr<int> b;  // expected-error {{cannot combine with previous 'int' declaration specifier}}
   _Ptr<int> void c = 0;   // expected-error {{cannot combine with previous '_Ptr' declaration specifier}}
   int _Ptr<int> d;        // expected-error {{cannot combine with previous 'int' declaration specifier}}


### PR DESCRIPTION
This change adds parsing and type checking for two new kinds of Checked C types: null-terminated arrays and pointers to null-terminated arrays.  Null-terminated arrays are written using the `nt_checked` keyword in place of the `checked` keyword.  An example declaration is `int arr nt_checked[10];`.   Pointers to null-terminated arrays are constructed using the  `nt_array_ptr` keyword instead of the `array_ptr` keyword (the backward-compatible names for the keywords are `_Nt_checked` and `_Nt_array_ptr`).

To represent nt_array_ptrs in the IR, the existing enumeration for the different kinds of pointers is extended.  For nt_checked arrays, the boolean indicating whether or not an array is checked is changed to an enumeration.  The parsing changes are straightforward.  The new keywords are recognized at the points where the existing Checked C keywords are recognized.  They are then mapped to the appropriate enumeration tag.

For type checking,  the profile methods for type object memorization/construction are changed to take into account the enumeration changes.    We also add checks that null-terminated arrays and pointers are only  constructed from integer or pointer types (the assumption for now is that the integer 0 will be the null terminator, so only data for which 0 is a valid value can be null-terminated).  We do not allow nt_array_ptrs of void (the problem is that conversions through void could allow the null terminator to be partially overwritten when types larger than a character are involved).

With these rules we can construct interesting data structures, such as arrays of null-terminated pointers (i.e. arrays of strings), arrays of null-terminated pointers to null-terminated pointers (and so on), and arrays of null-terminated arrays (arrays of pre-allocated strings of fixed sizes).

Most of the typechecking changes are extending the implicit conversion logic in SemaExpr.cpp to implement the implicit conversion rules for nt_array_ptr.  An nt_array_ptr can be converted implicitly to an array_ptr or ptr (bounds checking and checking of bounds declarations will prevent the null terminator from being overwritten).  However, implicit conversions in the other direction are not allowed. An unchecked pointer, array_ptr, or ptr cannot be converted implicitly to an array_ptr.  The data in memory may not be null-terminated or, if it is, there may be an alias that allows the terminator to be overwritten.

For conditional expressions (`e1 ? e2 : e3`), the implicit conversion rules are a bit more complex.  If the type of one arm of the conditional expression is an nt_array_ptr and the type of the other arm is an unchecked pointer or array_ptr, the resulting type is an array_ptr. Bounds checking will prevent the null terminator from being overwritten.

For pointers to arrays, we allow an unchecked array to be converted to a checked array, but not vice versa.  We do not allow an unchecked array to be converted to an nt_array.

This change contains code for one additional issue: we now disallow array_ptrs of function types (https://github.com/Microsoft/checkedc/issues/34).  This is because functions are indeterminate in size, so no bounds checking is possible.  We allow array_ptrs of ptrs to function types.

Testing:
- Extended the existing Checked C typechecking tests to cover nt_array_ptrs and checked arrays. Most of this work for this change went into extending those tests. These tests are pretty comprehensive and cover many situations where types are checked.   This will we be covered by a separate pull request for the Checked C repo.
- Passes existing automated testing for Linux and Windows, including the LNT test suite and LNT tests that have been converted to Checked C.