### PR TITLE
Not verbose and no C++

### DIFF
--- a/tools/checked-c-convert/utils/run.py
+++ b/tools/checked-c-convert/utils/run.py
@@ -11,7 +11,7 @@ It contains some work-arounds for cmake+nmake generated compile_commands.json
 files, where the files are malformed. 
 """
 
-DEFAULT_ARGS = ["-verbose", "-dump-stats", "-output-postfix=checked"]
+DEFAULT_ARGS = ["-dump-stats", "-output-postfix=checked"]
 if os.name == "nt":
   DEFAULT_ARGS.append("-extra-arg-before=--driver-mode=cl")
 

--- a/tools/checked-c-convert/utils/run.py
+++ b/tools/checked-c-convert/utils/run.py
@@ -44,7 +44,10 @@ def runMain(args):
 
   s = set()
   for i in cmds:
-    s.add(os.path.realpath(i['file']))
+    file_to_add = os.path.realpath(i['file'])
+    if file_to_add.endswith(".cpp"):
+      continue # Checked C extension doesn't support cpp files yet
+    s.add(file_to_add)
 
   print s
 


### PR DESCRIPTION
Two quality of life changes for using this tool on a large real-world codebase:
* Turn off verbosity being the default
* Filter out any .cpp files that may be in the compile_commands.json