### PR TITLE
Fix inference of bounds for members with ptr interop types.

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1018,7 +1018,7 @@ namespace {
             return CreateBoundsNotAllowedYet();
 
           if (!B && IT)
-            return CreateTypeBasedBounds(MemberBaseExpr, IT->getType(),
+            return CreateTypeBasedBounds(M, IT->getType(),
                                          /*IsParam=*/false,
                                          /*IsInteropTypeAnnotation=*/true);
           if(!B)

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2236,6 +2236,16 @@ namespace {
         TraverseStmt(Init, InCheckedScope);
     }
 
+    bool IsBoundsSafeInterfaceAssignment(QualType DestTy, Expr *E) {
+      if (DestTy->isUncheckedPointerType()) {
+        ImplicitCastExpr *ICE = dyn_cast<ImplicitCastExpr>(E);
+        if (ICE)
+          return ICE && ICE->getCastKind() == CK_BitCast &&
+                 ICE->getSubExpr()->getType()->isCheckedPointerType();
+      }
+      return false;
+    }
+
     void VisitBinaryOperator(BinaryOperator *E, bool InCheckedScope) {
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
@@ -2254,7 +2264,8 @@ namespace {
         // ptr<T> to ptr<T> assignment, no obligation to infer any bounds for either side
       }
       else if (LHSType->isCheckedPointerType() ||
-          LHSType->isIntegerType()) {
+               LHSType->isIntegerType() ||
+               IsBoundsSafeInterfaceAssignment(LHSType, RHS)) {
         // Check that the value being assigned has bounds if the
         // target of the LHS lvalue has bounds.
         LHSTargetBounds = S.InferLValueTargetBounds(LHS);
@@ -2336,13 +2347,12 @@ namespace {
       ArrayRef<Expr *> ArgExprs = llvm::makeArrayRef(const_cast<Expr**>(CE->getArgs()),
                                                      CE->getNumArgs());
       for (unsigned i = 0; i < Count; i++) {
-        if (FuncProtoTy->getParamType(i)->isUncheckedPointerType()) {
-          // Skip checking bounds for unchecked pointer parameters, unless
-          // the argument was subject to a bounds-safe interface cast.
-          ImplicitCastExpr *ICE = dyn_cast<ImplicitCastExpr>(CE->getArg(i));
-          if (!(ICE && ICE->getCastKind() == CK_BitCast &&
-                ICE->getSubExpr()->getType()->isCheckedPointerType()))
-            continue;
+        QualType ParamType = FuncProtoTy->getParamType(i);
+        // Skip checking bounds for unchecked pointer parameters, unless
+        // the argument was subject to a bounds-safe interface cast.
+        if (ParamType->isUncheckedPointerType() &&
+            !IsBoundsSafeInterfaceAssignment(ParamType, CE->getArg(i))) {
+          continue;
         }
 
         // We want to check the argument expression implies the desired parameter bounds.

--- a/test/CheckedC/inferred-bounds/member-reference.c
+++ b/test/CheckedC/inferred-bounds/member-reference.c
@@ -9,9 +9,9 @@
 // The description uses AST dumps.
 //
 // This line is for the clang test infrastructure:
-// RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
+// RUN: %clang_cc1 -fcheckedc-extension -fdump-inferred-bounds -verify -verify-ignore-unexpected=warning -verify-ignore-unexpected=note -fdump-inferred-bounds %s | FileCheck %s
 // expected-no-diagnostics
-
+ 
 struct S1 {
   _Array_ptr<int> p : count(len);
   int len;
@@ -23,6 +23,19 @@ struct S2 {
 
 struct S3 {
   int f;
+};
+
+struct Interop_S1 {
+  int *p : count(len);
+  int len;
+};
+
+struct Interop_S2 {
+  int arr[5] : itype(int _Checked[5]);
+};
+
+struct Interop_S4 {
+  int *p : itype(_Ptr<int>);
 };
 
 //-------------------------------------------------------------------------//
@@ -85,17 +98,18 @@ void f1(struct S1 a1, struct S2 b2) {
 // Test writing a member of a parameter                                    //
 //-------------------------------------------------------------------------//
 
+int global_arr1[5];
 void f2(struct S1 a3) {
-  int local_arr1[5];
   // TODO: need bundled block.
-  a3.p = local_arr1;
+  a3.p = global_arr1;
+  a3.len = 5;
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
 // CHECK: |-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue .p {{0x[0-9a-f]+}}
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S1':'struct S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a3' 'struct S1':'struct S1'
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
 // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <ArrayToPointerDecay>
-// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr1' 'int [5]'
 // CHECK: Target Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <LValueToRValue>
@@ -111,13 +125,11 @@ void f2(struct S1 a3) {
 // CHECK: RHS Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr1' 'int [5]'
 // CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *':'int *' '+'
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
-// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr1' 'int [5]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
-
-  a3.len = 5;
 }
 
 //-------------------------------------------------------------------------//
@@ -163,3 +175,286 @@ void f3(struct S3 c1) {
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 
 }
+
+//-------------------------------------------------------------------------//
+// Test reading a member of a parameter with an interop type               //
+//-------------------------------------------------------------------------//
+
+// In an unchecked scope.
+void f10(struct Interop_S1 a1, struct Interop_S2 b2,
+         struct Interop_S4 c3) {
+  _Array_ptr<int> ap : count(a1.len) = a1.p;
+
+// CHECK: VarDecl {{.*}}  ap '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:36> 'NULL TYPE' Element
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:30, col:33> 'int' <LValueToRValue>
+// CHECK: |   `-MemberExpr {{0x[0-9a-f]+}} <col:30, col:33> 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} <col:30> 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:40, col:43> '_Array_ptr<int>' <BitCast>
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:40, col:43> 'int *' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} <col:40, col:43> 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} <col:40> 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:   `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: Initializer Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+
+  _Array_ptr<int> bp : count(5) = b2.arr;
+
+// CHECK: VarDecl {{.*}}  bp '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:31> 'NULL TYPE' Element
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} <col:30> 'int' 5
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Array_ptr<int>' <BitCast>
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int *' <ArrayToPointerDecay>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} <col:35> 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: Initializer Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *':'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
+  _Array_ptr<int> cp : count(1) = c3.p;
+
+// CHECK: VarDecl {{.*}}  cp '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:31> 'NULL TYPE' Element
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} <col:30> 'int' 1
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Array_ptr<int>' <BitCast>
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int *' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} <col:35> 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'c3' 'struct Interop_S4':'struct Interop_S4'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-CStyleCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: |   `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'c3' 'struct Interop_S4':'struct Interop_S4'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-CStyleCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   | `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK:   |   `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'c3' 'struct Interop_S4':'struct Interop_S4'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+}
+
+// In a checked scope.
+_Checked void f11(struct Interop_S1 a1, struct Interop_S2 b2,
+                  struct Interop_S4 c3) {
+  _Array_ptr<int> ap : count(a1.len) = a1.p;
+  
+// CHECK: VarDecl {{.*}}  '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:36> 'NULL TYPE' Element
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:30, col:33> 'int' <LValueToRValue>
+// CHECK: |   `-MemberExpr {{0x[0-9a-f]+}} <col:30, col:33> 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} <col:30> 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:40, col:43> '_Array_ptr<int>' <LValueToRValue>
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:40, col:43> '_Array_ptr<int>' lvalue <LValueBitCast> BoundsSafeInterface
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} <col:40, col:43> 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} <col:40> 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:   `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: Initializer Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+
+  _Array_ptr<int> bp : count(5) = b2.arr;
+
+// CHECK: VarDecl {{.*}}  '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:31> 'NULL TYPE' Element
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} <col:30> 'int' 5
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Array_ptr<int>' <ArrayToPointerDecay> BoundsSafeInterface
+// CHECK:   `-MemberExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} <col:35> 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: Initializer Bounds:
+ // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *':'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
+// CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
+  _Array_ptr<int> cp : count(1) = c3.p;
+
+// CHECK: {{.*}}  cp '_Array_ptr<int>' cinit
+// CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} <col:24, col:31> 'NULL TYPE' Element
+// CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} <col:30> 'int' 1
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Array_ptr<int>' <BitCast>
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Ptr<int>' <LValueToRValue>
+// CHECK:     `-ImplicitCastExpr {{0x[0-9a-f]+}} <col:35, col:38> '_Ptr<int>' lvalue <LValueBitCast> BoundsSafeInterface
+// CHECK:       `-MemberExpr {{0x[0-9a-f]+}} <col:35, col:38> 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:         `-DeclRefExpr {{0x[0-9a-f]+}} <col:35> 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'c3' 'struct Interop_S4':'struct Interop_S4'
+// CHECK: Declared Bounds:
+// CHECK: CountBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Element
+// CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: Initializer Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-CStyleCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
+// CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue <LValueBitCast> BoundsSafeInterface
+// CHECK: |     `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'c3' 'struct Interop_S4':'struct Interop_S4'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-CStyleCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   | `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <LValueToRValue>
+// CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' lvalue <LValueBitCast> BoundsSafeInterface
+// CHECK:   |     `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'c3' 'struct Interop_S4':'struct Interop_S4'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+}
+
+int global_arr2 _Checked[5];
+
+void f12(struct Interop_S1 a1) {
+  // TODO: need bundled block.
+  a1.p = global_arr2;
+  a1.len = 5;
+}
+
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int *' '='
+// CHECK: |-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <BitCast> BoundsSafeInterface
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: RHS Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
+_Checked void f13(struct Interop_S1 a1) {
+  // TODO: need bundled block.
+  a1.p = global_arr2;
+  a1.len = 5;
+}
+
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue <LValueBitCast> BoundsSafeInterface
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
+// CHECK:     `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .len {{0x[0-9a-f]+}}
+// CHECK:       `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S1':'struct Interop_S1' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S1':'struct Interop_S1'
+// CHECK: RHS Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
+void f14(struct Interop_S4 a1) {
+  a1.p = global_arr2;
+}
+
+// CHECK: BinaryOperator {{0x[0-9a-f]+}} 'int *' '='
+// CHECK: |-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S4':'struct Interop_S4'
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <BitCast> BoundsSafeInterface
+// CHECK:   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:     `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: Target Bounds:
+// CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-CStyleCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK: | `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK: |   `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S4':'struct Interop_S4'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-CStyleCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <BitCast>
+// CHECK:   | `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <LValueToRValue>
+// CHECK:   |   `-MemberExpr {{0x[0-9a-f]+}} 'int *' lvalue .p {{0x[0-9a-f]+}}
+// CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S4':'struct Interop_S4' lvalue ParmVar {{0x[0-9a-f]+}} 'a1' 'struct Interop_S4':'struct Interop_S4'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
+// CHECK: RHS Bounds:
+// CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+
+_Checked void f15(struct Interop_S4 a1) {
+  a1.p = global_arr2;
+}
+
+// CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
+// CHECK: |-Inferred Bounds
+// CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
+// CHECK: |   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: |   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
+// CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'
+// CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
+// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue Var {{0x[0-9a-f]+}} 'global_arr2' 'int _Checked[5]'

--- a/test/CheckedC/regression-cases/bug_458_void_ptr_bounds_cast.c
+++ b/test/CheckedC/regression-cases/bug_458_void_ptr_bounds_cast.c
@@ -4,17 +4,18 @@
 //
 // This test checks that _Dynamic_bounds_cast from a void pointer compiles.
 //
-// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+// RUN: %clang -fcheckedc-extension -c -o%t %s
 // expected-no-diagnostics
 
 typedef struct {
 	void *ptr : itype(_Ptr<void>);
 } mytype_t;
 
-int
-main(void)
+int main(int argc, char *argv[])
 {
 	mytype_t m;
- (void)_Dynamic_bounds_cast<_Ptr<char>>(m.ptr);
+  (void)_Dynamic_bounds_cast<_Ptr<char>>(m.ptr);
+
+  return 0;
 }
 


### PR DESCRIPTION
@nmeum has reported that the compiler assert during code generation described in issue #458 is still happening.   There was a problem with inference of bounds for a member with a ptr interop type.  We were using the base expression of the member expression, not the member expression itself.

This change adds tests that check the inference of bounds for members with interop types.  It also updates the regression test case to generate an object file, instead of just doing semantic checking.  During testing, I found that checking of bounds declarations was not happening for some bounds-safe interface assignments (assignments in unchecked scopes of checked pointers to unchecked pointer lvalues that have bounds-safe interfaces).   I added an additional check for this case (the code for checking bounds declarations at calls already had a similar check).

Testing:
- Passed local testing on Windows x64.
- Passed Checked C, clang regression tests and LNT regression tests on Linux x64.
- We should look at further testing of other syntactic forms that can have interop types (variable
  assignments and calls), as well as testing of dynamic casts involving ptr source/destinations.


