### PR TITLE
Parse BEAR compile commands

### DIFF
--- a/tools/checked-c-convert/utils/convert-commands.py
+++ b/tools/checked-c-convert/utils/convert-commands.py
@@ -10,10 +10,12 @@ This tool will invoke checked-c-convert on a compile_commands.json database.
 It contains some work-arounds for cmake+nmake generated compile_commands.json 
 files, where the files are malformed. 
 """
+SLASH = "/"
 
 DEFAULT_ARGS = ["-dump-stats", "-output-postfix=checked"]
 if os.name == "nt":
   DEFAULT_ARGS.append("-extra-arg-before=--driver-mode=cl")
+  SLASH = "\\"
 
 def tryFixUp(s):
   """
@@ -53,7 +55,7 @@ def runMain(args):
     # Use that to detect BEAR and add the directory.
     if 'arguments' in i and not 'command' in i:
       # BEAR. Need to add directory.
-      file_to_add = i['directory'] + "/" + file_to_add
+      file_to_add = i['directory'] + SLASH + file_to_add
     file_to_add = os.path.realpath(file_to_add)
     s.add(file_to_add)
 

--- a/tools/checked-c-convert/utils/convert-commands.py
+++ b/tools/checked-c-convert/utils/convert-commands.py
@@ -44,9 +44,17 @@ def runMain(args):
 
   s = set()
   for i in cmds:
-    file_to_add = os.path.realpath(i['file'])
+    file_to_add = i['file']
     if file_to_add.endswith(".cpp"):
       continue # Checked C extension doesn't support cpp files yet
+
+    # BEAR uses relative paths for 'file' rather than absolute paths. It also 
+    # has a field called 'arguments' instead of 'command' in the cmake style.
+    # Use that to detect BEAR and add the directory.
+    if 'arguments' in i and not 'command' in i:
+      # BEAR. Need to add directory.
+      file_to_add = i['directory'] + "/" + file_to_add
+    file_to_add = os.path.realpath(file_to_add)
     s.add(file_to_add)
 
   print s


### PR DESCRIPTION
Add the ability to parse BEAR-style `compile_commands.json` files to the convert-commands utility script. Existing CMake-style functionality should be unaffected.

Fixes #525 