### PR TITLE
Change printing of array types to use actual keywords.

### DIFF
--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -476,12 +476,12 @@ void TypePrinter::printConstantArrayBefore(const ConstantArrayType *T,
 void TypePrinter::printArrayAfter(const ArrayType *T, Qualifiers Quals, raw_ostream &OS,
                                   bool checkedOuterDimension) {
   if (T->isExactlyChecked() && !checkedOuterDimension)
-    OS << "checked";
+    OS << "_Checked";
   else if (T->isNtChecked())
-      OS << "nt_checked";
+      OS << "_Nt_checked";
   else if (checkedOuterDimension && !T->isChecked()) {
     // This case is never supposed to happen, but print an accurate type name if it does.
-    OS << "unchecked";
+    OS << "_Unchecked";
   }
   switch (T->getTypeClass()) {
     case Type::IncompleteArray:

--- a/test/CheckedC/dynamic-checks/array-compound-assign-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-compound-assign-code-gen.c
@@ -400,13 +400,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
@@ -432,13 +432,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
@@ -463,13 +463,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
@@ -495,13 +495,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
@@ -526,13 +526,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // NOTE: No Non-null check inserted
@@ -755,15 +755,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
@@ -789,15 +789,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -824,15 +824,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
@@ -859,15 +859,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: UnaryOperator {{.*}} prefix '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -897,15 +897,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // NOTE: No Non-null check inserted
@@ -929,15 +929,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
@@ -975,15 +975,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
@@ -1017,15 +1017,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -1060,15 +1060,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
@@ -1103,15 +1103,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -1146,15 +1146,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1185,15 +1185,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 

--- a/test/CheckedC/dynamic-checks/array-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-increment-code-gen.c
@@ -401,13 +401,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // NOTE: No Non-null check inserted
@@ -433,13 +433,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -464,13 +464,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
   // NOTE: No Non-null check inserted
@@ -496,13 +496,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
@@ -527,13 +527,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -756,15 +756,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
@@ -790,15 +790,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
@@ -825,15 +825,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
@@ -860,15 +860,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: UnaryOperator {{.*}} prefix '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -898,15 +898,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -930,15 +930,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
@@ -976,15 +976,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
 
@@ -1018,15 +1018,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
@@ -1061,15 +1061,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
@@ -1104,15 +1104,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -1147,15 +1147,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
   // CHECK-IR-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne [3 x i32]* [[REG1]], null
@@ -1186,15 +1186,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr

--- a/test/CheckedC/dynamic-checks/array-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-read-code-gen.c
@@ -360,10 +360,10 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
 
   // NOTE: No Non-null check inserted
@@ -387,10 +387,10 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
 
   // NOTE: No Non-null check inserted
@@ -414,10 +414,10 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
   // NOTE: No Non-null check inserted
@@ -441,10 +441,10 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
   // NOTE: No Non-null check inserted
@@ -468,10 +468,10 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
 
   // NOTE: No Non-null check inserted
@@ -677,10 +677,10 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -706,10 +706,10 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -736,10 +736,10 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -766,10 +766,10 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -798,10 +798,10 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
@@ -827,10 +827,10 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -869,10 +869,10 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -906,10 +906,10 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -944,10 +944,10 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -982,10 +982,10 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
@@ -1019,10 +1019,10 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
@@ -1055,10 +1055,10 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr

--- a/test/CheckedC/dynamic-checks/array-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/array-write-code-gen.c
@@ -373,13 +373,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
 
@@ -402,13 +402,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'int _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted
@@ -430,13 +430,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
 
@@ -460,13 +460,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 4
 
@@ -489,13 +489,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'int _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // NOTE: No Non-null check inserted
@@ -707,15 +707,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
@@ -739,15 +739,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -772,15 +772,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
@@ -805,15 +805,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: UnaryOperator {{.*}} prefix '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -841,15 +841,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // NOTE: No Non-null check inserted
@@ -871,15 +871,15 @@ void f5() {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int checked[3][3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'gma' 'int _Checked[3][3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 
@@ -915,15 +915,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 1
@@ -955,15 +955,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -996,15 +996,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 3
@@ -1037,15 +1037,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '-'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
@@ -1078,15 +1078,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: UnaryOperator {{.*}} '*'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 5
 
   // CHECK-IR: [[REG1:%[a-zA-Z0-9.]*]] = load [3 x i32]*, [3 x i32]** %lma.addr
@@ -1115,15 +1115,15 @@ void f6(int lma _Checked[3][3]) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
-  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>' '+'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
+  // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-AST-NEXT: ArraySubscriptExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int checked[3]>':'_Array_ptr<int checked[3]>'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'lma' '_Array_ptr<int _Checked[3]>':'_Array_ptr<int _Checked[3]>'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 6
 

--- a/test/CheckedC/dynamic-checks/struct-compound-assign-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-compound-assign-code-gen.c
@@ -263,13 +263,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -292,13 +292,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -321,15 +321,15 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ParenExpr
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted

--- a/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-increment-code-gen.c
@@ -270,13 +270,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -300,13 +300,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -330,15 +330,15 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ParenExpr
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted

--- a/test/CheckedC/dynamic-checks/struct-read-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-read-code-gen.c
@@ -264,13 +264,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -293,13 +293,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -322,15 +322,15 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ParenExpr
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted

--- a/test/CheckedC/dynamic-checks/struct-write-code-gen.c
+++ b/test/CheckedC/dynamic-checks/struct-write-code-gen.c
@@ -251,13 +251,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 1
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 checked[1]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga1' 'S1 _Checked[1]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -278,13 +278,13 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
 
   // NOTE: No Non-null check inserted
   // NOTE: Only (addr LT upper) check generated, constant folder removes (lower LE addr) check
@@ -305,15 +305,15 @@ void f3(void) {
   // CHECK-AST-NEXT: Bounds
   // CHECK-AST-NEXT: RangeBoundsExpr
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '_Array_ptr<S1>':'_Array_ptr<S1>' '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'unsigned long long' 3
   // CHECK-AST-NEXT: ParenExpr
   // CHECK-AST-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-AST-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 checked[3]'
+  // CHECK-AST-NEXT: DeclRefExpr {{.*}} 'ga3' 'S1 _Checked[3]'
   // CHECK-AST-NEXT: IntegerLiteral {{.*}} 'int' 2
 
   // NOTE: No Non-null check inserted

--- a/test/CheckedC/inferred-bounds/inc-dec.c
+++ b/test/CheckedC/inferred-bounds/inc-dec.c
@@ -97,13 +97,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 0
 
   sum = --arr[0];
@@ -113,13 +113,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 0
 
   sum = arr[1]++;
@@ -129,13 +129,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 
   sum = arr[1]--;
@@ -145,13 +145,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK:`-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 
   return sum;

--- a/test/CheckedC/inferred-bounds/member-arrow-reference.c
+++ b/test/CheckedC/inferred-bounds/member-arrow-reference.c
@@ -70,7 +70,7 @@ void f1(struct S1 *a1, struct S2 *b2) {
 // CHECK: |-CountBoundsExpr {{.*}} 'NULL TYPE' Element
 // CHECK: | `-IntegerLiteral {{.*}} 'int' 5
 // CHECK: `-ImplicitCastExpr {{.*}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK:   `-MemberExpr {{.*}} 'int checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
+// CHECK:   `-MemberExpr {{.*}} 'int _Checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
 // CHECK:     `-ImplicitCastExpr {{.*}} 'struct S2 *' <LValueToRValue>
 // CHECK:       `-DeclRefExpr {{.*}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
 // CHECK: Declared Bounds:
@@ -79,12 +79,12 @@ void f1(struct S1 *a1, struct S2 *b2) {
 // CHECK: Initializer Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S2 *' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
 // CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
 // CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S2 *' <LValueToRValue>
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 5

--- a/test/CheckedC/inferred-bounds/member-base.c
+++ b/test/CheckedC/inferred-bounds/member-base.c
@@ -260,13 +260,13 @@ int f10(void) {
 // CHECK:   |-Bounds
 // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue Var {{0x[0-9a-f]+}} 'i' 'int'
 
@@ -279,13 +279,13 @@ int f10(void) {
 // CHECK:     |-Bounds
 // CHECK:     | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK:     |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:     |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:     |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:     |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK:     |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:     |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:     |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:     |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK:     `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 
   int y = arr->f;
 
@@ -293,13 +293,13 @@ int f10(void) {
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 
   int z = arr[2].f;
 
@@ -308,13 +308,13 @@ int f10(void) {
 // CHECK:   |-Bounds
 // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
 
   _Array_ptr<int> p : count(1) = &((*arr).f);
@@ -325,13 +325,13 @@ int f10(void) {
 // CHECK:     |-Bounds
 // CHECK:     | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK:     |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:     |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:     |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:     |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK:     |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:     |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:     |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:     |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 
   *p = 10;
   p = &(arr->f);
@@ -343,7 +343,7 @@ int f10(void) {
 // CHECK:     `-ParenExpr {{0x[0-9a-f]+}} 'int' lvalue
 // CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK:         `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:           `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: Target Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
@@ -357,25 +357,25 @@ int f10(void) {
 // CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
 // CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
 // CHECK: MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |-Base Expr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 
   *p = 11;
   p = &(arr[3].f);
@@ -388,7 +388,7 @@ int f10(void) {
 // CHECK:       `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK:         `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK:           |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:           | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:           `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: Target Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
@@ -404,14 +404,14 @@ int f10(void) {
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
 // CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 1
 
@@ -420,13 +420,13 @@ int f10(void) {
 // CHECK:   |-Bounds
 // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' '+'
 // CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S checked[6]'
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 
   *p = 12;
@@ -676,17 +676,17 @@ int f30(struct S arr _Checked[][10] : count(len), int i, int j, int len) {
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK:   |-Bounds
 // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>'
-// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' '+'
-// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' <LValueToRValue>
-// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>'
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>'
+// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' '+'
+// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' <LValueToRValue>
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>'
 // CHECK:   |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK:   |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S checked[10]' lvalue
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[10]>':'_Array_ptr<struct S checked[10]>'
+// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S _Checked[10]' lvalue
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[10]>':'_Array_ptr<struct S _Checked[10]>'
 // CHECK:   |   `-UnaryOperator {{0x[0-9a-f]+}} 'int' postfix '++'
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
@@ -702,17 +702,17 @@ void f31(struct S arr _Checked[][11] : count(len), int i, int j, int len) {
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK:   |-Bounds
 // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>'
-// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' '+'
-// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' <LValueToRValue>
-// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>'
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>'
+// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' '+'
+// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' <LValueToRValue>
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>'
 // CHECK:   |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK:   |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S checked[11]' lvalue
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[11]>':'_Array_ptr<struct S checked[11]>'
+// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S _Checked[11]' lvalue
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[11]>':'_Array_ptr<struct S _Checked[11]>'
 // CHECK:   |   `-UnaryOperator {{0x[0-9a-f]+}} 'int' postfix '++'
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
@@ -726,17 +726,17 @@ void f32(struct S arr _Checked[][12] : count(len), int i, int j, int len) {
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK:   |-Bounds
 // CHECK:   | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>'
-// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' '+'
-// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' <LValueToRValue>
-// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>'
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>'
+// CHECK:   |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' '+'
+// CHECK:   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' <LValueToRValue>
+// CHECK:   |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>'
 // CHECK:   |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK:   |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S checked[12]' lvalue
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>'
+// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S _Checked[12]' lvalue
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>'
 // CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>

--- a/test/CheckedC/inferred-bounds/member-reference.c
+++ b/test/CheckedC/inferred-bounds/member-reference.c
@@ -64,7 +64,7 @@ void f1(struct S1 a1, struct S2 b2) {
 // CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:31> 'NULL TYPE' Element
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} <col:30> 'int' 5
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: `-MemberExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int checked[5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK: `-MemberExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int _Checked[5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: `-DeclRefExpr {{0x[0-9a-f]+}} <col:35> 'struct S2':'struct S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2':'struct S2'
 // CHECK: Declared Bounds:
 // CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
@@ -72,11 +72,11 @@ void f1(struct S1 a1, struct S2 b2) {
 // CHECK: Initializer Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int checked[5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2':'struct S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2':'struct S2'
 // CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int checked[5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2':'struct S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2':'struct S2'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 5
 }

--- a/test/CheckedC/inferred-bounds/ptr-cast.c
+++ b/test/CheckedC/inferred-bounds/ptr-cast.c
@@ -157,9 +157,9 @@ void f5(struct S arr _Checked[][12] : count(len), int i, int j, int len) {
 // CHECK: |   | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |   |     | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S checked[12]' lvalue
-// CHECK: |   |     |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' <LValueToRValue>
-// CHECK: |   |     |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>'
+// CHECK: |   |     | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S _Checked[12]' lvalue
+// CHECK: |   |     |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' <LValueToRValue>
+// CHECK: |   |     |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>'
 // CHECK: |   |     |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK: |   |     |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: |   |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
@@ -169,9 +169,9 @@ void f5(struct S arr _Checked[][12] : count(len), int i, int j, int len) {
 // CHECK: |     | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |     |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK: |     |     | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S checked[12]' lvalue
-// CHECK: |     |     |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' <LValueToRValue>
-// CHECK: |     |     |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>'
+// CHECK: |     |     | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S _Checked[12]' lvalue
+// CHECK: |     |     |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' <LValueToRValue>
+// CHECK: |     |     |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>'
 // CHECK: |     |     |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK: |     |     |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: |     |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
@@ -182,9 +182,9 @@ void f5(struct S arr _Checked[][12] : count(len), int i, int j, int len) {
 // CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK:       `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK:         |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
-// CHECK:         | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S checked[12]' lvalue
-// CHECK:         |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' <LValueToRValue>
-// CHECK:         |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S checked[12]>':'_Array_ptr<struct S checked[12]>'
+// CHECK:         | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S _Checked[12]' lvalue
+// CHECK:         |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' <LValueToRValue>
+// CHECK:         |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S _Checked[12]>':'_Array_ptr<struct S _Checked[12]>'
 // CHECK:         |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK:         |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK:         `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>

--- a/test/CheckedC/inferred-bounds/ptr-read.c
+++ b/test/CheckedC/inferred-bounds/ptr-read.c
@@ -64,14 +64,14 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 
   int y = arr[2];
 
@@ -80,13 +80,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
 
   return x + y;
@@ -146,17 +146,17 @@ int f4(int arr _Checked[][10] : count(len), int i, int j, int len) {
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
 // CHECK: |-Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
-// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
-// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' '+'
-// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
-// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' <LValueToRValue>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' <LValueToRValue>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>'
 // CHECK: |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK: |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'len' 'int'
 // CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int checked[10]' lvalue
-// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
-// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK:   | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int _Checked[10]' lvalue
+// CHECK:   |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' <LValueToRValue>
+// CHECK:   |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>'
 // CHECK:   |   `-UnaryOperator {{0x[0-9a-f]+}} 'int' postfix '++'
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>

--- a/test/CheckedC/inferred-bounds/ptr-write.c
+++ b/test/CheckedC/inferred-bounds/ptr-write.c
@@ -69,13 +69,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: | |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: | |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: | |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: Target Bounds:
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
@@ -87,13 +87,13 @@ int f2(void) {
 // CHECK: |-Bounds
 // CHECK: | | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: | |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
 // CHECK: | |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 6
 // CHECK: | |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | | `-DeclRefExpr {{0x[0-9a-f]+}} 'int checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int checked[6]'
+// CHECK: | | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 4
 // CHECK: Target Bounds:
@@ -161,16 +161,16 @@ void f4(int arg _Checked[10][10]) {
 // CHECK: |-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int' lvalue
 // CHECK: |-Bounds
 // CHECK: | | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
-// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
-// CHECK: | |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' '+'
-// CHECK: | |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
-// CHECK: | |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' <LValueToRValue>
+// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>'
+// CHECK: | |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' '+'
+// CHECK: | |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' <LValueToRValue>
+// CHECK: | |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>'
 // CHECK: | |     `-IntegerLiteral {{0x[0-9a-f]+}} 'unsigned long long' 10
 // CHECK: | |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
-// CHECK: | | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int checked[10]' lvalue
-// CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' <LValueToRValue>
-// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int checked[10]>':'_Array_ptr<int checked[10]>'
+// CHECK: | | `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'int _Checked[10]' lvalue
+// CHECK: | |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' <LValueToRValue>
+// CHECK: | |   | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>' lvalue ParmVar {{0x[0-9a-f]+}} 'arg' '_Array_ptr<int _Checked[10]>':'_Array_ptr<int _Checked[10]>'
 // CHECK: | |   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 314

--- a/test/CheckedC/regression-cases/bug_254_aka_type.c
+++ b/test/CheckedC/regression-cases/bug_254_aka_type.c
@@ -15,7 +15,7 @@ void test(DefArrTy arr); // expected-note {{passing argument to parameter 'arr' 
 void f(void) {
   int i = 0;
   DefTy p = i; // expected-error {{initializing 'DefTy' (aka '_Ptr<int>') with an expression of incompatible type 'int'}}
-  test(i);     // expected-error {{passing 'int' to parameter of incompatible type 'DefArrTy' (aka '_Ptr<int checked[10]>')}}
+  test(i);     // expected-error {{passing 'int' to parameter of incompatible type 'DefArrTy' (aka '_Ptr<int _Checked[10]>')}}
 }
 
 


### PR DESCRIPTION
The compiler was using `checked` and `nt_checked` when printing the names of types.  It should use `_Checked` and `_Nt_checked`, which are the actual keywords.  This addresses issue #393

Testing:
- Automated testing in progress/



