### PR TITLE
Produce error messages for problems with returns.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -565,6 +565,22 @@ def warn_suggest_noreturn_block : Warning<
   "block could be declared with attribute 'noreturn'">,
   InGroup<MissingNoreturn>, DefaultIgnore;
 
+// Checked C-specific errors for falling off ends of functions
+def err_maybe_falloff_function_with_checked_return : Error<
+  "control may reach end of function with checked pointer return type">;
+def err_falloff_function_with_checked_return : Error<
+  "control reaches end of function with checked pointer return type">;
+
+def err_maybe_falloff_checked_function : Error<
+  "control may reach end of checked function body">;
+def err_falloff_checked_function : Error<
+  "control reaches end of checked function body">;
+
+def err_maybe_falloff_function_with_bounds : Error<
+  "control may reach end of function with return bounds">;
+def err_falloff_function_with_bounds : Error<
+  "control reaches end of function with return bounds">;
+
 // Unreachable code.
 def warn_unreachable : Warning<
   "code will never be executed">,
@@ -8157,12 +8173,24 @@ def warn_noreturn_function_has_return_expr : Warning<
 def warn_falloff_noreturn_function : Warning<
   "function declared 'noreturn' should not return">,
   InGroup<InvalidNoreturn>;
+
+// Checked C specific error messages about returns
+def err_return_missing_expr : Error<
+  "non-void function %0 must return a value in a checked scope">;
+def err_return_missing_expr_for_checked_pointer : Error<
+  "function %0 with checked pointer return type must return a value">;
+def err_return_missing_expr_for_bounds : Error<
+  "non-void function %0 must return a value when there are return bounds">;
+def err_return_has_expr : Error<
+  "void function %0 cannot return a value in a checked scope">;
+
 def err_noreturn_block_has_return_expr : Error<
   "block declared 'noreturn' should not return">;
 def err_noreturn_missing_on_first_decl : Error<
   "function declared '[[noreturn]]' after its first declaration">;
 def note_noreturn_missing_first_decl : Note<
   "declaration missing '[[noreturn]]' attribute is here">;
+
 def err_carries_dependency_missing_on_first_decl : Error<
   "%select{function|parameter}0 declared '[[carries_dependency]]' "
   "after its first declaration">;

--- a/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/lib/Sema/AnalysisBasedWarnings.cpp
@@ -600,11 +600,8 @@ struct CheckFallThroughDiagnostics {
     if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(Func)) {
       bool isCheckedReturn = FD->getReturnType()->isCheckedPointerType();
       bool hasReturnBounds = FD->getBoundsExpr() != nullptr;
-      bool isCheckedFunction = false;
-      if (FD->hasBody()) {
-        CompoundStmt *CS = dyn_cast<CompoundStmt>(FD->getBody());
-        isCheckedFunction = CS->isChecked();
-      }
+      CompoundStmt *CS = dyn_cast_or_null<CompoundStmt>(FD->getBody());
+      bool isCheckedFunction = CS && CS->isChecked();
       if (isCheckedReturn) {
         D.diag_MaybeFallThrough_ReturnsNonVoid =
           diag::err_maybe_falloff_function_with_checked_return;

--- a/lib/Sema/SemaStmt.cpp
+++ b/lib/Sema/SemaStmt.cpp
@@ -3430,7 +3430,7 @@ StmtResult Sema::BuildReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp) {
       } else if (!RetValExp->isTypeDependent()) {
         // C99 6.8.6.4p1 (ext_ since GCC warns)
         unsigned D = diag::ext_return_has_expr;
-        if (getLangOpts().CheckedC)
+        if (getCurScope()->isCheckedScope())
           D = diag::err_return_has_expr;
 
         if (RetValExp->getType()->isVoidType()) {


### PR DESCRIPTION
Clang checks for problems with return statements in C.  These problems include returning a value when none is expected, not returning a value when one is expected, and falling off the end of a function when a return value is expected.

These checks result in warnings.  Some of them are escalated to errors by default, but they can still be turned off by programmers. For Checked C, these problems must be errors when checked pointers and checked scopes are involved,  so that soundness guarantees for them  hold.  There should be errors when:
- A value is returned in a checked scope, when none is expected.
- The return value has a checked pointer type or bounds, and no value is returned when expected.

This modifies the existing code to issue error messages in these situations.  It cleans up SemaBounds.cpp to avoid returning unused boolean values when walking the AST while checking bounds and includes an empty function body for checking bounds on function return statements.

Testing:
- Added new tests cases to the Checked C repo for return statements.
- Passed automated testing.
