### PR TITLE
Fix checking of function pointer casts involving lvalues.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9579,7 +9579,7 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_cast_to_checked_fn_ptr_not_value_preserving : Error<
     "can only cast function names or null pointers to checked function pointer type %0">;
 
-  def err_cast_to_checked_fn_ptr_cannot_read_mem : Error<
+  def err_cast_to_checked_fn_ptr_from_unchecked_fn_ptr : Error<
     "cannot guarantee operand of cast to checked function pointer type %0 is a function pointer">;
 
   def err_cast_to_checked_fn_ptr_can_only_ref_deref_functions : Error<


### PR DESCRIPTION
A programmer reported that an indirect function call via a const member resulted in an unexpected compiler error message (Github issue #481).   The problem was that the compiler was too restrictive when handling lvalue-to-rvalue casts.  The lvalue-to-rvalue casts removes qualifiers on the type.  The compiler was checking for the exact type.

I reworked the code for checking a function pointer cast expression.  The existing code was hard to follow and there were some bugs in it. The code now has 3 distinct steps:
1. Handle casts to checked function pointers that are valid by default.
   This includes lvalue-to-rvalue casts and bounds-safe interface casts.
2. Otherwise, skip over value-preserving casts and value-preserving
   operations involving function pointers. Stop when you reach an expression E
   that has checked pointer type or that isn't a value-preserving cast
   or cast-like operation.
3. Check that E is guaranteed to produce a valid function pointer:
- E is a reference to a function name.
- E is a null pointer.
- E is checked pointer.

Testing:
- Add additional tests to the Checked C repo for function pointer casts.
- Passed local testing on Windows.
- Passed automated testing on Linux.