### PR TITLE
Rename bounds(none) to bounds(unknown).

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2850,8 +2850,8 @@ public:
     // expressions and prevent spurious downstream error messages
     // in bounds declaration checking.
     Invalid = 0,
-    // bounds(none)
-    None = 1,
+    // bounds(unknown)
+    Unknown = 1,
     // bounds(any)
     Any = 2,
     // count(e)
@@ -2906,8 +2906,8 @@ public:
     return getKind() == Invalid;
   }
 
-  bool isNone() const {
-    return getKind() == None;
+  bool isUnknown() const {
+    return getKind() == Unknown;
   }
 
   bool isAny() const {
@@ -5134,7 +5134,7 @@ class NullaryBoundsExpr : public BoundsExpr {
 public:
   NullaryBoundsExpr(Kind Kind, SourceLocation StartLoc, SourceLocation RParenLoc)
     : BoundsExpr(NullaryBoundsExprClass, Kind, StartLoc, RParenLoc)  {
-    assert(Kind == Invalid || Kind == None || Kind == Any);
+    assert(Kind == Invalid || Kind == Unknown || Kind == Any);
   }
 
   explicit NullaryBoundsExpr(EmptyShell Empty)

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -167,8 +167,8 @@ class Parser : public CodeCompletionHandler {
   /// \brief Identifier for "count".
   IdentifierInfo *Ident_count;
 
-  /// \brief Identifier for "none".
-  IdentifierInfo *Ident_none;
+  /// \brief Identifier for "unknown".
+  IdentifierInfo *Ident_unknown;
 
   /// \brief Identifier for "itype"
   IdentifierInfo *Ident_itype;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2587,7 +2587,7 @@ void ASTDumper::visitVerbatimLineComment(const VerbatimLineComment *C) {
 void ASTDumper::dumpBoundsKind(BoundsExpr::Kind K) {
   switch (K) {
     case BoundsExpr::Kind::Invalid: OS << " Invalid"; break;
-    case BoundsExpr::Kind::None: OS << " None"; break;
+    case BoundsExpr::Kind::Unknown: OS << " Unknown"; break;
     case BoundsExpr::Kind::Any: OS << " Any"; break;
     case BoundsExpr::Kind::ElementCount: OS << " Element"; break;
     case BoundsExpr::Kind::ByteCount: OS << " Byte"; break;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3934,7 +3934,7 @@ bool BoundsExpr::validateKind(Kind K) {
 
   switch (getStmtClass()) {
     case NullaryBoundsExprClass:
-      return (K == None || K == Any);
+      return (K == Unknown || K == Any);
     case CountBoundsExprClass:
       return K == ElementCount || K == ByteCount;
     case RangeBoundsExprClass:

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1905,8 +1905,8 @@ void StmtPrinter::VisitNullaryBoundsExpr(NullaryBoundsExpr *Node) {
     case BoundsExpr::Any:
       OS << "bounds(any)";
       break;
-    case BoundsExpr::None:
-      OS << "bounds(none)";
+    case BoundsExpr::Unknown:
+      OS << "bounds(Unknown)";
       break;
     default:
       llvm_unreachable("unexpected bounds kind for nullary bounds expr");

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1906,7 +1906,7 @@ void StmtPrinter::VisitNullaryBoundsExpr(NullaryBoundsExpr *Node) {
       OS << "bounds(any)";
       break;
     case BoundsExpr::Unknown:
-      OS << "bounds(Unknown)";
+      OS << "bounds(unknown)";
       break;
     default:
       llvm_unreachable("unexpected bounds kind for nullary bounds expr");

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2961,17 +2961,17 @@ ExprResult Parser::ParseBoundsExpression() {
                                             Result.get(),
                                            Tok.getLocation());
   } else if (Ident == Ident_bounds) {
-    // Parse bounds(none) or bounds(e1, e2)
+    // Parse bounds(unknown) or bounds(e1, e2)
     bool FoundNullaryOperator = false;
 
     // Start with "none"
     if (Tok.getKind() == tok::identifier) {
       IdentifierInfo *NextIdent = Tok.getIdentifierInfo();
-      if (NextIdent == Ident_none) {
+      if (NextIdent == Ident_unknown) {
         FoundNullaryOperator = true;
         ConsumeToken();
         Result = Actions.ActOnNullaryBoundsExpr(BoundsKWLoc, 
-                                                BoundsExpr::Kind::None,
+                                                BoundsExpr::Kind::Unknown,
                                                 Tok.getLocation());
       }
     }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -498,7 +498,7 @@ void Parser::Initialize() {
     Ident_bounds = &PP.getIdentifierTable().get("bounds");
     Ident_byte_count = &PP.getIdentifierTable().get("byte_count");
     Ident_count = &PP.getIdentifierTable().get("count");
-    Ident_none = &PP.getIdentifierTable().get("none");
+    Ident_unknown = &PP.getIdentifierTable().get("unknown");
     Ident_itype = &PP.getIdentifierTable().get("itype");
     Ident_rel_align = &PP.getIdentifierTable().get("rel_align");
     Ident_rel_align_value = &PP.getIdentifierTable().get("rel_align_value");
@@ -510,7 +510,7 @@ void Parser::Initialize() {
     Ident_bounds = nullptr;
     Ident_byte_count = nullptr;
     Ident_count = nullptr;
-    Ident_none = nullptr;
+    Ident_unknown = nullptr;
     Ident_itype = nullptr;
     Ident_rel_align = nullptr;
     Ident_rel_align_value = nullptr;

--- a/lib/Sema/CheckedCInterop.cpp
+++ b/lib/Sema/CheckedCInterop.cpp
@@ -52,8 +52,8 @@ QualType Sema::GetCheckedCInteropType(QualType Ty,
   switch (Bounds->getKind()) {
     case BoundsExpr::Kind::Invalid:
       break;
-    case BoundsExpr::Kind::None:
-      llvm_unreachable("should not be getting interop type for bounds(none)");
+    case BoundsExpr::Kind::Unknown:
+      llvm_unreachable("should not be getting interop type for bounds(unknown)");
       break;
     case BoundsExpr::Kind::InteropTypeAnnotation: {
       const InteropTypeBoundsAnnotation *Annot =

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -10958,7 +10958,7 @@ void Sema::ActOnUninitializedDecl(Decl *RealDecl) {
         Diag(Var->getLocation(), diag::err_initializer_expected_for_ptr)
           << Var;
       else if (B && !B->isInteropTypeAnnotation() && !B->isInvalid() &&
-               !B->isNone() && !Ty->isArrayType())
+               !B->isUnknown() && !Ty->isArrayType())
         Diag(Var->getLocation(), diag::err_initializer_expected_with_bounds)
           << Var;
     }

--- a/test/CheckedC/inferred-bounds/ptr-write.c
+++ b/test/CheckedC/inferred-bounds/ptr-write.c
@@ -33,7 +33,7 @@ void f1(_Array_ptr<int> a : bounds(a, a + 5)) {
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<int>'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 100
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown
 
   a[3] = 101;
 
@@ -52,7 +52,7 @@ void f1(_Array_ptr<int> a : bounds(a, a + 5)) {
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 101
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown
 
 }
 
@@ -78,7 +78,7 @@ int f2(void) {
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int _Checked[6]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown
 
   arr[2] = 4;
 
@@ -97,7 +97,7 @@ int f2(void) {
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 2
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 4
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown
 
   return arr[2];
 }
@@ -124,7 +124,7 @@ void f3(int b _Checked[7]) {
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<int>':'_Array_ptr<int>'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 102
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown
 
   b[3] = 103;
 
@@ -143,7 +143,7 @@ void f3(int b _Checked[7]) {
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 103
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown
 
 }
 
@@ -175,4 +175,4 @@ void f4(int arg _Checked[10][10]) {
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 314
 // CHECK: Target Bounds:
-// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' None
+// CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Unknown

--- a/test/CheckedC/pch.c
+++ b/test/CheckedC/pch.c
@@ -60,7 +60,7 @@ _Array_ptr<int> byte_arr : byte_count(sizeof(int));
 
 // NullaryBounds
 _Array_ptr<int> null_arr : count(1); // expected-error{{variable redeclaration has conflicting bounds}}
-_Array_ptr<int> null_arr : bounds(none);
+_Array_ptr<int> null_arr : bounds(unknown);
 
 // RangeBounds
 int two_arr[2];
@@ -89,10 +89,10 @@ _Array_ptr<int> byte_count_fn2(void) : byte_count(sizeof(int) + 1); // expected-
 _Array_ptr<int> byte_count_fn2(void) : byte_count(sizeof(int));
 
 // NullaryBounds
-int none_fn(_Array_ptr<int> null_arr : count(1)); // expected-error{{function redeclaration has conflicting parameter bounds}}
-int none_fn(_Array_ptr<int> null_arr : bounds(none));
-_Array_ptr<int> none_fn2(void) : count(1); // expected-error{{function redeclaration has conflicting return bounds}}
-_Array_ptr<int> none_fn2(void) : bounds(none);
+int unknown_fn(_Array_ptr<int> null_arr : count(1)); // expected-error{{function redeclaration has conflicting parameter bounds}}
+int unknown_fn(_Array_ptr<int> null_arr : bounds(unknown));
+_Array_ptr<int> unknown_fn2(void) : count(1); // expected-error{{function redeclaration has conflicting return bounds}}
+_Array_ptr<int> unknown_fn2(void) : bounds(unknown);
 
 // RangeBounds + PositionalParamater
 int range_fn(_Array_ptr<int> start : bounds(start, end - 1), _Array_ptr<int> end); // expected-error{{function redeclaration has conflicting parameter bounds}}
@@ -134,7 +134,7 @@ void uses_S2(struct S2 data) {
 // NullaryBounds
 struct S3;
 void uses_S3(struct S3 data) {
-  _Array_ptr<int> arr : bounds(none) = data.arr;
+  _Array_ptr<int> arr : bounds(unknown) = data.arr;
 }
 
 // RangeBounds

--- a/test/CheckedC/pch.h
+++ b/test/CheckedC/pch.h
@@ -27,7 +27,7 @@ _Array_ptr<int> one_arr : count(1);
 _Array_ptr<int> byte_arr : byte_count(sizeof(int));
 
 // NullaryBounds
-_Array_ptr<int> null_arr : bounds(none);
+_Array_ptr<int> null_arr : bounds(unknown);
 
 // RangeBounds
 int two_arr[2];
@@ -49,8 +49,8 @@ int byte_count_fn(_Array_ptr<int> arr : byte_count(sizeof(int)));
 _Array_ptr<int> byte_count_fn2(void) : byte_count(sizeof(int));
 
 // NullaryBounds
-int none_fn(_Array_ptr<int> null_arr : bounds(none));
-_Array_ptr<int> none_fn2(void) : bounds(none);
+int unknown_fn(_Array_ptr<int> null_arr : bounds(unknown));
+_Array_ptr<int> unknown_fn2(void) : bounds(unknown);
 
 // RangeBounds + PositionalParameter
 int range_fn(_Array_ptr<int> start : bounds(start, end), _Array_ptr<int> end);
@@ -80,7 +80,7 @@ struct S2 {
 
 // NullaryBounds
 struct S3 {
-  _Array_ptr<int> arr : bounds(none);
+  _Array_ptr<int> arr : bounds(unknown);
 };
 
 // RangeBounds


### PR DESCRIPTION
Change the compiler to match the specification and update the clang-specific Checked C tests.

Testing:
- There is a corresponding pull request for the Checked C repo.
- Automated testing running now.

