### PR TITLE
Newline each input file in the generated script

### DIFF
--- a/tools/checked-c-convert/utils/run.py
+++ b/tools/checked-c-convert/utils/run.py
@@ -57,7 +57,7 @@ def runMain(args):
   args.extend(DEFAULT_ARGS)
   args.extend(list(s))
   f = open('convert.sh', 'w')
-  f.write(" \\ \n".join(args))
+  f.write(" \\\n".join(args))
   f.close()
   subprocess.check_call(args)
 

--- a/tools/checked-c-convert/utils/run.py
+++ b/tools/checked-c-convert/utils/run.py
@@ -56,8 +56,8 @@ def runMain(args):
   args.append(prog_name)
   args.extend(DEFAULT_ARGS)
   args.extend(list(s))
-  f = open('bla', 'w')
-  f.write(" ".join(args))
+  f = open('convert.sh', 'w')
+  f.write(" \\ \n".join(args))
   f.close()
   subprocess.check_call(args)
 


### PR DESCRIPTION
Changes the output script produced to give each argument (both `-arguments` and file names) its own line. This will allow diffs and make it much easier to see how many files a particular configuration would send to the convert tool.

If the resulting script is read for purposes other than being a shell script, having the `\` present may require a little extra work, but I think the benefits of having line numbers would be worth the effort. Anyone else have thoughts?