### PR TITLE
Allow writing null terminators at nt_array_ptr upper bounds.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -1752,6 +1752,7 @@ public:
 enum BoundsCheckKind {
   BCK_None,
   BCK_NullTermRead,
+  BCK_NullTermWriteAssign,  // assignment through a pointer to a null-terminated array.
   BCK_Normal,
   BCK_MaxKind = BCK_Normal
 };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2613,6 +2613,7 @@ void ASTDumper::dumpBoundsCheckKind(BoundsCheckKind K) {
     case BoundsCheckKind::BCK_None: OS << "None"; break;
     case BoundsCheckKind::BCK_Normal: OS << "Normal"; break;
     case BoundsCheckKind::BCK_NullTermRead: OS << "Null-terminated read"; break;
+    case BoundsCheckKind::BCK_NullTermWriteAssign: OS << "Null-terminated assignment"; break;
   }
 }
 

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -3155,6 +3155,13 @@ Value *ScalarExprEmitter::VisitBinAssign(const BinaryOperator *E) {
     // this should improve codegen just a little.
     RHS = Visit(E->getRHS());
     LHS = EmitCheckedLValue(E->getLHS(), CodeGenFunction::TCK_Store);
+    if (E->getOpcode() == BO_Assign) {
+      BoundsExpr *BoundsCheck = CGF.GetNullTermBoundsCheck(E->getLHS());
+      if (BoundsCheck)
+        CGF.EmitDynamicBoundsCheck(LHS.getAddress(), BoundsCheck,
+                                   BoundsCheckKind::BCK_NullTermWriteAssign,
+                                   RHS);
+    }
 
     // Store the value into the LHS.  Bit-fields are handled specially
     // because the result is altered by the store, i.e., [C99 6.5.16p1]

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2548,15 +2548,20 @@ public:
   void EmitDynamicNonNullCheck(const Address BaseAddr, const QualType BaseTy);
   void EmitDynamicOverflowCheck(const Address BaseAddr, const QualType BaseTy,
                                 const Address PtrAddr);
+  /// \brief Emit a dynamic bounds check.  ValueToStore is optional and is
+  /// used for bounds checking writes to NUL-terminated pointers.
   void EmitDynamicBoundsCheck(const Address PtrAddr, const BoundsExpr *Bounds,
-                              BoundsCheckKind Kind);
+                              BoundsCheckKind Kind, llvm::Value *ValueToStore);
   void EmitDynamicBoundsCastCheck(const Address BaseAddr,
                                   const BoundsExpr *CastBounds,
                                   const BoundsExpr *SubExprBounds);
-  /// \brief Create a basic block that will call the trap intrinsic, and emit
-  /// a conditional branch to it, for Checked C's dynamic checks.
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
   llvm::BasicBlock *EmitDynamicCheckFailedBlock();
+  llvm::BasicBlock *EmitNulltermWriteAdditionalCheck(const Address PtrAddr,
+                                                     const Address Upper,
+                                                     llvm::Value *Val,
+                                                     llvm::BasicBlock *Suceeded);
+  BoundsExpr *GetNullTermBoundsCheck(Expr *LHS);
 
   llvm::Value *EmitBoundsCast(CastExpr *CE);
 

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2559,6 +2559,7 @@ public:
   llvm::BasicBlock *EmitDynamicCheckFailedBlock();
   llvm::BasicBlock *EmitNulltermWriteAdditionalCheck(const Address PtrAddr,
                                                      const Address Upper,
+                                                     llvm::Value *LowerChk,
                                                      llvm::Value *Val,
                                                      llvm::BasicBlock *Suceeded);
   BoundsExpr *GetNullTermBoundsCheck(Expr *LHS);

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1376,7 +1376,13 @@ namespace {
     // If the Array_ptr has unknown bounds, this is a compile-time error.
     // Generate an error message and set the bounds to an invalid bounds
     // expression.
-    bool AddBoundsCheck(Expr *E, bool IsOnlyMemoryRead, bool InCheckedScope) {
+    enum class OperationKind {
+      Read,   // just reads memory
+      Assign, // simple assignment to memory
+      Other   // reads and writes memory, struct base check
+    };
+
+    bool AddBoundsCheck(Expr *E, OperationKind OpKind, bool InCheckedScope) {
       assert(E->isLValue());
       bool NeedsBoundsCheck = false;
       QualType PtrType;
@@ -1384,8 +1390,15 @@ namespace {
         NeedsBoundsCheck = true;
         BoundsExpr *LValueBounds = S.InferLValueBounds(E);
         BoundsCheckKind Kind = BCK_Normal;
-        if (IsOnlyMemoryRead && PtrType->isCheckedPointerNtArrayType())
-          Kind = BCK_NullTermRead;
+        // Null-terminated array pointers have special semantics for
+        // bounds checks.
+        if (PtrType->isCheckedPointerNtArrayType()) {
+          if (OpKind == OperationKind::Read)
+            Kind = BCK_NullTermRead;
+          else if (OpKind == OperationKind::Assign)
+            Kind = BCK_NullTermWriteAssign;
+          // Otherwise, use the default range check for bounds.
+        }
         if (LValueBounds->isUnknown()) {
           S.Diag(E->getLocStart(), diag::err_expected_bounds) << E->getSourceRange();
           LValueBounds = S.CreateInvalidBoundsExpr();
@@ -1417,7 +1430,7 @@ namespace {
       if (!E->isArrow()) {
         // The base expression only needs a bounds check if it is an lvalue.
         if (Base->isLValue())
-          return AddBoundsCheck(Base, false, InCheckedScope);
+          return AddBoundsCheck(Base, OperationKind::Other, InCheckedScope);
         return false;
       }
 
@@ -2214,7 +2227,9 @@ namespace {
       // Check that the LHS lvalue of the assignment has bounds, if it is an
       // lvalue that was produced by dereferencing an _Array_ptr.
       bool LHSNeedsBoundsCheck = false;
-      LHSNeedsBoundsCheck = AddBoundsCheck(LHS, false, InCheckedScope);
+      OperationKind OpKind = (E->getOpcode() == BO_Assign) ?
+        OperationKind::Assign : OperationKind::Other;
+      LHSNeedsBoundsCheck = AddBoundsCheck(LHS, OpKind, InCheckedScope);
       if (DumpBounds && (LHSNeedsBoundsCheck ||
                          (LHSTargetBounds && !LHSTargetBounds->isUnknown())))
         DumpAssignmentBounds(llvm::outs(), E, LHSTargetBounds, RHSBounds);
@@ -2311,7 +2326,7 @@ namespace {
 
       CastKind CK = E->getCastKind();
       if (CK == CK_LValueToRValue && !E->getType()->isArrayType()) {
-        bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr(), true, InCheckedScope);
+        bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr(), OperationKind::Read, InCheckedScope);
         if (NeedsBoundsCheck && DumpBounds)
           DumpExpression(llvm::outs(), E);
 
@@ -2385,7 +2400,7 @@ namespace {
       if (!E->isIncrementDecrementOp())
         return true;
 
-      bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr(), false, InCheckedScope);
+      bool NeedsBoundsCheck = AddBoundsCheck(E->getSubExpr(), OperationKind::Other, InCheckedScope);
       if (NeedsBoundsCheck && DumpBounds)
           DumpExpression(llvm::outs(), E);
       return true;


### PR DESCRIPTION
In existing C code, a common pattern is to write a null terminator after copying data to a null-terminated array.  When converting the code to Checked C, this can lead to attempting to write a null-terminator exactly at the upper bound of an nt_array_ptr, when the entire array is filled with data. This was not allowed under Checked C bounds checking rules.   Even though it was not allowed, it is OK to allow it because the invariant for null-terminated arrays is preserved by the write. 

This change relaxes the bounds checking for nt_array_ptrs to allow writing null values exactly at upper bounds.  There is a matching Checked C pull request that updates the specification and tests: https://github.com/Microsoft/checkedc/pull/242.

We only allow this for simple assignments.  It is not allowed for compound assignments.  This was a little awkward to implement because all bounds checks are currently done as part of lvalue-expression evaluation.   In this case, we need to know the value that is being written.   I didn't want to move the bounds check insertion to all places that use lvalues.  Instead, we skip inserting the check when constructing an lvalue for this specific case.   We have a special case check in assignment.  We might to revisit this in the future and move the checks.

The generated LLVM IR for the check for the upper bound case is larger than necessary.   Given bounds (lb, ub), a destination pointer p,, and a value v, we check three conditions: p == ub &&  lb <= p and v == 0.     The lower bound check is needed to handle empty ranges properly.  We could avoid generating code for it by changing the regular bounds check to use branches instead of AND'ing conditions together.    That's a  significant change that should be evaluated separately because it could have performance effects.

Testing:
- Added new tests to the nullterm_pointers.c file in the Checked C repo.  The tests check writing null values and non-null values exactly at the upper bounds of nt_array_ptr and regular array_ptrs.
- Passes automated testing.

