### PR TITLE
Refactor some code into BoundsUtil class.

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -438,8 +438,6 @@ public:
 };
 }
 
-
-
 namespace {
   // Class for inferring bounds expressions for C expressions.
 


### PR DESCRIPTION
This refactors some generally useful code into a BoundsUtil class.  There should be no functional change.   I want to be able to call IgnoreValuePreservingOperations, which was embedded in bounds declaration check, when creating cast operations.  I generalized it slightly so that it can be used to squash only unnecessary casts.  I moved some other common code at the same time.

Testing:
- Passed local testing on Windows x64
- Passed automated testing on Linux x64.