### PR TITLE
Add constraints for checked c array type

### DIFF
--- a/test/CheckedCRewriter/some_checked.c
+++ b/test/CheckedCRewriter/some_checked.c
@@ -1,0 +1,17 @@
+// Tests for the Checked C rewriter tool.
+//
+// RUN: checked-c-convert %s -- -fcheckedc-extension | FileCheck -match-full-lines %s
+// RUN: checked-c-convert %s -- -fcheckedc-extension | %clang_cc1 -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+//
+
+void do_something(int *a, int b) {
+  *a = b;
+}
+//CHECK: void do_something(_Ptr<int> a, int b) {
+
+void test(_Array_ptr<int> p : count(len), int len) {
+  _Array_ptr<int> r : count(len - 1) =
+    _Dynamic_bounds_cast<_Array_ptr<int>>(p + 1, count(len - 1));
+}
+

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -96,7 +96,9 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, uint32_
           CS.addConstraint(CS.createNot(CS.createEq(V, CS.getWild())));
           ConstrainedVars.insert(K);
         } else if (Ty->isCheckedPointerArrayType()) {
-          llvm_unreachable("unsupported!");
+          CS.addConstraint(CS.createNot(CS.createEq(V, CS.getPtr())));
+          CS.addConstraint(CS.createNot(CS.createEq(V, CS.getWild())));
+          ConstrainedVars.insert(K);
         }
       } 
 


### PR DESCRIPTION
When constraints for existing checked arrays were encountered, we threw an exception because we didn't know how to support them. I'm pretty sure the way to support them is to constrain the appropriate constraint variables to "arr" which will then be untouched by the rest of the re-writer right now. T

This adds code to do that and a test case which crashed before and doesn't crash now. 

Fixes #519