### PR TITLE
Beginning of changes for merge of cast placement algorithm

### DIFF
--- a/test/CheckedCRewriter/boundary_tests.c
+++ b/test/CheckedCRewriter/boundary_tests.c
@@ -1,0 +1,27 @@
+// Tests for Checked C rewriter tool.
+//
+// RUN: checked-c-convert %s -- | FileCheck -match-full-lines %s
+// RUN: checked-c-convert %s -- | %clang_cc1 -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+
+void do_something(int *a, int b) {
+  *a = b;
+}
+//CHECK: void do_something(_Ptr<int> a, int b) {
+
+void mut(int *a, int b);
+//CHECK: void mut(int *a, int b); 
+
+void mut(int *a, int b) {
+  *a += b;
+}
+//CHECK: void mut(int *a, int b) {
+
+void bad_ctx(void) {
+  mut((int*)0x8001000, 1);
+}
+
+void good_ctx(void) {
+  int u = 0;
+  mut(&u, 1);
+}

--- a/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/tools/checked-c-convert/CheckedCConvert.cpp
@@ -95,7 +95,7 @@ ConstraintVariable *getHighest(std::set<ConstraintVariable*> Vs, ProgramInfo &In
 
   for (auto &P : Vs) {
     if (V) {
-      if (V->isLt(*P, Info) && !V->isEq(*P, Info))
+      if (V->isLt(*P, Info))
         V = P;
     } else {
       V = P;

--- a/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/tools/checked-c-convert/CheckedCConvert.cpp
@@ -87,6 +87,24 @@ bool canRewrite(Rewriter &R, SourceRange &SR) {
   return SR.isValid() && (R.getRangeSize(SR) != -1);
 }
 
+ConstraintVariable *getHighest(std::set<ConstraintVariable*> Vs, ProgramInfo &Info) {
+  if (Vs.size() == 0)
+    return nullptr;
+
+  ConstraintVariable *V = nullptr;
+
+  for (auto &P : Vs) {
+    if (V) {
+      if (V->isLt(*P, Info) && !V->isEq(*P, Info))
+        V = P;
+    } else {
+      V = P;
+    }
+  }
+
+  return V;
+}
+
 typedef std::pair<Decl*, DeclStmt*> DeclNStmt;
 typedef std::pair<DeclNStmt, std::string> DAndReplace;
 

--- a/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -352,15 +352,10 @@ public:
       unsigned i = 0;
       for (const auto &A : E->arguments()) {
         std::set<ConstraintVariable*> ParameterEC =
-          Info.getVariable(A, Context);
+          Info.getVariable(A, Context, false);
 
         if (i < FD->getNumParams()) {
-          ParmVarDecl *PVD = FD->getParamDecl(i);
-          std::set<ConstraintVariable*> ParameterDC =
-            Info.getVariable(PVD, Context);
-
-          // Constrain ParameterEC and ParameterDC to be equal.
-          constrainEq(ParameterEC, ParameterDC, Info);
+          constrainAssign(FD->getParamDecl(i), A);
         } else {
           // Constrain ParameterEC to wild if it is a pointer type.
           Constraints &CS = Info.getConstraints();
@@ -372,7 +367,7 @@ public:
       }
     } else if (DeclaratorDecl *DD = dyn_cast<DeclaratorDecl>(D)){
       // This could be a function pointer.
-      std::set<ConstraintVariable*> V = Info.getVariable(DD, Context);
+      std::set<ConstraintVariable*> V = Info.getVariable(DD, Context, false);
       if (V.size() > 0) {
         for (const auto &C : V) {
           FVConstraint *FV = nullptr;
@@ -389,7 +384,7 @@ public:
             unsigned i = 0;
             for (const auto &A : E->arguments()) {
               std::set<ConstraintVariable*> ParameterEC = 
-                Info.getVariable(A, Context);
+                Info.getVariable(A, Context, false);
               
               if (i < FV->numParams()) {
                 std::set<ConstraintVariable*> ParameterDC = 
@@ -411,7 +406,7 @@ public:
             // everything. 
             Constraints &CS = Info.getConstraints();
             for (const auto &A : E->arguments()) 
-              for (const auto &Ct : Info.getVariable(A, Context)) 
+              for (const auto &Ct : Info.getVariable(A, Context, false)) 
                 Ct->constrainTo(CS, CS.getWild());
             C->constrainTo(CS, CS.getWild());
           }
@@ -420,7 +415,7 @@ public:
         // Constrain everything to wild. 
         for (const auto &A : E->arguments()) {
           std::set<ConstraintVariable*> ParameterEC = 
-            Info.getVariable(A, Context);
+            Info.getVariable(A, Context, false);
           
           Constraints &CS = Info.getConstraints();
           for (const auto &C : ParameterEC) 
@@ -431,7 +426,7 @@ public:
       // Constrain everything to wild. 
       for (const auto &A : E->arguments()) {
         std::set<ConstraintVariable*> ParameterEC = 
-          Info.getVariable(A, Context);
+          Info.getVariable(A, Context, false);
         
         Constraints &CS = Info.getConstraints();
         for (const auto &C : ParameterEC) 

--- a/tools/checked-c-convert/PersistentSourceLoc.cpp
+++ b/tools/checked-c-convert/PersistentSourceLoc.cpp
@@ -16,14 +16,14 @@ using namespace llvm;
 // For Function and Parameter Decls, use the Spelling location, while for
 // variables, use the expansion location. 
 PersistentSourceLoc
-PersistentSourceLoc::mkPSL(Decl *D, ASTContext &C) {
+PersistentSourceLoc::mkPSL(const Decl *D, ASTContext &C) {
   SourceLocation SL = D->getLocation();
 
-  if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) 
+  if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) 
     SL = C.getSourceManager().getSpellingLoc(FD->getLocation());
-  else if (ParmVarDecl *PV = dyn_cast<ParmVarDecl>(D)) 
+  else if (const ParmVarDecl *PV = dyn_cast<ParmVarDecl>(D)) 
     SL = C.getSourceManager().getSpellingLoc(PV->getLocation());
-  else if(VarDecl *V = dyn_cast<ParmVarDecl>(D))
+  else if(const VarDecl *V = dyn_cast<ParmVarDecl>(D))
     SL = C.getSourceManager().getExpansionLoc(V->getLocation());
   
   return mkPSL(SL, C);
@@ -32,7 +32,7 @@ PersistentSourceLoc::mkPSL(Decl *D, ASTContext &C) {
 
 // Create a PersistentSourceLoc for a Stmt.
 PersistentSourceLoc
-PersistentSourceLoc::mkPSL(Stmt *S, ASTContext &Context) {
+PersistentSourceLoc::mkPSL(const Stmt *S, ASTContext &Context) {
   return mkPSL(S->getLocStart(), Context);
 }
 

--- a/tools/checked-c-convert/PersistentSourceLoc.h
+++ b/tools/checked-c-convert/PersistentSourceLoc.h
@@ -55,10 +55,10 @@ public:
   void dump() const { print(llvm::errs()); }
 
   static
-    PersistentSourceLoc mkPSL(clang::Decl *D, clang::ASTContext &Context);
+    PersistentSourceLoc mkPSL(const clang::Decl *D, clang::ASTContext &Context);
 
   static
-    PersistentSourceLoc mkPSL(clang::Stmt *S, clang::ASTContext &Context);
+    PersistentSourceLoc mkPSL(const clang::Stmt *S, clang::ASTContext &Context);
 
 private:
   static

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -759,7 +759,7 @@ bool ProgramInfo::link() {
 
         // Constrain the return values to be equal
         // TODO: make this behavior optional?
-        if (P1->hasBody() == false && P2->hasBody() == false) {
+        if (!P1->hasBody() && !P2->hasBody()) {
           constrainEq(P1->getReturnVars(), P2->getReturnVars(), *this);
 
           // Constrain the parameters to be equal, if the parameter arity is

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -150,6 +150,57 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, uint32_
       CS.addConstraint(CS.createEq(CS.getOrCreateVar(V), CS.getWild()));
 }
 
+bool PVConstraint::liftedOnCVars(const ConstraintVariable &O, 
+            ProgramInfo &Info,
+            llvm::function_ref<bool (ConstAtom *, ConstAtom *)> Op) const
+{
+  // If these aren't both PVConstraints, incomparable. 
+  if (!isa<PVConstraint>(O))
+    return false;
+
+  const PVConstraint *P = cast<PVConstraint>(&O);
+  const CVars &OC = P->getCvars(); 
+ 
+  // If they don't have the same number of cvars, incomparable.  
+  if (OC.size() != getCvars().size())
+    return false;
+
+  auto I = getCvars().begin();
+  auto J = OC.begin();
+  auto CS = Info.getConstraints();
+  auto env = CS.getVariables();
+
+  while(I != getCvars().end() && J != OC.end()) {
+    // Look up the valuation for I and J. 
+    ConstAtom *CI = env[CS.getVar(*I)]; 
+    ConstAtom *CJ = env[CS.getVar(*J)];
+
+    if (!Op(CI, CJ))
+      return false;
+
+    ++I;
+    ++J;
+  }
+
+  return true;
+}
+
+bool PVConstraint::isLt(const ConstraintVariable &Other, 
+                        ProgramInfo &Info) const 
+{
+  return liftedOnCVars(Other, Info, [](ConstAtom *A, ConstAtom *B) {
+        return *A < *B;
+      });
+}
+
+bool PVConstraint::isEq(const ConstraintVariable &Other,
+                        ProgramInfo &Info) const 
+{
+  return liftedOnCVars(Other, Info, [](ConstAtom *A, ConstAtom *B) {
+        return *A == *B;
+      });
+}
+
 void PointerVariableConstraint::print(raw_ostream &O) const {
   O << "{ ";
   for (const auto &I : vars) 
@@ -300,6 +351,19 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
 {
   QualType returnType;
   hasproto = false;
+  hasbody = false;
+
+  if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+    // FunctionDecl::hasBody will return true if *any* declaration in the 
+    // declaration chain has a body, which is not what we want to record.
+    // We want to record if *this* declaration has a body. To do that, 
+    // we'll check if the declaration that has the body is different
+    // from the current declaration. 
+    const FunctionDecl *oFD = nullptr;
+    if (FD->hasBody(oFD) && oFD == FD) 
+      hasbody = true;
+  }
+
   if (Ty->isFunctionPointerType()) {
     // Is this a function pointer definition?
     llvm_unreachable("should not hit this case");
@@ -339,8 +403,7 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
       if (isa<InteropTypeBoundsAnnotation>(RB))
         returnType = RB->getType();
     hasproto = true;
-  }
-  else if (Ty->isFunctionNoProtoType()) {
+  } else if (Ty->isFunctionNoProtoType()) {
     const FunctionNoProtoType *FT = Ty->getAs<FunctionNoProtoType>();
     assert(FT != nullptr);
     returnType = FT->getReturnType();
@@ -361,6 +424,64 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
       FVC->constrainTo(CS, CS.getWild());
     }
   }
+}
+
+bool FVConstraint::liftedOnCVars(const ConstraintVariable &Other, 
+            ProgramInfo &Info,
+            llvm::function_ref<bool (ConstAtom *, ConstAtom *)> Op) const
+ {
+  if (!isa<FVConstraint>(Other))
+    return false;
+
+  const FVConstraint *F = cast<FVConstraint>(&Other);
+
+  if (paramVars.size() != F->paramVars.size()) {
+    if (paramVars.size() < F->paramVars.size()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // Consider the return variables.
+  ConstraintVariable *U = getHighest(returnVars, Info);
+  ConstraintVariable *V = getHighest(F->returnVars, Info);
+
+  if (!U->liftedOnCVars(*V, Info, Op))
+    return false;
+
+  // Consider the parameters. 
+  auto I = paramVars.begin();
+  auto J = F->paramVars.begin();
+
+  while ((I != paramVars.end()) && (J != F->paramVars.end())) {
+    U = getHighest(*I, Info);
+    V = getHighest(*J, Info);
+
+    if (!U->liftedOnCVars(*V, Info, Op))
+      return false;
+
+    ++I;
+    ++J;
+  }
+
+  return true;
+}
+
+bool FVConstraint::isLt(const ConstraintVariable &Other,
+                        ProgramInfo &Info) const 
+{
+  return liftedOnCVars(Other, Info, [](ConstAtom *A, ConstAtom *B) {
+      return *A < *B;
+      });
+}
+
+bool FVConstraint::isEq(const ConstraintVariable &Other,
+                        ProgramInfo &Info) const 
+{
+  return liftedOnCVars(Other, Info, [](ConstAtom *A, ConstAtom *B) {
+      return *A == *B;
+      });
 }
 
 void FunctionVariableConstraint::constrainTo(Constraints &CS, ConstAtom *A, bool checkSkip) {
@@ -637,25 +758,28 @@ bool ProgramInfo::link() {
         FVConstraint *P2 = *J;
 
         // Constrain the return values to be equal
-        constrainEq(P1->getReturnVars(), P2->getReturnVars(), *this);
+        // TODO: make this behavior optional?
+        if (P1->hasBody() == false && P2->hasBody() == false) {
+          constrainEq(P1->getReturnVars(), P2->getReturnVars(), *this);
 
-        // Constrain the parameters to be equal, if the parameter arity is
-        // the same. If it is not the same, constrain both to be wild.
-        if (P1->numParams() == P2->numParams()) {
-          for ( unsigned i = 0;
-                i < P1->numParams();
-                i++)
-          {
-            constrainEq(P1->getParamVar(i), P2->getParamVar(i), *this);
-          } 
+          // Constrain the parameters to be equal, if the parameter arity is
+          // the same. If it is not the same, constrain both to be wild.
+          if (P1->numParams() == P2->numParams()) {
+            for ( unsigned i = 0;
+                  i < P1->numParams();
+                  i++)
+            {
+              constrainEq(P1->getParamVar(i), P2->getParamVar(i), *this);
+            } 
 
-        } else {
-          // It could be the case that P1 or P2 is missing a prototype, in
-          // which case we don't need to constrain anything.
-          if (P1->hasProtoType() && P2->hasProtoType()) {
-            // Nope, we have no choice. Constrain everything to wild.
-            P1->constrainTo(CS, CS.getWild(), true);
-            P2->constrainTo(CS, CS.getWild(), true);
+          } else {
+            // It could be the case that P1 or P2 is missing a prototype, in
+            // which case we don't need to constrain anything.
+            if (P1->hasProtoType() && P2->hasProtoType()) {
+              // Nope, we have no choice. Constrain everything to wild.
+              P1->constrainTo(CS, CS.getWild(), true);
+              P2->constrainTo(CS, CS.getWild(), true);
+            }
           }
         }
         ++I;
@@ -1062,20 +1186,81 @@ ProgramInfo::getVariableHelper(Expr *E,
 
 // Given a decl, return the variables for the constraints of the Decl.
 std::set<ConstraintVariable*>
-ProgramInfo::getVariable(Decl *D, ASTContext *C) {
+ProgramInfo::getVariable(Decl *D, ASTContext *C, bool inFunctionContext) {
   assert(persisted == false);
   VariableMap::iterator I = Variables.find(PersistentSourceLoc::mkPSL(D, *C));
-  if (I != Variables.end()) 
+  if (I != Variables.end()) {
+    // If we are looking up a variable, and that variable is a parameter variable,
+    // then we should see if we're looking this up in the context of a function or
+    // not. If we are not, then we should find a declaration 
+    if (ParmVarDecl *PD = dyn_cast<ParmVarDecl>(D)) {
+      if (!inFunctionContext) {
+        // We need to do 2 things:
+        //  - Look up a forward declaration of the function for this parameter.
+        //  - Map 'D', which is the ith parameter of Parent, to the ith parameter
+        //    of any forward declaration.
+        //
+        // If such a forward declaration doesn't exist, then we can back off. 
+
+        const DeclContext *DC = PD->getParentFunctionOrMethod();
+        assert(DC != nullptr);
+        if(const FunctionDecl *Parent = dyn_cast<FunctionDecl>(DC)) {
+          // Check that the current function declaration doesn't have a body.
+          bool hasbody = false; 
+          const FunctionDecl *oFD = nullptr;
+          if (Parent->hasBody(oFD) && oFD == Parent)
+            hasbody = true; 
+
+          // This ParmVarDecl belongs to a method declaration that has a body,
+          // and, our caller asked for a non-method declaration variable. Let's
+          // see if we can find one by looking through the re-declarations of
+          // Parent. 
+          if (hasbody) {
+            // Let's look through all the re-declarations of Parent. 
+            const FunctionDecl *fwdDecl = nullptr;
+            for (const auto &RD : Parent->redecls()) {
+              if (RD != Parent) {
+                fwdDecl = RD;
+                break;
+              }
+            }
+
+            if (fwdDecl) {
+              // We found one! Let's figure out the index that D has in Parent,
+              // then get that decl from fwdDecl and look it up in Variables
+              // by PSL, then return it. 
+              int idx = -1;
+              
+              for (unsigned i = 0; i < Parent->getNumParams(); i++) {
+                const ParmVarDecl *tmp = Parent->getParamDecl(i);
+
+                if (tmp == D) {
+                  idx = i;
+                  break;
+                }
+              }
+
+              assert(idx >= 0);
+
+              const ParmVarDecl *otherDecl = fwdDecl->getParamDecl(idx);
+              I = Variables.find(PersistentSourceLoc::mkPSL(otherDecl, *C));
+              assert(I != Variables.end());
+            }
+          }
+        }
+      }
+    }
     return I->second;
-   else 
+  } else {
     return std::set<ConstraintVariable*>();
+  }
 }
 // Given some expression E, what is the top-most constraint variable that
 // E refers to? It could be none, in which case the returned set is empty. 
 // Otherwise, the returned setcontains the constraint variable(s) that E 
 // refers to.
 std::set<ConstraintVariable*>
-ProgramInfo::getVariable(Expr *E, ASTContext *C) {
+ProgramInfo::getVariable(Expr *E, ASTContext *C, bool inFunctionContext) {
   assert(persisted == false);
 
   // Get the constraint variables represented by this Expr

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -100,8 +100,16 @@ public:
 
   virtual ~ConstraintVariable() {};
 
+  // Constraint atoms may be either constants or variables. The constants are
+  // trivial to compare, but the variables can only really be compared under
+  // a specific valuation. That valuation is stored in the ProgramInfo data 
+  // structure, so these functions (isLt, isEq) compare two ConstraintVariables
+  // with a specific assignment to the variables in mind. 
   virtual bool isLt(const ConstraintVariable &other, ProgramInfo &I) const = 0;
   virtual bool isEq(const ConstraintVariable &other, ProgramInfo &I) const = 0;
+
+  // A helper function for isLt and isEq where the last parameter is a lambda 
+  // for the specific comparison operation to perform. 
   virtual bool liftedOnCVars(const ConstraintVariable &O, 
       ProgramInfo &Info,
       llvm::function_ref<bool (ConstAtom *, ConstAtom *)>) const = 0;
@@ -127,7 +135,7 @@ private:
     O_Pointer,
     O_SizedArray,
     O_UnSizedArray
-  };  
+  };
   // Map from constraint variable to original type and size. 
   // If the original variable U was:
   //  * A pointer, then U -> (a,b) , a = O_Pointer, b has no meaning.

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -33,6 +33,8 @@
 #include "utils.h"
 #include "PersistentSourceLoc.h"
 
+class ProgramInfo;
+
 // Holds integers representing constraint variables, with semantics as 
 // defined in the comment at the top of the file.
 typedef std::set<uint32_t> CVars;
@@ -61,6 +63,7 @@ protected:
   // so that later on we do not introduce a spurious constraint 
   // making those variables WILD. 
   std::set<uint32_t> ConstrainedVars;
+
 public:
   ConstraintVariable(ConstraintVariableKind K, std::string T, std::string N) : 
     Kind(K),BaseType(T),Name(N) {}
@@ -96,6 +99,13 @@ public:
   }
 
   virtual ~ConstraintVariable() {};
+
+  virtual bool isLt(const ConstraintVariable &other, ProgramInfo &I) const = 0;
+  virtual bool isEq(const ConstraintVariable &other, ProgramInfo &I) const = 0;
+  virtual bool liftedOnCVars(const ConstraintVariable &O, 
+      ProgramInfo &Info,
+      llvm::function_ref<bool (ConstAtom *, ConstAtom *)>) const = 0;
+ 
 };
 
 class PointerVariableConstraint;
@@ -117,7 +127,7 @@ private:
     O_Pointer,
     O_SizedArray,
     O_UnSizedArray
-  };
+  };  
   // Map from constraint variable to original type and size. 
   // If the original variable U was:
   //  * A pointer, then U -> (a,b) , a = O_Pointer, b has no meaning.
@@ -161,6 +171,12 @@ public:
   void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);
   bool anyChanges(Constraints::EnvironmentMap &E);
 
+  bool isLt(const ConstraintVariable &other, ProgramInfo &P) const;
+  bool isEq(const ConstraintVariable &other, ProgramInfo &P) const;
+  bool liftedOnCVars(const ConstraintVariable &O, 
+      ProgramInfo &Info,
+      llvm::function_ref<bool (ConstAtom *, ConstAtom *)>) const;
+
   virtual ~PointerVariableConstraint() {};
 };
 
@@ -178,9 +194,10 @@ private:
   // Name of the function or function variable. Used by mkString.
   std::string name;
   bool hasproto;
+  bool hasbody;
 public:
   FunctionVariableConstraint() : 
-    ConstraintVariable(FunctionVariable, "", ""),name(""),hasproto(false) { }
+    ConstraintVariable(FunctionVariable, "", ""),name(""),hasproto(false),hasbody(false) { }
 
   FunctionVariableConstraint(clang::DeclaratorDecl *D, uint32_t &K,
     Constraints &CS, const clang::ASTContext &C);
@@ -194,6 +211,7 @@ public:
   std::string getName() { return name; }
 
   bool hasProtoType() { return hasproto; }
+  bool hasBody() { return hasbody; }
 
   static bool classof(const ConstraintVariable *S) {
     return S->getKind() == FunctionVariable;
@@ -211,6 +229,12 @@ public:
   void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);
   bool anyChanges(Constraints::EnvironmentMap &E);
 
+  bool isLt(const ConstraintVariable &other, ProgramInfo &P) const;
+  bool isEq(const ConstraintVariable &other, ProgramInfo &P) const;
+  bool liftedOnCVars(const ConstraintVariable &O, 
+      ProgramInfo &Info,
+      llvm::function_ref<bool (ConstAtom *, ConstAtom *)>) const;
+ 
   virtual ~FunctionVariableConstraint() {};
 };
 
@@ -283,9 +307,9 @@ public:
   // Given some expression E, what is the top-most constraint variable that
   // E refers to? 
   std::set<ConstraintVariable*>
-    getVariable(clang::Expr *E, clang::ASTContext *C);
+    getVariable(clang::Expr *E, clang::ASTContext *C, bool inFunctionContext = false);
   std::set<ConstraintVariable*>
-    getVariable(clang::Decl *D, clang::ASTContext *C);
+    getVariable(clang::Decl *D, clang::ASTContext *C, bool inFunctionContext = false);
 
   VariableMap &getVarMap() { return Variables;  }
 

--- a/tools/checked-c-convert/utils.h
+++ b/tools/checked-c-convert/utils.h
@@ -13,6 +13,7 @@
 #include "PersistentSourceLoc.h"
 
 class ConstraintVariable;
+class ProgramInfo;
 
 // Maps a Decl to the set of constraint variables for that Decl.
 typedef std::map<PersistentSourceLoc, 
@@ -25,4 +26,6 @@ extern llvm::cl::opt<bool> Verbose;
 extern llvm::cl::opt<bool> DumpIntermediate;
 
 const clang::Type *getNextTy(const clang::Type *Ty);
+
+ConstraintVariable *getHighest(std::set<ConstraintVariable*> Vs, ProgramInfo &Info);
 #endif


### PR DESCRIPTION
This change brings over the lower level infrastructure for doing cast placement. Specifically, the resolution mechanisms for function declarations can return either a declaration or definition reference, and that is tracked separately by ProgramInfo.