### PR TITLE
String literals with checked types and improved support for array literals.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9347,9 +9347,6 @@ def err_bounds_type_annotation_lost_checking : Error<
   def note_checked_scope_problem_type : Note<
      "%0 is not allowed in a checked scope">;
 
-  def err_checked_scope_type_for_casting : Error<
-    "invalid casting to unchecked type %0 in a checked scope">;
-
   def err_checked_scope_no_prototype_func : Error<
     "function without a prototype cannot be used or declared in a checked scope">;
 
@@ -9359,9 +9356,6 @@ def err_bounds_type_annotation_lost_checking : Error<
 
  def err_checked_scope_type_variable_args : Error<
     "type in a checked scope cannot have variable arguments">;
-
-  def err_checked_scope_no_variable_args_for_casting : Error<
-    "invalid casting to type having variable arguments in a checked scope">;
 
   def err_checked_scope_no_variadic_func_for_declaration : Error<
     "variable arguments function cannot be made in a checked scope">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9332,10 +9332,14 @@ def err_bounds_type_annotation_lost_checking : Error<
     "|argument for parameter used in function return bounds expression"
     "|argument for parameter used in function parameter bounds expression}1">;
 
-  def err_checked_scope_type: Error<
+  def err_checked_scope_decl_type: Error<
     "%select{parameter|return|local variable|global variable|member}0 %select{|used }1in a checked scope must have "
     "%select{a |a pointer, array or function type that uses only |a bounds-safe interface type that uses only }2"
     "checked %plural{0:type %plural{2:|:or a bounds-safe interface}0|:types or parameter/return types with bounds-safe interfaces}2">;
+
+  def err_checked_scope_type: Error<
+    "type in a checked scope must %plural{0:be a checked pointer or array type"
+    "|:use only checked types or parameter/return types with bounds-safe interfaces}0">;
 
   def note_checked_scope_declaration : Note<
     "%select{parameter|return|local variable|global variable|member}0 declared here">;
@@ -9349,9 +9353,12 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_checked_scope_no_prototype_func : Error<
     "function without a prototype cannot be used or declared in a checked scope">;
 
-  def err_checked_scope_no_variable_args : Error<
+  def err_checked_scope_decl_variable_args : Error<
     "%select{parameter|return|local variable|global variable|member}0 %select{|used }1in a checked scope "
     "cannot have variable arguments">;
+
+ def err_checked_scope_type_variable_args : Error<
+    "type in a checked scope cannot have variable arguments">;
 
   def err_checked_scope_no_variable_args_for_casting : Error<
     "invalid casting to type having variable arguments in a checked scope">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -3831,6 +3831,8 @@ public:
   bool DiagnoseCheckedDecl(const ValueDecl *D,
                            SourceLocation UseLoc = SourceLocation());
 
+  bool DiagnoseTypeInCheckedScope(QualType Ty, SourceLocation Start, SourceLocation End);
+
   /// \brief Warn if we're implicitly casting from a _Nullable pointer type to a
   /// _Nonnull one.
   void diagnoseNullableToNonnullConversion(QualType DstType, QualType SrcType,

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -690,8 +690,10 @@ namespace {
           return LValueBounds(ICE->getSubExpr());
          return CreateBoundsUnknown();
       }
-      // TODO: fill in these cases.
+      // TODO: these cases need CurrentExprValue to be implemented to express
+      // the bounds.
       case Expr::CompoundLiteralExprClass:
+      case Expr::StringLiteralClass:
         return CreateBoundsAllowedButNotComputed();
       default:
         return CreateBoundsUnknown();

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -1732,7 +1732,7 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
   // the nul terminator character as well as the string length for pascal
   // strings.
   CheckedArrayKind ArrayKind = getCurScope()->isCheckedScope() ?
-    CheckedArrayKind::Checked : CheckedArrayKind::Unchecked;
+    CheckedArrayKind::NtChecked : CheckedArrayKind::Unchecked;
 
   QualType StrTy = Context.getConstantArrayType(CharTyConst,
                                                 llvm::APInt(32, Literal.GetNumStringChars() + 1),

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -160,7 +160,8 @@ static void CheckStringInit(Expr *Str, QualType &DeclT, const ArrayType *AT,
     // Return a new array type (C99 6.7.8p22).
     DeclT = S.Context.getConstantArrayType(IAT->getElementType(),
                                            ConstVal,
-                                           ArrayType::Normal, 0);
+                                           ArrayType::Normal, 0,
+                                           IAT->getKind());
     updateStringLiteralType(Str, DeclT);
     return;
   }
@@ -1698,7 +1699,8 @@ void InitListChecker::CheckArrayType(const InitializedEntity &Entity,
     }
 
     DeclType = SemaRef.Context.getConstantArrayType(elementType, maxElements,
-                                                     ArrayType::Normal, 0);
+                                                     ArrayType::Normal, 0,
+                                                    arrayType->getKind());
   }
   if (!hadError && VerifyOnly) {
     // If there are any members of the array that get value-initialized, check


### PR DESCRIPTION
This adds compiler support for using string literals in checked scopes.   In C, a string literal has the type "array of character", where there are several possible character types.  In Checked C, that corresponds to an "unchecked array of character".  To be able to use string in checked scopes, we need a way that they can be typed as a "checked null-terminated array of characters."

We support this in two ways.  First we alter the type of string literals that appears in checked scopes to have null-terminated array types.   Array-to-pointer conversion converts this to having an nt_array_ptr test, and at assignments nt_array_ptr can converted array_ptr..

Second,  we allow array literals (of which strings are a special case) to be converted implicitly to a checked pointer type when a checked pointer type is expected.  The checked pointer type should have the same pointer kind as the expected pointer type.    The implicit conversions can happen at assignments, function calls, and within initializers.    The language rules haven't been added to the Checked C specification yet.  The proposed rule is described[here](https://github.com/Microsoft/checkedc/issues/207).

Array literals specified using initializers or compound literal expressions already worked for the most part.   The C language rules use the type of the variable being initialized or the type of the compound literal expression as guides for filling in the type.   The clang machinery for filling in arrays worked for checked arrays too.   

This commit adds one important missing case: incomplete array types.   We were not propagating the checked enum when the complete array type was formed after the number of array elements had been determined.   It also checks in a checked scope that the compound literal type is a checked type.   This closes off one more route by which an unchecked type could appear in a checked scope.

This commit adds a new method for checking types that appear syntactically in expressions in checked scopes (for example, in cast operators and compound literal expressions).    This produces error message with similar detail to those produced for declarations, calling out the problematic unchecked type within a constructed type if necessary.    The existing error message for cast operations are switched to use this method, so we get better error message for cast expressions too.

Testing:
- Added new tests in the Checked C repo in initializers.c that cover strings, array initializers, and pointers initialized via  strings or compound literal expressions with array type.
- Passes existing automated testing for Linux and Windows.  I had to modify several LNT benchmarks because the improved typing discovered that we were passing strings to methods with bounds-safe interfaces.



