### PR TITLE
Fix inference of return bounds for nt_array_ptr return types.

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4664,11 +4664,13 @@ public:
 
   bool DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
                               BoundsAnnotations &BA, bool IsReturnAnnots);
-  void ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations &Annots,
+  void ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations Annots,
                        bool MergeDeferredBounds = false);
 
   void ActOnEmptyBoundsDecl(DeclaratorDecl *D);
   void ActOnInvalidBoundsDecl(DeclaratorDecl *D);
+  /// \brief Add default bounds/interop type expressions to Annots, if appropriate.
+  void InferBoundsAnnots(QualType Ty, BoundsAnnotations &Annots, bool IsParam);
 
   // \#pragma BOUNDS_CHECKED.
   void ActOnPragmaBoundsChecked(Scope *S, tok::OnOffSwitch OOS);
@@ -4689,11 +4691,11 @@ public:
   BoundsExpr *CreateInvalidBoundsExpr();
   /// /brief Synthesize the interop type expression implied by the presence
   /// of a bounds expression.  Ty is the original unchecked type.  Returns null
-  // if none exists.
+  /// if none exists.
   InteropTypeExpr *SynthesizeInteropTypeExpr(QualType Ty, bool IsParam);
   BoundsExpr *CreateCountForArrayType(QualType QT);
 
-  /// CheckNonModifying - checks whether an expression is non-modifying
+  /// /brief Checks whether an expression is non-modifying
   /// (see Checked C Spec, 3.6.1).  Returns true if the expression is non-modifying,
   /// false otherwise.
   bool CheckIsNonModifying(Expr *E, NonModifyingContext Req =
@@ -4702,8 +4704,13 @@ public:
 
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);
+  /// \brief Take a bounds expression with positional parameters from a function
+  /// type and substitute DeclRefs to the corresonding parameters in Params.
   BoundsExpr *ConcretizeFromFunctionType(BoundsExpr *Expr,
                                          ArrayRef<ParmVarDecl *> Params);
+  /// \brief Take a member bounds expression with member references and
+  /// replace the member references with member access expressions using
+  /// MemberBase as the base.  Returns a nullptr if there is an error.
   BoundsExpr *MakeMemberBoundsConcrete(Expr *MemberBase, bool IsArrow,
                                        BoundsExpr *Bounds);
   BoundsExpr *ConcretizeFromFunctionTypeWithArgs(BoundsExpr *Bounds, ArrayRef<Expr *> Args,

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -256,7 +256,7 @@ namespace {
           clang::ExprValueKind::VK_LValue, SourceLocation());
       } else {
         llvm_unreachable("out of range index for positional parameter");
-        return ExprResult();
+        return ExprError();
       }
     }
   };
@@ -318,12 +318,13 @@ namespace {
                                          ShouldReportError)) {
           SubstitutedModifyingExpression = true;
           ErroredForArgument.set(index);
+          return ExprError();
         }
 
         return SemaRef.MakeAssignmentImplicitCastExplicit(AE);
       } else {
         llvm_unreachable("out of range index for positional argument");
-        return ExprResult();
+        return ExprError();
       }
     }
   };
@@ -385,14 +386,14 @@ namespace {
     // - We assume field expressions are lvalues, so we will have lvalue-to-rvalue
     //   conversions applied to rvalues.  We need to remove these conversions.
     // - The address of a field is taken.  It is illegal to take the address of
-    //   an lvalue.
+    //   an rvalue.
     //
     // rVvalue structs can arise from function returns of struct values.
     ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
       if (FieldDecl *FD = dyn_cast<FieldDecl>(E->getDecl())) {
         if (Base->isRValue() && !IsArrow)
-          // For now, return nothing if we see an rvalue base.
-          return ExprResult();
+          // For now, return an error if we see an rvalue base.
+          return ExprError();
         ASTContext &Context = SemaRef.getASTContext();
         ExprValueKind ResultKind;
         if (IsArrow)
@@ -814,6 +815,12 @@ namespace {
           BoundsExpr *B = FD->getBoundsExpr();
           if (B) {
             B = SemaRef.MakeMemberBoundsConcrete(ME->getBase(), ME->isArrow(), B);
+            if (!B) {
+               assert(ME->getBase()->isRValue());
+              // This can happen if the base expression is an rvalue expression.
+              // It could be a function call that returns a struct, for example.
+              CreateBoundsNotAllowedYet();
+            }
             if (B->isElementCount() || B->isByteCount()) {
               Expr *Base = CreateImplicitCast(Context.getDecayedType(E->getType()),
                                               CastKind::CK_ArrayToPointerDecay,
@@ -953,8 +960,8 @@ namespace {
           if (!B || B->isUnknown())
             return CreateBoundsAlwaysUnknown();
 
-            Expr *Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, E);
-            return ExpandToRange(Base, B);
+          Expr *Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, E);
+          return ExpandToRange(Base, B);
         }
         case Expr::UnaryOperatorClass: {
           UnaryOperator *UO = cast<UnaryOperator>(E);
@@ -990,6 +997,12 @@ namespace {
             return CreateBoundsAlwaysUnknown();
 
           Expr *MemberBaseExpr = M->getBase();
+          // TODO: this check is only correct when the lvalue is read.
+          // If the lvalue is being assigned to and the member has
+          // bounds that depend on other members, we may need to issue
+          // an error message.   If an lvalue target has unknown bounds,
+          // we don't check that assignments meet the bounds requirements.
+          // The member may have specific bounds requirements that must be met.
           if (!SemaRef.CheckIsNonModifying(MemberBaseExpr,
                                          Sema::NonModifyingContext::NMC_Unknown,
               /*ReportError=*/false))
@@ -1003,8 +1016,12 @@ namespace {
             return CreateBoundsAlwaysUnknown();
 
           B = SemaRef.MakeMemberBoundsConcrete(MemberBaseExpr, M->isArrow(), B);
-          if (!B)
-            return CreateBoundsInferenceError();
+          if (!B) {
+             // This can happen when MemberBaseExpr is an rvalue expression.  An example
+             // of this a function call that returns a struct.  MakeMemberBoundsConcrete
+             // can't handle this yet.
+            return CreateBoundsNotAllowedYet();
+          }
 
           if (B->isElementCount() || B->isByteCount()) {
              Expr *MemberRValue;

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -12812,7 +12812,7 @@ bool Sema::DiagnoseBoundsDeclType(QualType Ty, DeclaratorDecl *D,
 //   It must meet typing requirements and be valid for the declaration.
 // - For VarDecls, make sure that a bounds expression on a redeclaration
 // is valid.
-void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations &Annots,
+void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations Annots,
                            bool MergeDeferredBounds) {
   if (!D || D->isInvalidDecl())
     return;
@@ -12826,24 +12826,9 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations &Annots,
   BoundsExpr *BoundsExpr = Annots.getBoundsExpr();
   InteropTypeExpr *IType = Annots.getInteropTypeExpr();
   bool NoAnnotations = !BoundsExpr && !IType;
-  if (BoundsExpr) {
-    NonModifyingContext req = NMC_Unknown;
-    if (isa<RangeBoundsExpr>(BoundsExpr)) {
-      req = NMC_Range;
-    }
-    else if (const CountBoundsExpr *CountBounds = dyn_cast<CountBoundsExpr>(BoundsExpr)) {
-      req = CountBounds->isByteCount() ? NMC_Byte_Count : NMC_Count;
-    }
-
-    if (!CheckIsNonModifying(BoundsExpr, req)) {
-      ActOnInvalidBoundsDecl(D);
-      return;
-    }
-
-    if (BoundsExpr->isInvalid()) {
+  if (BoundsExpr && BoundsExpr->isInvalid()) {
       D->setBoundsExpr(getASTContext(), BoundsExpr);
       return;
-    }
   }
 
   if (VD && VD->isLocalVarDecl()) {
@@ -12883,21 +12868,6 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations &Annots,
     }
   }
 
-  // If a declaration has no declared bounds, set the default bounds for types
-  // that have default bounds other than bounds(unknown),
-  if (!BoundsExpr) {
-    // Handle parameters that originally had a checked array type.
-    if (ParmVarDecl *PV = dyn_cast<ParmVarDecl>(D)) {
-      if (PV->getOriginalType()->isCheckedArrayType())
-        BoundsExpr = CreateCountForArrayType(PV->getOriginalType());
-    }
-
-    if (!BoundsExpr)
-      if (Ty->isCheckedPointerNtArrayType() || (IType &&
-                   IType->getType()->isCheckedPointerNtArrayType()))
-        BoundsExpr = Context.getPrebuiltCountZero();
-  }
-
   // When bounds are deferred parsed, the resulting annotations should have
   // only a bounds expression.  The interop type annotation should already
   // be set on the declaration, so pick that up.
@@ -12907,15 +12877,13 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations &Annots,
     IType = D->getInteropTypeExpr();
   }
 
-  // Synthesize the interop type if necessary. We need to do this for the
-  // non-deferred case of parsing bounds expressions.
-  if (BoundsExpr && !IType)
-    IType = SynthesizeInteropTypeExpr(Ty, isa<ParmVarDecl>(D));
-
   BoundsAnnotations NewAnnots(BoundsExpr, IType);
+  InferBoundsAnnots(Ty, NewAnnots, isa<ParmVarDecl>(D));
   if (DiagnoseBoundsDeclType(Ty, D, NewAnnots, /*IsReturnAnnots=*/false)) {
     return;
   }
+  BoundsExpr = NewAnnots.getBoundsExpr();
+  IType = NewAnnots.getInteropTypeExpr();
 
   // If this is a VarDecl, handle already existing annotations from a prior
   // declaration, if there is a prior declaration.
@@ -12942,6 +12910,36 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations &Annots,
 
   D->setBoundsExpr(getASTContext(), BoundsExpr);
   D->setInteropTypeExpr(getASTContext(), IType);
+}
+
+void Sema::InferBoundsAnnots(QualType Ty, BoundsAnnotations &Annots, bool IsParam) {
+  BoundsExpr *BoundsExpr = Annots.getBoundsExpr();
+  InteropTypeExpr *IType = Annots.getInteropTypeExpr();
+
+  // If a declaration has no declared bounds, set the default bounds for types
+  // that have default bounds other than bounds(unknown),
+  if (!BoundsExpr) {
+      // Handle parameters that originally had a checked array type.
+    if (const DecayedType *DType = Ty->getAs<DecayedType>())
+      if (DType->getOriginalType()->isCheckedArrayType())
+        BoundsExpr = CreateCountForArrayType(DType->getOriginalType());
+
+    if (!BoundsExpr && IType && IType->getType()->isCheckedArrayType())
+        BoundsExpr = CreateCountForArrayType(IType->getType());
+
+    if (!BoundsExpr)
+      if (Ty->isCheckedPointerNtArrayType() || (IType &&
+                   IType->getType()->isCheckedPointerNtArrayType()))
+        BoundsExpr = Context.getPrebuiltCountZero();
+  }
+
+  // Synthesize the interop type if necessary. We need to do this for the
+  // non-deferred case of parsing bounds expressions.
+  if (BoundsExpr && !IType)
+    IType = SynthesizeInteropTypeExpr(Ty, IsParam);
+
+  Annots.setBoundsExpr(BoundsExpr);
+  Annots.setInteropTypeExpr(IType);
 }
 
 void Sema::ActOnEmptyBoundsDecl(DeclaratorDecl *D) {

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13312,13 +13312,6 @@ ExprResult Sema::ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
     return ExprError();
   }
 
-  NonModifyingContext AnalysisContext =
-    Kind == BoundsExpr::Kind::ElementCount ?
-      NonModifyingContext::NMC_Count : NonModifyingContext::NMC_Byte_Count;
-
-  if (!CheckIsNonModifying(CountExpr, AnalysisContext))
-    return ExprError();
-
   return new (Context) CountBoundsExpr(Kind, CountExpr, BoundsKWLoc,
                                        RParenLoc);
 }
@@ -13355,9 +13348,6 @@ const Type *Sema::ValidateBoundsExprArgument(Expr *Arg) {
     Diag(Arg->getLocStart(), diag::err_typecheck_bounds_expr) << ArgType;
     return nullptr;
   }
-
-  if (!CheckIsNonModifying(Arg, NonModifyingContext::NMC_Range))
-    return nullptr;
 
   // Return the canonical unqualified pointee type.
   return ArgTypePointee.getTypePtr();

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13311,6 +13311,14 @@ ExprResult Sema::ActOnCountBoundsExpr(SourceLocation BoundsKWLoc,
       << ResultType;
     return ExprError();
   }
+
+  NonModifyingContext AnalysisContext =
+    Kind == BoundsExpr::Kind::ElementCount ?
+      NonModifyingContext::NMC_Count : NonModifyingContext::NMC_Byte_Count;
+
+  if (!CheckIsNonModifying(CountExpr, AnalysisContext))
+    return ExprError();
+
   return new (Context) CountBoundsExpr(Kind, CountExpr, BoundsKWLoc,
                                        RParenLoc);
 }
@@ -13347,6 +13355,9 @@ const Type *Sema::ValidateBoundsExprArgument(Expr *Arg) {
     Diag(Arg->getLocStart(), diag::err_typecheck_bounds_expr) << ArgType;
     return nullptr;
   }
+
+  if (!CheckIsNonModifying(Arg, NonModifyingContext::NMC_Range))
+    return nullptr;
 
   // Return the canonical unqualified pointee type.
   return ArgTypePointee.getTypePtr();

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4826,14 +4826,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         }
 
         BoundsAnnotations ReturnAnnots = FTI.getReturnAnnots();
-
-        if (T->isCheckedPointerNtArrayType() && !ReturnAnnots.getBoundsExpr())
-           ReturnAnnots = BoundsAnnotations(Context.getPrebuiltCountZero(), nullptr);
-
-        // If there is no interop type, try synthesizing one implied by the
-        // presence of a bounds expression.
-        if (!ReturnAnnots.getInteropTypeExpr() && ReturnAnnots.getBoundsExpr())
-          ReturnAnnots.setInteropTypeExpr(S.SynthesizeInteropTypeExpr(T, false));
+        S.InferBoundsAnnots(T, ReturnAnnots, false);
 
         if (S.DiagnoseBoundsDeclType(T, nullptr, ReturnAnnots, true))
           D.setInvalidType(true);


### PR DESCRIPTION
This fixes issue #424, where the compiler wasn't inferring return bounds of count(0) for `nt_array_ptr` return types.   The code for inferring bounds and interface types was duplicated two places. One place handled variable declarations and the other place handled returns.  The one for returns was missing a case.  This change creates a shared method for inferring bounds and interface types and uses that instead.

This also includes some clean ups:
- I noticed that in some of our uses of TreeTransform.h, we were calling ExprResult() instead of ExprError().  The first method leaves the expression result marked as valid, but returns a null pointer for the expression.  The second method marks the ExprResult as invalid.  This caused a null pointer dereference crash because code was checking for invalid expressions.   The check succeeded and subsequent code was handed a null pointer.
- I improved some of the error handling of SemaBounds.cpp, which had methods that were checking for invalid expressions and returning null pointers for those cases.  That could cause the callers to crash if they didn't handle the null pointer.

Testing:
- There will be a separate PR for the Checked C repo with additional tests and updated tests.
- Passed Checked C tests and Checked C clang testing on x64 Linux.
- Passed LNT testing on x64 Linux.
- Passed local testing on Windows.