### PR TITLE
Modify bounds checking for null-terminated pointers.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -1749,6 +1749,14 @@ public:
   }
 };
 
+enum BoundsCheckKind {
+  BCK_None,
+  BCK_NullTermRead,
+  BCK_Normal,
+  BCK_MaxKind = BCK_Normal
+};
+
+
 /// UnaryOperator - This represents the unary-expression's (except sizeof and
 /// alignof), the postinc/postdec operators from postfix-expression, and various
 /// extensions.
@@ -1881,6 +1889,18 @@ public:
 
   /// \brief Set the bounds to use during the bounds check of this expression.
   void setBoundsExpr(BoundsExpr *E) { Bounds = E; }
+
+  static_assert(BCK_MaxKind < (1 << NumBoundsCheckKindBits), "kind field too small");
+
+  /// \brief Return the kind of bounds check to do.
+  BoundsCheckKind getBoundsCheckKind() const {
+    return (BoundsCheckKind)UnaryOperatorBits.BoundsCheckKind;
+  }
+
+  /// \brief Set the kind of bounds check to do.
+  void setBoundsCheckKind(BoundsCheckKind Kind) {
+    UnaryOperatorBits.BoundsCheckKind = Kind;
+  }
 };
 
 /// Helper class for OffsetOfExpr.
@@ -2286,6 +2306,16 @@ public:
 
   /// \brief Set the bounds to use during the bounds check of this expression.
   void setBoundsExpr(BoundsExpr *E) { Bounds = E; }
+
+  /// \brief Return the kind of bounds check to do.
+  BoundsCheckKind getBoundsCheckKind() const {
+    return (BoundsCheckKind) ArraySubscriptExprBits.BoundsCheckKind;
+  }
+
+  /// \brief Set the kind of bounds check to do.
+  void setBoundsCheckKind(BoundsCheckKind Kind) {
+    ArraySubscriptExprBits.BoundsCheckKind = Kind;
+  }
 };
 
 /// CallExpr - Represents a function call (C99 6.5.2.2, C++ [expr.call]).

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -271,6 +271,22 @@ protected:
     unsigned Kind : NumBoundsExprKindBits;
   };
 
+  enum { NumBoundsCheckKindBits = 2 };
+
+  class ArraySubscriptExprBitFields {
+    friend class ArraySubscriptExpr;
+
+    unsigned : NumExprBits;
+    unsigned BoundsCheckKind : NumBoundsCheckKindBits;
+  };
+
+  class UnaryOperatorBitFields {
+    friend class UnaryOperator;
+
+    unsigned : NumExprBits;
+    unsigned BoundsCheckKind : NumBoundsCheckKindBits;
+  };
+
   union {
     StmtBitfields StmtBits;
     CompoundStmtBitfields CompoundStmtBits;
@@ -289,6 +305,8 @@ protected:
     TypeTraitExprBitfields TypeTraitExprBits;
     CoawaitExprBitfields CoawaitBits;
     BoundsExprBitFields BoundsExprBits;
+    ArraySubscriptExprBitFields ArraySubscriptExprBits;
+    UnaryOperatorBitFields UnaryOperatorBits;
   };
 
   friend class ASTStmtReader;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4538,11 +4538,12 @@ public:
   ExprResult ConvertToFullyCheckedType(Expr *E, BoundsExpr *B, bool IsParamUse,
                                        ExprValueKind VK);
 
-  /// GetArrayPtrDereference - determine if an lvalue expression is
-  /// a dereference of an Array_ptr (via '*" or an array subscript operator).
-  /// Returns the expression with the dereference (skipping parenthesis expressions)
-  /// or null, if this is not a dereference of an Array_ptr
-  Expr *GetArrayPtrDereference(Expr *E);
+  /// GetArrayPtrDereference - determine if an lvalue expression is a
+  /// dereference of an _Array_ptr or _Nt_array_ptr (via '*" or an array
+  /// subscript operator).  If it is, return the actual dereference expression
+  /// and set Result to the pointer type being dereferenced.  Otherwise, return
+  /// null.
+  Expr *GetArrayPtrDereference(Expr *E, QualType &Result);
 
   /// InferLValueBounds - infer a bounds expression for an lvalue.
   /// The bounds determine whether the lvalue to which an

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -606,6 +606,7 @@ namespace  {
     void VisitInteropTypeBoundsAnnotation(
       const InteropTypeBoundsAnnotation *Node);
     void dumpBoundsKind(BoundsExpr::Kind kind);
+    void dumpBoundsCheckKind(BoundsCheckKind kind);
     void VisitPositionalParameterExpr(const PositionalParameterExpr *Node);
   };
 }
@@ -2120,6 +2121,8 @@ void ASTDumper::VisitUnaryOperator(const UnaryOperator *Node) {
     dumpChild([=] {
       OS << "Bounds";
       dumpStmt(Bounds);
+      OS << "BoundsCheckKind ";
+      dumpBoundsCheckKind(Node->getBoundsCheckKind());
     });
   }
 }
@@ -2195,6 +2198,8 @@ void ASTDumper::VisitArraySubscriptExpr(const ArraySubscriptExpr *Node) {
     dumpChild([=] {
       OS << "Bounds";
       dumpStmt(Bounds);
+      OS << "BoundsCheckKind ";
+      dumpBoundsCheckKind(Node->getBoundsCheckKind());
       });
   }
 }
@@ -2588,6 +2593,14 @@ void ASTDumper::dumpBoundsKind(BoundsExpr::Kind K) {
     case BoundsExpr::Kind::ByteCount: OS << " Byte"; break;
     case BoundsExpr::Kind::Range: OS << " Range"; break;
     case BoundsExpr::Kind::InteropTypeAnnotation: OS << " InteropTypeAnnotation"; break;
+  }
+}
+
+void ASTDumper::dumpBoundsCheckKind(BoundsCheckKind K) {
+  switch (K) {
+    case BoundsCheckKind::BCK_None: OS << "None"; break;
+    case BoundsCheckKind::BCK_Normal: OS << "Normal"; break;
+    case BoundsCheckKind::BCK_NullTermRead: OS << "Null-terminated read"; break;
   }
 }
 

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -2352,7 +2352,7 @@ LValue CodeGenFunction::EmitUnaryOpLValue(const UnaryOperator *E) {
     LV.getQuals().setAddressSpace(ExprTy.getAddressSpace());
 
     EmitDynamicNonNullCheck(Addr, BaseTy);
-    EmitDynamicBoundsCheck(Addr, E->getBoundsExpr());
+    EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), E->getBoundsCheckKind());
 
     // We should not generate __weak write barrier on indirect reference
     // of a pointer to object; as in void foo (__weak id *param); *param = 0;
@@ -3090,7 +3090,8 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
                                        E->getBase()->getType(),
                                        LHS.getAlignmentSource());
 
-    EmitDynamicBoundsCheck(LV.getVectorAddress(), E->getBoundsExpr());
+    EmitDynamicBoundsCheck(LV.getVectorAddress(), E->getBoundsExpr(),
+                           E->getBoundsCheckKind());
 
     return LV;
   }
@@ -3108,7 +3109,7 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
     Addr = emitArraySubscriptGEP(*this, Addr, Idx, EltType, /*inbounds*/ true);
     LValue AddrLV = MakeAddrLValue(Addr, EltType, LV.getAlignmentSource());
 
-    EmitDynamicBoundsCheck(Addr, E->getBoundsExpr());
+    EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), E->getBoundsCheckKind());
 
     return AddrLV;
   }
@@ -3207,7 +3208,7 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
 
   // TODO: Preserve/extend path TBAA metadata?
 
-  EmitDynamicBoundsCheck(Addr, E->getBoundsExpr());
+  EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), E->getBoundsCheckKind());
 
   if (getLangOpts().ObjC1 &&
       getLangOpts().getGC() != LangOptions::NonGC) {
@@ -3488,7 +3489,7 @@ LValue CodeGenFunction::EmitMemberExpr(const MemberExpr *E) {
     // unchecked, or is a checked array with its own bounds.
     // A second reason for always checking the BaseLV is that it is the same for
     // all the fields in the struct, so more of the checks should optimize away.
-    EmitDynamicBoundsCheck(Addr, E->getBoundsExpr());
+    EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), BCK_Normal);
 
   } else
     BaseLV = EmitCheckedLValue(BaseExpr, TCK_MemberAccess);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2546,8 +2546,10 @@ public:
 
   void EmitExplicitDynamicCheck(const Expr *Condition);
   void EmitDynamicNonNullCheck(const Address BaseAddr, const QualType BaseTy);
-  void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy, const Address PtrAddr);
-  void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds);
+  void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy,
+                                const Address PtrAddr);
+  void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds,
+                              BoundsCheckKind Kind);
   void EmitDynamicBoundsCastCheck(const Address BaseAddr,
                                   const BoundsExpr *CastBounds,
                                   const BoundsExpr *SubExprBounds);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1281,8 +1281,8 @@ namespace {
     // Add bounds check to an lvalue expression, if it is an Array_ptr
     // dereference.  The caller has determined that the lvalue is being
     // used in a way that requies a bounds check if the lvalue is an
-    // Array_ptr dereferences.  The lvalue uses are to read or write memory
-    // or as the base expression of a member reference.
+    // _Array_ptr or _Nt_array_ptr dereference.  The lvalue uses are to read
+    // or write memory or as the base expression of a member reference.
     //
     // If the Array_ptr has unknown bounds, this is a compile-time error.
     // Generate an error message and set the bounds to an invalid bounds
@@ -1292,6 +1292,7 @@ namespace {
       bool NeedsBoundsCheck = false;
       QualType PtrType;
       if (Expr *Deref = S.GetArrayPtrDereference(E, PtrType)) {
+        NeedsBoundsCheck = true;
         BoundsExpr *LValueBounds = S.InferLValueBounds(E);
         BoundsCheckKind Kind = BCK_Normal;
         if (IsOnlyMemoryRead && PtrType->isCheckedPointerNtArrayType())

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1142,7 +1142,7 @@ namespace {
   };
 }
 
-Expr *Sema::GetArrayPtrDereference(Expr *E) {
+Expr *Sema::GetArrayPtrDereference(Expr *E, QualType &Result) {
   assert(E->isLValue());
   E = E->IgnoreParens();
   switch (E->getStmtClass()) {
@@ -1157,8 +1157,10 @@ Expr *Sema::GetArrayPtrDereference(Expr *E) {
         return nullptr;
       }
       if (UO->getOpcode() == UnaryOperatorKind::UO_Deref &&
-          UO->getSubExpr()->getType()->isCheckedPointerArrayType())
+          UO->getSubExpr()->getType()->isCheckedPointerArrayType()) {
+        Result = UO->getSubExpr()->getType();
         return E;
+      }
 
       return nullptr;
     }
@@ -1177,8 +1179,10 @@ Expr *Sema::GetArrayPtrDereference(Expr *E) {
       //  the "checkedness" of the outermost array.
 
       // getBase returns the pointer-typed expression.
-      if (AS->getBase()->getType()->isCheckedPointerArrayType())
+      if (AS->getBase()->getType()->isCheckedPointerArrayType()) {
+        Result = AS->getBase()->getType();
         return E;
+      }
 
       return nullptr;
     }
@@ -1189,7 +1193,7 @@ Expr *Sema::GetArrayPtrDereference(Expr *E) {
         return nullptr;
       }
       if (IC->getCastKind() == CK_LValueBitCast)
-        return GetArrayPtrDereference(IC->getSubExpr());
+        return GetArrayPtrDereference(IC->getSubExpr(), Result);
       return nullptr;
     }
     default: {
@@ -1283,13 +1287,15 @@ namespace {
     // If the Array_ptr has unknown bounds, this is a compile-time error.
     // Generate an error message and set the bounds to an invalid bounds
     // expression.
-    bool AddBoundsCheck(Expr *E) {
+    bool AddBoundsCheck(Expr *E, bool IsOnlyMemoryRead) {
       assert(E->isLValue());
       bool NeedsBoundsCheck = false;
-      BoundsExpr *LValueBounds = nullptr;
-      if (Expr *Deref = S.GetArrayPtrDereference(E)) {
-        NeedsBoundsCheck = true;
-        LValueBounds = S.InferLValueBounds(E);
+      QualType PtrType;
+      if (Expr *Deref = S.GetArrayPtrDereference(E, PtrType)) {
+        BoundsExpr *LValueBounds = S.InferLValueBounds(E);
+        BoundsCheckKind Kind = BCK_Normal;
+        if (IsOnlyMemoryRead && PtrType->isCheckedPointerNtArrayType())
+          Kind = BCK_NullTermRead;
         if (LValueBounds->isNone()) {
           S.Diag(E->getLocStart(), diag::err_expected_bounds) << E->getSourceRange();
           LValueBounds = S.CreateInvalidBoundsExpr();
@@ -1297,9 +1303,11 @@ namespace {
         if (UnaryOperator *UO = dyn_cast<UnaryOperator>(Deref)) {
           assert(!UO->hasBoundsExpr());
           UO->setBoundsExpr(LValueBounds);
+          UO->setBoundsCheckKind(Kind);
         } else if (ArraySubscriptExpr *AS = dyn_cast<ArraySubscriptExpr>(Deref)) {
           assert(!AS->hasBoundsExpr());
           AS->setBoundsExpr(LValueBounds);
+          AS->setBoundsCheckKind(Kind);
         } else
           llvm_unreachable("unexpected expression kind");
       }
@@ -1316,7 +1324,7 @@ namespace {
       if (!E->isArrow()) {
         // The base expression only needs a bounds check if it is an lvalue.
         if (Base->isLValue())
-          return AddBoundsCheck(Base);
+          return AddBoundsCheck(Base, false);
         return false;
       }
 
@@ -1457,7 +1465,7 @@ namespace {
       // Check that the LHS lvalue of the assignment has bounds, if it is an
       // lvalue that was produced by dereferencing an _Array_ptr.
       bool LHSNeedsBoundsCheck = false;
-      LHSNeedsBoundsCheck = AddBoundsCheck(LHS);
+      LHSNeedsBoundsCheck = AddBoundsCheck(LHS, false);
       if (DumpBounds && (LHSNeedsBoundsCheck ||
                          (LHSTargetBounds && !LHSTargetBounds->isNone())))
         DumpAssignmentBounds(llvm::outs(), E, LHSTargetBounds, RHSBounds);
@@ -1553,7 +1561,7 @@ namespace {
 
       CastKind CK = E->getCastKind();
       if (CK == CK_LValueToRValue && !E->getType()->isArrayType()) {
-        bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr());
+        bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr(), true);
         if (NeedsBoundsCheck && DumpBounds)
           DumpExpression(llvm::outs(), E);
 
@@ -1620,7 +1628,7 @@ namespace {
       if (!E->isIncrementDecrementOp())
         return true;
 
-      bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr());
+      bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr(), false);
       if (NeedsBoundsCheck && DumpBounds)
           DumpExpression(llvm::outs(), E);
       return true;


### PR DESCRIPTION
Checked C allows reads at exactly the upper bound for null-terminated pointers
so that the potential terminating value can be examined.  This modifies runtime
array bounds checks to allow that.

The IR is extended with a bounds check kind, so that we know when generating
a check whether the check should allow the upper bound location to be read.
Bounds checks are done as part of lvalue expression evaluation, so we need
to know whether the lvalue will be read or written.  We can't just look at the
type of the pointer to determine the kind of bounds check.  The bounds check
kind is added to the dereference and array subscript expression classes.
It is stored in the statement bitfields data structure, so no extra memory
is used.

For code generation of bounds checks for a null-terminated pointer read,
generate a 'less than or equal' comparison instead of a 'less than'
comparison.

Testing:
- Added new dynamic tests for the Checked C repo in nullterm_pointer.c that
  check that the memory location at the upper bound is accessible
  for null-terminated array pointers, and not accessible for
  non-null-terminated array pointers.
- Passing existing automated testing for Linux.
