### PR TITLE
Fix compiler assert involving dynamic_bounds_cast from ptr<void>.

### DIFF
--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -4793,7 +4793,7 @@ llvm::Value *CodeGenFunction::EmitBoundsCast(CastExpr *CE) {
   if (Kind == CK_DynamicPtrBounds) {
     BoundsCastExpr *BCE = cast<BoundsCastExpr>(CE);
     EmitDynamicBoundsCastCheck(Addr,
-                               BCE->getCastBoundsExpr(),
+                               BCE->getNormalizedBoundsExpr(),
                                BCE->getSubExprBoundsExpr());
   }
   return Addr.getPointer();

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -78,11 +78,9 @@ public:
   // The code for casts is adapted from Expr::IgnoreNoopCasts, which seems like doesn't
   // do enough filtering (it'll ignore LValueToRValue casts for example).
   // TODO: reconcile with CheckValuePreservingCast
-  static Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E,
-                                               bool OnlyCasts = false) {
+  static Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E) {
     while (true) {
-      if (!OnlyCasts)
-        E = E->IgnoreParens();
+      E = E->IgnoreParens();
 
       if (CastExpr *P = dyn_cast<CastExpr>(E)) {
         CastKind CK = P->getCastKind();
@@ -110,8 +108,6 @@ public:
             continue;
           }
         }
-      } else if (OnlyCasts) {
-        ;
       } else if (const UnaryOperator *UO = dyn_cast<UnaryOperator>(E)) {
         QualType ETy = UO->getType();
         Expr *SE = UO->getSubExpr();
@@ -139,6 +135,19 @@ public:
 
       return E;
     }
+  }
+
+  static Expr *IgnoreRedundantCast(ASTContext &Ctx, CastKind NewCK, Expr *E) {
+    CastExpr *P = dyn_cast<CastExpr>(E);
+    if (!P)
+      return E;
+
+    CastKind ExistingCK = P->getCastKind();
+    Expr *SE = P->getSubExpr();
+    if (NewCK == CK_BitCast && ExistingCK == CK_BitCast)
+      return SE;
+
+    return E;
   }
 };
 }
@@ -562,7 +571,7 @@ namespace {
     Expr *CreateExplicitCast(QualType Target, CastKind CK, Expr *E,
                              bool isBoundsSafeInterface) {
       // Avoid building up nested chains of no-op casts.
-      E = BoundsUtil::IgnoreValuePreservingOperations(Context, E, true);
+      E = BoundsUtil::IgnoreRedundantCast(Context, CK, E);
 
       // Synthesize some dummy type source source information.
       TypeSourceInfo *DI = Context.getTrivialTypeSourceInfo(Target);
@@ -1445,6 +1454,25 @@ namespace {
       if (RHSBounds) {
         OS << "RHS Bounds:\n ";
         RHSBounds->dump(OS);
+      }
+    }
+
+    void DumpBoundsCastBounds(raw_ostream &OS, CastExpr *E,
+                              BoundsExpr *Declared, BoundsExpr *NormalizedDeclared,
+                              BoundsExpr *SubExprBounds) {
+      OS << "\n";
+      E->dump(OS);
+      if (Declared) {
+        OS << "Declared Bounds:\n";
+        Declared->dump(OS);
+      }
+      if (NormalizedDeclared) {
+        OS << "Normalized Declared Bounds:\n ";
+        NormalizedDeclared->dump(OS);
+      }
+      if (SubExprBounds) {
+        OS << "Inferred Subexpression Bounds:\n ";
+        SubExprBounds->dump(OS);
       }
     }
 
@@ -2370,23 +2398,34 @@ namespace {
         return;
       }
 
-      // If inferred bounds of e1 are bounds(unknown), compile-time error.
-      // If inferred bounds of e1 are bounds(any), no runtime checks.
-      // Otherwise, the inferred bounds is bounds(lb, ub).
-      // bounds of cast operation is bounds(e2, e3).
-      // In code generation, it inserts dynamic_check(lb <= e2 && e3 <= ub).
+      // Handle dynamic_bounds_casts.
+      //
+      // If the inferred bounds of the subexpression are:
+      // - bounds(unknown), this is a compile-time error.
+      // - bounds(any), there is no runtime checks.
+      // - bounds(lb, ub):  If the declared bounds of the cast operation are
+      // (e2, e3),  a runtime check that lb <= e2 && e3 <= ub is inserted
+      // during code generation.
       if (CK == CK_DynamicPtrBounds) {
         Expr *SubExpr = E->getSubExpr();
+        Expr *SubExprAtNewType =
+          BoundsInference(S).CreateExplicitCast(E->getType(),
+                                                CastKind::CK_BitCast,
+                                                SubExpr, true);
+        BoundsExpr *DeclaredBounds = E->getBoundsExpr();
+        BoundsExpr *NormalizedBounds = S.ExpandToRange(SubExprAtNewType,
+                                                       DeclaredBounds);
         BoundsExpr *SubExprBounds = S.InferRValueBounds(SubExpr);
-        BoundsExpr *CastBounds = S.InferRValueBounds(E);
-
         if (SubExprBounds->isUnknown()) {
           S.Diag(SubExpr->getLocStart(), diag::err_expected_bounds);
         }
 
-        assert(CastBounds);
-        E->setCastBoundsExpr(CastBounds);
+        assert(NormalizedBounds);
+        E->setNormalizedBoundsExpr(NormalizedBounds);
         E->setSubExprBoundsExpr(SubExprBounds);
+        if (DumpBounds)
+          DumpBoundsCastBounds(llvm::outs(), E, DeclaredBounds,
+                               NormalizedBounds, SubExprBounds);
       }
 
       // Casts to _Ptr type must have a source for which we can infer bounds.

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13510,10 +13510,8 @@ ExprResult Sema::ActOnBoundsCastExprSingle(
     SourceLocation LAngleBracketLoc, ParsedType D,
     SourceLocation RAngleBracketLoc, RelativeBoundsClause *RelativeClause,
     SourceLocation LParenLoc, SourceLocation RParenLoc, Expr *E1) {
-
-  RangeBoundsExpr *Range = nullptr;
   TypeSourceInfo *castTInfo;
-  ExprResult bounds(true);
+  BoundsExpr *bounds;
 
   QualType DestTy = GetTypeFromParser(D, &castTInfo);
   SourceLocation TypeLoc = (castTInfo->getTypeLoc()).getBeginLoc();
@@ -13522,36 +13520,19 @@ ExprResult Sema::ActOnBoundsCastExprSingle(
     return ExprError();
 
   if (DestTy->isCheckedPointerPtrType() || DestTy->isUncheckedPointerType()) {
-    llvm::APInt I = llvm::APInt(1, 1, false);
-    uint64_t Bits = I.getZExtValue();
-    unsigned Width = Context.getIntWidth(Context.UnsignedLongLongTy);
-    llvm::APInt ResultVal(Width, Bits);
-    IntegerLiteral *One = IntegerLiteral::Create(
-        Context, ResultVal, Context.UnsignedLongLongTy, SourceLocation());
-    bounds =
-        ActOnCountBoundsExpr(SourceLocation(), BoundsExpr::Kind::ElementCount,
-                             One, SourceLocation());
+    if (DestTy->isVoidPointerType())
+      bounds = Context.getPrebuiltByteCountOne();
+    else
+      bounds = Context.getPrebuiltCountOne();
   } else {
     Diag(TypeLoc, diag::err_bounds_cast_error_with_single_syntax);
     return ExprError();
   }
 
-  if (bounds.isInvalid())
-    return ExprError();
-
-  if (RelativeClause != nullptr) {
-    RelativeBoundsClause::Kind kind = RelativeClause->getClauseKind();
-    if (((kind == RelativeBoundsClause::Kind::Type) ||
-         (kind == RelativeBoundsClause::Kind::Const)) &&
-        (Range = dyn_cast<RangeBoundsExpr>(bounds.get()))) {
-      Range->setRelativeBoundsClause(RelativeClause);
-    }
-  }
-
   return BuildBoundsCastExpr(OpLoc, Kind, castTInfo,
                              SourceRange(LAngleBracketLoc, RAngleBracketLoc),
                              SourceRange(LParenLoc, RParenLoc), E1,
-                             dyn_cast<BoundsExpr>(bounds.get()));
+                             bounds);
 }
 
 ExprResult Sema::ActOnBoundsCastExprCount(

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -701,7 +701,7 @@ void ASTStmtReader::VisitCastExpr(CastExpr *E) {
   }
   bool hasCastBoundsExpr = Record.readInt();
   if (hasCastBoundsExpr) {
-    E->setCastBoundsExpr(Record.readBoundsExpr());
+    E->setNormalizedBoundsExpr(Record.readBoundsExpr());
   }
   bool hasSubExprBoundsExpr = Record.readInt();
   if (hasSubExprBoundsExpr) {

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -687,9 +687,9 @@ void ASTStmtWriter::VisitCastExpr(CastExpr *E) {
   if (E->hasBoundsExpr()) {
     Record.AddStmt(E->getBoundsExpr());
   }
-  Record.push_back(E->hasCastBoundsExpr());
-  if (E->hasCastBoundsExpr()) {
-    Record.AddStmt(E->getCastBoundsExpr());
+  Record.push_back(E->hasNormalizedBoundsExpr());
+  if (E->hasNormalizedBoundsExpr()) {
+    Record.AddStmt(E->getNormalizedBoundsExpr());
   }
 
   Record.push_back(E->hasSubExprBoundsExpr());

--- a/test/CheckedC/regression-cases/bug_458_void_ptr_bounds_cast.c
+++ b/test/CheckedC/regression-cases/bug_458_void_ptr_bounds_cast.c
@@ -1,5 +1,5 @@
 //
-// These is a regression test case for 
+// These is a regression test case for
 // https://github.com/Microsoft/checkedc-clang/issues/458
 //
 // This test checks that _Dynamic_bounds_cast from a void pointer compiles.

--- a/test/CheckedC/regression-cases/bug_458_void_ptr_bounds_cast.c
+++ b/test/CheckedC/regression-cases/bug_458_void_ptr_bounds_cast.c
@@ -1,0 +1,20 @@
+//
+// These is a regression test case for 
+// https://github.com/Microsoft/checkedc-clang/issues/458
+//
+// This test checks that _Dynamic_bounds_cast from a void pointer compiles.
+//
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+// expected-no-diagnostics
+
+typedef struct {
+	void *ptr : itype(_Ptr<void>);
+} mytype_t;
+
+int
+main(void)
+{
+	mytype_t m;
+ (void)_Dynamic_bounds_cast<_Ptr<char>>(m.ptr);
+}
+


### PR DESCRIPTION
This fixes issue #458, a user-reported compiler crash.  Some simple code that
converted from a ptr<void> to ptr<char> caused an internal compiler crash.

We were generating malformed IR for this operation.  I found two problems:
1. We have code for deleting unnecessary C-style cast operations during the
inference of bounds information.  This code clean up the bounds so that
compiler error messages are easier to read.  We were being too aggressive
in deleting casts, resulting in invalid casts in the LLVM IR (we deleted an
array-to-pointer decay cast).  The fix is to be less aggressive.  I created a
separate method for determining whether a cast should be removed, independent
of the current method that determines whether a cast does not change values
(and can be ignored when comparing expressions for equality).  This issue
is what likely caused the crash.
2. We were not properly constructing the target (desired) bounds for the
runtime checking.  Given dynamic_bounds_cast<ptr<T>>(e1), we were putting
target bounds for "e1 : count(1)" into a normalized form.   To ensure the
bounds are wide enough for a value of type T, the bounds need to be at the
type ptr<T>, not whatever type e1 happens to be.  So we need to put
((ptr<T>) e1) : count(1) into a normalized form.  Also, if ptr<T> is ptr<void>,
we need to use byte_count(1).

This change includes several clean ups:
- In the representation of cast expressions, we had some methods of the form
{get,set}CastBounds, as well as an associated enum value for the position of
the operand.  This isn't very clear and is confusing to read.  This is a
normalized form of the bounds expression, which we create for the benefit
of the code generator.  Rename the methods and values.
- The code for ActOnBoundsCastExprSingle handles the case for
dynamic_bounds_cast<ptr<T>>. It was constructing a count(1) expression.
We now have count(1) and byte_count(1) prebuilt, so use that instead.  We also
had some code for attaching a relative alignment clause.  This is for obsolete
syntax; issue #448 covers removing  the syntax.  In fact, this code never did
anything.   The bounds expression is always a count bounds expression.
It never made sense to allow a relative alignment clause for this case and
there should have been an error message generated.  We're going to delete this
syntax anyway, so delete the useless code (continue throwing away the clause.)

Testing:
- Added a new regression test for the user-reported crash.
- Improve the testing of dynamic_bounds_cast in the Checked C repo.  This will be a separate PR.
- Passed local testing on Windows.
- Passed clang debug x64 testing on Linux.
- Passed LNT testing on Linux.


