### PR TITLE
Fix subtle issues related to substitution of arguments for parameters

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4722,6 +4722,16 @@ public:
   BoundsExpr *CreateTypeBasedBounds(Expr *E, QualType Ty, bool IsParam,
                                     bool IsBoundsSafeInterface);
 
+  /// ReplaceAssignmentImplicitCast: E has had assignment conversion rules
+  /// applied to it. If an implicit cast has been introduced because of the
+  /// assignment conversion rules, replace it with an explicit cast.
+  /// This allows us to substitute E into other operator expressions without worrying
+  /// about the different implicit conversion rules between assignments and
+  //// other operators.   Sema tree rewriting assumes that semantic
+  /// analysis will recreate implicit casts.  That doesn't happen properly if
+  /// E is taken from an assignment expression and used in another operator expression.
+  Expr *MakeAssignmentImplicitCastExplicit(Expr *E);
+
   /// InferLValueTargetBounds - infer the bounds for the
   /// target of an lvalue.
   BoundsExpr *InferLValueTargetBounds(Expr *E);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4713,8 +4713,14 @@ public:
   BoundsExpr *InferLValueBounds(Expr *E);
 
   /// CreateTypeBasedBounds: the bounds that can be inferred from
-  /// the type alone.  Useful for Ptr types and interop types.
-  BoundsExpr *CreateTypeBasedBounds(QualType QT, bool IsParam);
+  /// the type alone.
+  /// * E is the base expression for which we are inferring bounds
+  /// * Ty is the target type.  It may differ from E's tu[e because it is
+  ///   an interoperation type.
+  /// * IsParam indicates wheteher E is a parameter variable.
+  /// * IsBoundsSafeInterface indicates whether Ty is a bounds-safe
+  BoundsExpr *CreateTypeBasedBounds(Expr *E, QualType Ty, bool IsParam,
+                                    bool IsBoundsSafeInterface);
 
   /// InferLValueTargetBounds - infer the bounds for the
   /// target of an lvalue.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4425,7 +4425,8 @@ public:
   ExprResult BuildCStyleCastExpr(SourceLocation LParenLoc,
                                  TypeSourceInfo *Ty,
                                  SourceLocation RParenLoc,
-                                 Expr *Op);
+                                 Expr *Op,
+                                 bool isCheckedScope = false);
   CastKind PrepareScalarCast(ExprResult &src, QualType destType);
 
   /// \brief Build an altivec or OpenCL literal.

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -1742,19 +1742,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     llvm_unreachable("scalar cast to non-scalar value");
 
   case CK_LValueToRValue:
-  /*
-    llvm::outs() << "E->getType() = ";
-    E->getType()->dump(llvm::outs());
-    llvm::outs() << "DestTy = ";
-    DestTy->dump(llvm::outs());
-    llvm::outs() << "CE = ";
-    CE->dump(llvm::outs());
-    llvm::outs() << "SubExpr = ";
-    E->dump(llvm::outs());
-    llvm::outs().flush();
-  */
     assert(CGF.getContext().hasSameUnqualifiedType(E->getType(), DestTy));
-
     assert(E->isGLValue() && "lvalue-to-rvalue applied to r-value!");
     return Visit(const_cast<Expr*>(E));
 

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -1742,7 +1742,19 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     llvm_unreachable("scalar cast to non-scalar value");
 
   case CK_LValueToRValue:
+  /*
+    llvm::outs() << "E->getType() = ";
+    E->getType()->dump(llvm::outs());
+    llvm::outs() << "DestTy = ";
+    DestTy->dump(llvm::outs());
+    llvm::outs() << "CE = ";
+    CE->dump(llvm::outs());
+    llvm::outs() << "SubExpr = ";
+    E->dump(llvm::outs());
+    llvm::outs().flush();
+  */
     assert(CGF.getContext().hasSameUnqualifiedType(E->getType(), DestTy));
+
     assert(E->isGLValue() && "lvalue-to-rvalue applied to r-value!");
     return Visit(const_cast<Expr*>(E));
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2261,10 +2261,15 @@ namespace {
 
         // We have a bounds of the form  count(e) or byte_count(e).  Expand
         // the bounds to a standard form, using the current argument as the
-        // base expression. We are short circuiting a step here.  The full
-        // expansion would use the parameter represented as a symbolic index.
-        // In the step below, we would then substitute the actual argument for
-        // that parameter represented using an index.
+        // base expression.
+        //
+        // We are are short-ciructing a step here.  In expanding the parameter
+        // bounds, we could use the parameter represented as a symbolic index.
+        // This more properly represents the parameter bounds.  However, code
+        // below will eventually substitute Arg for the symbolic parameter.
+        // Instead of going to the trouble of building the symbolic parameter
+        // expression, which we will throw away soon anyway, we just use Arg
+        // here.
         if (ParamBounds->isElementCount() || ParamBounds->isByteCount())
           ParamBounds = S.ExpandToRange(Arg, const_cast<BoundsExpr *>(ParamBounds));
 
@@ -2286,7 +2291,7 @@ namespace {
         }
         else {
           // Concretize parameter bounds with argument expressions. This fails
-          // and return null if an argument expression is a modifying
+          // and returns null if an argument expression is a modifying
           // expression, but we've already issued an error about about that.
           BoundsExpr *SubstParamBounds =
             S.ConcretizeFromFunctionTypeWithArgs(

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -728,7 +728,6 @@ namespace {
       }
     }
 
-
     BoundsExpr *CreateTypeBasedBounds(QualType Ty, bool IsParam) {
       // If the target value v is a Ptr type, it has bounds(v, v + 1), unless
       // it is a function pointer type, in which case it has no required
@@ -2258,9 +2257,6 @@ namespace {
               << (i + 1) << CE->getArg(i)->getSourceRange();
           }
       }
-
-
-
 
       ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
                                                      CE->getNumArgs());

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -220,9 +220,8 @@ namespace {
 BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
   BoundsExpr *Bounds, ArrayRef<Expr *> Args,
   NonModifyingContext ErrorKind) {
-  if (!Bounds)
+  if (!Bounds || Bounds->isInvalid())
     return Bounds;
-  assert(!Bounds->isInvalid());
 
   BoundsExpr *Result;
   auto Concretizer = ConcretizeBoundsExprWithArgs(*this, Args, ErrorKind);
@@ -231,9 +230,6 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
       return nullptr;
   }
   else if (ConcreteBounds.isInvalid()) {
-    llvm::outs() << "Failed concretizing\n";
-    Bounds->dump(llvm::outs());
-    llvm::outs().flush();
     llvm_unreachable("unexpected failure in making function bounds concrete with arguments");
     return nullptr;
   }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -230,6 +230,7 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
       return nullptr;
   }
   else if (ConcreteBounds.isInvalid()) {
+#ifndef NDEBUG
     llvm::outs() << "Failed concretizing\n";
     llvm::outs() << "Bounds:\n";
     Bounds->dump(llvm::outs());
@@ -239,6 +240,7 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
       Args[i]->dump(llvm::outs());
     }
     llvm::outs().flush();
+#endif
     llvm_unreachable("unexpected failure in making function bounds concrete with arguments");
     return nullptr;
   }
@@ -752,7 +754,7 @@ namespace {
 
       if (Ty->isCheckedPointerPtrType()) {
         if (Ty->isFunctionPointerType())
-          ;
+          BE = CreateBoundsEmpty();
         else if (Ty->isVoidPointerType())
           BE = Context.getPrebuiltByteCountOne();
         else

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -230,6 +230,15 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
       return nullptr;
   }
   else if (ConcreteBounds.isInvalid()) {
+    llvm::outs() << "Failed concretizing\n";
+    llvm::outs() << "Bounds:\n";
+    Bounds->dump(llvm::outs());
+    int count = Args.size();
+    for (int i = 0; i < count; i++) {
+      llvm::outs() << "Dumping arg " << i << "\n";
+      Args[i]->dump(llvm::outs());
+    }
+    llvm::outs().flush();
     llvm_unreachable("unexpected failure in making function bounds concrete with arguments");
     return nullptr;
   }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -728,27 +728,6 @@ namespace {
       }
     }
 
-    BoundsExpr *CreateTypeBasedBounds(QualType Ty, bool IsParam) {
-      // If the target value v is a Ptr type, it has bounds(v, v + 1), unless
-      // it is a function pointer type, in which case it has no required
-      // bounds.
-      if (Ty->isCheckedPointerPtrType()) {
-        if (Ty->isFunctionPointerType())
-          return CreateBoundsEmpty();
-        if (Ty->isVoidPointerType())
-          return Context.getPrebuiltByteCountOne();
-        else
-          return Context.getPrebuiltCountOne();
-      } else if (Ty->isCheckedArrayType() && IsParam) {
-        return CreateBoundsForArrayType(Ty);
-      } else if (Ty->isCheckedPointerNtArrayType()) {
-        // Null-terminated pointers get a zero element bounds.
-        return Context.getPrebuiltCountZero();
-      }
-
-      return CreateBoundsEmpty();
-    }
-
     // Given a Ptr type or a bounds-safe interface type, create the
     // bounds implied by the type.  Place the bounds in standard form
     // (do not use count or byte_count because their meaning changes

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -194,6 +194,43 @@ namespace {
       return SubstitutedModifyingExpression;
     }
 
+    // HACK - we don't want semantic analysis re-run on C style casts.  We may have synthesized
+    // them to make bounds-safe interfaces casts explicit in  the IR, and they could be illegal
+    // in a checked context.
+    Expr *CreateExplicitCast(SourceLocation LParen, TypeSourceInfo *TInfo, SourceLocation RParen,
+                             Expr *E, CastKind CK, bool isBoundsSafeInterface) {
+      CStyleCastExpr *CE = CStyleCastExpr::Create(SemaRef.Context, TInfo->getType(),
+        ExprValueKind::VK_RValue, CK, E, nullptr, TInfo, LParen,
+        RParen);
+      CE->setBoundsSafeInterface(isBoundsSafeInterface);
+      return CE;
+    }
+
+    ExprResult TransformCStyleCastExpr(CStyleCastExpr *E) {
+      assert(E->getBoundsExpr() == nullptr &&
+        "inferred bounds checks should not be present");
+      TypeSourceInfo *Type = getDerived().TransformType(E->getTypeInfoAsWritten());
+      if (!Type)
+        return ExprError();
+
+      ExprResult SubExpr
+        = getDerived().TransformExpr(E->getSubExprAsWritten());
+      if (SubExpr.isInvalid())
+        return ExprError();
+
+      if (!getDerived().AlwaysRebuild() &&
+        Type == E->getTypeInfoAsWritten() &&
+        SubExpr.get() == E->getSubExpr())
+        return E;
+
+      return CreateExplicitCast(E->getLParenLoc(),
+        Type,
+        E->getRParenLoc(),
+        SubExpr.get(),
+        E->getCastKind(),
+        E->isBoundsSafeInterface());
+    }
+
     ExprResult TransformPositionalParameterExpr(PositionalParameterExpr *E) {
       unsigned index = E->getIndex();
       if (index < Arguments.size()) {

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13362,13 +13362,6 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
                                       Expr *LowerBound,
                                       Expr *UpperBound,
                                       SourceLocation RParenLoc) {
-  /*
-  llvm::outs() << "ActOnRangeBoundsExpr";
-  llvm::outs() << "LowerBound\n";
-  LowerBound->dump(llvm::outs());
-  llvm::outs() << "UpperBound\n";
-  UpperBound->dump(llvm::outs());
-*/
   ExprResult Result = UsualUnaryConversions(LowerBound);
   if (Result.isInvalid())
      return ExprError();
@@ -13394,9 +13387,6 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
       << UpperBound->getSourceRange();
     return ExprError();
   }
-  /*
-  llvm::outs() << "Successfully creating range bounds expr";
-  */
   return new (Context) RangeBoundsExpr(LowerBound, UpperBound, BoundsKWLoc,
                                        RParenLoc);
 }

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -6319,7 +6319,8 @@ Sema::ActOnCastExpr(Scope *S, SourceLocation LParenLoc,
 
   DiscardMisalignedMemberAddress(castType.getTypePtr(), CastExpr);
 
-  return BuildCStyleCastExpr(LParenLoc, castTInfo, RParenLoc, CastExpr);
+  return BuildCStyleCastExpr(LParenLoc, castTInfo, RParenLoc, CastExpr,
+                             S->isCheckedScope());
 }
 
 ExprResult Sema::BuildVectorLiteral(SourceLocation LParenLoc,

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13362,6 +13362,13 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
                                       Expr *LowerBound,
                                       Expr *UpperBound,
                                       SourceLocation RParenLoc) {
+  /*
+  llvm::outs() << "ActOnRangeBoundsExpr";
+  llvm::outs() << "LowerBound\n";
+  LowerBound->dump(llvm::outs());
+  llvm::outs() << "UpperBound\n";
+  UpperBound->dump(llvm::outs());
+*/
   ExprResult Result = UsualUnaryConversions(LowerBound);
   if (Result.isInvalid())
      return ExprError();
@@ -13387,7 +13394,9 @@ ExprResult Sema::ActOnRangeBoundsExpr(SourceLocation BoundsKWLoc,
       << UpperBound->getSourceRange();
     return ExprError();
   }
-
+  /*
+  llvm::outs() << "Successfully creating range bounds expr";
+  */
   return new (Context) RangeBoundsExpr(LowerBound, UpperBound, BoundsKWLoc,
                                        RParenLoc);
 }

--- a/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
@@ -1,0 +1,37 @@
+// Tests for checking that bounds declarations involving bounds-safe interfaces
+// hold after assignments to variables and initialization of variables.  Because the static
+// checker is mostly unimplemented, we only issue warnings when bounds declarations
+// cannot be provided to hold.
+//
+// RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
+
+
+// Test uses of incomplete types
+
+struct S;
+extern void test_f1(const void* p_ptr : byte_count(1));
+
+int f1(_Ptr<struct S> p) {
+  // TODO: Github Checked C repo issue #422: Extend constant-sized ranges to cover Ptr to an incomplete type
+  test_f1(p); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+               // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)(const void *)p, (_Array_ptr<char>)(const void *)p + 1)'}} \
+               // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 1)'}}
+  return 0;
+}
+
+int f2(_Ptr<void> p) {
+  test_f1(p);
+  return 0;
+}
+
+#pragma BOUNDS_CHECKED ON
+
+extern void test_f3(const void* p_ptr : byte_count(1));
+
+int f3(_Ptr<struct S> p) {
+  // TODO: Github Checked C repo issue #422: Extend constant-sized ranges to cover Ptr to an incomplete type
+  test_f3(p); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+              // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)(_Array_ptr<const void>)p, (_Array_ptr<char>)(_Array_ptr<const void>)p + 1)'}} \
+              // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 1)'}}
+  return 0;
+}

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -254,16 +254,15 @@ void test_addition_commutativity(void) {
   _Array_ptr<int> r : bounds(p + 1, 5 + p) = p;
 }
 
-
 // Test uses of incomplete types
 
 struct S;
-extern void test_f30(const void* p_ptr : byte_count(1));
+extern void test_f30(_Array_ptr<const void> p_ptr : byte_count(1));
 
 int f30(_Ptr<struct S> p) {
   // TODO: Github Checked C repo issue #422: Extend constant-sized ranges to cover Ptr to an incomplete type
   test_f30(p); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
-               // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 1)'}} \
+               // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)(_Array_ptr<const void>)p, (_Array_ptr<char>)(_Array_ptr<const void>)p + 1)'}} \
                // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 1)'}}
   return 0;
 }


### PR DESCRIPTION
This addresses issue #451.  During checking of bounds declarations, we need to check that the actual arguments meet the bounds constraints of the parameters.  The way we do this is by taking the bounds declaration for a parameter and substituting in the actual arguments to derive the desired bounds expression, in the context of the caller.  We then check that the actual argument implies the validity of this bounds expression.

It turns out that substituting an argument expression for a parameter variable is trickier than you might think in clang.  The issue is that the argument expression might be subject to implicit casts.   You can substitute the expression in for the parameter in your bounds expression, but if you call TreeTransform on the bounds expression, your implicit casts might get dropped.    The rules for implicit casts differ between call arguments/assignments and other operators.   This can lead to changes in the types of subexpressions of the bounds expressions, which could change their meaning or lead to illegally-typed expressions.  For example, an argument expression with void pointer type could be implicitly cast to some pointer to T.   The implicit cast could be lost, leading to a bounds expression with pointer arithmetic on void pointers, which is nonsensical.

For now, I'm taking the approach that we'll convert these implicit casts to explicit casts in the IR, so that these subtle problems don't happen.  Note that we can't keep all implicit casts during TreeTransform: it assumes that implicit casts are being resynthesized.

This change updates argument substitution to convert implicit casts that aren't the usual unary conversions to explicit casts. 

It also removes a version of GetTypeBasedBounds that can be dangerous to use.   The bounds inference code is generally expecting to work on expressions in an "expanded" form, where count/byte_count have been removed as sugar.   The removed version of GetTypeBasedBounds produces a count/byte_count, which could unexpectedly propagate if the caller isn't careful.

Finally, it puts the target bounds expressions for a parameter in the expanded standard form as soon as possible, when checking call arguments.  While I think this isn't strictly necessary because the checking of call arguments puts the desired target into the standard form, it is easier to reason about.

There's a hack in the code: we use CStyleCasts to represent the explicit casts.   However, when using TreeTransform to actually do substitution of arguments for parameters, this re-runs semantic checking on CStyleCasts.   This can cause an error when semantic checking is re-run in the context of a checked scope.  An explicit cast may be a bounds-safe interface that converts from a checked pointer to an unchecked pointer   We need to fix how we represent whether an operation is in a checked scope/unchecked scope, but that's a separate issue.  For now, we override the handling of CStyleCasts in the substitution class to not do semantic checking.

Testing:
- Passed local testing on Windows.
- Passed automated testing on Linux, including running the LNT tests and tests that have been converted to Checked C.
- Add new test that highlights the subtle issue around a dropped conversion.