### PR TITLE
Warn about unprovable bounds declarations in checked scopes. 

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9373,9 +9373,14 @@ def err_bounds_type_annotation_lost_checking : Error<
       : Error<"invalid bounds cast: expected _Array_ptr type">;
 
   def warn_bounds_declaration_invalid : Warning<
-    "declared bounds for %1 may be invalid after "
-    " %select{assignment|initialization}0">,
+    "cannot prove declared bounds for %1 are valid after "
+    "%select{assignment|initialization}0">,
     DefaultIgnore,
+    InGroup<CheckBoundsDecls>;
+
+  def warn_checked_scope_bounds_declaration_invalid : Warning<
+    "cannot prove declared bounds for %1 are valid after "
+    "%select{assignment|initialization}0">,
     InGroup<CheckBoundsDecls>;
 
   def error_bounds_declaration_invalid : Error<
@@ -9399,8 +9404,12 @@ def err_bounds_type_annotation_lost_checking : Error<
    "is used in a bounds expression">;
 
   def warn_argument_bounds_invalid : Warning<
-    "argument may not meet declared bounds for %ordinal0 parameter">,
+    "cannot prove argument meets declared bounds for %ordinal0 parameter">,
     DefaultIgnore,
+    InGroup<CheckBoundsDecls>;
+
+  def warn_checked_scope_argument_bounds_invalid : Warning<
+    "cannot prove argument meets declared bounds for %ordinal0 parameter">,
     InGroup<CheckBoundsDecls>;
 
   def error_argument_bounds_invalid : Error<
@@ -9410,8 +9419,12 @@ def err_bounds_type_annotation_lost_checking : Error<
     "(expanded) expected argument bounds are '%0'">;
 
   def warn_static_cast_bounds_invalid : Warning<
-    "cast source bounds may be too narrow for %0">,
+    "cannot prove cast source bounds are wide enough for %0">,
     DefaultIgnore,
+    InGroup<CheckBoundsDecls>;
+
+  def warn_checked_scopestatic_cast_bounds_invalid : Warning<
+    "cannot prove cast source bounds are wide enough for %0">,
     InGroup<CheckBoundsDecls>;
 
   def error_static_cast_bounds_invalid : Error<

--- a/test/CheckedC/static-checking/bounds-decl-checking-cs.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking-cs.c
@@ -1,0 +1,10 @@
+// Test for checked scopes that bounds declaration checking always
+// produces warnings about bounds declarations that are not provably
+// true or false.
+//
+// RUN: %clang -cc1 -fcheckedc-extension -verify %s
+
+#pragma BOUNDS_CHECKED ON
+
+#include "bounds-decl-checking.c"
+

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -253,3 +253,22 @@ void test_addition_commutativity(void) {
   _Array_ptr<int> q : bounds(1 + p, p + 5) = p;
   _Array_ptr<int> r : bounds(p + 1, 5 + p) = p;
 }
+
+
+// Test uses of incomplete types
+
+struct S;
+extern void test_f30(const void* p_ptr : byte_count(1));
+
+int f30(_Ptr<struct S> p) {
+  // TODO: Github Checked C repo issue #422: Extend constant-sized ranges to cover Ptr to an incomplete type
+  test_f30(p); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+               // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 1)'}} \
+               // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 1)'}}
+  return 0;
+}
+
+int f31(_Ptr<void> p) {
+  test_f30(p);
+  return 0;
+}

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -19,7 +19,7 @@ void f2(_Array_ptr<int> p : bounds(p, p + x), int x) {
 // Initialization by expression without syntactically identical
 // normalized bounds - warning expected.
 void f3(_Array_ptr<int> p : bounds(p, p + x), int x) {
-  _Array_ptr<int> r : count(x) = p;     // expected-warning {{may be invalid}} \
+  _Array_ptr<int> r : count(x) = p;     // expected-warning {{cannot prove declared bounds}} \
                                         // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
                                         // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
 }
@@ -42,7 +42,7 @@ void f5(_Array_ptr<int> p : count(x), int x) {
 // no warning.
 void f6(_Array_ptr<int> p : count(x), int x) {
   _Array_ptr<int> r : count(x) = 0;
-  r = p;      // expected-warning {{may be invalid}} \
+  r = p;      // expected-warning {{cannot prove declared bounds}} \
               // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
 }
@@ -162,7 +162,7 @@ void f22(_Array_ptr<int> q : count(5)) {
           // expected-note {{destination lower bound is below source lower bound}} \
           // expected-note {{(expanded) expected argument bounds are 'bounds(q - 1, q + 4)'}} \
           // expected-note {{(expanded) inferred bounds are 'bounds(q, q + 5)'}}
-  constant_sized_bound2(q + 1);  // expected-warning {{argument may not meet declared bounds for 1st parameter}} \
+  constant_sized_bound2(q + 1);  // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
                                  // expected-note {{(expanded) expected argument bounds are 'bounds(q + 1 - 1, q + 1 + 4)'}} \
                                  // expected-note {{(expanded) inferred bounds are 'bounds(q, q + 5)'}}
                                 // TODO: no warning/error expected.  We need reassocation of arithmetic
@@ -186,10 +186,12 @@ void test_cast(_Ptr<struct S1> s1, _Ptr<struct S2> s2) {
   _Ptr<char> cp = 0;
   cp = (_Ptr<char>) p;
   p = (_Ptr<int>) cp; // expected-error {{cast source bounds are too narrow for '_Ptr<int>'}} \
+                      // expected-note {{target upper bound is above source upper bound}} \
                       // expected-note{{(expanded) required bounds are 'bounds((_Ptr<int>)cp, (_Ptr<int>)cp + 1)'}} \
                       // expected-note {{(expanded) inferred bounds are 'bounds(cp, cp + 1)'}} \
   _Ptr<struct S1> prefix = (_Ptr<struct S1>) s2;
   _Ptr<struct S2> suffix = (_Ptr<struct S2>) s1; // expected-error {{cast source bounds are too narrow for '_Ptr<struct S2>'}} \
+                                                 // expected-note {{target upper bound is above source upper bound}} \
                                                  // expected-note {{(expanded) required bounds are 'bounds((_Ptr<struct S2>)s1, (_Ptr<struct S2>)s1 + 1)'}} \
                                                  // expected-note{{(expanded) inferred bounds are 'bounds(s1, s1 + 1)'}}
 
@@ -199,9 +201,11 @@ _Ptr<void> test_void(void);
 
 void test_ptr_void_cast(_Ptr<void> p) {
   _Ptr<int> ip = (_Ptr<int>) p; // expected-error {{cast source bounds are too narrow for '_Ptr<int>'}} \
+                                // expected-note {{target upper bound is above source upper bound}} \
                                 // expected-note {{(expanded) required bounds are 'bounds((_Ptr<int>)p, (_Ptr<int>)p + 1)'}} \
                                 // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 1)'}}
   _Ptr<struct S1> sp = (_Ptr<struct S1>) p; // expected-error {{cast source bounds are too narrow for '_Ptr<struct S1>'}} \
+                                            // expected-note {{target upper bound is above source upper bound}} \
                                             // expected-note {{(expanded) required bounds are 'bounds((_Ptr<struct S1>)p, (_Ptr<struct S1>)p + 1)'}} \
                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 1)'}}
   _Ptr<char> cp = (_Ptr<char>) p;
@@ -220,6 +224,7 @@ void test_nt_array_casts(void) {
 
   _Ptr<int _Nt_checked[6]> nt_parr2 = 0;
   nt_parr2 = (_Ptr<int _Nt_checked[6]>) &nt_arr; // expected-error {{cast source bounds are too narrow for '_Ptr<int _Nt_checked[6]>'}} \
+                    // expected-note {{target upper bound is above source upper bound}} \
                     // expected-note {{(expanded) required bounds are 'bounds((_Ptr<int _Nt_checked[6]>)&nt_arr, (_Ptr<int _Nt_checked[6]>)&nt_arr + 1)'}} \
                     // expected-note {{(expanded) inferred bounds are 'bounds(nt_arr, nt_arr + 5)'}}
 
@@ -232,11 +237,13 @@ void test_nt_array_casts(void) {
 
   _Ptr<int _Checked[5]> parr5 = 0;
   parr5 = (_Ptr<int _Checked[5]>) &nt_arr; // expected-error {{cast source bounds are too narrow for '_Ptr<int _Checked[5]>'}} \
+                                           // expected-note {{target upper bound is above source upper bound}} \
                                            // expected-note {{(expanded) required bounds are 'bounds((_Ptr<int _Checked[5]>)&nt_arr, (_Ptr<int _Checked[5]>)&nt_arr + 1)'}} \
                                            // expected-note {{(expanded) inferred bounds are 'bounds(nt_arr, nt_arr + 4)}}
 
   _Ptr<int _Checked[5]> parr6 = 0;
   parr6 = (_Ptr<int _Checked[5]>) &nt_arr;  // expected-error {{cast source bounds are too narrow for '_Ptr<int _Checked[5]>'}} \
+                    // expected-note {{target upper bound is above source upper bound}} \
                     // expected-note {{(expanded) required bounds are 'bounds((_Ptr<int _Checked[5]>)&nt_arr, (_Ptr<int _Checked[5]>)&nt_arr + 1)'}} \
                     // expected-note {{(expanded) inferred bounds are 'bounds(nt_arr, nt_arr + 4)'}}
 }


### PR DESCRIPTION
The Checked C compiler will now always warn in checked scopes about bounds declarations that cannot be proved true or false.  For unchecked scopes, the warning is off by default.

I replaced the RecursiveASTVisitor with a recursive function because I needed to pass information about checked scopes downward from compound statements to their children.

To avoid having to unnecessarily change tests in the Checked C repo, I generalized the code for constant-sized ranges to detect equivalence of base expressions beyond lexical equivalence.  It now canonicalizes base expressions by stripping off outer operations that do not change the runtime value of the expression.  This includes parentheses, value-preserving casts, and certain operations involving
function/array types.  For example, the address-of operator applied to an array does not actually change runtime values.  It gives you a pointer to the same location with a different type.

Testing:
- Updated Checked C repo tests with new warnings about that occur for bounds declarations in checked scopes.  There is a separate pull request for this: https://github.com/Microsoft/checkedc/pull/240
- For the clang Checked C repo, added a new test of bounds declarations that verifies that warnings are always produced for checked scopes.  It includes the existing test of bounds declarations, but uses a pragma to put it in a checked scope.
- Update tests with new warning messages.
- Passed automated testing on Linux; local testing on Windows.
