### PR TITLE
Add default bounds for null-terminated array pointers

### DIFF
--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2442,8 +2442,19 @@ public:
 private:
   QualType matchArrayCheckedness(QualType LHS, QualType RHS);
 
+  BoundsExpr *PrebuiltCountZero;
+  BoundsExpr *PrebuiltCountOne;
+  BoundsExpr *PrebuiltBoundsUnknown;
+
 public:
   bool EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2);
+
+  BoundsExpr *getPrebuiltCountZero();
+  BoundsExpr *getPrebuiltCountOne();
+  BoundsExpr *getPrebuiltBoundsUnknown();
+
+
+
 
   //===--------------------------------------------------------------------===//
   //                    Integer Predicates

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2876,6 +2876,7 @@ public:
     : Expr(StmtClass, Ty, VK_RValue, OK_Ordinary, false,
            false, false, false), StartLoc(StartLoc), EndLoc(EndLoc) {
     setKind(BoundsKind);
+    setCompilerGenerated(false);
   }
 
   BoundsExpr(StmtClass StmtClass, Kind BoundsKind, SourceLocation StartLoc,
@@ -2886,6 +2887,7 @@ public:
   explicit BoundsExpr(StmtClass StmtClass, EmptyShell Empty) :
     Expr(StmtClass, Empty) {
     setKind(Invalid);
+    setCompilerGenerated(false);
   }
 
 
@@ -2900,6 +2902,14 @@ public:
   void setKind(Kind Kind) {
     assert(validateKind(Kind));
     BoundsExprBits.Kind = Kind;
+  }
+
+  bool isCompilerGenerated() const {
+    return BoundsExprBits.IsCompilerGenerated;
+  }
+
+  void setCompilerGenerated(bool IsGenerated) {
+    BoundsExprBits.IsCompilerGenerated = IsGenerated;
   }
 
   bool isInvalid() const {

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -269,6 +269,7 @@ protected:
 
     unsigned : NumExprBits;
     unsigned Kind : NumBoundsExprKindBits;
+    unsigned IsCompilerGenerated : 1;
   };
 
   enum { NumBoundsCheckKindBits = 2 };

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9261,20 +9261,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     "%select{function redeclaration added bounds for parameter|function "
     "redeclaration added return bounds|variable redeclaration added bounds}0">;
 
-  def err_decl_added_bounds_differ_from_inferred : Error<
-    "%select{function redeclaration added bounds for parameter|function "
-    "redeclaration added return bounds|variable redeclaration added bounds}0; "
-    "declared bounds differ from prior inferred bounds">;
-
   def err_decl_dropped_bounds : Error<
     "%select{function redeclaration dropped bounds for parameter|function "
     "redeclaration dropped return bounds|variable redeclaration dropped "
     "bounds}0">;
-
-  def err_decl_dropped_bounds_differ_from_declared : Error<
-    "%select{function redeclaration dropped bounds for parameter|function "
-    "redeclaration dropped return bounds|variable redeclaration dropped "
-    "bounds}0; inferred bounds differ from prior declared bounds">;
 
   def err_conflicting_bounds : Error<"conflicting bounds for %0">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9261,10 +9261,20 @@ def err_bounds_type_annotation_lost_checking : Error<
     "%select{function redeclaration added bounds for parameter|function "
     "redeclaration added return bounds|variable redeclaration added bounds}0">;
 
+  def err_decl_added_bounds_differ_from_inferred : Error<
+    "%select{function redeclaration added bounds for parameter|function "
+    "redeclaration added return bounds|variable redeclaration added bounds}0; "
+    "declared bounds differ from prior inferred bounds">;
+
   def err_decl_dropped_bounds : Error<
     "%select{function redeclaration dropped bounds for parameter|function "
     "redeclaration dropped return bounds|variable redeclaration dropped "
     "bounds}0">;
+
+  def err_decl_dropped_bounds_differ_from_declared : Error<
+    "%select{function redeclaration dropped bounds for parameter|function "
+    "redeclaration dropped return bounds|variable redeclaration dropped "
+    "bounds}0; inferred bounds differ from prior declared bounds">;
 
   def err_conflicting_bounds : Error<"conflicting bounds for %0">;
 
@@ -9382,6 +9392,9 @@ def err_bounds_type_annotation_lost_checking : Error<
     "(expanded) declared bounds are '%0'">;
 
   def note_inferred_bounds : Note<
+    "inferred bounds are '%0'">;
+
+  def note_expanded_inferred_bounds : Note<
     "(expanded) inferred bounds are '%0'">;
 
   def err_modifying_expr_not_supported : Error<

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -8934,6 +8934,7 @@ BoundsExpr *ASTContext::getPrebuiltCountZero() {
     PrebuiltCountZero =
       new (*this) CountBoundsExpr(BoundsExpr::Kind::ElementCount,
                                   ZeroLiteral, SourceLocation(), SourceLocation());
+    PrebuiltCountZero->setCompilerGenerated(true);
   }
   return PrebuiltCountZero;
 }
@@ -8947,6 +8948,7 @@ BoundsExpr *ASTContext::getPrebuiltCountOne() {
       new (*this) CountBoundsExpr(BoundsExpr::Kind::ElementCount,
                                   OneLiteral, SourceLocation(),
                                   SourceLocation());
+    PrebuiltCountOne->setCompilerGenerated(true);
   }
   return PrebuiltCountOne;
 
@@ -8957,6 +8959,7 @@ BoundsExpr *ASTContext::getPrebuiltBoundsUnknown() {
     PrebuiltBoundsUnknown =
       new (*this) NullaryBoundsExpr(BoundsExpr::Kind::Unknown,
                                     SourceLocation(), SourceLocation());
+    PrebuiltBoundsUnknown->setCompilerGenerated(true);
   }
   return PrebuiltBoundsUnknown;
 }

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -742,8 +742,7 @@ void TypePrinter::printFunctionProtoAfter(const FunctionProtoType *T,
 
       print(T->getParamType(i), OS, StringRef());
       if (HasBounds) {
-        const BoundsExpr *const Bounds = T->getParamBounds(i);
-        if (Bounds && !Bounds->isCompilerGenerated()) {
+        if (const BoundsExpr *const Bounds = T->getParamBounds(i)) {
           OS << " : ";
           Bounds->printPretty(OS, nullptr, Policy);
         }

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -742,7 +742,8 @@ void TypePrinter::printFunctionProtoAfter(const FunctionProtoType *T,
 
       print(T->getParamType(i), OS, StringRef());
       if (HasBounds) {
-        if (const BoundsExpr *const Bounds = T->getParamBounds(i)) {
+        const BoundsExpr *const Bounds = T->getParamBounds(i);
+        if (Bounds && !Bounds->isCompilerGenerated()) {
           OS << " : ";
           Bounds->printPretty(OS, nullptr, Policy);
         }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4082,15 +4082,16 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc, unsigned TagType,
         if (FD.BoundsExprTokens != nullptr)
           deferredBoundsExpressions.emplace_back(Field,
             std::move(FD.BoundsExprTokens));
-        else  if (InteropTypeBoundsAnnotation *BoundsAnnotation =
+
+        if (InteropTypeBoundsAnnotation *BoundsAnnotation =
             FD.BoundsAnnotation) {
           if (BoundsAnnotation->isInvalid())
             Actions.ActOnInvalidBoundsDecl(Field);
           else
             Actions.ActOnBoundsDecl(Field, BoundsAnnotation);
 	    } else
-           // Set a default bounds declaration, if necessary.
-           Actions.ActOnBoundsDecl(Field, nullptr);
+          // Set a default bounds declaration, if necessary.
+          Actions.ActOnBoundsDecl(Field, nullptr);
       };
 
       // Parse all the comma separated declarators.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4082,14 +4082,15 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc, unsigned TagType,
         if (FD.BoundsExprTokens != nullptr)
           deferredBoundsExpressions.emplace_back(Field,
             std::move(FD.BoundsExprTokens));
-
-        if (InteropTypeBoundsAnnotation *BoundsAnnotation =
+        else  if (InteropTypeBoundsAnnotation *BoundsAnnotation =
             FD.BoundsAnnotation) {
           if (BoundsAnnotation->isInvalid())
             Actions.ActOnInvalidBoundsDecl(Field);
           else
             Actions.ActOnBoundsDecl(Field, BoundsAnnotation);
-	     }
+	    } else
+           // Set a default bounds declaration, if necessary.
+           Actions.ActOnBoundsDecl(Field, nullptr);
       };
 
       // Parse all the comma separated declarators.
@@ -6573,37 +6574,43 @@ void Parser::ParseParameterDeclarationClause(
       // Inform the actions module about the parameter declarator, so it gets
       // added to the current scope.
       ParmVarDecl *Param = Actions.ActOnParamDeclarator(getCurScope(), ParmDeclarator);
-
-      // Parse an optional Checked C bounds expression or bounds-safe interface
-      // type annotation.  Bounds expressions must be delay parsed because they
-      // can refer to parameters declared after this one.
-      if (getLangOpts().CheckedC && Tok.is(tok::colon)) {
-        ConsumeToken();
-        if (StartsBoundsExpression(Tok)) {
-          // Consume and store tokens until a bounds-like expression has been
-          // read or a parsing error has happened.  Store the tokens even if a
-          // parsing error occurs so that ParseBoundsExpression can generate
-          // the error message.  This way the error messages from parsing of bounds
-          // expressions will be the same or very similar regardless of whether
-          // parsing is deferred or not.
-          std::unique_ptr<CachedTokens> BoundsExprTokens{ new CachedTokens };
-          bool ParsingError = !ConsumeAndStoreBoundsExpression(*BoundsExprTokens);
-          deferredBoundsExpressions.emplace_back(Param, std::move(BoundsExprTokens));
-          if (ParsingError)
-            SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
-        }
+      // Handle Checked C bounds expression or bounds-safe interface type annotation.
+      if (getLangOpts().CheckedC) {
+        if (!Tok.is(tok::colon))
+          // There is no bounds expression or type annotation.  Set the default
+          // bounds expression, if any.
+          Actions.ActOnBoundsDecl(Param, nullptr);
         else {
-           // fall back to general code that eagerly parses a bounds expression
-           // bounds-safe interface type annotation
-          ExprResult BoundsAnnotation =
-            ParseBoundsExpressionOrInteropType(ParmDeclarator);
-          if (BoundsAnnotation.isInvalid()) {
-            SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
-            Actions.ActOnInvalidBoundsDecl(Param);
+          ConsumeToken();
+          if (StartsBoundsExpression(Tok)) {
+            // Bounds expressions are delay parsed because they can refer to 
+            // parameters declared after this one.
+            //
+            // Consume and store tokens until a bounds-like expression has been
+            // read or a parsing error has happened.  Store the tokens even if a
+            // parsing error occurs so that ParseBoundsExpression can generate
+            // the error message.  This way the error messages from parsing of bounds
+            // expressions will be the same or very similar regardless of whether
+            // parsing is deferred or not.
+            std::unique_ptr<CachedTokens> BoundsExprTokens{ new CachedTokens };
+            bool ParsingError = !ConsumeAndStoreBoundsExpression(*BoundsExprTokens);
+            deferredBoundsExpressions.emplace_back(Param, std::move(BoundsExprTokens));
+            if (ParsingError)
+              SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
           }
-          else
-            Actions.ActOnBoundsDecl(Param,
-                                    cast<BoundsExpr>(BoundsAnnotation.get()));
+          else {
+             // Fall back to general code that eagerly parses a bounds expression
+             // bounds-safe interface type annotation.
+            ExprResult BoundsAnnotation =
+              ParseBoundsExpressionOrInteropType(ParmDeclarator);
+            if (BoundsAnnotation.isInvalid()) {
+              SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
+              Actions.ActOnInvalidBoundsDecl(Param);
+            }
+            else
+              Actions.ActOnBoundsDecl(Param,
+                                      cast<BoundsExpr>(BoundsAnnotation.get()));
+          }
         }
       }
 

--- a/lib/Sema/CheckedCInterop.cpp
+++ b/lib/Sema/CheckedCInterop.cpp
@@ -32,12 +32,17 @@ QualType Sema::GetCheckedCInteropType(QualType Ty,
                                       const BoundsExpr *Bounds,
                                       bool isParam) {
   // Nothing to do.
-  if (Ty.isNull() || Ty->isCheckedArrayType() || Ty->isCheckedPointerType())
+  if (Ty.isNull() || Ty->isCheckedArrayType() ||
+      Ty->isCheckedPointerType())
+    return Ty;
+
+  if (Bounds == nullptr)
+    return QualType();
+
+  if (Bounds->isUnknown())
     return Ty;
 
   QualType ResultType = QualType();
-  if (Bounds == nullptr)
-    return ResultType;
 
   // Parameter types that are array types are adusted to be
   // pointer types.  We'll work with the original type instead.
@@ -53,7 +58,7 @@ QualType Sema::GetCheckedCInteropType(QualType Ty,
     case BoundsExpr::Kind::Invalid:
       break;
     case BoundsExpr::Kind::Unknown:
-      llvm_unreachable("should not be getting interop type for bounds(unknown)");
+      llvm_unreachable("should already have been handled");
       break;
     case BoundsExpr::Kind::InteropTypeAnnotation: {
       const InteropTypeBoundsAnnotation *Annot =

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -796,11 +796,6 @@ namespace {
 
           BoundsExpr *B = D->getBoundsExpr();
 
-          // Null-terminated pointers with no bounds get a zero-element
-          // bounds.
-          if (!B && DR->getType()->isCheckedPointerNtArrayType())
-            B = Context.getPrebuiltCountZero();
-
           if (!B || B->isUnknown())
             return CreateBoundsAlwaysUnknown();
 
@@ -858,12 +853,6 @@ namespace {
             return CreateBoundsInferenceError();
 
           BoundsExpr *B = F->getBoundsExpr();
-
-          // Null-terminated pointers with no bounds get a zero-element
-          // bounds.
-          if (!B && F->getType()->isCheckedPointerNtArrayType())
-            B = Context.getPrebuiltCountZero();
-
           if (!B || B->isUnknown())
             return CreateBoundsAlwaysUnknown();
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -476,6 +476,13 @@ namespace {
     // Given an array type with constant dimension size, produce a count
     // expression with that size.
     BoundsExpr *CreateBoundsForArrayType(QualType QT) {
+      const IncompleteArrayType *IAT = Context.getAsIncompleteArrayType(QT);
+      if (IAT) {
+        if (IAT->getKind() == CheckedArrayKind::NtChecked)
+          return Context.getPrebuiltCountZero();
+        else
+          return CreateBoundsAlwaysUnknown();
+      }
       const ConstantArrayType *CAT = Context.getAsConstantArrayType(QT);
       if (!CAT)
         return CreateBoundsAlwaysUnknown();

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -8879,6 +8879,7 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
         const_cast<BoundsExpr *>(FT->getReturnBounds());
       DeclaratorChunk::FunctionTypeInfo &FTI = D.getFunctionTypeInfo();
       BoundsExpr *DeclaredReturnBounds = FTI.getReturnBounds();
+
       // Check the return bounds on the type to determine if the bounds
       // expression is valid for the return type.  Construction of the function
       // type for the declarator checked whether the return bounds was valid for
@@ -12033,10 +12034,6 @@ ParmVarDecl *Sema::CheckParameter(DeclContext *DC, SourceLocation StartLoc,
   ParmVarDecl *New = ParmVarDecl::Create(Context, DC, StartLoc, NameLoc, Name,
                                          Context.getAdjustedParameterType(T),
                                          TSInfo, SC, nullptr);
-  if (T->isCheckedArrayType()) {
-     New->setBoundsExpr(CreateCountForArrayType(T));
-  }
-
   // Parameters can not be abstract class types.
   // For record types, this is done by the AbstractClassUsageDiagnoser once
   // the class has been completely parsed.

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8245,8 +8245,8 @@ static bool arrayConstantCheckedConversion(Sema &S, QualType LHSType,
 
   // See if the constant needs to be retyped.
   QualType RHSType = RHS.get()->getType();
-  const PointerType *RHSPointerType = dyn_cast<PointerType>(RHSType);
-  const PointerType *LHSPointerType = dyn_cast<PointerType>(LHSType);
+  const PointerType *RHSPointerType = RHSType->getAs<PointerType>();
+  const PointerType *LHSPointerType = LHSType->getAs<PointerType>();
 
   if (!LHSType->isCheckedPointerType() || !RHSPointerType ||
       LHSPointerType->getKind() == RHSPointerType->getKind())
@@ -8257,7 +8257,7 @@ static bool arrayConstantCheckedConversion(Sema &S, QualType LHSType,
   // Retype the constant.
 
   // For checked null-terminated pointers, only retype the constant if the
-  // type would be a valid null-termianted ponter type.
+  // type would be a valid null-terminated ponter type.
   if (LHSType->isCheckedPointerNtArrayType() && !RHSPointee->isIntegerType() &&
       !RHSPointee->isPointerType())
     return false;

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4703,12 +4703,6 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
             HasAnyParameterBounds = true;
             Bounds = S.AbstractForFunctionType(Bounds, ParamInfo);
           }
-          else if (ParamTy->isCheckedPointerNtArrayType()) {
-            // _Nt_array_ptr parameters with no bounds have the default
-            // bounds of count(0).
-            HasAnyParameterBounds = true;
-            Bounds = S.Context.getPrebuiltCountZero();
-          }
           ParamBounds.push_back(Bounds);
 
           if (LangOpts.ObjCAutoRefCount && Param->hasAttr<NSConsumedAttr>()) {
@@ -4736,10 +4730,9 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
             ReturnBounds = S.CreateInvalidBoundsExpr();
           else
             ReturnBounds = S.AbstractForFunctionType(ReturnBounds, ParamInfo);
-        } else if (T->isCheckedPointerNtArrayType()) {
-          // Return values with type _Nt_array_ptr and no bounds are given a
-          // default bounds of count(0).
-          ReturnBounds = S.CreateTypeBasedBounds(T, false);
+        } else {
+          if (T->isCheckedPointerNtArrayType())
+            ReturnBounds = Context.getPrebuiltCountZero();
         }
 
         // Record bounds for Checked C extension.  Only record parameter bounds array if there are

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4703,6 +4703,12 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
             HasAnyParameterBounds = true;
             Bounds = S.AbstractForFunctionType(Bounds, ParamInfo);
           }
+          else if (ParamTy->isCheckedPointerNtArrayType()) {
+            // _Nt_array_ptr parameters with no bounds have the default
+            // bounds of count(0).
+            HasAnyParameterBounds = true;
+            Bounds = S.CreateTypeBasedBounds(ParamTy, true);
+          }
           ParamBounds.push_back(Bounds);
 
           if (LangOpts.ObjCAutoRefCount && Param->hasAttr<NSConsumedAttr>()) {
@@ -4730,6 +4736,10 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
             ReturnBounds = S.CreateInvalidBoundsExpr();
           else
             ReturnBounds = S.AbstractForFunctionType(ReturnBounds, ParamInfo);
+        } else if (T->isCheckedPointerNtArrayType()) {
+          // Return values with type _Nt_array_ptr and no bounds are given a
+          // default bounds of count(0).
+          ReturnBounds = S.CreateTypeBasedBounds(T, false);
         }
 
         // Record bounds for Checked C extension.  Only record parameter bounds array if there are

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4707,7 +4707,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
             // _Nt_array_ptr parameters with no bounds have the default
             // bounds of count(0).
             HasAnyParameterBounds = true;
-            Bounds = S.CreateTypeBasedBounds(ParamTy, true);
+            Bounds = S.Context.getPrebuiltCountZero();
           }
           ParamBounds.push_back(Bounds);
 


### PR DESCRIPTION
This change adds a default bounds of count(0) for null-terminated array pointers.    This bounds is used when no bounds is specified for an nt_array_ptr variable or in cases where we currently do not provide a way to specify bounds (such as the bounds of a pointer returned by a pointer dereference).

- Add prebuilt bounds expressions for count(0), count(1), and bounds(unknown).   We use count(0) and bounds(unknown) for now.  I deferred switching to count(1) because I want to make sure fix the types of integer literals first (issue #405).
- Extend bounds expressions with a bit that tells whether a bounds expression is compiler-generated or not.  The bit is not meaningful from a semantics-checking perspective.  It is used when printing error messages so that we know when we are dealing with bounds that did not appear in the program text.
- For variables, members, and returns, add the default bounds of count(0) early during semantics checking.  We now always call ActOnBoundsDecl, providing it with a null parameter for the bounds expression when none is specified.
- Extend bounds checking to infer count(0) for pointers returned by memory access operations (both lvalue targets and lvalues).    Also infer count(0) for bounds inferred for interface types (I eventually plan to move that inference earlier when I separate the representation of interface types from bounds expressions).
- In the IR, we currently represent no bounds specified by the user using null pointers.  I experimented with adding prebuilt bounds of bounds(unknown) during semantics checking to variables and methods, but decided not to.  This made handling of type compatibility for unchecked pointer types more complex,.  It would also trigger the allocation and unnecessary processing of arrays of bounds for function types.  It also made handling of .
- I did decide to make the code more robust about how it handles the equivalence between "no bounds" and bounds unknown.   The method `EquivalentBounds` now handles null pointers and checks for that case.  This led to some clean up in existing code for checking type compatibility and redeclarations.
- Bug fix: for non-scalar initializers, don't check the bounds of the right-hand side value.   The C semantics for initializers ensure that a properly-sized value is allocated.

Testing:
- Extending existing Checked C tests with tests for nt_array_ptr.  Those tests will be in a separate pull request for the Checked C repo.
- Passes existing automated testing for Windows and Linux.
