### PR TITLE
Rename BOUNDS_CHECKED pragma to CHECKED_SCOPE.

### DIFF
--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -814,10 +814,10 @@ ANNOTATION(pragma_fp)
 // Annotation for the attribute pragma directives - #pragma clang attribute ...
 ANNOTATION(pragma_attribute)
 
-// Annotations for BOUNDS_CHECKED pragma directives for checkedc
+// Annotations for CHECKED_SCOPE pragma directives for checkedc
 // The lexer produces these so that they only take effect when the parser
-// handles #pragma BOUNDS_CHECKED ... directives.
-ANNOTATION(pragma_bounds_checked)
+// handles #pragma CHECKED_SCOPE ... directives.
+ANNOTATION(pragma_checked_scope)
 
 // Annotations for module import translated from #include etc.
 ANNOTATION(module_include)

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -640,8 +640,8 @@ private:
   void HandlePragmaAttribute();
 
   /// \brief Handle the annotation token produced for
-  /// #pragma BOUNDS_CHECKED [on-off-switch]
-  void HandlePragmaBoundsChecked();
+  /// #pragma CHECKED_SCOPE [on-off-switch]
+  void HandlePragmaCheckedScope();
 
   /// GetLookAheadToken - This peeks ahead N tokens and returns that token
   /// without consuming any tokens.  LookAhead(0) returns 'Tok', LookAhead(1)

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4657,8 +4657,8 @@ public:
   /// \brief Add default bounds/interop type expressions to Annots, if appropriate.
   void InferBoundsAnnots(QualType Ty, BoundsAnnotations &Annots, bool IsParam);
 
-  // \#pragma BOUNDS_CHECKED.
-  void ActOnPragmaBoundsChecked(Scope *S, tok::OnOffSwitch OOS);
+  // \#pragma CHECKED_SCOPE.
+  void ActOnPragmaCheckedScope(Scope *S, tok::OnOffSwitch OOS);
 
   // Represents the context where an expression must be non-modifying.
   enum NonModifyingContext {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4100,8 +4100,8 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc, unsigned TagType,
       continue;
     }
 
-    if (Tok.is(tok::annot_pragma_bounds_checked)) {
-      HandlePragmaBoundsChecked();
+    if (Tok.is(tok::annot_pragma_checked_scope)) {
+      HandlePragmaCheckedScope();
       continue;
     }
 

--- a/lib/Parse/ParsePragma.cpp
+++ b/lib/Parse/ParsePragma.cpp
@@ -192,7 +192,7 @@ private:
 };
 
 struct PragmaCheckedScopeHandler : public PragmaHandler {
-  PragmaCheckedScopeHandler() : PragmaHandler("BOUNDS_CHECKED") {}
+  PragmaCheckedScopeHandler() : PragmaHandler("CHECKED_SCOPE") {}
   void HandlePragma(Preprocessor &PP, PragmaIntroducerKind Introducer,
                     Token &FirstToken) override;
 };
@@ -1431,13 +1431,13 @@ void Parser::HandlePragmaAttribute() {
                                    std::move(SubjectMatchRules));
 }
 
-// #pragma BOUNDS_CHECKED [on-off-switch]
-void Parser::HandlePragmaBoundsChecked() {
-  assert(Tok.is(tok::annot_pragma_bounds_checked));
+// #pragma CHECKED_SCOPE [on-off-switch]
+void Parser::HandlePragmaCheckedScope() {
+  assert(Tok.is(tok::annot_pragma_checked_scope));
   tok::OnOffSwitch OOS =
     static_cast<tok::OnOffSwitch>(
     reinterpret_cast<uintptr_t>(Tok.getAnnotationValue()));
-  Actions.ActOnPragmaBoundsChecked(Actions.getCurScope(), OOS);
+  Actions.ActOnPragmaCheckedScope(Actions.getCurScope(), OOS);
   ConsumeAnnotationToken(); // The annotation token.
 }
 
@@ -3019,7 +3019,7 @@ void PragmaAttributeHandler::HandlePragma(Preprocessor &PP,
 }
 
 // Handle the checked-c top level scope checked property.
-// #pragma BOUNDS_CHECKED [on-off-switch]
+// #pragma CHECKED_SCOPE [on-off-switch]
 // To handle precise scope property, annotation token is better
 void PragmaCheckedScopeHandler::HandlePragma(Preprocessor &PP,
                                              PragmaIntroducerKind Introducer,
@@ -3031,7 +3031,7 @@ void PragmaCheckedScopeHandler::HandlePragma(Preprocessor &PP,
   MutableArrayRef<Token> Toks(PP.getPreprocessorAllocator().Allocate<Token>(1),
                               1);
   Toks[0].startToken();
-  Toks[0].setKind(tok::annot_pragma_bounds_checked);
+  Toks[0].setKind(tok::annot_pragma_checked_scope);
   Toks[0].setLocation(Tok.getLocation());
   Toks[0].setAnnotationEndLoc(Tok.getLocation());
   Toks[0].setAnnotationValue(

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -394,8 +394,8 @@ Retry:
     HandlePragmaAttribute();
     return StmtEmpty();
 
-  case tok::annot_pragma_bounds_checked:
-    HandlePragmaBoundsChecked();
+  case tok::annot_pragma_checked_scope:
+    HandlePragmaCheckedScope();
     return StmtEmpty();
   }
 
@@ -966,8 +966,8 @@ void Parser::ParseCompoundStatementLeadingPragmas() {
     case tok::annot_pragma_dump:
       HandlePragmaDump();
       break;
-    case tok::annot_pragma_bounds_checked:
-      HandlePragmaBoundsChecked();
+    case tok::annot_pragma_checked_scope:
+      HandlePragmaCheckedScope();
       break;
     default:
       checkForPragmas = false;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -585,8 +585,8 @@ bool Parser::ParseTopLevelDecl(DeclGroupPtrTy &Result) {
     HandlePragmaUnused();
     return false;
 
-  case tok::annot_pragma_bounds_checked:
-    HandlePragmaBoundsChecked();
+  case tok::annot_pragma_checked_scope:
+    HandlePragmaCheckedScope();
     return false;
 
   case tok::kw_import:

--- a/lib/Sema/SemaAttr.cpp
+++ b/lib/Sema/SemaAttr.cpp
@@ -685,9 +685,9 @@ void Sema::ActOnPragmaOptimize(bool On, SourceLocation PragmaLoc) {
     OptimizeOffPragmaLocation = PragmaLoc;
 }
 
-// Checked C - #pragma BOUNDS_CHECKED action, adjust top level scope flags.
-// Adjust checked property of scope where '#pragma BOUNDS_CHECKED' is set.
-void Sema::ActOnPragmaBoundsChecked(Scope *S, tok::OnOffSwitch OOS) {
+// Checked C - #pragma CHECKED_SCOPE action, adjust top level scope flags.
+// Adjust checked property of scope where '#pragma CHECKED_SCOPE' is set.
+void Sema::ActOnPragmaCheckedScope(Scope *S, tok::OnOffSwitch OOS) {
   unsigned ScopeFlags = S->getFlags();
   switch (OOS) {
   case tok::OOS_ON:

--- a/test/CheckedC/checked-scope/error-messages.c
+++ b/test/CheckedC/checked-scope/error-messages.c
@@ -20,13 +20,13 @@ extern void f4(void) _Checked {
   int *p = 0;  // expected-error {{local variable in a checked scope must have a checked type}}
 }
 
-#pragma BOUNDS_CHECKED ON
+#pragma CHECKED_SCOPE ON
 extern int *gp1; // expected-error {{global variable in a checked scope must have a checked type or a bounds-safe interface}}
 
 struct S1 {
   int *f;       // expected-error {{member in a checked scope must have a checked type or a bounds-safe interface}}
 };
-#pragma BOUNDS_CHECKED OFF
+#pragma CHECKED_SCOPE OFF
 
 //=========================================================================================
 // Error messages for uses of variables and members with unchecked types in checked scopes.
@@ -106,10 +106,10 @@ extern void f25(void) {
   }
 }
 
-#pragma BOUNDS_CHECKED ON
+#pragma CHECKED_SCOPE ON
 extern ty gp3; // expected-error {{global variable in a checked scope must have a checked type or a bounds-safe interface}} \
                // expected-note {{'ty' (aka 'int *') is not allowed in a checked scope}}
-#pragma BOUNDS_CHECKED OFF
+#pragma CHECKED_SCOPE OFF
 
 struct S3 {
   ty f;       // expected-note {{member declared here}}

--- a/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
@@ -24,7 +24,7 @@ int f2(_Ptr<void> p) {
   return 0;
 }
 
-#pragma BOUNDS_CHECKED ON
+#pragma CHECKED_SCOPE ON
 
 extern void test_f3(const void* p_ptr : byte_count(1));
 

--- a/test/CheckedC/static-checking/bounds-decl-checking-cs.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking-cs.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang -cc1 -fcheckedc-extension -verify %s
 
-#pragma BOUNDS_CHECKED ON
+#pragma CHECKED_SCOPE ON
 
 #include "bounds-decl-checking.c"
 


### PR DESCRIPTION
- Rename pragma and associated methods within the compiler.
- Update tests
- There are corresponding PRs for Checked C and the Checked C LNT repos: https://github.com/Microsoft/checkedc/pull/282 and https://github.com/Microsoft/checkedc-llvm-test-suite/pull/86.

Testing:
- Passed local testing on Windows and automated testing on Linux.