### PR TITLE
Disallow inferred bounds containing modifying expressions.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9590,6 +9590,11 @@ def err_bounds_type_annotation_lost_checking : Error<
     "dynamic check will always fail">,
 	InGroup<CheckedC>;
 
+  def err_inferred_modifying_bounds : Error<
+    "inferred bounds '%0' contain a modifying expression; use a temporary instead">;
+
+  def note_modifying_expression : Note<"modifying expression">;
+
   def err_not_non_modifying_expr : Error<
 	"%select{assignment|increment|decrement|call|volatile}0 expression not "
     "allowed in %select{expression|dynamic check expression|count expression"

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4683,9 +4683,15 @@ public:
   /// /brief Checks whether an expression is non-modifying
   /// (see Checked C Spec, 3.6.1).  Returns true if the expression is non-modifying,
   /// false otherwise.
+  enum NonModifyingMessage {
+    NMM_None,
+    NMM_Error,
+    NMM_Note
+  };
+
   bool CheckIsNonModifying(Expr *E, NonModifyingContext Req =
                                NonModifyingContext::NMC_Unknown,
-                               bool ReportError = true);
+                            NonModifyingMessage = NMM_Error);
 
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4693,6 +4693,8 @@ public:
                                NonModifyingContext::NMC_Unknown,
                             NonModifyingMessage = NMM_Error);
 
+  BoundsExpr *CheckNonModifyingBounds(BoundsExpr *Bounds, Expr *E);
+
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);
   /// \brief Take a bounds expression with positional parameters from a function

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2338,9 +2338,12 @@ namespace {
         // Put the parameter bounds in a standard form if necessary.
         if (SubstParamBounds->isElementCount() ||
             SubstParamBounds->isByteCount()) {
-          if (S.CheckIsNonModifying(Arg,
+          // TODO: turn this check on after implementing current_expr_value.
+          // Turning it on now would cause errors to be issued for arguments
+          // that are calls.
+          if (true /* S.CheckIsNonModifying(Arg,
                               Sema::NonModifyingContext::NMC_Function_Parameter,
-                                    Sema::NonModifyingMessage::NMM_Error))
+                                    Sema::NonModifyingMessage::NMM_Error) */)
             SubstParamBounds = S.ExpandToRange(Arg,
                                     const_cast<BoundsExpr *>(SubstParamBounds));
            else

--- a/test/CheckedC/static-checking/bounds-decl-challenges.c
+++ b/test/CheckedC/static-checking/bounds-decl-challenges.c
@@ -12,7 +12,7 @@ extern _Array_ptr<int> h4(void) : count(3) {
 
 extern void f7(void *p) {
   _Array_ptr<int> r : count(3) = 0;
-  r = _Assume_bounds_cast<_Array_ptr<int>>(h4(), count(3));  // expected-warning {{cannot prove declared bounds for r are valid after assignment}}
+  r = _Assume_bounds_cast<_Array_ptr<int>>(h4(), count(3));  // expected-error {{contain a modifying expression}}
 }
 
 // Deferencing an array of nt_checked arrays.


### PR DESCRIPTION
Bounds expressions aren't allowed to contain modifying expressions. It is possible for bounds inference to create bounds expressions containing modifying expressions when inferring bounds expressions for member operator expressions.

We have code that attempts to disallow the creation of invalid bounds expressions by making the bounds be unknown. This code is wrong because it can cause the compiler to skip checking bounds declarations when the inferred target bounds for the LHS of an assignment contains a modifying expression. 

Instead of trying to hack the results of the inference analysis, cast a wide net by directly checking that bounds expressions created by bounds inference are non-modifying expressions.  This directly prevents the creation of bounds checks with side-effects embedded in them and incorrect analysis of bounds expressions with side effects.

- Rework the checking of bounds for call expressions to avoid the complicated short-circuiting code.    The new code is simpler and easier to understand.
- Generalize the diagnostics code for identifying modifying bounds expressions to allow notes to be printed.  This lets us print notes identifying problematic modifying expressions.  Change the code to prevent  duplicate messages.  Print an error message the first time an expression is seen.  The expansion of bounds to a standard form can create the situation where an expression occurs multiple times.
- Delete disabled code for identifying problematic modifying arguments.   The current approach of specifically identifying the argument in the context of a specific bounds is better because it is more precise, and easier for a programmer to understand.
- The code for identifying volatile variables used in a bounds expression was too restrictive: it flagged even taking the address of a volatile variable.   We should only flag reads of volatile variables.

Testing:
- Added new tests to the Checked C repo of expressions that result in inferred bounds that contain modifying expressions.   It was tough to even come up with code that did that, beyond structure member accesses.
- Passing existing Checked C tests on Linux (clang and LNT tests, including converted code with LNT tests).
- Passed Checked C tests on Windows locally.




