### PR TITLE
Check initializers of NT_CHECKED types for null terminators

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4408,6 +4408,15 @@ public:
   /// idiomatic?
   bool isIdiomaticZeroInitializer(const LangOptions &LangOpts) const;
 
+  /// If the Type of InitListExpr is _NT_CHECKED array or pointer to _NT_CHECKED array
+  /// the initializer must end with null terminator. Returns true if null terminator is
+  /// not required, or if null terminator is required and it exists.
+  /// Returns false if null terminator is missing for _NT_CHECKED array or pointer to _NT_CHECKED
+  /// array types
+  bool handleNullTerminationCheck(ASTContext &C,
+                                  const InitListExpr *Init,
+                                  QualType VDeclType) const;
+
   SourceLocation getLBraceLoc() const { return LBraceLoc; }
   void setLBraceLoc(SourceLocation Loc) { LBraceLoc = Loc; }
   SourceLocation getRBraceLoc() const { return RBraceLoc; }

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4409,6 +4409,7 @@ public:
   bool isIdiomaticZeroInitializer(const LangOptions &LangOpts) const;
 
   /// Does the given InitListExpr contain an explicit null terminator?
+  /// DeclArraySize - Size of the array that is initialized
   bool isNullTerminated(ASTContext &C, unsigned DeclArraySize) const;
 
   SourceLocation getLBraceLoc() const { return LBraceLoc; }

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4409,7 +4409,7 @@ public:
   bool isIdiomaticZeroInitializer(const LangOptions &LangOpts) const;
 
   /// Does the given InitListExpr contain an explicit null terminator?
-  bool isNullTerminated(ASTContext &C) const;
+  bool isNullTerminated(ASTContext &C, unsigned DeclArraySize) const;
 
   SourceLocation getLBraceLoc() const { return LBraceLoc; }
   void setLBraceLoc(SourceLocation Loc) { LBraceLoc = Loc; }

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4408,14 +4408,8 @@ public:
   /// idiomatic?
   bool isIdiomaticZeroInitializer(const LangOptions &LangOpts) const;
 
-  /// If the Type of InitListExpr is _NT_CHECKED array or pointer to _NT_CHECKED array
-  /// the initializer must end with null terminator. Returns true if null terminator is
-  /// not required, or if null terminator is required and it exists.
-  /// Returns false if null terminator is missing for _NT_CHECKED array or pointer to _NT_CHECKED
-  /// array types
-  bool handleNullTerminationCheck(ASTContext &C,
-                                  const InitListExpr *Init,
-                                  QualType VDeclType) const;
+  /// Does the given InitListExpr contain an explicit null terminator?
+  bool isNullTerminatied(ASTContext &C) const;
 
   SourceLocation getLBraceLoc() const { return LBraceLoc; }
   void setLBraceLoc(SourceLocation Loc) { LBraceLoc = Loc; }

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -4409,7 +4409,7 @@ public:
   bool isIdiomaticZeroInitializer(const LangOptions &LangOpts) const;
 
   /// Does the given InitListExpr contain an explicit null terminator?
-  bool isNullTerminatied(ASTContext &C) const;
+  bool isNullTerminated(ASTContext &C) const;
 
   SourceLocation getLBraceLoc() const { return LBraceLoc; }
   void setLBraceLoc(SourceLocation Loc) { LBraceLoc = Loc; }

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1764,7 +1764,6 @@ public:
   bool isFunctionProtoType() const { return getAs<FunctionProtoType>(); }
   bool isPointerType() const;
   bool isCheckedPointerType() const;
-  bool isNTCheckedPointerType() const;
   bool isUncheckedPointerType() const;
   bool isCheckedPointerPtrType() const;            // Checked C _Ptr type.
   bool isCheckedPointerArrayType() const;          // Checked C _Array_ptr or
@@ -6003,11 +6002,6 @@ inline bool Type::isCheckedPointerType() const {
   if (const PointerType *T = getAs<PointerType>())
     return T->isChecked();
   return false;
-}
-inline bool Type::isNTCheckedPointerType() const {
-	if (const PointerType *T = getAs<PointerType>())
-		return T->isNTChecked();
-	return false;
 }
 inline bool Type::isUncheckedPointerType() const {
   if (const PointerType *T = getAs<PointerType>())

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1764,6 +1764,7 @@ public:
   bool isFunctionProtoType() const { return getAs<FunctionProtoType>(); }
   bool isPointerType() const;
   bool isCheckedPointerType() const;
+  bool isNTCheckedPointerType() const;
   bool isUncheckedPointerType() const;
   bool isCheckedPointerPtrType() const;            // Checked C _Ptr type.
   bool isCheckedPointerArrayType() const;          // Checked C _Array_ptr or
@@ -1923,6 +1924,10 @@ public:
     HasIntWithBounds,
     HasUncheckedPointer
   };
+
+  /// \brief check whether an array, or an object of struct/union type contains a checked value
+  bool containsNTCheckedValue() const;
+
   /// \brief check whether an array, or an object of struct/union type contains a checked value
   CheckedValueKind containsCheckedValue(bool InCheckedScope) const;
 
@@ -2370,6 +2375,7 @@ public:
            otherQuals.isAddressSpaceSupersetOf(thisQuals);
   }
 
+  bool isNTChecked() const { return getKind() == CheckedPointerKind::NtArray; }
   bool isChecked() const { return getKind() != CheckedPointerKind::Unchecked; }
   bool isUnchecked() const { return getKind() == CheckedPointerKind::Unchecked; }
   bool isSugared() const { return false; }
@@ -5997,6 +6003,11 @@ inline bool Type::isCheckedPointerType() const {
   if (const PointerType *T = getAs<PointerType>())
     return T->isChecked();
   return false;
+}
+inline bool Type::isNTCheckedPointerType() const {
+	if (const PointerType *T = getAs<PointerType>())
+		return T->isNTChecked();
+	return false;
 }
 inline bool Type::isUncheckedPointerType() const {
   if (const PointerType *T = getAs<PointerType>())

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -1925,9 +1925,6 @@ public:
   };
 
   /// \brief check whether an array, or an object of struct/union type contains a checked value
-  bool containsNTCheckedValue() const;
-
-  /// \brief check whether an array, or an object of struct/union type contains a checked value
   CheckedValueKind containsCheckedValue(bool InCheckedScope) const;
 
   /// \brief Whether this type is or contains an unchecked type.

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9571,10 +9571,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
   def err_initializer_not_null_terminated_for_nt_checked : Error<
-      "null terminator expected in NT_CHECKED array initializer">;
+      "null terminator expected in _Nt_checked array initializer">;
 
   def err_initializer_not_null_terminated_for_nt_checked_string_literal : Error<
-        "initializer-string for NT_CHECKED char array is too long">;
+        "initializer-string for _Nt_checked char array is too long">;
 
   def err_initializer_expected_for_integer_with_bounds_expr : Error<
     "integer variable %0 with a bounds expression must have an initializer">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9570,12 +9570,6 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_initializer_expected_for_ptr : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
-  def err_initializer_not_null_terminated_for_nt_checked : Error<
-      "null terminator expected in _Nt_checked array initializer">;
-
-  def err_initializer_not_null_terminated_for_nt_checked_string_literal : Error<
-        "initializer-string for _Nt_checked char array is too long">;
-
   def err_initializer_expected_for_integer_with_bounds_expr : Error<
     "integer variable %0 with a bounds expression must have an initializer">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9571,7 +9571,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
   def err_initializer_not_null_terminated_for_nt_checked : Error<
-      "NT_CHECKED array type initializer must include an explicit null terminator">;
+      "null terminator expected in NT_CHECKED array initializer">;
+
+  def err_initializer_not_null_terminated_for_nt_checked_string_literal : Error<
+        "initializer-string for NT_CHECKED char array is too long">;
 
   def err_initializer_expected_for_integer_with_bounds_expr : Error<
     "integer variable %0 with a bounds expression must have an initializer">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9570,6 +9570,12 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_initializer_expected_for_ptr : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
+  def err_initializer_not_null_terminated_for_nt_checked : Error<
+    "null terminator expected in _Nt_checked array initializer">;
+
+  def err_initializer_not_null_terminated_for_nt_checked_string_literal : Error<
+     "initializer-string for _Nt_checked char array is too long">;
+
   def err_initializer_expected_for_integer_with_bounds_expr : Error<
     "integer variable %0 with a bounds expression must have an initializer">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9570,6 +9570,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_initializer_expected_for_ptr : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
+  def err_initializer_not_null_terminated_for_nt_checked : Error<
+      "NT_CHECKED array type initializer must include an explicit null terminator">;
+
   def err_initializer_expected_for_integer_with_bounds_expr : Error<
     "integer variable %0 with a bounds expression must have an initializer">;
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -1972,7 +1972,7 @@ public:
                             SourceLocation EqualLoc = SourceLocation());
   void ActOnUninitializedDecl(Decl *dcl);
   void ActOnInitializerError(Decl *Dcl);
-  bool Sema::ValidateNTCheckedType(ASTContext &C, QualType VDeclType, Expr *Init);
+  bool ValidateNTCheckedType(ASTContext &C, QualType VDeclType, Expr *Init);
 
   void ActOnPureSpecifier(Decl *D, SourceLocation PureSpecLoc);
   void ActOnCXXForRangeDecl(Decl *D);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -1972,7 +1972,7 @@ public:
                             SourceLocation EqualLoc = SourceLocation());
   void ActOnUninitializedDecl(Decl *dcl);
   void ActOnInitializerError(Decl *Dcl);
-  bool Sema::ValidateNTCheckedType(ASTContext &C, QualType T, Expr *Init);
+  bool Sema::ValidateNTCheckedType(ASTContext &C, QualType VDeclType, Expr *Init);
 
   void ActOnPureSpecifier(Decl *D, SourceLocation PureSpecLoc);
   void ActOnCXXForRangeDecl(Decl *D);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -1972,6 +1972,7 @@ public:
                             SourceLocation EqualLoc = SourceLocation());
   void ActOnUninitializedDecl(Decl *dcl);
   void ActOnInitializerError(Decl *Dcl);
+  bool Sema::ValidateNTCheckedType(ASTContext &C, QualType T, Expr *Init);
 
   void ActOnPureSpecifier(Decl *D, SourceLocation PureSpecLoc);
   void ActOnCXXForRangeDecl(Decl *D);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2006,13 +2006,13 @@ bool InitListExpr::isNullTerminated(ASTContext &C, unsigned DeclArraySize) const
                              "after semantic initialization of all "
                              "sub-objects are made explicit");
 
-  if(getNumInits() == 0) {
+  if (getNumInits() == 0) {
     return true;
   }
   
-  if(getNumInits() == 1 && getInit(0) && isa<StringLiteral>(getInit(0))) {
+  if (getNumInits() == 1 && getInit(0) && isa<StringLiteral>(getInit(0))) {
     const StringLiteral *InitializerString = cast<StringLiteral>(getInit(0));
-    if(DeclArraySize < InitializerString->getLength())
+    if (DeclArraySize < InitializerString->getLength())
     {
       const char *StringConstant = InitializerString->getString().data();
       return (StringConstant[DeclArraySize - 1] == '\0');  

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2006,12 +2006,6 @@ bool InitListExpr::handleNullTerminationCheck(ASTContext &C, const InitListExpr 
   QualType T = Init->getType();
   // Null termination required only for _NT_CHECKED arrays and for pointers to
   // _NT_CHECKED arrays
-  if (!VDeclType->isNtCheckedArrayType()) {
-    if (!T->isCheckedPointerNtArrayType()) {
-      return true;
-    }
-  }
-
   assert(isSemanticForm() && "Null terminator check must be performed "
                              "after all the initialization of all "
                              "subobjects are made explicit");

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2001,25 +2001,21 @@ bool InitListExpr::isIdiomaticZeroInitializer(const LangOptions &LangOpts) const
   return Lit && Lit->getValue() == 0;
 }
 
-bool InitListExpr::handleNullTerminationCheck(ASTContext &C, const InitListExpr *Init, QualType VDeclType) const {
-  //Init->dump();
-  QualType T = Init->getType();
-  // Null termination required only for _NT_CHECKED arrays and for pointers to
-  // _NT_CHECKED arrays
+bool InitListExpr::isNullTerminatied(ASTContext &C) const {
   assert(isSemanticForm() && "Null terminator check must be performed "
-                             "after all the initialization of all "
-                             "subobjects are made explicit");
+                             "after semantic initialization of all "
+                             "sub-objects are made explicit");
 
-  const Expr *LastItem = getInit(InitExprs.size() - 1);
-  /*if (T->isCheckedPointerArrayType()) {
+  if(InitExprs.size() == 1 && isa<StringLiteral>(getInit(0))) {
+	const StringLiteral *InitializerString = cast<StringLiteral>(getInit(0));
+	const char *StringConstant = InitializerString->getString().data();
+	char m = *(StringConstant + (InitializerString->getLength() -1));
+	return (m == '\0');
+  }
 
-  } else if (T->isNtCheckedArrayType()) {
-	  LastItem->isNu
-
-  }*/
+  const Expr *LastItem = getInit(InitExprs.size() - 1);	  
   Expr::NullPointerConstantKind E = LastItem->isNullPointerConstant(C, Expr::NPC_ValueDependentIsNull);
   return E != NPCK_NotNull;
-  //return LastItem == NULL;
 }
 
 SourceLocation InitListExpr::getLocStart() const {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2001,6 +2001,33 @@ bool InitListExpr::isIdiomaticZeroInitializer(const LangOptions &LangOpts) const
   return Lit && Lit->getValue() == 0;
 }
 
+bool InitListExpr::handleNullTerminationCheck(ASTContext &C, const InitListExpr *Init, QualType VDeclType) const {
+  //Init->dump();
+  QualType T = Init->getType();
+  // Null termination required only for _NT_CHECKED arrays and for pointers to
+  // _NT_CHECKED arrays
+  if (!VDeclType->isNtCheckedArrayType()) {
+    if (!T->isCheckedPointerNtArrayType()) {
+      return true;
+    }
+  }
+
+  assert(isSemanticForm() && "Null terminator check must be performed "
+                             "after all the initialization of all "
+                             "subobjects are made explicit");
+
+  const Expr *LastItem = getInit(InitExprs.size() - 1);
+  /*if (T->isCheckedPointerArrayType()) {
+
+  } else if (T->isNtCheckedArrayType()) {
+	  LastItem->isNu
+
+  }*/
+  Expr::NullPointerConstantKind E = LastItem->isNullPointerConstant(C, Expr::NPC_ValueDependentIsNull);
+  return E != NPCK_NotNull;
+  //return LastItem == NULL;
+}
+
 SourceLocation InitListExpr::getLocStart() const {
   if (InitListExpr *SyntacticForm = getSyntacticForm())
     return SyntacticForm->getLocStart();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2007,10 +2007,10 @@ bool InitListExpr::isNullTerminated(ASTContext &C) const {
                              "sub-objects are made explicit");
 
   if(InitExprs.size() == 1 && isa<StringLiteral>(getInit(0))) {
-	const StringLiteral *InitializerString = cast<StringLiteral>(getInit(0));
-	const char *StringConstant = InitializerString->getString().data();
-	char m = *(StringConstant + (InitializerString->getLength() -1));
-	return (m == '\0');
+    const StringLiteral *InitializerString = cast<StringLiteral>(getInit(0));
+    const char *StringConstant = InitializerString->getString().data();
+    char m = *(StringConstant + (InitializerString->getLength() -1));
+    return (m == '\0');
   }
 
   const Expr *LastItem = getInit(InitExprs.size() - 1);	  

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2001,7 +2001,7 @@ bool InitListExpr::isIdiomaticZeroInitializer(const LangOptions &LangOpts) const
   return Lit && Lit->getValue() == 0;
 }
 
-bool InitListExpr::isNullTerminatied(ASTContext &C) const {
+bool InitListExpr::isNullTerminated(ASTContext &C) const {
   assert(isSemanticForm() && "Null terminator check must be performed "
                              "after semantic initialization of all "
                              "sub-objects are made explicit");

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -10925,6 +10925,17 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
       VDecl->setInvalidDecl();
   }
 
+  if (InitListExpr *E = dyn_cast<InitListExpr>(Init)) {
+    /// $TODO$ Remove dump calls.
+    /// $TODO$ Handle constant string types (char array)
+    //Init->dump();
+    //RealDecl->is
+    if (!E->handleNullTerminationCheck(RealDecl->getASTContext(), E, VDecl->getType())) {
+      RealDecl->setInvalidDecl();
+      return;
+    }
+  }
+
   // If adding the initializer will turn this declaration into a definition,
   // and we already have a definition for this variable, diagnose or otherwise
   // handle the situation.

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11065,7 +11065,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
       getCurFunction()->markSafeWeakUse(Init);
   }
 
-  // Checked C: All initializers to _NT_CHECKED type arrays must be null
+  // Checked C: All initializers to _Nt_checked type arrays must be null
   // terminated
   if (!VDecl->isInvalidDecl()) {
     if (!ValidateNTCheckedType(RealDecl->getASTContext(),
@@ -11273,8 +11273,9 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
 }
 
 /// Checked C: Validate that the _Nt_checked type array initializers must be
-/// null terminated VDeclType - CanonicalType of the declared variable that is
-/// initialized Init - initializer expression for a declaration with VDeclType
+/// null terminated
+/// VDeclType - CanonicalType of the declared variable that is initialized
+/// Init - initializer expression for a declaration with VDeclType
 bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
                                  Expr *Init) {
   if (!Init) {
@@ -11283,8 +11284,8 @@ bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
   const Type *current = VDeclType.getTypePtr();
   switch (current->getTypeClass()) {
   case Type::Pointer: {
-    // Pointers to _Nt_checked types (nt_arry_ptr) are enforced to point to
-    // null- terminated values, by static type checking and checking of casts.
+    // Pointers to _Nt_checked types (nt_array_ptr) are enforced to point to
+    // null-terminated values, by static type checking and checking of casts.
     return true;
   }
   case Type::ConstantArray: {
@@ -11352,6 +11353,7 @@ bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
       }
       // if this is a struct/union type, we must iterate over all its members
       unsigned index = 0;
+      bool FieldValidationFailed = false;
       for (FieldDecl *FD : RD->fields()) {
         // Recurse until all _Nt_checked type fields are discovered and
         // validated
@@ -11366,8 +11368,11 @@ bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
         // Recursive call to handle members of the RecordDecl fields
         if (!ValidateNTCheckedType(Ctx, FD->getType().getCanonicalType(),
                                    CurrInit)) {
-          return false;
+          FieldValidationFailed = true;
         }
+      }
+      if (FieldValidationFailed) {
+        return false;
       }
     }
     return true;

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11065,14 +11065,6 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
       getCurFunction()->markSafeWeakUse(Init);
   }
 
-  // Checked C: All initializers to _NT_CHECKED type arrays must be null terminated
-  if (!VDecl->isInvalidDecl()) {
-    if(!ValidateNTCheckedType(RealDecl->getASTContext(), VDecl->getType().getCanonicalType(), Init)) {
-      VDecl->setInvalidDecl();
-      return;
-    }
-  }
-
   // The initialization is usually a full-expression.
   //
   // FIXME: If this is a braced initialization of an aggregate, it is not
@@ -11268,106 +11260,6 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
   }
 
   CheckCompleteVariableDeclaration(VDecl);
-}
-
-/// Checked C: Validate that the _Nt_checked type array initializers must be null terminated
-/// VDeclType - CanonicalType of the declared variable that is initialized
-/// Init - initializer expression for a declaration with VDeclType
-bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType, Expr *Init) {
-  if(!Init) {
-    return true;
-  }
-  const Type *current = VDeclType.getTypePtr();
-  switch (current->getTypeClass()) {
-    case Type::Pointer: {
-      // Pointers to _Nt_checked types (nt_arry_ptr) are enforced to point to null-
-      // terminated values, by static type checking and checking of casts.
-      return true;
-    }
-    case Type::ConstantArray: {
-      if (current->isNtCheckedArrayType()) {
-        const ConstantArrayType *CAT = Ctx.getAsConstantArrayType(VDeclType);
-        const auto DeclaredArraySize = CAT->getSize().getRawData();
-        InitListExpr *InitEx = dyn_cast<InitListExpr>(Init);
-        StringLiteral *InitializerString = nullptr;
-
-        // Initializer-string enclosed in {} e.g. {"test"}
-        if(InitEx && InitEx->getNumInits() == 1 && 
-			InitEx->getInit(0) && isa<StringLiteral>(InitEx->getInit(0))) {
-          InitializerString = cast<StringLiteral>(InitEx->getInit(0));
-        }
-        
-        // Initializer-string
-        if (Init && isa<StringLiteral>(Init)) {
-          InitializerString = cast<StringLiteral>(Init);
-        }
-        
-        if(InitializerString) {
-          if (*DeclaredArraySize < InitializerString->getLength()) {
-            const char *StringConstant = InitializerString->getString().data();
-            if(StringConstant[*DeclaredArraySize - 1] != '\0') {
-              Diag(Init->getLocStart(), 
-				  diag::err_initializer_not_null_terminated_for_nt_checked_string_literal) 
-              << Init->getSourceRange();
-              return false;
-            }
-          }
-        } else if (InitListExpr *E = dyn_cast<InitListExpr>(Init)) {
-          if (!E->isNullTerminated(Ctx, *DeclaredArraySize)) {
-            const Expr *LastItem = E->getInit(E->getNumInits() - 1);
-            Diag(LastItem->getLocStart(), 
-				diag::err_initializer_not_null_terminated_for_nt_checked) 
-            << LastItem->getSourceRange();
-            return false;
-          }
-        }
-      }
-      return true;
-    }
-    //Use RecordType to process Struct/Union
-    case Type::Elaborated:
-    case Type::Record: {
-      RecordDecl *RD;
-      if(isa<ElaboratedType>(current)) {
-        const ElaboratedType *ET = cast<ElaboratedType>(current);
-        TagDecl *TG = ET->getAsTagDecl();
-        if(!TG) {
-          return true;
-        }
-        if(!isa<RecordDecl>(TG)) { //Enum types
-          return true;
-        }
-        RD = cast<RecordDecl>(TG);
-      } else {
-        const RecordType *RT = cast<RecordType>(current);
-        RD = RT->getDecl();
-      }
-      if(InitListExpr *ILE = dyn_cast<InitListExpr>(Init)) {
-        if (RD->isInvalidDecl()) {
-          return false;
-        }
-        // if this is a struct/union type, we must iterate over all its members
-        unsigned index = 0;
-        for (FieldDecl *FD : RD->fields()) {
-          // Recurse until all _Nt_checked type fields are discovered and validated
-          if(ILE->getNumInits() <= index) {
-              break;
-          }
-          Expr *CurrInit = ILE->getInit(index++);
-          if (FD->getType()->isIntegerType() || FD->getType()->isUncheckedPointerType()) {
-            continue;
-          }
-          // Recursive call to handle members of the RecordDecl fields
-          if (!ValidateNTCheckedType(Ctx, FD->getType().getCanonicalType(), CurrInit)) {
-            return false;
-          }
-        }
-      }
-      return true;
-    }
-    default:
-      return true;
-  }
 }
 
 /// ActOnInitializerError - Given that there was an error parsing an

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11272,6 +11272,9 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
 
 /// Checked C: Validate that the NT_CHECKED type array initializers must be null terminated
 bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType, Expr *Init) {
+  if(!Init) {
+    return true;
+  }
   const Type *current = VDeclType.getTypePtr();
   switch (current->getTypeClass()) {
     case Type::Pointer: {
@@ -11310,8 +11313,11 @@ bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType, Expr *Init
       if(isa<ElaboratedType>(current)) {
         const ElaboratedType *ET = cast<ElaboratedType>(current);
         TagDecl *TG = ET->getAsTagDecl();
+        if(!TG) {
+          return true;
+        }
         if(!isa<RecordDecl>(TG)) { //Enum types
-            return true;
+          return true;
         }
         RD = cast<RecordDecl>(TG);
       } else {

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11065,6 +11065,16 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
       getCurFunction()->markSafeWeakUse(Init);
   }
 
+  // Checked C: All initializers to _NT_CHECKED type arrays must be null
+  // terminated
+  if (!VDecl->isInvalidDecl()) {
+    if (!ValidateNTCheckedType(RealDecl->getASTContext(),
+                               VDecl->getType().getCanonicalType(), Init)) {
+      VDecl->setInvalidDecl();
+      return;
+    }
+  }
+
   // The initialization is usually a full-expression.
   //
   // FIXME: If this is a braced initialization of an aggregate, it is not
@@ -11260,6 +11270,111 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit,
   }
 
   CheckCompleteVariableDeclaration(VDecl);
+}
+
+/// Checked C: Validate that the _Nt_checked type array initializers must be
+/// null terminated VDeclType - CanonicalType of the declared variable that is
+/// initialized Init - initializer expression for a declaration with VDeclType
+bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
+                                 Expr *Init) {
+  if (!Init) {
+    return true;
+  }
+  const Type *current = VDeclType.getTypePtr();
+  switch (current->getTypeClass()) {
+  case Type::Pointer: {
+    // Pointers to _Nt_checked types (nt_arry_ptr) are enforced to point to
+    // null- terminated values, by static type checking and checking of casts.
+    return true;
+  }
+  case Type::ConstantArray: {
+    if (current->isNtCheckedArrayType()) {
+      const ConstantArrayType *CAT = Ctx.getAsConstantArrayType(VDeclType);
+      const auto DeclaredArraySize = CAT->getSize().getRawData();
+      InitListExpr *InitEx = dyn_cast<InitListExpr>(Init);
+      StringLiteral *InitializerString = nullptr;
+
+      // Initializer-string enclosed in {} e.g. {"test"}
+      if (InitEx && InitEx->getNumInits() == 1 && InitEx->getInit(0) &&
+          isa<StringLiteral>(InitEx->getInit(0))) {
+        InitializerString = cast<StringLiteral>(InitEx->getInit(0));
+      }
+
+      // Initializer-string
+      if (Init && isa<StringLiteral>(Init)) {
+        InitializerString = cast<StringLiteral>(Init);
+      }
+
+      if (InitializerString) {
+        if (*DeclaredArraySize < InitializerString->getLength()) {
+          const char *StringConstant = InitializerString->getString().data();
+          if (StringConstant[*DeclaredArraySize - 1] != '\0') {
+            Diag(
+                Init->getLocStart(),
+                diag::err_initializer_not_null_terminated_for_nt_checked_string_literal)
+                << Init->getSourceRange();
+            return false;
+          }
+        }
+      } else if (InitListExpr *E = dyn_cast<InitListExpr>(Init)) {
+        if (!E->isNullTerminated(Ctx, *DeclaredArraySize)) {
+          const Expr *LastItem = E->getInit(E->getNumInits() - 1);
+          Diag(LastItem->getLocStart(),
+               diag::err_initializer_not_null_terminated_for_nt_checked)
+              << LastItem->getSourceRange();
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+    // Use RecordType to process Struct/Union
+  case Type::Elaborated:
+  case Type::Record: {
+    RecordDecl *RD;
+    if (isa<ElaboratedType>(current)) {
+      const ElaboratedType *ET = cast<ElaboratedType>(current);
+      TagDecl *TG = ET->getAsTagDecl();
+      if (!TG) {
+        return true;
+      }
+      if (!isa<RecordDecl>(TG)) { // Enum types
+        return true;
+      }
+      RD = cast<RecordDecl>(TG);
+    } else {
+      const RecordType *RT = cast<RecordType>(current);
+      RD = RT->getDecl();
+    }
+    if (InitListExpr *ILE = dyn_cast<InitListExpr>(Init)) {
+      if (RD->isInvalidDecl()) {
+        return false;
+      }
+      // if this is a struct/union type, we must iterate over all its members
+      unsigned index = 0;
+      for (FieldDecl *FD : RD->fields()) {
+        // Recurse until all _Nt_checked type fields are discovered and
+        // validated
+        if (ILE->getNumInits() <= index) {
+          break;
+        }
+        Expr *CurrInit = ILE->getInit(index++);
+        if (FD->getType()->isIntegerType() ||
+            FD->getType()->isUncheckedPointerType()) {
+          continue;
+        }
+        // Recursive call to handle members of the RecordDecl fields
+        if (!ValidateNTCheckedType(Ctx, FD->getType().getCanonicalType(),
+                                   CurrInit)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+  default:
+    return true;
+  }
 }
 
 /// ActOnInitializerError - Given that there was an error parsing an


### PR DESCRIPTION
Initializers of NT_CHECKED types must contain null terminators.
- If NT_CHECKED type arrays are part of other data types (e.g. structs), then the initializer of the parent type must be validated to make sure the NT_CHECKED contains a null terminator
- character arrays can be initialized with string literals. Must end with '\0' 
- Pointer to NT_CHECKED types when initialized, employ an implicit cast. Such cases are not handled as part of this task. 

Testing:
- Added checkedc tests for NT_CHECKED initializers
- Automated tests: DevTest Debug X64 Linux, DevTest Debug x64 Windows, DevTest Debug X86 Windows, DevTest Release Linux X64 LNT

Related to Issue: https://github.com/Microsoft/checkedc-clang/issues/397

