### PR TITLE
Get the program name out of args before args gets emptied.

### DIFF
--- a/tools/checked-c-convert/utils/run.py
+++ b/tools/checked-c-convert/utils/run.py
@@ -45,8 +45,10 @@ def runMain(args):
     s.add(os.path.realpath(i['file']))
 
   print s
+
+  prog_name = args.prog_name
   args = []
-  args.append(args.prog_name)
+  args.append(prog_name)
   args.extend(DEFAULT_ARGS)
   args.extend(list(s))
   f = open('bla', 'w')


### PR DESCRIPTION
Copy the prog_name out of args to a local variable before args is emptied so it can be re-added to the new args list.
Fixes #507.