### PR TITLE
Fix internal assert caused by visiting AST nodes twice.

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1428,13 +1428,16 @@ namespace {
     // RecursiveASTVisitor visits both syntactic and semantic forms of
     // initializer lists, causing AST nodes used in both forms to be visited
     // twice by default. The statement in RecursiveASTVisitors that AST nodes
-    // are visit exactly once isn't quite correct.
+    // are visited exactly once isn't quite correct.
     //
-    // To fix this, override the traverse method for initializer lists to visit
-    // only the semantic form. That's what we need to check to verify
-    // correctness of bounds information.  We also want to avoid duplicate error
-    // messages and for sanity checking, we assert elsewhere in this class that
-    // bounds information is only computed once.
+    // We assume in this class that nodes are only traversed once.  We want
+    // to sanity check that bounds information is not being recomputed
+    // and to avoid duplicate error messages.
+    //
+    // Achieve this by overriding the traverse method for initializer lists to
+    // visit only the semantic form of initializer lists.  We'll need to use the
+    // semantic form when checking that struct initializers meet member bounds
+    // requirements anyway.
     bool TraverseInitListExpr(InitListExpr *S,
                               DataRecursionQueue *Q = nullptr) {
       InitListExpr *SemaForm = S->isSemanticForm() ? S : S->getSemanticForm();

--- a/test/CheckedC/regression-cases/initializer_list_bug_221.c
+++ b/test/CheckedC/regression-cases/initializer_list_bug_221.c
@@ -1,0 +1,19 @@
+//
+// These are regression tests cases for 
+//  https://github.com/Microsoft/checkedc/issues/221
+//
+// The compiler crashed with an assert while checking bounds declarations. It
+// had found that bounds information was already present.  The cause was that RecursiveASTVisitor
+// actually visits nodes in initializer lists twice by default, despite the documentation
+// saying that nodes are only visited once.  This test checks that the compiler does
+// not crash and also issues an expected error message.
+//
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+
+void f(void) {
+  int x;
+  struct S { _Ptr<int> p_variable; };
+  struct S t1 = { &x };     // crashed compiler
+  struct S t2 = { 0xabcd }; // expected-error {{initializing '_Ptr<int>' with an expression of incompatible type 'int'}}
+}
+


### PR DESCRIPTION
This fixes a compiler crash reported in https://github.com/Microsoft/checkedc/issues/221.  The checking of bounds information was failling an assertion that bounds are only set once for cast expression nodes.  I tracked the problem to an issue in RecursiveASTVisitor.h.  It turns out that nodes in initializer lists are visited multiple times if they appear in both semantic and syntactic forms of an initializer list. The comment in RecursiveASTVisitor.h about AST nodes being visited exactly once isn't quite accurate.

The fix is to borrow an approach used in lib\index\IndexBody.cpp and visit only one form.  In our case, we want to visit the semantic form. We'll eventually have more complex checking that ensures that structs are initialized to satisfy their member bounds invariants, and we'll need to use the semantic form for that.

Testing:
- Added a regression test case to the test\CheckedC directory.
- Passed clang regression tests on Linux.  Additional automated testing progress.