### PR TITLE
Avoid spurious warnings during checking of bounds declarations.

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4783,6 +4783,28 @@ public:
   // will always fail.
   void WarnDynamicCheckAlwaysFails(const Expr *Condition);
 
+  /// \brief RAII class used to indicate that we are substituting one
+  /// expression into another expression during bounds checking.  This
+  /// should never produce a semantic error, but it might produce
+  /// warnings or notes we need to suppress.
+  class ExprSubstitutionScope {
+    Sema &SemaRef;
+    bool PrevDisableSubstitionDiagnostics;
+  public:
+    explicit ExprSubstitutionScope(Sema &SemaRef)
+        : SemaRef(SemaRef),
+          PrevDisableSubstitionDiagnostics(
+            SemaRef.DisableSubstitionDiagnostics) {
+      SemaRef.DisableSubstitionDiagnostics = true;
+    }
+    ~ExprSubstitutionScope() {
+      SemaRef.DisableSubstitionDiagnostics =
+        PrevDisableSubstitionDiagnostics;
+    }
+  };
+
+  bool DisableSubstitionDiagnostics;
+
   //===---------------------------- Clang Extensions ----------------------===//
 
   /// __builtin_convertvector(...)

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4783,10 +4783,12 @@ public:
   // will always fail.
   void WarnDynamicCheckAlwaysFails(const Expr *Condition);
 
-  /// \brief RAII class used to indicate that we are substituting one
-  /// expression into another expression during bounds checking.  This
-  /// should never produce a semantic error, but it might produce
-  /// warnings or notes we need to suppress.
+  /// \brief RAII class used to indicate that we are substituting an expression
+  /// into another expression during bounds checking.  We need to suppress 
+  /// diagnostics emission during this.  We are doing type-preserving
+  /// substitutions, so we don't expect semantic errors during substitution.
+  /// There could be warnings, which would confuse users.  The warnings could
+  /// could also be escalated to errors, which would cause compilation failures.
   class ExprSubstitutionScope {
     Sema &SemaRef;
     bool PrevDisableSubstitionDiagnostics;

--- a/lib/Sema/Sema.cpp
+++ b/lib/Sema/Sema.cpp
@@ -137,7 +137,8 @@ Sema::Sema(Preprocessor &pp, ASTContext &ctxt, ASTConsumer &consumer,
       ValueWithBytesObjCTypeMethod(nullptr), NSArrayDecl(nullptr),
       ArrayWithObjectsMethod(nullptr), NSDictionaryDecl(nullptr),
       DictionaryWithObjectsMethod(nullptr), GlobalNewDeleteDeclared(false),
-      TUKind(TUKind), NumSFINAEErrors(0), AccessCheckingSFINAE(false),
+      TUKind(TUKind), DisableSubstitionDiagnostics(false),
+      NumSFINAEErrors(0), AccessCheckingSFINAE(false),
       InNonInstantiationSFINAEContext(false), NonInstantiationEntries(0),
       ArgumentPackSubstitutionIndex(-1), CurrentInstantiationScope(nullptr),
       DisableTypoCorrection(false), TyposCorrected(0), AnalysisWarnings(*this),
@@ -1269,6 +1270,12 @@ void Sema::EmitCurrentDiagnostic(unsigned DiagID) {
       Diags.Clear();
       return;
     }
+  }
+
+  if (DisableSubstitionDiagnostics) {
+     Diags.setLastDiagnosticIgnored();
+     Diags.Clear();
+     return;
   }
 
   // Set up the context's printing policy based on our current state.

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -206,51 +206,58 @@ BoundsExpr *Sema::ConcretizeFromFunctionType(BoundsExpr *Expr,
 }
 
 namespace {
+  class CheckForModifyingArgs : public RecursiveASTVisitor<CheckForModifyingArgs> {
+  private:
+    Sema &SemaRef;
+    const ArrayRef<Expr *> Arguments;
+    llvm::SmallBitVector VisitedArgs;
+    Sema::NonModifyingContext ErrorKind;
+    bool ModifyingArg;
+  public:
+    CheckForModifyingArgs(Sema &SemaRef, ArrayRef<Expr *> Args,
+                          Sema::NonModifyingContext ErrorKind) :
+      SemaRef(SemaRef),
+      Arguments(Args),
+      VisitedArgs(Args.size()),
+      ErrorKind(ErrorKind),
+      ModifyingArg(false) {}
+
+    bool FoundModifyingArg() {
+      return ModifyingArg;
+    }
+
+    bool VisitPositionalParameterExpr(PositionalParameterExpr *E) {
+      unsigned index = E->getIndex();
+      if (index < Arguments.size() && !VisitedArgs[index]) {
+        VisitedArgs.set(index);
+        if (!SemaRef.CheckIsNonModifying(Arguments[index], ErrorKind,
+                                         Sema::NonModifyingMessage::NMM_Error)) {
+          ModifyingArg = true;
+        }
+      }
+      return true;
+    }
+  };
+}
+
+namespace {
   class ConcretizeBoundsExprWithArgs : public TreeTransform<ConcretizeBoundsExprWithArgs> {
     typedef TreeTransform<ConcretizeBoundsExprWithArgs> BaseTransform;
 
   private:
-    const ArrayRef<Expr *> Arguments;
-    // This stores whether we've emitted an error for a particular substitution
-    // so that we don't duplicate error messages.
-    llvm::SmallBitVector ErroredForArgument;
-    Sema::NonModifyingContext ErrorKind;
-    bool SubstitutedModifyingExpression;
-
+    ArrayRef<Expr *> Args;
 
   public:
-    ConcretizeBoundsExprWithArgs(Sema &SemaRef, ArrayRef<Expr *> Args,
-                                 Sema::NonModifyingContext ErrorKind) :
+    ConcretizeBoundsExprWithArgs(Sema &SemaRef, ArrayRef<Expr *> Args) :
       BaseTransform(SemaRef),
-      Arguments(Args),
-      ErroredForArgument(Args.size()),
-      ErrorKind(ErrorKind),
-      SubstitutedModifyingExpression(false) { }
-
-    bool substitutedModifyingExpression() {
-      return SubstitutedModifyingExpression;
-    }
+      Args(Args) { }
 
     ExprResult TransformPositionalParameterExpr(PositionalParameterExpr *E) {
       unsigned index = E->getIndex();
-      if (index < Arguments.size()) {
-        Expr *AE = Arguments[index];
-       Sema::NonModifyingMessage Message = ErroredForArgument[index] ?
-          Sema:: NonModifyingMessage::NMM_None :
-          Sema::NonModifyingMessage::NMM_Error;
-
-        // We may only substitute if this argument expression is
-        // a non-modifying expression.
-        if (!SemaRef.CheckIsNonModifying(AE, ErrorKind,
-                                         Message)) {
-          SubstitutedModifyingExpression = true;
-          ErroredForArgument.set(index);
-          return ExprError();
-        }
-
-        return SemaRef.MakeAssignmentImplicitCastExplicit(AE);
+      if (index < Args.size()) {
+        return Args[index];
       } else {
-        llvm_unreachable("out of range index for positional argument");
+        llvm_unreachable("out of range index for positional parameter");
         return ExprError();
       }
     }
@@ -263,15 +270,15 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
   if (!Bounds || Bounds->isInvalid())
     return Bounds;
 
-  BoundsExpr *Result;
-  ExprSubstitutionScope Scope(*this); // suppress diagnostics
+  auto CheckArgs = CheckForModifyingArgs(*this, Args, ErrorKind);
+  CheckArgs.TraverseStmt(Bounds);
+  if (CheckArgs.FoundModifyingArg())
+    return nullptr;
 
-  auto Concretizer = ConcretizeBoundsExprWithArgs(*this, Args, ErrorKind);
+  ExprSubstitutionScope Scope(*this); // suppress diagnostics
+  auto Concretizer = ConcretizeBoundsExprWithArgs(*this, Args);
   ExprResult ConcreteBounds = Concretizer.TransformExpr(Bounds);
-  if (Concretizer.substitutedModifyingExpression()) {
-      return nullptr;
-  }
-  else if (ConcreteBounds.isInvalid()) {
+  if (ConcreteBounds.isInvalid()) {
 #ifndef NDEBUG
     llvm::outs() << "Failed concretizing\n";
     llvm::outs() << "Bounds:\n";
@@ -287,7 +294,7 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
     return nullptr;
   }
   else {
-    Result = dyn_cast<BoundsExpr>(ConcreteBounds.get());
+    BoundsExpr *Result = dyn_cast<BoundsExpr>(ConcreteBounds.get());
     assert(Result && "unexpected dyn_cast failure");
     return Result;
   }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -191,6 +191,8 @@ BoundsExpr *Sema::ConcretizeFromFunctionType(BoundsExpr *Expr,
     return Expr;
 
   BoundsExpr *Result;
+  ExprSubstitutionScope Scope(*this); // suppress diagnostics
+
   ExprResult ConcreteBounds = ConcretizeBoundsExpr(*this, Params).TransformExpr(Expr);
   if (ConcreteBounds.isInvalid()) {
     llvm_unreachable("unexpected failure in making bounds concrete");
@@ -262,6 +264,8 @@ BoundsExpr *Sema::ConcretizeFromFunctionTypeWithArgs(
     return Bounds;
 
   BoundsExpr *Result;
+  ExprSubstitutionScope Scope(*this); // suppress diagnostics
+
   auto Concretizer = ConcretizeBoundsExprWithArgs(*this, Args, ErrorKind);
   ExprResult ConcreteBounds = Concretizer.TransformExpr(Bounds);
   if (Concretizer.substitutedModifyingExpression()) {
@@ -336,11 +340,11 @@ namespace {
   };
 }
 
-
 BoundsExpr *Sema::MakeMemberBoundsConcrete(
   Expr *Base,
   bool IsArrow,
   BoundsExpr *Bounds) {
+  ExprSubstitutionScope Scope(*this); // suppress diagnostics
   ExprResult ConcreteBounds =
     ConcretizeMemberBounds(*this, Base, IsArrow).TransformExpr(Bounds);
   if (ConcreteBounds.isInvalid())

--- a/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
+++ b/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
@@ -18,12 +18,11 @@ static void myfunc2(_Array_ptr<int> data : count(len), int len) {
   (void)data;
 }
 
-int main(void)
-{
+int main(void) {
   int a _Checked[5];
   myfunc1(a, 0);  // expected-warning {{cannot prove argument meets declared bounds}} \
                   // expected-note {{expected argument bounds}} \
                   // expected-note {{inferred bounds}}
   myfunc2(0, 0);
-	return 0;
+  return 0;
 }

--- a/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
+++ b/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
@@ -1,0 +1,29 @@
+//
+// These is a regression test case for 
+// https://github.com/Microsoft/checkedc-clang/issues/457
+//
+// This test checks that bounds declaration checking does not
+// introduce a spurious warning about pointer arithmetic on a null
+// value.
+// RUN: %clang -cc1 -verify -Wextra -fcheckedc-extension %s
+
+#pragma CHECKED_SCOPE ON
+
+static void myfunc1(_Array_ptr<void> data : bounds(other_data, other_data + 5),
+                    _Array_ptr<char> other_data) {
+  (void)data;
+}
+
+static void myfunc2(_Array_ptr<int> data : count(len), int len) {
+  (void)data;
+}
+
+int main(void)
+{
+  int a _Checked[5];
+  myfunc1(a, 0);  // expected-warning {{cannot prove argument meets declared bounds}} \
+                  // expected-note {{expected argument bounds}} \
+                  // expected-note {{inferred bounds}}
+  myfunc2(0, 0);
+	return 0;
+}


### PR DESCRIPTION
A programmer reported that the compiler is emitting a spurious warning about pointer arithmetic involving a null pointer (issue #457).   The warning is being emitted during checking of bounds declarations.   The compiler substitutes actual arguments for parameters in a bounds expression.  This triggers a warning when the actual argument is a null pointer, and the parameter bounds involves pointer arithmetic.

We are doing type-preserving substitutions, so we don't expect semantic errors during substitution into bounds. There could be warnings because the compiler runs semantic analysis when a substitution happens.   This is problematic because there's no way to fix the warnings, the warnings could confuse users, and the warnings could also be escalated to errors, which would cause compilation failures.

This updates the compiler to suppress diagnostic messages during substitution of expressions.   We add a member on Sema to control whether diagnostic messages are being suppressed, and use an RAII pattern to set/restore this variable.   This is a vastly simplified version of the SFINAE (substitution failure is not an error) support code for C++ templates.   I thought about re-using the SFINAE code, but it did not seem worth the risk/trouble.

Testing:
- Added 2 new regression test cases.  A recent compiler change made the compiler stop showing the original reported warning (the compiler now recognizes that null implies that any parameter bounds is true, so when an actual argument is null, it doesn't even substitute into bounds) .  I had to write a more convoluted case to trigger the problem.
- Passes local testing on Windows.
- Passed automated testing on Linux.
