### PR TITLE
Only add the cl driver mode if on windows

### DIFF
--- a/tools/checked-c-convert/utils/run.py
+++ b/tools/checked-c-convert/utils/run.py
@@ -11,7 +11,9 @@ It contains some work-arounds for cmake+nmake generated compile_commands.json
 files, where the files are malformed. 
 """
 
-DEFAULT_ARGS = ["-verbose", "-dump-stats", "-extra-arg-before=--driver-mode=cl", "-output-postfix=checked"]
+DEFAULT_ARGS = ["-verbose", "-dump-stats", "-output-postfix=checked"]
+if os.name == "nt":
+  DEFAULT_ARGS.append("-extra-arg-before=--driver-mode=cl")
 
 def tryFixUp(s):
   """


### PR DESCRIPTION
On Linux, the "driver-mode=cl" is not the right thing to do with clang. Instead, that should be added only if on Windows.