### PR TITLE
Use simple facts about expression equality.  Expand checking of bounds declarations.

### DIFF
--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2517,7 +2517,7 @@ public:
   bool EquivalentAnnotations(const BoundsAnnotations &Annots1,
                              const BoundsAnnotations &Annots2);
   bool EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2,
-                        EquivExprLists *EquivExprs = nullptr);
+                        EquivExprSets *EquivExprs = nullptr);
   bool EquivalentInteropTypes(const InteropTypeExpr *Expr1,
                               const InteropTypeExpr *Expr2);
 

--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -17,6 +17,7 @@
 
 #include "clang/AST/ASTTypeTraits.h"
 #include "clang/AST/CanonicalType.h"
+#include "clang/AST/CanonBounds.h"
 #include "clang/AST/CommentCommandTraits.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclarationName.h"
@@ -2515,7 +2516,8 @@ private:
 public:
   bool EquivalentAnnotations(const BoundsAnnotations &Annots1,
                              const BoundsAnnotations &Annots2);
-  bool EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2);
+  bool EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2, 
+                        EqualityRelation *ER = nullptr);
   bool EquivalentInteropTypes(const InteropTypeExpr *Expr1,
                               const InteropTypeExpr *Expr2);
 

--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2516,8 +2516,8 @@ private:
 public:
   bool EquivalentAnnotations(const BoundsAnnotations &Annots1,
                              const BoundsAnnotations &Annots2);
-  bool EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2, 
-                        EqualityRelation *ER = nullptr);
+  bool EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2,
+                        EquivExprLists *EquivExprs = nullptr);
   bool EquivalentInteropTypes(const InteropTypeExpr *Expr1,
                               const InteropTypeExpr *Expr2);
 

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -86,8 +86,7 @@ namespace clang {
     Result CompareImpl(const BinaryOperator *E1, const BinaryOperator *E2);
     Result CompareImpl(const CompoundAssignOperator *E1,
                    const CompoundAssignOperator *E2);
-    Result CompareImpl(const ImplicitCastExpr *E1, const ImplicitCastExpr *E2);
-    Result CompareImpl(const CStyleCastExpr *E1, const CStyleCastExpr *E2);
+    Result CompareImpl(const CastExpr *E1, const CastExpr *E2);
     Result CompareImpl(const CompoundLiteralExpr *E1,
                    const CompoundLiteralExpr *E2);
     Result CompareImpl(const GenericSelectionExpr *E1,

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -35,12 +35,8 @@ namespace clang {
   class Expr;
   class VarDecl;
 
-  // Abstract base class that provides information what variables
-  // currently are equal to each other.
-  class EqualityRelation {
-  public:
-     virtual const VarDecl *getRepresentative(const VarDecl *V) = 0;
-  };
+  // List of list of equivalent expressions
+  typedef SmallVector<SmallVector<Expr *, 4> *, 4> EquivExprLists;
 
   class Lexicographic {
   public:
@@ -52,7 +48,7 @@ namespace clang {
 
   private:
     ASTContext &Context;
-    EqualityRelation *EqualVars;
+    EquivExprLists *EquivExprs;
     bool Trace;
 
     template <typename T>
@@ -105,7 +101,7 @@ namespace clang {
 
 
   public:
-    Lexicographic(ASTContext &Ctx, EqualityRelation *EV);
+    Lexicographic(ASTContext &Ctx, EquivExprLists *EquivExprs);
 
     /// \brief Lexicographic comparison of expressions that can occur in
     /// bounds expressions.

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -35,8 +35,8 @@ namespace clang {
   class Expr;
   class VarDecl;
 
-  // List of list of equivalent expressions
-  typedef SmallVector<SmallVector<Expr *, 4> *, 4> EquivExprLists;
+  // List of sets of equivalent expressions.
+  typedef SmallVector<SmallVector<Expr *, 4> *, 4> EquivExprSets;
 
   class Lexicographic {
   public:
@@ -48,7 +48,7 @@ namespace clang {
 
   private:
     ASTContext &Context;
-    EquivExprLists *EquivExprs;
+    EquivExprSets *EquivExprs;
     bool Trace;
 
     template <typename T>
@@ -104,7 +104,7 @@ namespace clang {
 
 
   public:
-    Lexicographic(ASTContext &Ctx, EquivExprLists *EquivExprs);
+    Lexicographic(ASTContext &Ctx, EquivExprSets *EquivExprs);
 
     /// \brief Lexicographic comparison of expressions that can occur in
     /// bounds expressions.

--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -62,6 +62,10 @@ namespace clang {
       return Lexicographic::CompareImpl(E1, E2);
     }
 
+    // See if E1 and E2 are considered equivalent using EquivExprs.  If
+    // they are not, return Current.
+    Result CheckEquivExprs(Result Current, const Expr *E1, const Expr *E2);
+
     Result CompareInteger(signed I1, signed I2);
     Result CompareInteger(unsigned I1, unsigned I2);
     Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
@@ -111,6 +115,7 @@ namespace clang {
     /// or types.
     Result CompareDecl(const NamedDecl *D1, const NamedDecl *D2);
     Result CompareType(QualType T1, QualType T2);
+    Result CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2);
   };
 }  // end namespace clang
 

--- a/include/clang/Basic/DiagnosticGroups.td
+++ b/include/clang/Basic/DiagnosticGroups.td
@@ -893,7 +893,11 @@ def MicrosoftEndOfFile : DiagGroup<"microsoft-end-of-file">;
 def MicrosoftInaccessibleBase : DiagGroup<"microsoft-inaccessible-base">;
 
 // Checked C warnings for bounds declaration checking.
-def CheckBoundsDecls : DiagGroup<"check-bounds-decls">;
+def CheckBoundsDeclsUnchecked : DiagGroup<"check-bounds-decls-unchecked-scope">;
+def CheckBoundsDeclsChecked : DiagGroup<"check-bounds-decls-checked-scope">;
+def CheckBoundsDecls : DiagGroup<"check-bounds-decls",
+   [CheckBoundsDeclsUnchecked,
+    CheckBoundsDeclsChecked]>;
 // Checked C warnings about memory accesses determined to be out of
 // declared bounds.
 def CheckMemoryAccesses : DiagGroup<"check-memory-accesses">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9669,7 +9669,6 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def warn_argument_bounds_invalid : Warning<
     "cannot prove argument meets declared bounds for %ordinal0 parameter">,
-    DefaultIgnore,
     InGroup<CheckBoundsDecls>;
 
   def warn_checked_scope_argument_bounds_invalid : Warning<

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9640,7 +9640,6 @@ def err_bounds_type_annotation_lost_checking : Error<
   def warn_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
     "%select{assignment|initialization}0">,
-    DefaultIgnore,
     InGroup<CheckBoundsDecls>;
 
   def warn_checked_scope_bounds_declaration_invalid : Warning<

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9640,12 +9640,12 @@ def err_bounds_type_annotation_lost_checking : Error<
   def warn_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
     "%select{assignment|initialization}0">,
-    InGroup<CheckBoundsDecls>;
+    InGroup<CheckBoundsDeclsUnchecked>;
 
   def warn_checked_scope_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
     "%select{assignment|initialization}0">,
-    InGroup<CheckBoundsDecls>;
+    InGroup<CheckBoundsDeclsChecked>;
 
   def error_bounds_declaration_invalid : Error<
     "declared bounds for %1 are invalid after "
@@ -9669,11 +9669,11 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def warn_argument_bounds_invalid : Warning<
     "cannot prove argument meets declared bounds for %ordinal0 parameter">,
-    InGroup<CheckBoundsDecls>;
+    InGroup<CheckBoundsDeclsUnchecked>;
 
   def warn_checked_scope_argument_bounds_invalid : Warning<
     "cannot prove argument meets declared bounds for %ordinal0 parameter">,
-    InGroup<CheckBoundsDecls>;
+    InGroup<CheckBoundsDeclsChecked>;
 
   def error_argument_bounds_invalid : Error<
     "argument does not meet declared bounds for %ordinal0 parameter">;
@@ -9684,11 +9684,11 @@ def err_bounds_type_annotation_lost_checking : Error<
   def warn_static_cast_bounds_invalid : Warning<
     "cannot prove cast source bounds are wide enough for %0">,
     DefaultIgnore,
-    InGroup<CheckBoundsDecls>;
+    InGroup<CheckBoundsDeclsUnchecked>;
 
   def warn_checked_scopestatic_cast_bounds_invalid : Warning<
     "cannot prove cast source bounds are wide enough for %0">,
-    InGroup<CheckBoundsDecls>;
+    InGroup<CheckBoundsDeclsChecked>;
 
   def error_static_cast_bounds_invalid : Error<
     "cast source bounds are too narrow for %0">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4587,7 +4587,7 @@ public:
   //===---------------------------- Checked C Extension ----------------------===//
 
 private:
-  const Type *ValidateBoundsExprArgument(Expr *Arg);
+  QualType ValidateBoundsExprArgument(Expr *Arg);
 
 public:
   ExprResult ActOnNullaryBoundsExpr(SourceLocation BoundKWLoc,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -9048,9 +9048,9 @@ bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
 }
 
 bool ASTContext::EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2,
-                                  EqualityRelation *ER) {
+                                  EquivExprLists *EquivExprs) {
   if (Expr1 && Expr2) {
-    Lexicographic::Result Cmp = Lexicographic(*this, ER).CompareExpr(Expr1, Expr2);
+    Lexicographic::Result Cmp = Lexicographic(*this, EquivExprs).CompareExpr(Expr1, Expr2);
     return Cmp == Lexicographic::Result::Equal;
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -9047,9 +9047,10 @@ bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
   return false;
 }
 
-bool ASTContext::EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2) {
+bool ASTContext::EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2,
+                                  EqualityRelation *ER) {
   if (Expr1 && Expr2) {
-    Lexicographic::Result Cmp = Lexicographic(*this, nullptr).CompareExpr(Expr1, Expr2);
+    Lexicographic::Result Cmp = Lexicographic(*this, ER).CompareExpr(Expr1, Expr2);
     return Cmp == Lexicographic::Result::Equal;
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -9048,7 +9048,7 @@ bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
 }
 
 bool ASTContext::EquivalentBounds(const BoundsExpr *Expr1, const BoundsExpr *Expr2,
-                                  EquivExprLists *EquivExprs) {
+                                  EquivExprSets *EquivExprs) {
   if (Expr1 && Expr2) {
     Lexicographic::Result Cmp = Lexicographic(*this, EquivExprs).CompareExpr(Expr1, Expr2);
     return Cmp == Lexicographic::Result::Equal;

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -326,7 +326,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
    Stmt::StmtClass E1Kind = E1->getStmtClass();
    Stmt::StmtClass E2Kind = E2->getStmtClass();
    Result Cmp = CompareInteger(E1Kind, E2Kind);
-   if (Cmp != Result::Equal)
+   if (Cmp != Result::Equal && !(isa<CastExpr>(E1) && isa<CastExpr>(E2)))
      return CheckEquivExprs(Cmp, E1, E2);
 
    Cmp = Result::Equal; 

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -332,7 +332,28 @@ Lexicographic::CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2) {
 
 Result
 Lexicographic::CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2) {
-  return CompareDecl(E1->getDecl(), E2->getDecl());
+  Lexicographic::Result Cmp = CompareDecl(E1->getDecl(), E2->getDecl());
+  if (!EqualVars || Cmp == Result::Equal)
+    return Cmp;
+/*
+  llvm::outs() << "Examining unequal vars\n";
+  */
+  const VarDecl *V1 = dyn_cast<VarDecl>(E1->getDecl());
+  if (!V1)
+    return Cmp;
+ const VarDecl *V2 = dyn_cast<VarDecl>(E2->getDecl());
+  if (!V2)
+    return Cmp;
+  const VarDecl *V1Rep = EqualVars->getRepresentative(V1);
+  const VarDecl *V2Rep = EqualVars->getRepresentative(V2);
+  if (!V1Rep || !V2Rep) 
+    return Cmp;
+/*
+  llvm::outs() << "Representative vars\n";
+  V1Rep->dump(llvm::outs());
+  V2Rep->dump(llvm::outs());
+*/
+  return CompareDecl(V1Rep, V2Rep);
 }
 
 Result

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -17,12 +17,124 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/AST/CanonBounds.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/Stmt.h"
 
 using namespace clang;
 using Result = Lexicographic::Result;
+
+namespace {
+  // Return true if this cast preserve the bits of the value,
+  // false otherwise.
+  static bool IsValuePreserving(CastKind CK) {
+    switch (CK) {
+      case CK_BitCast:
+      case CK_LValueBitCast:
+      case CK_NoOp:
+      case CK_ArrayToPointerDecay:
+      case CK_FunctionToPointerDecay:
+      case CK_NullToPointer:
+      case CK_AssumePtrBounds:
+      case CK_DynamicPtrBounds:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  static bool isPointerToArrayType(QualType Ty) {
+    if (const PointerType *T = Ty->getAs<PointerType>())
+      return T->getPointeeType()->isArrayType();
+    else
+      return false;
+  }
+  // Ignore operations that don't change runtime values: parens, some cast operations,
+  // array/function address-of and dereference operators, and address-of/dereference
+  // operators that cancel (&* and *&).
+  //
+  // The code for casts is adapted from Expr::IgnoreNoopCasts, which seems like doesn't
+  // do enough filtering (it'll ignore LValueToRValue casts for example).
+  // TODO: reconcile with CheckValuePreservingCast
+  static Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E) {
+    while (true) {
+      E = E->IgnoreParens();
+
+      if (CastExpr *P = dyn_cast<CastExpr>(E)) {
+        CastKind CK = P->getCastKind();
+        Expr *SE = P->getSubExpr();
+        if (IsValuePreserving(CK)) {
+          E = SE;
+          continue;
+        }
+
+        // Ignore integer <-> casts that are of the same width, ptr<->ptr
+        // and ptr<->int casts of the same width.
+        if (CK == CK_IntegralToPointer || CK == CK_PointerToIntegral ||
+            CK == CK_IntegralCast) {
+          if (Ctx.hasSameUnqualifiedType(E->getType(), SE->getType())) {
+            E = SE;
+            continue;
+          }
+
+          if ((E->getType()->isPointerType() ||
+                E->getType()->isIntegralType(Ctx)) &&
+                (SE->getType()->isPointerType() ||
+                SE->getType()->isIntegralType(Ctx)) &&
+              Ctx.getTypeSize(E->getType()) == Ctx.getTypeSize(SE->getType())) {
+            E = SE;
+            continue;
+          }
+        }
+      } else if (const UnaryOperator *UO = dyn_cast<UnaryOperator>(E)) {
+        QualType ETy = UO->getType();
+        Expr *SE = UO->getSubExpr();
+        QualType SETy = SE->getType();
+
+        UnaryOperator::Opcode Op = UO->getOpcode();
+        if (Op == UO_Deref) {
+          // This may be more conservative than necessary.
+          bool between_functions = ETy->isFunctionType() && SETy->isFunctionPointerType();
+          bool between_arrays = ETy->isArrayType() && isPointerToArrayType(SETy);
+          if (between_functions || between_arrays) {
+            E = SE;
+            continue;
+          }
+
+          // handle *&e, which reduces to e.
+          if (const UnaryOperator *Child =
+              dyn_cast<UnaryOperator>(SE->IgnoreParens())) {
+            if (Child->getOpcode() == UO_AddrOf) {
+              E = Child->getSubExpr();
+              continue;
+            }
+          }
+
+        } else if (Op == UO_AddrOf) {
+          // This may be more conservative than necessary.
+          bool between_functions = ETy->isFunctionPointerType() && SETy->isFunctionType();
+          bool between_arrays = isPointerToArrayType(ETy) && SETy->isArrayType();
+          if (between_functions || between_arrays) {
+            E = SE;
+            continue;
+          }
+
+          // handle &*e, which reduces to e.
+          if (const UnaryOperator *Child =
+              dyn_cast<UnaryOperator>(SE->IgnoreParens())) {
+            if (Child->getOpcode() == UO_Deref) {
+              E = Child->getSubExpr();
+              continue;
+            }
+          }
+        }
+      }
+
+      return E;
+    }
+  }
+}
 
 Lexicographic::Lexicographic(ASTContext &Ctx, EquivExprLists *EquivExprs) :
   Context(Ctx), EquivExprs(EquivExprs), Trace(false) {
@@ -188,24 +300,34 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) {
   return Result::LessThan;
 }
 
-Result Lexicographic::CompareExpr(const Expr *E1, const Expr *E2) {
+Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
    if (Trace) {
      raw_ostream &OS = llvm::outs();
      OS << "Lexicographic comparing expressions\n";
      OS << "E1:\n";
-     E1->dump(OS);
+     Arg1->dump(OS);
      OS << "E2:\n";
-     E2->dump(OS);
+     Arg2->dump(OS);
    }
 
-   if (E1 == E2)
-     return Result::Equal;
+   Expr *E1 = const_cast<Expr *>(Arg1);
+   Expr *E2 = const_cast<Expr *>(Arg2);
 
+  E1 = IgnoreValuePreservingOperations(Context, E1);
+  E2 = IgnoreValuePreservingOperations(Context, E2);
+
+  if (E1 == E2)
+    return Result::Equal;
+
+   // Commpare expressions structurally, recursively invoking
+   // comparison for subcomponents.  If that fails, consult
+   // EquivExprs to see if the expressions are considered
+   // equivalent.
    Stmt::StmtClass E1Kind = E1->getStmtClass();
    Stmt::StmtClass E2Kind = E2->getStmtClass();
    Result Cmp = CompareInteger(E1Kind, E2Kind);
    if (Cmp != Result::Equal)
-     goto different;
+     return CheckEquivExprs(Cmp, E1, E2);
 
    Cmp = Result::Equal; 
    switch (E1Kind) {
@@ -274,7 +396,7 @@ Result Lexicographic::CompareExpr(const Expr *E1, const Expr *E2) {
    }
 
    if (Cmp != Result::Equal)
-     goto different;
+     return CheckEquivExprs(Cmp, E1, E2);
 
    // Check children
    auto I1 = E1->child_begin();
@@ -287,7 +409,7 @@ Result Lexicographic::CompareExpr(const Expr *E1, const Expr *E2) {
      if (ordered) {
        if (Cmp == Result::Equal)
          continue;
-       goto different;
+       return CheckEquivExprs(Cmp, E1, E2);
       }
      assert(E1Child && E2Child);
      const Expr *E1ChildExpr = dyn_cast<Expr>(E1Child);
@@ -296,7 +418,21 @@ Result Lexicographic::CompareExpr(const Expr *E1, const Expr *E2) {
      if (E1ChildExpr && E2ChildExpr) {
        Cmp = CompareExpr(E1ChildExpr, E2ChildExpr);
        if (Cmp != Result::Equal)
-         goto different;
+         return CheckEquivExprs(Cmp, E1, E2);
+       // TODO: treat operations where checkedness of pointers
+       // changes semantics as distinct:
+       // - pointer arithmetic (overflow, non-null checking)
+       // - memory access
+       // TODO: consider treating operations whose types differ
+       // but that still produce the same value as being the
+       // same.  For example:
+       // - Pointer arithmetic where the pointer referent types are the same
+       //   size, checkedness is the same, and the integer types are the
+      //    same size/signedness.
+       Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(),
+                                          E2ChildExpr->getType());
+       if (Cmp != Result::Equal)
+         return CheckEquivExprs(Cmp, E1, E2);
      } else
        // assert fired - return something
        return Result::LessThan;
@@ -305,24 +441,20 @@ Result Lexicographic::CompareExpr(const Expr *E1, const Expr *E2) {
    // Make sure the number of children was equal.  If E1 has
    // fewer children than E2, make it less than E2.  If it has more
    // children, make it greater than E2.
-   if (I1 == E1->child_end() && I2 != E2->child_end()) {
-     Cmp = Result::LessThan;
-     goto different;
-   }
+   if (I1 == E1->child_end() && I2 != E2->child_end())
+     return CheckEquivExprs(Result::LessThan, E1, E2);
 
-   if (I1 != E1->child_end() && I2 == E2->child_end()) {
-     Cmp = Result::GreaterThan;
-     goto different;
-    }
+   if (I1 != E1->child_end() && I2 == E2->child_end())
+     return CheckEquivExprs(Result::GreaterThan, E1, E2);
 
    return Result::Equal;
+}
 
-different:
-  assert(Cmp != Result::Equal);
-  // See if the expressions are considered equivalent using the list of lists
-  // of equivalent expressions.
+// See if the expressions are considered equivalent using the list of lists
+// of equivalent expressions.
+Result Lexicographic::CheckEquivExprs(Result Current, const Expr *E1, const Expr *E2) {
   if (!EquivExprs)
-    return Cmp;
+    return Current;
 
   Lexicographic SimpleComparer = Lexicographic(Context, nullptr);
   for (auto OuterList = EquivExprs->begin(); OuterList != EquivExprs->end();
@@ -350,14 +482,26 @@ different:
       return Result::Equal;
   }
 
-  return Cmp;
-}
+  return Current;
+ }
+
 
 Result
 Lexicographic::CompareType(QualType QT1, QualType QT2) {
   QT1 = QT1.getCanonicalType();
   QT2 = QT2.getCanonicalType();
   if (QT1 == QT2)
+    return Result::Equal;
+  else
+    // TODO: fill this in
+    return Result::LessThan;
+}
+
+Result
+Lexicographic::CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) {
+  QT1 = QT1.getCanonicalType();
+  QT2 = QT2.getCanonicalType();
+  if (Context.isEqualIgnoringChecked(QT1, QT2))
     return Result::Equal;
   else
     // TODO: fill this in

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -356,8 +356,8 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::CompoundAssignOperatorClass:
        Cmp = Compare<CompoundAssignOperator>(E1, E2); break;
      case Expr::BinaryConditionalOperatorClass: break;
-     case Expr::ImplicitCastExprClass: Cmp = Compare<ImplicitCastExpr>(E1, E2); break;
-     case Expr::CStyleCastExprClass: Cmp = Compare<CStyleCastExpr>(E1, E2); break;
+     case Expr::ImplicitCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
+     case Expr::CStyleCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CompoundLiteralExprClass: Cmp = Compare<CompoundLiteralExpr>(E1, E2); break;
      // TODO:
      // case: ExtVectorElementExpr
@@ -611,15 +611,12 @@ Lexicographic::CompareImpl(const CompoundAssignOperator *E1,
 }
 
 Result
-Lexicographic::CompareImpl(const ImplicitCastExpr *E1,
-                           const ImplicitCastExpr *E2) {
-  return CompareInteger(E1->getValueKind(), E2->getValueKind());
-}
-
-Result
-Lexicographic::CompareImpl(const CStyleCastExpr *E1,
-                           const CStyleCastExpr *E2) {
-  return CompareType(E1->getType(), E2->getType());
+Lexicographic::CompareImpl(const CastExpr *E1,
+                           const CastExpr *E2) {
+  Result Cmp = CompareInteger(E1->getCastKind(), E2->getCastKind());
+  if (Cmp != Result::Equal)
+    return Cmp;
+  return CompareTypeIgnoreCheckedness(E1->getType(), E2->getType());
 }
 
 Result

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1582,7 +1582,7 @@ namespace {
       }
 
       // Is R in range of this range?
-      ProofResult InRange(ConstantSizedRange &R, ProofFailure &Cause, EquivExprLists *EquivExprs) {
+      ProofResult InRange(ConstantSizedRange &R, ProofFailure &Cause, EquivExprSets *EquivExprs) {
         if (EqualValue(S.Context, Base, R.Base, EquivExprs)) {
           ProofResult Result = ProofResult::True;
           if (LowerOffset > R.LowerOffset) {
@@ -1741,7 +1741,7 @@ namespace {
       Offset = llvm::APSInt(PointerWidth, false);
     }
 
-    static bool EqualValue(ASTContext &Ctx, Expr *E1, Expr *E2, EquivExprLists *EquivExprs) {
+    static bool EqualValue(ASTContext &Ctx, Expr *E1, Expr *E2, EquivExprSets *EquivExprs) {
       Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(E1, E2);
       return R == Lexicographic::Result::Equal;
     }
@@ -1749,7 +1749,7 @@ namespace {
     // Convert a bounds expression to a constant-sized range.  Returns true if the
     // the bounds expression can be converted and false if it cannot be converted.
     bool CreateConstantRange(const BoundsExpr *Bounds, ConstantSizedRange *R,
-                             EquivExprLists *EquivExprs) {
+                             EquivExprSets *EquivExprs) {
       switch (Bounds->getKind()) {
         case BoundsExpr::Kind::Invalid:
         case BoundsExpr::Kind::Unknown:
@@ -1786,7 +1786,7 @@ namespace {
     ProofResult ProveBoundsDeclValidity(const BoundsExpr *DeclaredBounds,
                                         const BoundsExpr *SrcBounds,
                                         ProofFailure &Cause,
-                                        EquivExprLists *EquivExprs,
+                                        EquivExprSets *EquivExprs,
                                         ProofStmtKind Kind =
                                           ProofStmtKind::BoundsDeclaration) {
       assert(BoundsUtil::IsStandardForm(DeclaredBounds) &&

--- a/test/CheckedC/inferred-bounds/basic.c
+++ b/test/CheckedC/inferred-bounds/basic.c
@@ -15,7 +15,7 @@
 // The description uses AST dumps.
 //
 // This line is for the clang test infrastructure:
-// RUN: %clang_cc1 -fcheckedc-extension -verify -verify-ignore-unexpected=warning -fdump-inferred-bounds %s | FileCheck %s
+// RUN: %clang_cc1 -fcheckedc-extension -verify -verify-ignore-unexpected=warning -verify-ignore-unexpected=note -fdump-inferred-bounds %s | FileCheck %s
 
 //-------------------------------------------------------------------------//
 // Test assignment of integers to _Array_ptr variables.  This covers both  //

--- a/test/CheckedC/inferred-bounds/member-arrow-reference.c
+++ b/test/CheckedC/inferred-bounds/member-arrow-reference.c
@@ -10,7 +10,6 @@
 //
 // This line is for the clang test infrastructure:
 // RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
-// expected-no-diagnostics
 
 struct S1 {
   _Array_ptr<int> p : count(len);
@@ -97,7 +96,9 @@ void f1(struct S1 *a1, struct S2 *b2) {
 void f2(struct S1 *a3) {
   int local_arr1[5];
   // TODO: need bundled block.
-  a3->p = local_arr1;
+  a3->p = local_arr1;  // expected-warning {{cannot prove declared bounds for a3->p are valid after assignment}} \
+                       // expected-note {{(expanded) declared bounds are 'bounds(a3->p, a3->p + a3->len)'}} \
+                       // expected-note {{(expanded) inferred bounds are 'bounds(local_arr1, local_arr1 + 5)'}}
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
 // CHECK: |-MemberExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue ->p {{0x[0-9a-f]+}}

--- a/test/CheckedC/static-checking/bounds-decl-challenges.c
+++ b/test/CheckedC/static-checking/bounds-decl-challenges.c
@@ -1,0 +1,31 @@
+// Tests that the current static checking of bounds declaration can't
+// handle.
+//
+// RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify -verify-ignore-unexpected=note %s
+
+// A function call on the rhs that returns a value with bounds.
+
+extern _Array_ptr<int> h4(void) : count(3) {
+  _Array_ptr<int> p : bounds(p, p + 3) = 0;
+  return p;
+}
+
+extern void f7(void *p) {
+  _Array_ptr<int> r : count(3) = 0;
+  r = _Assume_bounds_cast<_Array_ptr<int>>(h4(), count(3));  // expected-warning {{cannot prove declared bounds for r are valid after assignment}}
+}
+
+// Deferencing an array of nt_checked arrays.
+extern void check_assign(int val, int p[10], int q[], int r _Checked[10], int s _Checked[],
+                         int s2d _Checked[10][10], int v _Nt_checked[10], int w _Nt_checked[],
+                         int w2d _Checked[10]_Nt_checked[10]) {
+  int x2d _Checked[10]_Nt_checked[10];
+  _Nt_array_ptr<int> t13b = w2d[0];  // expected-warning {{cannot prove declared bounds for 't13b' are valid after initialization}}
+  _Nt_array_ptr<int> t15b = x2d[0];  // expected-warning {{cannot prove declared bounds for 't15b' are valid after initialization}}
+}
+
+// Creating a pointer with count bounds into an existing array.
+void passing_test_1(void) {
+  int a _Checked[10] = { 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  _Array_ptr<int> b : count(5) = &a[2];  // expected-warning {{cannot prove declared bounds for 'b' are valid after initialization}}
+}

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -16,12 +16,24 @@ void f2(_Array_ptr<int> p : bounds(p, p + x), int x) {
   _Array_ptr<int> r : bounds(p, p + x) = p;
 }
 
-// Initialization by expression without syntactically identical
-// normalized bounds - warning expected.
+// Initialization of a pointer by an array with syntactically identical
+// normalized bounds.
+void f2a(void) {
+  int a _Checked[10];
+  _Array_ptr<int> r : bounds(a, a + 10) = a;
+}
+
+// Initialization by expression with bounds that are syntactically identical
+// modulo expression equality implied by initialization - no warning.
 void f3(_Array_ptr<int> p : bounds(p, p + x), int x) {
-  _Array_ptr<int> r : count(x) = p;     // expected-warning {{cannot prove declared bounds}} \
-                                        // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
-                                        // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
+  _Array_ptr<int> r : count(x) = p;
+}
+
+// Initialization by an array with bounds that syntactically identical
+// modulo expression equality implied by initialization - no warning.
+void f3a(void) {
+  int a _Checked[10];
+  _Array_ptr<int> r : count(10) = a;
 }
 
 
@@ -38,13 +50,11 @@ void f5(_Array_ptr<int> p : count(x), int x) {
   r = p;
 }
 
-// Assignment of expression without syntactically identical normalized bounds -
-// no warning.
+// Assignment of expression with bounds that are syntactically identical
+// modulo expression equality implied by assignment - no warning.
 void f6(_Array_ptr<int> p : count(x), int x) {
   _Array_ptr<int> r : count(x) = 0;
-  r = p;      // expected-warning {{cannot prove declared bounds}} \
-              // expected-note {{(expanded) declared bounds are 'bounds(r, r + x)'}} \
-              // expected-note {{(expanded) inferred bounds are 'bounds(p, p + x)'}}
+  r = p;
 }
 
 // Parameter passing
@@ -93,6 +103,15 @@ void f20(_Array_ptr<int> p: count(5)) {
                                             // expected-note {{(expanded) declared bounds are 'bounds(p - 1, p + 6)'}} \
                                             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
 }
+
+// Initialization of pointers using top-level arrays
+int a0 _Checked[9] = { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+_Array_ptr<int> a1 : count(3) = a0;
+_Array_ptr<int> a2 : count(11) = a0;   // expected-error {{declared bounds for 'a2' are invalid after initialization}} \
+                                       // expected-note {{destination bounds are wider than the source bounds}} \
+                                       // expected-note {{destination upper bound is above source upper bound}} \
+                                       // expected-note {{(expanded) declared bounds are 'bounds(a2, a2 + 11)'}} \
+                                       // expected-note {{(expanded) inferred bounds are 'bounds(a0, a0 + 9)'}}
 
 // Assignments
 void f21(_Array_ptr<int> p: count(5)) {


### PR DESCRIPTION
This change extends the compiler to collect and use simple facts about expression equality when checking bounds declarations.  It also turns on checking of bounds declarations for unchecked scopes by default.  It was only on by default for checked scopes.  The checking of bounds declarations is still simple, so it may produce (many) unnecessary warnings.   It can be turned off using  `-Wno-check-bounds-decls` (everywhere), `-Wno-check-bounds-decl-unchecked-scope` (for unchecked scopes), and `-Wno-check-bounds-decls-checked-scope` (for checked scopes), and.  This change addresses issues #474 and #472.

Equality facts are gathered at assignments and initializers.  They are not propagated across statements. For example, given `x = y`, when checking the bounds for `x` are implied by the bounds for `y`, we assume `x == y`.  In general, given `e1 = e2`, we check that `e1` and `e2` are non-modifying expressions and collect the fact that `e1 == e2`.   (We still need to check that the assignment doesn't modify an lvalue used by` e2`, and will add that in the future.  We may miss issuing warnings that we should issue,)
- We pass a list of sets of equivalent expressions to CanonBounds, which checks whether two expressions compute the same value.  We try to compare expressions and if that fails, we consult the list of sets.  We check each expression to see if it is equivalent to an expression in a set (we don't recursively use the equality information).
- When setting up the equality fact `e1 == e2`, we add an lvalue-to-rvalue cast for the IR for `e1`, .   Given a declarator for a variable v with an initializer, we make sure to turn v into a lvalue-to-rvalue cast of a decl-ref.
- There was code in SemaBounds.cpp that puts an expression into a standard form by ignoring non-value changing operations.   That code is moved to CanonBounds.cpp.
- The types of subexpressions of an expression affect the meaning of an expression.  When comparing two expressions, check that the types of their subexpressions match.  This wasn't a concern before when the code was strictly comparing lexical  equality.  There is a TODO for work needed for bounds-safe interfaces, tracked by Github issue #475.

The change fixes a few bugs found during testing of the code for checking equivalence of expressions:
- CanonBounds.cpp needs to treat implicit and C-style casts as being equivalent if they cast to/from the same type.
- In SemaBounds.cpp, when we infer the rvalue bounds of a bounds cast expression of the form *_bounds_cast<T>(`e1`, bounds-expr), the bounds need to be for `(T) e1`, not `e1` (`e1` has the wrong type).
- In SemaExpr.cpp, when type checking bounds(`e1`, `e2`), we need to check that e1 and e2 point to compatible types, not exactly the same type.

Testing:
- Updated the Checked C repo tests.  This will be covered by a separate pull request:
  - Added more tests of expression equivalence (lexical_equality should be renamed, as it checks for expression equivalence using a few additional facts about C expressions).
  - Updated tests to handle the fact that checking of bounds declaration is on everywhere by default.  Replace a bunch of TODO's with an expected warning message. Also deleted some warnings that are no longer issued because the compiler can prove the bounds are valid.
  - Kept checking of bounds declarations on for most tests and only disabled it for some parsing and typechecking tests.
  - In some cases, made simple changes to avoid warnings about bounds declarations (the original cases are captured in the new Checked C clang repo file test/CheckedC/static-checking/bounds-decl-challenges.c)
- Update the Checked C clang tests:
  - In bounds-decl-checking.c, remove expected warnings that are now gone because the compiler understand equality facts.  Add code that checks the compiler understands equality facts involving arrays.  Include a negative test where the compiler concludes that an array is too small for the declared bounds for an array_ptr variable.
- Passed automated testing on Linux x64 (clang regression tests and LNT testing)

