### PR TITLE
Update error message to use the term "unknown bounds".

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9281,22 +9281,22 @@ def err_bounds_type_annotation_lost_checking : Error<
     "only reference parameters from its own parameter list)">;
 
   def err_expected_bounds : Error<
-    "expression has no bounds">;
+    "expression has unknown bounds">;
 
   def err_expected_bounds_for_ptr_cast : Error<
-    "expression has no bounds"
+    "expression has unknown bounds"
     ", cast to ptr<T> expects source to have bounds">;
 
   def err_expected_bounds_for_assignment : Error<
-    "expression has no bounds"
+    "expression has unknown bounds"
     ", right-hand side of assignment expected to have bounds because the left-hand side has bounds">;
 
   def err_expected_bounds_for_initializer : Error<
-    "expression has no bounds"
+    "expression has unknown bounds"
     ", initializer expected to have bounds because the variable being declared has bounds">;
 
   def err_expected_bounds_for_argument : Error<
-    "argument has no bounds, bounds expected because the "
+    "argument has unknown bounds, bounds expected because the "
     "%ordinal0 parameter has bounds">;
 
   def err_initializer_expected_with_bounds : Error<

--- a/test/CheckedC/inferred-bounds/basic.c
+++ b/test/CheckedC/inferred-bounds/basic.c
@@ -131,7 +131,7 @@ void f5(void) {
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 void f6(_Array_ptr<int> a : bounds(a, a + 5)) {
-  a = (_Array_ptr<int>) 5; // expected-error {{expression has no bounds}}
+  a = (_Array_ptr<int>) 5; // expected-error {{expression has unknown bounds}}
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
@@ -150,7 +150,7 @@ void f6(_Array_ptr<int> a : bounds(a, a + 5)) {
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
 
 void f7(void) {
-  _Array_ptr<int> d : count(5) = (_Array_ptr<int>) 5; // expected-error {{expression has no bounds}}
+  _Array_ptr<int> d : count(5) = (_Array_ptr<int>) 5; // expected-error {{expression has unknown bounds}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} d '_Array_ptr<int>' cinit
@@ -190,7 +190,7 @@ void f8(_Array_ptr<int> a, _Array_ptr<int> b : count(5)) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 
 void f9(int a) {
-  _Array_ptr<int> b : count(5) = (_Array_ptr<int>) !a; // expected-error {{expression has no bounds}}
+  _Array_ptr<int> b : count(5) = (_Array_ptr<int>) !a; // expected-error {{expression has unknown bounds}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
@@ -207,7 +207,7 @@ void f9(int a) {
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
 
 void f10(float a) {
-  _Array_ptr<int> b : count(5) = (_Array_ptr<int>)((int)a); // expected-error {{expression has no bounds}}
+  _Array_ptr<int> b : count(5) = (_Array_ptr<int>)((int)a); // expected-error {{expression has unknown bounds}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
@@ -260,7 +260,7 @@ void f20(_Array_ptr<int> a : count(len),
 
 void f21(_Array_ptr<int> a : count(5),
          _Array_ptr<int> b) {
-  a = b;  // expected-error {{expression has no bounds}}
+  a = b;  // expected-error {{expression has unknown bounds}}
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
@@ -280,7 +280,7 @@ void f21(_Array_ptr<int> a : count(5),
 
 // Only test declarations for the negative case (where an error is expected}
 void f22(_Array_ptr<int> b) {
-  _Array_ptr<int> a : count(5) = b;  // expected-error {{expression has no bounds}}
+  _Array_ptr<int> a : count(5) = b;  // expected-error {{expression has unknown bounds}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} a '_Array_ptr<int>' cinit

--- a/test/CheckedC/regression-cases/ptr_cast_bug_242.c
+++ b/test/CheckedC/regression-cases/ptr_cast_bug_242.c
@@ -10,16 +10,16 @@
 // Test explicit cast.
 void f(int *p) {
   // Test explicit cast where bounds are expected for the entire initializing expression.
-  _Array_ptr<int> q : count(1) = (_Ptr<int>)(p); // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  _Array_ptr<int> q : count(1) = (_Ptr<int>)(p); // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   // Test explicit cast.
-  _Ptr<int> r = (_Ptr<int>)(p);    // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  _Ptr<int> r = (_Ptr<int>)(p);    // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   // Test implicit cast.
-  _Ptr<int> s = p;                 // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  _Ptr<int> s = p;                 // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   _Array_ptr<int> t : count(1) = 0;
   // Test explicit cast involving assignment;
-  t = (_Ptr<int>)(p);              // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  t = (_Ptr<int>)(p);              // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   _Ptr<int> u = 0;
   // Test implicit cast involving assignment.
-  u = p;                           // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+  u = p;                           // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
 }
 

--- a/test/CheckedC/type-checking-crash.c
+++ b/test/CheckedC/type-checking-crash.c
@@ -1,13 +1,13 @@
-// Tests to make sure the Checked C code does not crash the compiler when it 
+// Tests to make sure the Checked C code does not crash the compiler when it
 // encounters an incorrectly constructed AST caused by type checking error.
 //
-// More specifically, take a look at the four test cases below. First of all, 
-// even when clang encounters a type checking error, it does its best to create 
-// the entire AST, before it exits with an error message. 
-// Struct_int_array_type_checking_crash_test_1 creates an invalid AST, where 
-// "arr" is not an lvalue, although it should be an lvalue. Interestingly, for 
-// the other three test cases, the constructed AST has "arr" to be an lvalue. 
-// This test makes sure that no matter the case, the Checked C code will not 
+// More specifically, take a look at the four test cases below. First of all,
+// even when clang encounters a type checking error, it does its best to create
+// the entire AST, before it exits with an error message.
+// Struct_int_array_type_checking_crash_test_1 creates an invalid AST, where
+// "arr" is not an lvalue, although it should be an lvalue. Interestingly, for
+// the other three test cases, the constructed AST has "arr" to be an lvalue.
+// This test makes sure that no matter the case, the Checked C code will not
 // exit the program with an exception.
 //
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
@@ -23,7 +23,7 @@ struct S {
 
 void struct_int_array_type_checking_crash_test_1(int i) {
   struct S s = { { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }, 10 };
-  s->arr[i] = 1; //expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} //expected-error{{expression has no bounds}}
+  s->arr[i] = 1; //expected-error{{member reference type 'struct S' is not a pointer; did you mean to use '.'?}} //expected-error{{expression has unknown bounds}}
 }
 
 //====================================================================


### PR DESCRIPTION
We changed the language to use bounds(unknown) instead of bounds(none) because bounds(none) was ambiguous.  Make a similar update to compiler error messages, changing from using the phrase "no bounds" to "unknown bounds."

Also fix line endings for test\CheckedC\type-checking-crash.c