### PR TITLE
Remove parsing support for old bounds cast expression syntax.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9631,11 +9631,11 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_checked_scope_no_assume_bounds_casting : Error<
     "_Assume_bounds_cast not allowed in a checked scope or function">;
 
-  def err_bounds_cast_error_with_single_syntax
-      : Error<"invalid bounds cast: expected _Ptr or * type">;
+  def err_bounds_cast_expected_ptr_or_unchecked : Error<
+    "expected _Ptr or * type">;
 
-  def err_bounds_cast_error_with_array_syntax
-      : Error<"invalid bounds cast: expected _Array_ptr type">;
+  def err_bounds_cast_expected_array_ptr : Error<
+    "expected _Array_ptr type">;
 
   def warn_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9455,6 +9455,9 @@ def err_typecheck_void_pointer_count_bounds_decl : Error<
 def err_typecheck_void_pointer_count_return_bounds : Error<
   "count bounds expression not allowed for a void pointer return type">;
 
+def err_typecheck_void_pointer_count_bounds_cast : Error<
+  "count bounds expression not allowed for a bounds cast to void pointer">;
+
 def err_typecheck_non_count_bounds_decl : Error<
   "expected %0 to have a pointer, array, or integer type">;
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4632,29 +4632,14 @@ public:
   ActOnBoundsCastExprBounds(Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
                             SourceLocation LAnagleBracketLoc, ParsedType D,
                             SourceLocation RAngleBracketLoc,
-                            RelativeBoundsClause *RelativeClause,
                             SourceLocation LParenLoc, SourceLocation RParenLoc,
-                            Expr *E1, Expr *ParsedBounds);
+                            Expr *E1, BoundsExpr *ParsedBounds);
 
   ExprResult ActOnBoundsCastExprSingle(
       Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
       SourceLocation LAnagleBracketLoc, ParsedType D,
-      SourceLocation RAngleBracketLoc, RelativeBoundsClause *RelativeClause,
+      SourceLocation RAngleBracketLoc,
       SourceLocation LParenLoc, SourceLocation RParenLoc, Expr *E1);
-
-  ExprResult ActOnBoundsCastExprCount(
-      Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
-      SourceLocation LAnagleBracketLoc, ParsedType D,
-      SourceLocation RAngleBracketLoc, RelativeBoundsClause *RelativeClause,
-      SourceLocation LParenLoc, SourceLocation RParenLoc, Expr *E1, Expr *E2);
-
-  ExprResult
-  ActOnBoundsCastExprRange(Scope *S, SourceLocation OpLoc, tok::TokenKind Kind,
-                           SourceLocation LAnagleBracketLoc, ParsedType D,
-                           SourceLocation RAngleBracketLoc,
-                           RelativeBoundsClause *RelativeClause,
-                           SourceLocation LParenLoc, SourceLocation RParenLoc,
-                           Expr *E1, Expr *E2, Expr *E3);
 
   ExprResult BuildBoundsCastExpr(SourceLocation OpLoc, tok::TokenKind Kind,
                                  TypeSourceInfo *CastTypeInfo,

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13556,9 +13556,9 @@ ExprResult Sema::ActOnBoundsCastExprCount(
   if (!DestTy->isCheckedPointerArrayType()) {
     Diag(TypeLoc, diag::err_bounds_cast_error_with_array_syntax);
     return ExprError();
-  } else if ((E1->getType())->isVoidPointerType()) {
-    Diag(E1->getLocStart(),
-         diag::err_typecheck_void_pointer_count_return_bounds);
+  } else if (DestTy->isVoidPointerType()) {
+    Diag(OpLoc,
+         diag::err_typecheck_void_pointer_count_bounds_cast);
     return ExprError();
   } else {
     if (!ResE2.isInvalid())

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13471,7 +13471,8 @@ ExprResult Sema::ActOnBoundsCastExprBounds(
   TypeSourceInfo *CastTInfo;
 
   QualType DestTy = GetTypeFromParser(D, &CastTInfo);
-  SourceLocation TypeLoc = (CastTInfo->getTypeLoc()).getBeginLoc();
+  SourceLocation TypeLoc =
+     CastTInfo ? (CastTInfo->getTypeLoc()).getBeginLoc() : LAngleBracketLoc;
 
   if (CheckBoundsCastBaseType(E1))
     return ExprError();
@@ -13499,7 +13500,8 @@ ExprResult Sema::ActOnBoundsCastExprSingle(
   BoundsExpr *Bounds;
 
   QualType DestTy = GetTypeFromParser(D, &CastTInfo);
-  SourceLocation TypeLoc = (CastTInfo->getTypeLoc()).getBeginLoc();
+  SourceLocation TypeLoc =
+     CastTInfo ? (CastTInfo->getTypeLoc()).getBeginLoc() : LAngleBracketLoc;
 
   if (CheckBoundsCastBaseType(E1))
     return ExprError();

--- a/test/CheckedC/parsing/invalid-bounds-cast-expr.c
+++ b/test/CheckedC/parsing/invalid-bounds-cast-expr.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// Test parsing errors for incorrect bounds cast expressions.
+
+void f(int *p) {
+  _Array_ptr<int> ap = _Assume_bounds_cast<_Array_ptr<int>>(p, 1);  // expected-error {{expected bounds expression}}
+  // Clang doesn't differentiate between parsing errors and semantic errors
+  // during recovery from errors, so make sure recover works OK for a 
+  // type checking error.
+  ap = _Assume_bounds_cast<_Array_ptr<int>>(p, count(p));             // expected-error {{invalid argument type 'int *'}}
+  ap =  _Assume_bounds_cast<_Array_ptr<int>>(p, bounds(p, p + 1) b);  // expected-error {{expected ')'}} \
+                                                                      // expected-note {{to match this '('}}
+}


### PR DESCRIPTION
We changed bounds cast expressions to take a bounds expression as the
second argument, instead of implicitly inferring the kind of bounds
expression from the number of arguments.  This is more verbose but
clearer.  Bounds cast expressions now have two forms:

Op<T>(e1)
Op<T>(e1, bounds-expression)

where Op is one of _Assume_bounds_cast or _Dynamic_bounds_cast
and T must be a pointer type.

This change also improves the error messages and renames the
error message names to be clearer.

Testing:
- There will be a corresponding Checked C repo change to tests
  for bounds cast expressions.
- Add a test for error recovery from bounds cast expression syntax
  errors.
- Passed local testing on x64 Windows and automated testing on Linux.
