### PR TITLE
Lower parallelism because of VSTS automation failures.

### DIFF
--- a/automation/Windows/config-vars.bat
+++ b/automation/Windows/config-vars.bat
@@ -163,7 +163,7 @@ if NOT DEFINED MSBUILD_CPU_COUNT (
 
 if NOT DEFINED CL_CPU_COUNT (
   rem It would be better to calculate this based on total physical memory availablity.
-  set CL_CPU_COUNT=6
+  set CL_CPU_COUNT=4
 )
 
 echo Configured environment variables:


### PR DESCRIPTION
The test machines for Windows are becoming unresponsive while compiling clang.  This causes VSTS to report that it has lost the network connection to a test machine.   First try lowering the parallelism that we're using during testing on Windows.

