### PR TITLE
 Add support for polymorphic bounds safe interface functions

### DIFF
--- a/docs/checkedc/2018-07-27-BoundsSafeInterfaces.md
+++ b/docs/checkedc/2018-07-27-BoundsSafeInterfaces.md
@@ -1,0 +1,24 @@
+**Function Specifier for Bounds Safe Interfaces:**
+
+*itype_for_any(<COMMA_SEPARATED_TYPE_VARIABLES>)*
+
+* Creates a new scope
+* Restrictions on parameters:
+    * No type variable can be used as the type of function parameters
+    * Type variables of parameters must be contained within itype clauses
+        * e.g. 
+            `itype_for_any(T)
+                void* foo(void* arg1 : itype(_Ptr<T>));`
+* There are no restrictions on local variables
+    * i.e., Typevariables can be used as the type of local variables created within function body; even if the scope is unchecked. 
+* itype_for_any and for_any scopes cannot be nested
+* Design discussion with David MoM:
+    * The bounds interface function will have a polymorphic type associated with it
+    * If the caller doesn't apply a type, then the default type of the parameters will be applied as types
+    * e.g
+        * For the foo function shown above, the caller `foo<int>(x)` will force arg1 to be a pointer to int
+        * But the caller `foo(y)` will treat arg1 as pointer to void type
+        * This design is to enable foo to be called from unchecked scopes to allow incremental adoption
+        
+
+      

--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -1198,10 +1198,12 @@ public:
   /// pointer to blocks.
   QualType getBlockDescriptorExtendedType() const;
 
-  /// Returns a type variable type based on the depth of the "for any" scope 
-  /// where type variable is declared, and the position of the type variable in
-  /// _For_any qualifier.
-  QualType getTypeVariableType(unsigned int depth, unsigned int position) const;
+  /// Returns a type variable type based on the depth of "for any" or
+  /// "itype for any" scope where type variable is declared, and the
+  /// position of the type variable in _For_any or _Itype_for_any
+  ///.qualifier respectively
+  QualType getTypeVariableType(unsigned int depth, unsigned int position,
+                               bool isBoundsInterfaceType) const;
 
   void setcudaConfigureCallDecl(FunctionDecl *FD) {
     cudaConfigureCallDecl = FD;
@@ -2486,12 +2488,16 @@ public:
   /// at least as much checking as the other type T2.  Return true if it does
   /// or false if it does not or the types differ in some other way than
   /// checkedness.
+  /// Note:: Checked C - In bounds safe interface scopes, this function
+  /// returns true if T2 is a TypeVariableType and T1 is a pointer to void type
   bool isAtLeastAsCheckedAs(QualType T1, QualType T2) const;
 
   /// \brief Determine whether a pointer, array, or function type T1
   /// is the same as the other pointer, array, or function type T2 if
   /// checkedness is ignored.  Return true if does or false if the types
   /// differ in some other way than checkedness.
+  /// Note:: Checked C - In bounds safe interface scopes, this function
+  /// returns true if T2 is a TypeVariableType and T1 is a pointer to void type
   bool isEqualIgnoringChecked(QualType T1, QualType T2) const;
 
   /// \brief Return true if this type is a checked type that is not

--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2489,7 +2489,7 @@ public:
   /// or false if it does not or the types differ in some other way than
   /// checkedness.
   /// Note:: In bounds safe interface scopes, this function
-  /// returns true if T2 is a TypeVariableType and T1 is a pointer to void type
+  /// returns true if T1 is a TypeVariableType and T2 is a pointer to void type
   bool isAtLeastAsCheckedAs(QualType T1, QualType T2) const;
 
   /// \brief Determine whether a pointer, array, or function type T1
@@ -2497,7 +2497,7 @@ public:
   /// checkedness is ignored.  Return true if does or false if the types
   /// differ in some other way than checkedness.
   /// Note:: In bounds safe interface scopes, this function
-  /// returns true if T2 is a TypeVariableType and T1 is a pointer to void type
+  /// returns true if T1 is a TypeVariableType and T2 is a pointer to void type
   bool isEqualIgnoringChecked(QualType T1, QualType T2) const;
 
   /// \brief Return true if this type is a checked type that is not

--- a/include/clang/AST/ASTContext.h
+++ b/include/clang/AST/ASTContext.h
@@ -2488,7 +2488,7 @@ public:
   /// at least as much checking as the other type T2.  Return true if it does
   /// or false if it does not or the types differ in some other way than
   /// checkedness.
-  /// Note:: Checked C - In bounds safe interface scopes, this function
+  /// Note:: In bounds safe interface scopes, this function
   /// returns true if T2 is a TypeVariableType and T1 is a pointer to void type
   bool isAtLeastAsCheckedAs(QualType T1, QualType T2) const;
 
@@ -2496,7 +2496,7 @@ public:
   /// is the same as the other pointer, array, or function type T2 if
   /// checkedness is ignored.  Return true if does or false if the types
   /// differ in some other way than checkedness.
-  /// Note:: Checked C - In bounds safe interface scopes, this function
+  /// Note:: In bounds safe interface scopes, this function
   /// returns true if T2 is a TypeVariableType and T1 is a pointer to void type
   bool isEqualIgnoringChecked(QualType T1, QualType T2) const;
 

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1789,6 +1789,7 @@ private:
   unsigned IsLateTemplateParsed : 1;
   unsigned IsConstexpr : 1;
   unsigned IsGenericFunction : 1;
+  unsigned IsItypeGenericFunction : 1; //Checked C - Function specifier _Itype_for_any
   // Indicates whether the function is declared with a _Checked or
   // _Unchecked specifier.
   unsigned CheckedSpecifier : 2;
@@ -1896,7 +1897,7 @@ protected:
         IsDeleted(false), IsTrivial(false), IsDefaulted(false),
         IsExplicitlyDefaulted(false), HasImplicitReturnZero(false),
         IsLateTemplateParsed(false), IsConstexpr(isConstexprSpecified),
-        IsGenericFunction(false),
+        IsGenericFunction(false), IsItypeGenericFunction(false),
         CheckedSpecifier(CheckedFunctionSpecifiers::CFS_None),
         InstantiationIsPending(false),
         UsesSEHTry(false), HasSkippedBody(false), WillHaveBody(false),
@@ -1963,6 +1964,9 @@ public:
 
   void setGenericFunctionFlag(bool f) { IsGenericFunction = f; }
   bool isGenericFunction() const { return IsGenericFunction; }
+
+  void setItypeGenericFunctionFlag(bool f) { IsItypeGenericFunction = f; }
+  bool isItypeGenericFunction() const { return IsItypeGenericFunction; }
 
   void setCheckedSpecifier(CheckedFunctionSpecifiers CS) { CheckedSpecifier = CS; }
   CheckedFunctionSpecifiers getCheckedSpecifier() {

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3845,10 +3845,11 @@ class TypeVariableType : public Type, public llvm::FoldingSetNode {
   // prototype scope depth, this keeps track of the depth of forany scope.
   unsigned int depth;
   unsigned int index;
+  bool isBoundsInterfaceType;
 protected:
-  TypeVariableType(unsigned int inDepth, unsigned int inIndex)
+  TypeVariableType(unsigned int inDepth, unsigned int inIndex, bool inBoundsInterface)
     : Type(TypeVariable, QualType(), false, false, false, false),
-    depth(inDepth), index(inIndex) { }
+    depth(inDepth), index(inIndex), isBoundsInterfaceType(inBoundsInterface) { }
   friend class ASTContext;
 public:
   bool isSugared(void) const { return false; }
@@ -3857,6 +3858,12 @@ public:
   void SetDepth(unsigned int i) { depth = i; }
   unsigned int GetIndex(void) const { return index; }
   void SetIndex(unsigned int i) { index = i; }
+  void SetInBoundsInterface (bool isInBoundsInterface) {
+    isBoundsInterfaceType = isInBoundsInterface;
+  }
+  bool IsBoundsInterfaceType () const {
+    return isBoundsInterfaceType;
+  }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, depth, index);

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3427,12 +3427,14 @@ public:
   /// Extra information about a function prototype.
   struct ExtProtoInfo {
     ExtProtoInfo()
-        : Variadic(false), HasTrailingReturn(false), numTypeVars(0), 
+        : Variadic(false), HasTrailingReturn(false), numTypeVars(0),
+          GenericFunction(false), ItypeGenericFunction(false),
           TypeQuals(0), RefQualifier(RQ_None), ExtParameterInfos(nullptr),
           ParamAnnots(nullptr), ReturnAnnots() {}
 
     ExtProtoInfo(CallingConv CC)
-        : ExtInfo(CC), Variadic(false), HasTrailingReturn(false), numTypeVars(0), 
+        : ExtInfo(CC), Variadic(false), HasTrailingReturn(false), numTypeVars(0),
+          GenericFunction(false), ItypeGenericFunction(false),
           TypeQuals(0), RefQualifier(RQ_None), ExtParameterInfos(nullptr),
           ParamAnnots(nullptr), ReturnAnnots() {}
 
@@ -3446,6 +3448,8 @@ public:
     bool Variadic : 1;
     bool HasTrailingReturn : 1;
     unsigned numTypeVars : 15;
+    bool GenericFunction : 1;
+    bool ItypeGenericFunction : 1;
     unsigned char TypeQuals;
     RefQualifierKind RefQualifier;
     ExceptionSpecInfo ExceptionSpec;
@@ -3484,6 +3488,9 @@ private:
 
   /// Whether the function is variadic.
   unsigned Variadic : 1;
+
+  bool GenericFunction : 1;
+  bool ItypeGenericFunction : 1;
 
   /// Whether this function has a trailing return type.
   unsigned HasTrailingReturn : 1;
@@ -3551,6 +3558,9 @@ public:
     return param_type_begin()[i];
   }
   unsigned getNumTypeVars() const { return NumTypeVars; }
+  bool isGenericFunction() const { return GenericFunction; }
+  bool isItypeGenericFunction() const { return ItypeGenericFunction; }
+
   ArrayRef<QualType> getParamTypes() const {
     return llvm::makeArrayRef(param_type_begin(), param_type_end());
   }
@@ -3586,6 +3596,8 @@ public:
     EPI.ParamAnnots = hasParamAnnots() ? param_annots_begin() : nullptr;
     EPI.ReturnAnnots = getReturnAnnots();
     EPI.numTypeVars = getNumTypeVars();
+    EPI.GenericFunction = isGenericFunction();
+    EPI.ItypeGenericFunction = isItypeGenericFunction();
     return EPI;
   }
 

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1204,6 +1204,18 @@ def err_forany_type_variable_identifier_expected : Error<
 def err_forany_unexpected_token : Error<
   "unexpected token in _For_any specifier">;
 
+def err_itypeforany_comma_or_parenthesis_expected : Error<
+  "expected , or )">;
+
+def err_interfacetype_unexpected_token : Error<
+  "unexpected token in _Itype_forany specifier">;
+
+def err_interfacetype_expect_forany_token : Error<
+  "expected _For_any specifier for the _Itype_forany">;
+
+def err_itypeforany_unexpected_token : Error<
+  "unexpected token in _Itype_for_any specifier">;
+
 def err_forany_comma_or_parenthesis_expected : Error<
   "expected , or )">;
 

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1201,29 +1201,14 @@ def err_forany_type_variable_declaration_expected : Error<
 def err_forany_type_variable_identifier_expected : Error<
   "expected type variable identifier">;
 
-def err_forany_unexpected_token : Error<
-  "unexpected token in _For_any specifier">;
+def err_generic_specifier_unexpected_token : Error<
+  "unexpected token in %0 specifier">;
 
-def err_itypeforany_comma_or_parenthesis_expected : Error<
-  "expected , or )">;
-
-def err_interfacetype_unexpected_token : Error<
-  "unexpected token in _Itype_forany specifier">;
-
-def err_interfacetype_expect_forany_token : Error<
-  "expected _For_any specifier for the _Itype_forany">;
-
-def err_itypeforany_unexpected_token : Error<
-  "unexpected token in _Itype_for_any specifier">;
-
-def err_forany_comma_or_parenthesis_expected : Error<
+def err_generic_specifier_comma_or_parenthesis_expected : Error<
   "expected , or )">;
 
 def err_expected_list_of_types_expr_for_generic_function : Error<
   "expected a list of type arguments for a generic function">;
-
-def err_expected_list_of_types_expr_for_itype_generic_function : Error<
-  "expected a list of type arguments for an itype generic function">;
 
 def err_type_function_comma_or_greater_expected : Error<
   "expected , or >">;

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1222,6 +1222,9 @@ def err_forany_comma_or_parenthesis_expected : Error<
 def err_expected_list_of_types_expr_for_generic_function : Error<
   "expected a list of type arguments for a generic function">;
 
+def err_expected_list_of_types_expr_for_itype_generic_function : Error<
+  "expected a list of type arguments for an itype generic function">;
+
 def err_type_function_comma_or_greater_expected : Error<
   "expected , or >">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9516,7 +9516,7 @@ def err_bounds_type_annotation_lost_checking : Error<
    "bounds to have no prototype">;
 
  def note_previous_bounds_decl : Note<"previous %select{bounds|interop type}0 declaration is here">;
- 
+
   def err_decl_conflicting_annot : Error<
     "%select{function redeclaration has conflicting parameter %select{bounds|interop type}0|function "
     "redeclaration has conflicting return %select{bounds|interop type}0|variable redeclaration has "
@@ -9532,6 +9532,9 @@ def err_bounds_type_annotation_lost_checking : Error<
     "%select{bounds|interop type}0}1">;
 
   def err_conflicting_annots : Error<"conflicting bounds annotations for %0">;
+
+  def err_decl_conflicting_function_specifiers : Error<
+    "conflicting function specifiers for %0. %1 and %2 are incompatible function specifiers.">;
 
   def err_out_of_scope_function_type_local : Error<
     "out-of-scope variable for bounds in a function type (a function type "

--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -653,6 +653,7 @@ KEYWORD(_Unchecked                 , KEYCHECKEDC)
 KEYWORD(_Assume_bounds_cast        , KEYCHECKEDC)
 KEYWORD(_Dynamic_bounds_cast       , KEYCHECKEDC)
 KEYWORD(_For_any                   , KEYCHECKEDC)
+KEYWORD(_Itype_for_any             , KEYCHECKEDC)
 
 // Borland Extensions which should be disabled in strict conformance mode.
 ALIAS("_pascal"      , __pascal   , KEYBORLAND)

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -2487,6 +2487,8 @@ private:
   void ParseAtomicSpecifier(DeclSpec &DS);
   void ParseCheckedPointerSpecifiers(DeclSpec & DS);
   void ParseForanySpecifier(DeclSpec &DS);
+  bool ParseGenericFunctionSpecifierHelper(DeclSpec &DS,
+                                            Scope::ScopeFlags S);
   void ParseItypeforanySpecifier(DeclSpec &DS);
 
   ExprResult ParseAlignArgument(SourceLocation Start,

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1765,6 +1765,7 @@ private:
 
   ExprResult ParseBoundsExpression();
   bool ParseGenericFunctionExpression(ExprResult &Res);
+  //bool ParseItypeGenericFunctionExpression(ExprResult &Res); //$TODO$ Need to be implemented
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> &typeNames);
 
@@ -2486,6 +2487,7 @@ private:
   void ParseAtomicSpecifier(DeclSpec &DS);
   void ParseCheckedPointerSpecifiers(DeclSpec & DS);
   void ParseForanySpecifier(DeclSpec &DS);
+  void ParseItypeforanySpecifier(DeclSpec &DS);
 
   ExprResult ParseAlignArgument(SourceLocation Start,
                                 SourceLocation &EllipsisLoc);

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1764,7 +1764,7 @@ private:
   ExprResult ParseBoundsCastExpression();
 
   ExprResult ParseBoundsExpression();
-  bool ParseGenericFunctionExpression(ExprResult &Res);
+  bool ParseItypeAndGenericFunctionExpression(ExprResult &Res);
   //bool ParseItypeGenericFunctionExpression(ExprResult &Res); //$TODO$ Need to be implemented
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> &typeNames);

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1765,7 +1765,7 @@ private:
 
   ExprResult ParseBoundsExpression();
   bool ParseItypeAndGenericFunctionExpression(ExprResult &Res);
-  //bool ParseItypeGenericFunctionExpression(ExprResult &Res); //$TODO$ Need to be implemented
+
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> &typeNames);
 

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -464,6 +464,7 @@ public:
       // Checked C - checked function
       FS_checked_specified(CFS_None),
       FS_forany_specified(false),
+      FS_itypeforany_specified(false),
       Friend_specified(false),
       Constexpr_specified(false),
       Concept_specified(false),
@@ -645,6 +646,8 @@ public:
     FS_checkedLoc = SourceLocation();
     FS_forany_specified = false;
     FS_foranyLoc = SourceLocation();
+    FS_itypeforany_specified = false;
+    FS_itypeforanyloc= SourceLocation();
   }
 
   /// \brief Return true if any type-specifier has been found.

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -366,7 +366,7 @@ private:
   unsigned FS_checked_specified : 2;
   // Checked C - For-any function specifier
   unsigned FS_forany_specified : 1;
-  // Checked C - Interface_type function specifier
+  // Checked C - _Itype_for_any function specifier
   unsigned FS_itypeforany_specified : 1;
 
   // friend-specifier

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -366,6 +366,8 @@ private:
   unsigned FS_checked_specified : 2;
   // Checked C - For-any function specifier
   unsigned FS_forany_specified : 1;
+  // Checked C - Interface_type function specifier
+  unsigned FS_itypeforany_specified : 1;
 
   // friend-specifier
   unsigned Friend_specified : 1;
@@ -387,6 +389,9 @@ private:
 
   TypedefDecl **TypeVarInfo;
   unsigned NumTypeVars : 15;
+  bool GenericFunction : 1;
+  bool ItypeGenericFunction : 1;
+
 
   // Scope specifier for the type spec, if applicable.
   CXXScopeSpec TypeScope;
@@ -409,7 +414,7 @@ private:
   SourceLocation FS_inlineLoc, FS_virtualLoc, FS_explicitLoc, FS_noreturnLoc;
   SourceLocation FS_forceinlineLoc;
   // Checked C - checked keyword location
-  SourceLocation FS_checkedLoc, FS_foranyLoc;
+  SourceLocation FS_checkedLoc, FS_foranyLoc, FS_itypeforanyloc;
   SourceLocation FriendLoc, ModulePrivateLoc, ConstexprLoc, ConceptLoc;
   SourceLocation TQ_pipeLoc;
 
@@ -465,6 +470,8 @@ public:
       Attrs(attrFactory),
       TypeVarInfo(nullptr),
       NumTypeVars(0),
+      GenericFunction(false),
+      ItypeGenericFunction(false),
       writtenBS(),
       ObjCQualifiers(nullptr) {
   }
@@ -605,11 +612,16 @@ public:
   SourceLocation getCheckedSpecLoc() const { return FS_checkedLoc; }
 
   bool isForanySpecified() const { return FS_forany_specified; }
+  bool isItypeforanySpecified() const { return FS_itypeforany_specified; }
   SourceLocation getForanySpecLoc() const { return FS_foranyLoc; }
 
   void setTypeVars(ASTContext &C, ArrayRef<TypedefDecl *> NewTypeVarInfo, unsigned NewNumTypeVars);
+  void setGenericFunction(bool IsGeneric) { GenericFunction = IsGeneric; }
+  void setItypeGenericFunction(bool IsItypeGeneric) { ItypeGenericFunction = IsItypeGeneric; }
   void setNumTypeVars(unsigned NewNumTypeVars) { NumTypeVars = NewNumTypeVars; }
   unsigned getNumTypeVars(void) const { return NumTypeVars; }
+  bool isGenericFunction(void) const { return GenericFunction; }
+  bool isItypeGenericFunction(void) const { return ItypeGenericFunction; }
 
   ArrayRef<TypedefDecl *> typeVariables() const {
     return { TypeVarInfo, getNumTypeVars() };
@@ -742,6 +754,8 @@ public:
                                 unsigned &DiagID);
   bool setFunctionSpecForany(SourceLocation Loc, const char *&PrevSpec,
                                 unsigned &DiagID);
+  bool setFunctionSpecItypeforany(SourceLocation Loc, const char *&PrevSpec,
+                                    unsigned &DiagID);
   bool SetFriendSpec(SourceLocation Loc, const char *&PrevSpec,
                      unsigned &DiagID);
   bool setModulePrivateSpec(SourceLocation Loc, const char *&PrevSpec,

--- a/include/clang/Sema/Scope.h
+++ b/include/clang/Sema/Scope.h
@@ -139,7 +139,10 @@ public:
     UncheckedScope = 0x2000000,
 
     /// Checked C - _For_any Polymorphic type scopes
-    ForanyScope = 0x4000000
+    ForanyScope = 0x4000000,
+
+    /// Checked C - _Itype_for_any Polymorphic bounds safe interface type scopes
+    ItypeforanyScope = 0x8000000
 
   };
 private:
@@ -346,6 +349,9 @@ public:
 
   /// isForanyScope - Return true if this scope is _For_any scope.
   bool isForanyScope() const { return (getFlags() & Scope::ForanyScope); }
+
+  /// isItypeforanyScope - Return true if this scope is _Itype_for_any scope.
+  bool isItypeforanyScope() const { return (getFlags() & Scope::ItypeforanyScope); }
 
   /// isInCXXInlineMethodScope - Return true if this scope is a C++ inline
   /// method scope or is inside one.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -8157,10 +8157,10 @@ QualType ASTContext::mergeFunctionTypes(QualType lhs, QualType rhs,
 
     // Compatible functions must have the same number of type variables.    
     if (lproto->getNumTypeVars() != rproto->getNumTypeVars()) {
-      if(lproto->isItypeGenericFunction() && !rproto->isItypeGenericFunction()) {
+      if (lproto->isItypeGenericFunction() && !rproto->isItypeGenericFunction()) {
         allRTypes = false;
         NumTypeVars = lproto->getNumTypeVars();
-      } else if(!lproto->isItypeGenericFunction() && rproto->isItypeGenericFunction()) {
+      } else if (!lproto->isItypeGenericFunction() && rproto->isItypeGenericFunction()) {
         allLTypes = false;
         NumTypeVars = rproto->getNumTypeVars();
       } else {
@@ -8821,13 +8821,12 @@ bool ASTContext::isAtLeastAsCheckedAs(QualType T1, QualType T2) const {
     return true;
 
   Type::TypeClass T1TypeClass = T1->getTypeClass();
-  if(T1TypeClass == Type::Pointer)
-  {
+  if (T1TypeClass == Type::Pointer) {
     const PointerType *T1PtrType = cast<PointerType>(T1Type);
     QualType T1PointeeType = T1PtrType->getPointeeType();    
-    if(isa<TypeVariableType>(T1PointeeType)) { // Use of TypeVariableType
+    if (isa<TypeVariableType>(T1PointeeType)) { // Use of TypeVariableType
       const TypeVariableType *AnnotatedType = cast<TypeVariableType>(T1PointeeType);
-      if(AnnotatedType->IsBoundsInterfaceType()) { // Use of TypeVariableType in _Itype_for_any scope
+      if (AnnotatedType->IsBoundsInterfaceType()) { // Use of TypeVariableType in _Itype_for_any scope
         return T2->isVoidPointerType();
       }
     }
@@ -8951,13 +8950,12 @@ bool ASTContext::isEqualIgnoringChecked(QualType T1, QualType T2) const {
     return true;
 
   Type::TypeClass T1TypeClass = T1->getTypeClass();
-  if(T1TypeClass == Type::Pointer)
-  {
+  if (T1TypeClass == Type::Pointer) {
     const PointerType *T1PtrType = cast<PointerType>(T1Type);
     QualType T1PointeeType = T1PtrType->getPointeeType();    
-    if(isa<TypeVariableType>(T1PointeeType)) { // Use of TypeVariableType
+    if (isa<TypeVariableType>(T1PointeeType)) { // Use of TypeVariableType
       const TypeVariableType *AnnotatedType = cast<TypeVariableType>(T1PointeeType);
-      if(AnnotatedType->IsBoundsInterfaceType()) { // Use of TypeVariableType in _Itype_for_any scope
+      if (AnnotatedType->IsBoundsInterfaceType()) { // Use of TypeVariableType in _Itype_for_any scope
         return T2->isVoidPointerType();
       }
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2854,10 +2854,11 @@ FunctionProtoType::FunctionProtoType(QualType result, ArrayRef<QualType> params,
       NumExceptions(epi.ExceptionSpec.Exceptions.size()),
       ExceptionSpecType(epi.ExceptionSpec.Type),
       HasExtParameterInfos(epi.ExtParameterInfos != nullptr),
-      Variadic(epi.Variadic), HasTrailingReturn(epi.HasTrailingReturn),
-      HasParamAnnots(epi.ParamAnnots != nullptr),
+      Variadic(epi.Variadic),
       GenericFunction(epi.GenericFunction),
       ItypeGenericFunction(epi.ItypeGenericFunction),
+      HasTrailingReturn(epi.HasTrailingReturn),
+      HasParamAnnots(epi.ParamAnnots != nullptr),
       ReturnAnnots(epi.ReturnAnnots) {
   assert(NumParams == params.size() && "function has too many parameters");
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3057,7 +3057,7 @@ void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID, QualType Result,
     ID.AddPointer(ArgTys[i].getAsOpaquePtr());
 
   // This method is relatively performance sensitive, so as a performance
-  // shortcut, use one AddInteger call instead of four for the next four
+  // shortcut, use one AddInteger call instead of eight for the next eight
   // fields.
   assert(!(unsigned(epi.Variadic) & ~1) &&
          !(unsigned(epi.HasTrailingReturn) & ~1) &&

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3058,7 +3058,7 @@ void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID, QualType Result,
     ID.AddPointer(ArgTys[i].getAsOpaquePtr());
 
   // This method is relatively performance sensitive, so as a performance
-  // shortcut, use one AddInteger call instead of eight for the next eight
+  // shortcut, use one AddInteger call instead of four for the next four
   // fields.
   assert(!(unsigned(epi.Variadic) & ~1) &&
          !(unsigned(epi.HasTrailingReturn) & ~1) &&
@@ -3070,13 +3070,9 @@ void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID, QualType Result,
          !(unsigned(epi.ExceptionSpec.Type) & ~15) &&
          "Values larger than expected.");
   ID.AddInteger(unsigned(epi.Variadic) +
-                unsigned(epi.HasTrailingReturn << 1) +
-                unsigned(epi.numTypeVars << 2) +
-                unsigned(epi.GenericFunction << 17) +
-                unsigned(epi.ItypeGenericFunction << 18) +
-                (epi.TypeQuals << 19) +
-                (epi.RefQualifier << 27) +
-                (epi.ExceptionSpec.Type << 28));
+                (epi.TypeQuals << 1) +
+                (epi.RefQualifier << 9) +
+                (epi.ExceptionSpec.Type << 11));
   if (epi.ExceptionSpec.Type == EST_Dynamic) {
     for (QualType Ex : epi.ExceptionSpec.Exceptions)
       ID.AddPointer(Ex.getAsOpaquePtr());
@@ -3101,6 +3097,10 @@ void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID, QualType Result,
       ID.AddInteger(epi.ExtParameterInfos[i].getOpaqueValue());
   }
   epi.ExtInfo.Profile(ID);
+  ID.AddBoolean(epi.HasTrailingReturn);
+  ID.AddInteger(epi.numTypeVars);
+  ID.AddBoolean(epi.GenericFunction);
+  ID.AddBoolean(epi.ItypeGenericFunction);
 }
 
 void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID,

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -723,8 +723,12 @@ FunctionProtoType::printExceptionSpecification(raw_ostream &OS,
 
 void TypePrinter::printFunctionProtoBefore(const FunctionProtoType *T, 
                                            raw_ostream &OS) {
-  if (T->getNumTypeVars() > 0)
+  if (T->isGenericFunction() && T->getNumTypeVars() > 0)
     OS << "_For_any(" << T->getNumTypeVars() << ") ";
+
+  if (T->isItypeGenericFunction() && T->getNumTypeVars() > 0)
+    OS << "_Itype_for_any(" << T->getNumTypeVars() << ") ";
+
   if (T->hasTrailingReturn()) {
     OS << "auto ";
     if (!HasEmptyPlaceHolder)

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -943,7 +943,11 @@ void TypePrinter::printUnresolvedUsingAfter(const UnresolvedUsingType *T,
 
 void TypePrinter::printTypeVariableBefore(const TypeVariableType *T,
                                              raw_ostream &OS) {
-  OS << "(" << T->GetDepth() << ", " << T->GetIndex() << ")";
+  OS << "(" << T->GetDepth() << ", " << T->GetIndex();
+  if(T->IsBoundsInterfaceType()) {
+    OS << "__BoundsInterfaceScope(true)";
+  }
+  OS << ")";
 }
 
 void TypePrinter::printTypeVariableAfter(const TypeVariableType *T, raw_ostream &OS) { }

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -945,7 +945,7 @@ void TypePrinter::printTypeVariableBefore(const TypeVariableType *T,
                                              raw_ostream &OS) {
   OS << "(" << T->GetDepth() << ", " << T->GetIndex();
   if(T->IsBoundsInterfaceType()) {
-    OS << "__BoundsInterfaceScope(true)";
+    OS << " __BoundsInterfaceScope(true)";
   }
   OS << ")";
 }

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -944,7 +944,7 @@ void TypePrinter::printUnresolvedUsingAfter(const UnresolvedUsingType *T,
 void TypePrinter::printTypeVariableBefore(const TypeVariableType *T,
                                              raw_ostream &OS) {
   OS << "(" << T->GetDepth() << ", " << T->GetIndex();
-  if(T->IsBoundsInterfaceType()) {
+  if (T->IsBoundsInterfaceType()) {
     OS << " __BoundsInterfaceScope(true)";
   }
   OS << ")";

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7227,7 +7227,7 @@ void Parser::ParseItypeforanySpecifier(DeclSpec &DS) {
     ExitScope();
     return;
   }
-  //$TODO Replicate ParseForAnySpecifier logic to identify the type variables and adding them to AST
+
   tok::TokenKind prevToken = tok::l_paren;
 
   SmallVector<TypedefDecl*, 16> typevars;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7260,7 +7260,7 @@ void Parser::ParseItypeforanySpecifier(DeclSpec &DS) {
       // DeclSpec of typedef, in order to use clang code for checking whether
       // the type name already exists. The underlying type of typedef is
       // TypeVariableType.
-      QualType R = Actions.Context.getTypeVariableType(forAnyDepth, typeVariableIndex);
+      QualType R = Actions.Context.getTypeVariableType(forAnyDepth, typeVariableIndex, true);
       TypeSourceInfo *TInfo = Actions.Context.CreateTypeSourceInfo(R);
       TypedefDecl *NewTD = TypedefDecl::Create(Actions.Context, Actions.CurContext,
         ItypeforanyStartLoc,
@@ -7344,7 +7344,7 @@ void Parser::ParseForanySpecifier(DeclSpec &DS) {
       // DeclSpec of typedef, in order to use clang code for checking whether 
       // the type name already exists. The underlying type of typedef is
       // TypeVariableType.
-      QualType R = Actions.Context.getTypeVariableType(forAnyDepth, typeVariableIndex);
+      QualType R = Actions.Context.getTypeVariableType(forAnyDepth, typeVariableIndex, false);
       TypeSourceInfo *TInfo = Actions.Context.CreateTypeSourceInfo(R);
       TypedefDecl *NewTD = TypedefDecl::Create(Actions.Context, Actions.CurContext,
         ForAnyStartLoc,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7221,133 +7221,65 @@ void Parser::ParseCheckedPointerSpecifiers(DeclSpec &DS) {
 }
 
 void Parser::ParseItypeforanySpecifier(DeclSpec &DS) {
-  EnterScope(Scope::DeclScope | Scope::ItypeforanyScope);
-  SourceLocation ItypeforanyStartLoc = ConsumeToken();
-  if (ExpectAndConsume(tok::l_paren, diag::err_interfacetype_unexpected_token)) {
-    ExitScope();
-    return;
-  }
-
-  tok::TokenKind prevToken = tok::l_paren;
-
-  SmallVector<TypedefDecl*, 16> typevars;
-  bool breakOutOfWhileLoop = false;
-  unsigned int typeVariableIndex = 0;
-
-  // Calculate the depth of "for any" scope for our generic types
-  unsigned int forAnyDepth = 0;
-  Scope *tempScope = getCurScope()->getParent();
-  while (!tempScope) {
-    if (tempScope->isItypeforanyScope())
-      forAnyDepth++;
-    tempScope = tempScope->getParent();
-  }
-
-  // Obtain list of type variables bound to for any.
-  while (!breakOutOfWhileLoop) {
-    // The tokens should be one of the three. tok::identifier, tok::comma,
-    // tok::r_paren. Anything else will be an error
-    if (Tok.getKind() == tok::identifier) {
-      // We'd expect the previous token to not be an identifier.
-      if (prevToken == tok::identifier) {
-        Diag(Tok.getLocation(), diag::err_itypeforany_comma_or_parenthesis_expected);
-        SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-        breakOutOfWhileLoop = true;
-        break;
-      }
-
-      // Introduce typedef name that will be bound to type variable. Create a
-      // DeclSpec of typedef, in order to use clang code for checking whether
-      // the type name already exists. The underlying type of typedef is
-      // TypeVariableType.
-      QualType R = Actions.Context.getTypeVariableType(forAnyDepth, typeVariableIndex, true);
-      TypeSourceInfo *TInfo = Actions.Context.CreateTypeSourceInfo(R);
-      TypedefDecl *NewTD = TypedefDecl::Create(Actions.Context, Actions.CurContext,
-        ItypeforanyStartLoc,
-        Tok.getLocation(),
-        Tok.getIdentifierInfo(),
-        TInfo);
-      Actions.PushOnScopeChains(NewTD, getCurScope(), true);
-      typevars.push_back(NewTD);
-
-      typeVariableIndex++;
-      prevToken = tok::identifier;
-      ConsumeToken();
-    } else if (Tok.getKind() == tok::comma) {
-      // We'd expect the previous token to be an identifier
-      if (prevToken != tok::identifier) {
-        Diag(Tok.getLocation(), diag::err_forany_type_variable_identifier_expected);
-        SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-        breakOutOfWhileLoop = true;
-        break;
-      }
-      prevToken = tok::comma;
-      ConsumeToken();
-    } else if (Tok.getKind() == tok::r_paren) {
-      // We'd expect the previous token to be an identifier
-      if (prevToken != tok::identifier) {
-        Diag(Tok.getLocation(), diag::err_forany_type_variable_identifier_expected);
-        SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-        breakOutOfWhileLoop = true;
-        break;
-      }
-      // Add parsed type variables to Decl Spec.
-      DS.setTypeVars(Actions.getASTContext(), typevars, typeVariableIndex);
-      DS.setItypeGenericFunction(true);
-      ConsumeParen();
-      breakOutOfWhileLoop = true;
-    } else {
-      Diag(Tok.getLocation(), diag::err_itypeforany_unexpected_token);
-      SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-      breakOutOfWhileLoop = true;
-      break;
-    }
+  if(!ParseGenericFunctionSpecifierHelper(DS, Scope::ItypeforanyScope)) {
+    DS.setItypeGenericFunction(true);
   }
 }
 
 void Parser::ParseForanySpecifier(DeclSpec &DS) {
-  EnterScope(Scope::DeclScope | Scope::ForanyScope);
-  SourceLocation ForAnyStartLoc = ConsumeToken();
-  if (ExpectAndConsume(tok::l_paren, diag::err_forany_unexpected_token)) {
+  if(!ParseGenericFunctionSpecifierHelper(DS, Scope::ForanyScope)) {
+    DS.setGenericFunction(true);
+  }
+}
+
+/// Parses type variables that are part of function specifiers "_For_any" and "_Itype_for_any"
+/// Parameter "S" can either be "ForanyScope" or "ItypeforanyScope"
+/// Parameter "Ident" is the identifier string(_For_any or _Itype_for_any) that will be used within the parsing error messages
+bool Parser::ParseGenericFunctionSpecifierHelper(DeclSpec &DS,
+                                                  Scope::ScopeFlags S) {
+  assert((S == Scope::ForanyScope) || (S == Scope::ItypeforanyScope));  
+  EnterScope(Scope::DeclScope | S);
+  SourceLocation Loc = ConsumeToken();
+
+  StringRef Key = (S == Scope::ForanyScope) ? "_For_any" : "Itype_for_any";
+  if (ExpectAndConsume(tok::l_paren, diag::err_generic_specifier_unexpected_token, Key)) {
     ExitScope();
-    return;
+    return true;
   }
   tok::TokenKind prevToken = tok::l_paren;
 
   SmallVector<TypedefDecl*, 16> typevars;
-  bool breakOutOfWhileLoop = false;
   unsigned int typeVariableIndex = 0;
 
-  // Calculate the depth of "for any" scope for our generic types
-  unsigned int forAnyDepth = 0;
+  // Calculate the depth of "for any"/"itype for any" scope for our generic types
+  unsigned int Depth = 0;
   Scope *tempScope = getCurScope()->getParent();
   while (!tempScope) {
     if (tempScope->isForanyScope())
-      forAnyDepth++;
+      Depth++;
     tempScope = tempScope->getParent();
   }
 
   // Obtain list of type variables bound to for any.
-  while (!breakOutOfWhileLoop) {
+  while (true) {
     // The tokens should be one of the three. tok::identifier, tok::comma, 
     // tok::r_paren. Anything else will be an error.
     if (Tok.getKind() == tok::identifier) {
       // We'd expect the previous token to not be an identifier.
       if (prevToken == tok::identifier) {
-        Diag(Tok.getLocation(), diag::err_forany_comma_or_parenthesis_expected);
+        Diag(Tok.getLocation(), diag::err_generic_specifier_comma_or_parenthesis_expected);
         SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-        breakOutOfWhileLoop = true;
-        break;
+        return true;
       }
 
       // Introduce typedef name that will be bound to type variable. Create a 
       // DeclSpec of typedef, in order to use clang code for checking whether 
       // the type name already exists. The underlying type of typedef is
       // TypeVariableType.
-      QualType R = Actions.Context.getTypeVariableType(forAnyDepth, typeVariableIndex, false);
+      QualType R = Actions.Context.getTypeVariableType(Depth, typeVariableIndex, S == Scope::ItypeforanyScope);
       TypeSourceInfo *TInfo = Actions.Context.CreateTypeSourceInfo(R);
       TypedefDecl *NewTD = TypedefDecl::Create(Actions.Context, Actions.CurContext,
-        ForAnyStartLoc,
+        Loc,
         Tok.getLocation(),
         Tok.getIdentifierInfo(),
         TInfo);
@@ -7362,8 +7294,7 @@ void Parser::ParseForanySpecifier(DeclSpec &DS) {
       if (prevToken != tok::identifier) {
         Diag(Tok.getLocation(), diag::err_forany_type_variable_identifier_expected);
         SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-        breakOutOfWhileLoop = true;
-        break;
+        return true;
       }
       prevToken = tok::comma;
       ConsumeToken();
@@ -7372,19 +7303,17 @@ void Parser::ParseForanySpecifier(DeclSpec &DS) {
       if (prevToken != tok::identifier) {
         Diag(Tok.getLocation(), diag::err_forany_type_variable_identifier_expected);
         SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-        breakOutOfWhileLoop = true;
-        break;
+        return true;
       }
       // Add parsed type variables to Decl Spec.
       DS.setTypeVars(Actions.getASTContext(), typevars, typeVariableIndex);
-      DS.setGenericFunction(true);
       ConsumeParen();
-      breakOutOfWhileLoop = true;
+      //End of parsing type variables
+      return false;
     } else {
-      Diag(Tok.getLocation(), diag::err_forany_unexpected_token);
+      Diag(Tok.getLocation(), diag::err_generic_specifier_unexpected_token) << "_For_any";
       SkipUntil(tok::r_paren, SkipUntilFlags::StopAtSemi);
-      breakOutOfWhileLoop = true;
-      break;
+      return true;
     }
   }
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1432,7 +1432,7 @@ ExprResult Parser::ParseCastExpression(bool isUnaryExpression,
   // are compiling for OpenCL, we need to return an error as this implies
   // that the address of the function is being taken, which is illegal in CL.
 
-  // Check to see if resExpr is a itype genric or generic function call.
+  // Check to see if resExpr is a itype generic or generic function call.
   // In this case, we must parse a list of type names that follows
   // function decl identifier where applicable
   if (ParseItypeAndGenericFunctionExpression(Res)) return ExprError();
@@ -3226,7 +3226,7 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
     BoundsAnnotations ReturnBAnnot = fpType->getReturnAnnots();
     InteropTypeExpr *RBIT = ReturnBAnnot.getInteropTypeExpr();
     QualType returnQualType;
-    if(RBIT) {
+    if (RBIT) {
       returnQualType = SubstituteTypeVariable(RBIT->getTypeAsWritten() , typeNames);
     } else {
       returnQualType = SubstituteTypeVariable(fpType->getReturnType() , typeNames);
@@ -3238,7 +3238,7 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
     for (QualType opt : fpType->getParamTypes()) {
       BoundsAnnotations BAnnot = fpType->getParamAnnots(iCnt);
       InteropTypeExpr *BIT = BAnnot.getInteropTypeExpr();
-      if(BIT) {
+      if (BIT) {
         newParamTypes.push_back(SubstituteTypeVariable(BIT->getTypeAsWritten(), typeNames));
       } else {
         newParamTypes.push_back(SubstituteTypeVariable(opt, typeNames));
@@ -3327,16 +3327,13 @@ bool Parser::ParseItypeAndGenericFunctionExpression(ExprResult &Res) {
   // 2. It's a polymorphic bounds safe interface function and 
   //    a. The call expression is inside _Checked scope
   //    b. The call expression is in any scope but the type parameters are provided by the caller
-  if(funcType->isGenericFunction() || 
+  if (funcType->isGenericFunction() || 
       (funcType->isItypeGenericFunction() && 
         (getCurScope()->isCheckedScope() || Tok.getKind() == tok::less))) {
     // Expect a '<' to denote that a list of type specifiers are incoming.
     SourceLocation lessLoc = Tok.getLocation();
-    auto Msg = diag::err_expected_list_of_types_expr_for_generic_function;
-    if(funcType->isItypeGenericFunction()) {
-      Msg = diag::err_expected_list_of_types_expr_for_itype_generic_function;
-    }
-    if (ExpectAndConsume(tok::less, Msg)) {
+    if (ExpectAndConsume(tok::less,
+                          diag::err_expected_list_of_types_expr_for_generic_function)) {
       // We want to consume greater, but not consume semi
       SkipUntil(tok::greater, StopAtSemi | StopBeforeMatch);
       if (Tok.getKind() == tok::greater) ConsumeToken();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3226,8 +3226,17 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
       SubstituteTypeVariable(fpType->getReturnType(), typeNames);
     // Initialize parameter types if it's type variable
     SmallVector<QualType, 16> newParamTypes;
+
+    int iCnt = 0;
     for (QualType opt : fpType->getParamTypes()) {
-      newParamTypes.push_back(SubstituteTypeVariable(opt, typeNames));
+      BoundsAnnotations BAnnot = fpType->getParamAnnots(iCnt);
+      InteropTypeExpr *BIT = BAnnot.getInteropTypeExpr();
+      if(BIT) {
+        newParamTypes.push_back(SubstituteTypeVariable(BIT->getTypeAsWritten(), typeNames));
+      } else {
+        newParamTypes.push_back(SubstituteTypeVariable(opt, typeNames));
+      }
+      iCnt++;
     }
     // Indicate that this function type is fully instantiated
     FunctionProtoType::ExtProtoInfo newExtProtoInfo = fpType->getExtProtoInfo();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1432,9 +1432,10 @@ ExprResult Parser::ParseCastExpression(bool isUnaryExpression,
   // are compiling for OpenCL, we need to return an error as this implies
   // that the address of the function is being taken, which is illegal in CL.
 
-  // Check to see if resExpr is a generic function call. In this case, we must
-  // parse a list of type names that follows generic function decl identifier.
-  if (ParseGenericFunctionExpression(Res)) return ExprError();
+  // Check to see if resExpr is a itype genric or generic function call.
+  // In this case, we must parse a list of type names that follows
+  // function decl identifier where applicable
+  if (ParseItypeAndGenericFunctionExpression(Res)) return ExprError();
 
   // These can be followed by postfix-expr pieces.
   Res = ParsePostfixExpressionSuffix(Res);
@@ -3222,8 +3223,14 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
       return QT;
     }
     // Initialize return type if it's type variable
-    QualType returnQualType =
-      SubstituteTypeVariable(fpType->getReturnType(), typeNames);
+    BoundsAnnotations ReturnBAnnot = fpType->getReturnAnnots();
+    InteropTypeExpr *RBIT = ReturnBAnnot.getInteropTypeExpr();
+    QualType returnQualType;
+    if(RBIT) {
+      returnQualType = SubstituteTypeVariable(RBIT->getTypeAsWritten() , typeNames);
+    } else {
+      returnQualType = SubstituteTypeVariable(fpType->getReturnType() , typeNames);
+    }
     // Initialize parameter types if it's type variable
     SmallVector<QualType, 16> newParamTypes;
 
@@ -3287,10 +3294,12 @@ QualType Parser::SubstituteTypeVariable(QualType QT,
 }
 
 // With primary-expression, before parsing postfix-expression, check to make
-// sure that Expr is declRefExpr of generic function with _For_any specifier
+// sure that Expr is declRefExpr of itype generic or generic function
+// with _Itype_for_any or _For_any specifier respectively
+// No type variables necessary for itype generic function calls from unchecked scope
 //
 // Returns false if parsing succeed and true if an error occurred.
-bool Parser::ParseGenericFunctionExpression(ExprResult &Res) {
+bool Parser::ParseItypeAndGenericFunctionExpression(ExprResult &Res) {
   Expr *resExpr = Res.get();
   // Have to make sure that resExpr down to FunctionDecl is not null, because
   // if there is a parsing error before, one of these may be null.
@@ -3308,64 +3317,69 @@ bool Parser::ParseGenericFunctionExpression(ExprResult &Res) {
     if (!(funDecl->isGenericFunction() || funDecl->isItypeGenericFunction())) return false;
   }
 
-  // Expect a '<' to denote that a list of type specifiers are incoming.
-  SourceLocation lessLoc = Tok.getLocation();
-  if (ExpectAndConsume(tok::less,
-                diag::err_expected_list_of_types_expr_for_generic_function)) {
-    // We want to consume greater, but not consume semi
-    SkipUntil(tok::greater, StopAtSemi | StopBeforeMatch);
-    if (Tok.getKind() == tok::greater) ConsumeToken();
-    return true;
-  }
-
-  bool firstTypeArgument = true;
-
   SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> typeArgumentInfos;
-  // Expect to see a list of type names, followed by a '>'.
-  while (Tok.getKind() != tok::greater) {
-    if (!firstTypeArgument) {
-      if (ExpectAndConsume(tok::comma,
-        diag::err_type_function_comma_or_greater_expected)) {
-        // We want to consume greater, but not consume semi
-        SkipUntil(tok::greater, StopAtSemi | StopBeforeMatch);
-        if (Tok.getKind() == tok::greater) ConsumeToken();
-        return true;
-      }
-    } else
-      firstTypeArgument = false;
-
-    // Expect to see type name.
-    TypeResult Ty = ParseTypeName();
-    if (Ty.isInvalid()) {
-      // We do not need to write an error message since ParseTypeName does.
+  //bool unused = getCurScope()->isCheckedScope();
+  //$TODO$ replace isCheckedScope() with appropriate scope check. isCheckedScope always returns false here
+  if(funcType->isGenericFunction() || getCurScope()->isCheckedScope() || Tok.getKind() == tok::less) {
+    // Expect a '<' to denote that a list of type specifiers are incoming.
+    SourceLocation lessLoc = Tok.getLocation();
+    auto Msg = diag::err_expected_list_of_types_expr_for_generic_function;
+    if(funcType->isItypeGenericFunction()) {
+      Msg = diag::err_expected_list_of_types_expr_for_itype_generic_function;
+    }
+    if (ExpectAndConsume(tok::less, Msg)) {
       // We want to consume greater, but not consume semi
       SkipUntil(tok::greater, StopAtSemi | StopBeforeMatch);
       if (Tok.getKind() == tok::greater) ConsumeToken();
       return true;
     }
 
-    TypeSourceInfo *TInfo;
-    QualType realType = Actions.GetTypeFromParser(Ty.get(), &TInfo);
-    typeArgumentInfos.push_back({ realType, TInfo });
+    bool firstTypeArgument = true;
+    // Expect to see a list of type names, followed by a '>'.
+    while (Tok.getKind() != tok::greater) {
+      if (!firstTypeArgument) {
+        if (ExpectAndConsume(tok::comma,
+          diag::err_type_function_comma_or_greater_expected)) {
+          // We want to consume greater, but not consume semi
+          SkipUntil(tok::greater, StopAtSemi | StopBeforeMatch);
+          if (Tok.getKind() == tok::greater) ConsumeToken();
+          return true;
+        }
+      } else
+        firstTypeArgument = false;
+
+      // Expect to see type name.
+      TypeResult Ty = ParseTypeName();
+      if (Ty.isInvalid()) {
+        // We do not need to write an error message since ParseTypeName does.
+        // We want to consume greater, but not consume semi
+        SkipUntil(tok::greater, StopAtSemi | StopBeforeMatch);
+        if (Tok.getKind() == tok::greater) ConsumeToken();
+        return true;
+      }
+
+      TypeSourceInfo *TInfo;
+      QualType realType = Actions.GetTypeFromParser(Ty.get(), &TInfo);
+      typeArgumentInfos.push_back({ realType, TInfo });
+    }
+    ConsumeToken(); // consume '>' token
+
+    // Sanity check to make sure that the number of type names equals the
+    // number of type variables in func Type.
+    if (funcType->getNumTypeVars() != typeArgumentInfos.size()) {
+      // The location of beginning of _For_any is stored in typeVariables
+      Diag(lessLoc,
+        diag::err_type_list_and_type_variable_num_mismatch);
+      Diag(funDecl->typeVariables()[0]->getLocStart(),
+        diag::note_type_variables_declared_at);
+      return true;
+    }
+    // Add parsed list of type names to declRefExpr for future references
+    declRef->SetGenericInstInfo(Actions.getASTContext(), typeArgumentInfos);
+
+    // Substitute Type Variables of Function Type in DeclRefExpr
+    declRef->setType(SubstituteTypeVariable(funDecl->getType(), typeArgumentInfos));
   }
-  ConsumeToken(); // consume '>' token
-
-  // Sanity check to make sure that the number of type names equals the
-  // number of type variables in func Type.
-  if (funcType->getNumTypeVars() != typeArgumentInfos.size()) {
-    // The location of beginning of _For_any is stored in typeVariables
-    Diag(lessLoc,
-      diag::err_type_list_and_type_variable_num_mismatch);
-    Diag(funDecl->typeVariables()[0]->getLocStart(),
-      diag::note_type_variables_declared_at);
-    return true;
-  }
-
-  // Add parsed list of type names to declRefExpr for future references
-  declRef->SetGenericInstInfo(Actions.getASTContext(), typeArgumentInfos);
-
-  // Substitute Type Variables of Function Type in DeclRefExpr
-  declRef->setType(SubstituteTypeVariable(funDecl->getType(), typeArgumentInfos));
   return false;
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3293,8 +3293,11 @@ bool Parser::ParseGenericFunctionExpression(ExprResult &Res) {
   // Only parse the list of type arguments if it's a generic function.
   const FunctionProtoType *funcType =
     dyn_cast<FunctionProtoType>(funDecl->getType().getTypePtr());
-
-  if (!(funcType->isGenericFunction() || funcType->isItypeGenericFunction())) return false;
+  if(funcType) {
+    if (!(funcType->isGenericFunction() || funcType->isItypeGenericFunction())) return false;
+  } else {
+    if (!(funDecl->isGenericFunction() || funDecl->isItypeGenericFunction())) return false;
+  }
 
   // Expect a '<' to denote that a list of type specifiers are incoming.
   SourceLocation lessLoc = Tok.getLocation();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3291,7 +3291,10 @@ bool Parser::ParseGenericFunctionExpression(ExprResult &Res) {
   if (!resDecl || !isa<FunctionDecl>(resDecl)) return false;
   FunctionDecl* funDecl = dyn_cast<FunctionDecl>(resDecl);
   // Only parse the list of type arguments if it's a generic function.
-  if (!funDecl->isGenericFunction()) return false;
+  const FunctionProtoType *funcType =
+    dyn_cast<FunctionProtoType>(funDecl->getType().getTypePtr());
+
+  if (!(funcType->isGenericFunction() || funcType->isItypeGenericFunction())) return false;
 
   // Expect a '<' to denote that a list of type specifiers are incoming.
   SourceLocation lessLoc = Tok.getLocation();
@@ -3334,9 +3337,6 @@ bool Parser::ParseGenericFunctionExpression(ExprResult &Res) {
     typeArgumentInfos.push_back({ realType, TInfo });
   }
   ConsumeToken(); // consume '>' token
-
-  const FunctionProtoType *funcType =
-  dyn_cast<FunctionProtoType>(funDecl->getType().getTypePtr());
 
   // Sanity check to make sure that the number of type names equals the
   // number of type variables in func Type.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1204,7 +1204,7 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
   // Tell the actions module that we have entered a function definition with the
   // specified Declarator for the function.
   Sema::SkipBodyInfo SkipBody;
-  Scope* funcDeclScope = (D.getDeclSpec().isForanySpecified() || D.getDeclSpec().isItypeforanySpecified())?
+  Scope* funcDeclScope = (D.getDeclSpec().isForanySpecified() || D.getDeclSpec().isItypeforanySpecified()) ?
                             getCurScope()->getParent() : getCurScope();
   Decl *Res = Actions.ActOnStartOfFunctionDef(funcDeclScope, D,
                                               TemplateInfo.TemplateParams

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1204,7 +1204,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
   // Tell the actions module that we have entered a function definition with the
   // specified Declarator for the function.
   Sema::SkipBodyInfo SkipBody;
-  Scope* funcDeclScope = D.getDeclSpec().isForanySpecified() ? getCurScope()->getParent() : getCurScope();
+  Scope* funcDeclScope = (D.getDeclSpec().isForanySpecified() || D.getDeclSpec().isItypeforanySpecified())?
+                            getCurScope()->getParent() : getCurScope();
   Decl *Res = Actions.ActOnStartOfFunctionDef(funcDeclScope, D,
                                               TemplateInfo.TemplateParams
                                                   ? *TemplateInfo.TemplateParams

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -975,7 +975,12 @@ bool DeclSpec::setFunctionSpecUnchecked(SourceLocation Loc,
 bool DeclSpec::setFunctionSpecForany(SourceLocation Loc,
                                         const char *&PrevSpec,
                                         unsigned &DiagID) {
-  if (FS_itypeforany_specified || FS_forany_specified) {
+  if (FS_itypeforany_specified) {
+    PrevSpec = "_Itype_for_any";
+    DiagID = diag::err_invalid_decl_spec_combination;
+    return true;
+  }
+  if (FS_forany_specified) {
     DiagID = diag::warn_duplicate_declspec;
     PrevSpec = "unchecked";
     return true;
@@ -988,7 +993,12 @@ bool DeclSpec::setFunctionSpecForany(SourceLocation Loc,
 bool DeclSpec::setFunctionSpecItypeforany(SourceLocation Loc,
                                               const char *&PrevSpec,
                                               unsigned &DiagID) {
-  if (FS_itypeforany_specified || FS_forany_specified) {
+  if (FS_forany_specified) {
+    PrevSpec = "_For_any";
+    DiagID = diag::err_invalid_decl_spec_combination;
+    return true;
+  }
+  if (FS_itypeforany_specified) {
     DiagID = diag::warn_duplicate_declspec;
     PrevSpec = "unchecked";
     return true;

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -975,13 +975,26 @@ bool DeclSpec::setFunctionSpecUnchecked(SourceLocation Loc,
 bool DeclSpec::setFunctionSpecForany(SourceLocation Loc,
                                         const char *&PrevSpec,
                                         unsigned &DiagID) {
-  if (FS_forany_specified) {
+  if (FS_itypeforany_specified || FS_forany_specified) {
     DiagID = diag::warn_duplicate_declspec;
     PrevSpec = "unchecked";
     return true;
   }
   FS_forany_specified = true;
   FS_foranyLoc = Loc;
+  return false;
+}
+
+bool DeclSpec::setFunctionSpecItypeforany(SourceLocation Loc,
+                                              const char *&PrevSpec,
+                                              unsigned &DiagID) {
+  if (FS_itypeforany_specified || FS_forany_specified) {
+    DiagID = diag::warn_duplicate_declspec;
+    PrevSpec = "unchecked";
+    return true;
+  }
+  FS_itypeforany_specified = true;
+  FS_itypeforanyloc = Loc;
   return false;
 }
 

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -3415,6 +3415,14 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD,
       New->setParams(Params);
     }
 
+    if((New->isItypeGenericFunction() && Old->isGenericFunction())
+        || (New->isGenericFunction() && Old->isItypeGenericFunction()))
+    {
+      Diag(New->getLocation(), diag::err_conflicting_function_specifiers)
+            << New->getDeclName() << "_Itype_for_any" << "_For_any";
+      return true;
+    }
+
     return MergeCompatibleFunctionDecls(New, Old, S, MergeTypeWithOld);
   }
 

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -3418,7 +3418,7 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD,
     if((New->isItypeGenericFunction() && Old->isGenericFunction())
         || (New->isGenericFunction() && Old->isItypeGenericFunction()))
     {
-      Diag(New->getLocation(), diag::err_conflicting_function_specifiers)
+      Diag(New->getLocation(), diag::err_decl_conflicting_function_specifiers)
             << New->getDeclName() << "_Itype_for_any" << "_For_any";
       return true;
     }

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -8729,6 +8729,17 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
     }
   }
 
+  if (D.getDeclSpec().isItypeforanySpecified()) {
+    if (NewFD->hasPrototype()) {
+      NewFD->setItypeGenericFunctionFlag(true);
+      NewFD->setTypeVars(D.getDeclSpec().typeVariables());
+    } else {
+      // Diagnose generic no-prototype function declarator
+      Diag(NewFD->getLocation(), diag::no_prototype_generic_function);
+      NewFD->setInvalidDecl();
+    }
+  }
+
   if (D.getDeclSpec().isCheckedSpecified())
     NewFD->setCheckedSpecifier(CheckedFunctionSpecifiers::CFS_Checked);
   else if (D.getDeclSpec().isUncheckedSpecified())

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -3415,8 +3415,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD,
       New->setParams(Params);
     }
 
-    if((New->isItypeGenericFunction() && Old->isGenericFunction())
-        || (New->isGenericFunction() && Old->isItypeGenericFunction()))
+    if ((New->isItypeGenericFunction() && Old->isGenericFunction())
+          || (New->isGenericFunction() && Old->isItypeGenericFunction()))
     {
       Diag(New->getLocation(), diag::err_decl_conflicting_function_specifiers)
             << New->getDeclName() << "_Itype_for_any" << "_For_any";
@@ -8726,21 +8726,15 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
                                               isVirtualOkay);
   if (!NewFD) return nullptr;
 
-  if (D.getDeclSpec().isForanySpecified()) {
+  if (D.getDeclSpec().isForanySpecified() || D.getDeclSpec().isItypeforanySpecified()) {
     if (NewFD->hasPrototype()) {
-      NewFD->setGenericFunctionFlag(true);
       NewFD->setTypeVars(D.getDeclSpec().typeVariables());
-    } else {
-      // Diagnose generic no-prototype function declarator
-      Diag(NewFD->getLocation(), diag::no_prototype_generic_function);
-      NewFD->setInvalidDecl();
-    }
-  }
-
-  if (D.getDeclSpec().isItypeforanySpecified()) {
-    if (NewFD->hasPrototype()) {
-      NewFD->setItypeGenericFunctionFlag(true);
-      NewFD->setTypeVars(D.getDeclSpec().typeVariables());
+      if (D.getDeclSpec().isForanySpecified()) {
+        NewFD->setGenericFunctionFlag(true);
+      }
+      if (D.getDeclSpec().isItypeforanySpecified()) {
+        NewFD->setItypeGenericFunctionFlag(true);
+      }
     } else {
       // Diagnose generic no-prototype function declarator
       Diag(NewFD->getLocation(), diag::no_prototype_generic_function);

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -4847,6 +4847,8 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         }
 
         EPI.numTypeVars = D.getDeclSpec().getNumTypeVars();
+        EPI.GenericFunction = D.getDeclSpec().isGenericFunction();
+        EPI.ItypeGenericFunction = D.getDeclSpec().isItypeGenericFunction();
 
         SmallVector<QualType, 4> Exceptions;
         SmallVector<ParsedType, 2> DynamicExceptions;

--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -6019,7 +6019,6 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
   case TYPE_TYPEVARIABLE: {
     unsigned int depth = Record[0];
     unsigned int index = Record[1];
-    //$TODO$ not sure how to distinguish between for_any and itype_for_any here
     bool isInBoundsSafeInterface = Record[2];
     return Context.getTypeVariableType(depth, index, isInBoundsSafeInterface);
   }

--- a/lib/Serialization/ASTReader.cpp
+++ b/lib/Serialization/ASTReader.cpp
@@ -6019,7 +6019,9 @@ QualType ASTReader::readTypeRecord(unsigned Index) {
   case TYPE_TYPEVARIABLE: {
     unsigned int depth = Record[0];
     unsigned int index = Record[1];
-    return Context.getTypeVariableType(depth, index);
+    //$TODO$ not sure how to distinguish between for_any and itype_for_any here
+    bool isInBoundsSafeInterface = Record[2];
+    return Context.getTypeVariableType(depth, index, isInBoundsSafeInterface);
   }
 
   case TYPE_DECLTYPE: {

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -463,6 +463,7 @@ void ASTStmtReader::VisitDeclRefExpr(DeclRefExpr *E) {
   E->DeclRefExprBits.HadMultipleCandidates = Record.readInt();
   E->DeclRefExprBits.RefersToEnclosingVariableOrCapture = Record.readInt();
   bool isGenericFunction = Record.readInt();
+  bool isItypeGenericFunction = Record.readInt();
 
   unsigned NumTemplateArgs = 0;
   if (E->hasTemplateKWAndArgsInfo())
@@ -480,7 +481,7 @@ void ASTStmtReader::VisitDeclRefExpr(DeclRefExpr *E) {
         *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
         E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
 
-  if (isGenericFunction) {
+  if (isGenericFunction || isItypeGenericFunction) {
     unsigned numTypeNameInfos = Record.readInt();
     SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 16> typeArgumentInfos;
     for (unsigned i = 0; i < numTypeNameInfos; i++) {
@@ -3269,7 +3270,7 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
         /*HasFoundDecl=*/Record[ASTStmtReader::NumExprFields + 1],
         /*HasTemplateKWAndArgsInfo=*/Record[ASTStmtReader::NumExprFields + 2],
         /*NumTemplateArgs=*/Record[ASTStmtReader::NumExprFields + 2] ?
-          Record[ASTStmtReader::NumExprFields + 6] : 0);
+          Record[ASTStmtReader::NumExprFields + 7] : 0);
       break;
 
     case EXPR_INTEGER_LITERAL:

--- a/lib/Serialization/ASTWriter.cpp
+++ b/lib/Serialization/ASTWriter.cpp
@@ -338,6 +338,7 @@ void ASTTypeWriter::VisitTypedefType(const TypedefType *T) {
 void ASTTypeWriter::VisitTypeVariableType(const TypeVariableType *T) {
   Record.push_back(T->GetDepth());
   Record.push_back(T->GetIndex());
+  Record.push_back(T->IsBoundsInterfaceType());
   Code = TYPE_TYPEVARIABLE;
 }
 

--- a/lib/Serialization/ASTWriterDecl.cpp
+++ b/lib/Serialization/ASTWriterDecl.cpp
@@ -2122,6 +2122,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed,
                            1)); // RefersToEnclosingVariableOrCapture
   Abv->Add(BitCodeAbbrevOp(0));                       // isGenericFunction
+  Abv->Add(BitCodeAbbrevOp(0));                       // isItypeGenericFunction
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // DeclRef
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Location
   DeclRefExprAbbrev = Stream.EmitAbbrev(std::move(Abv));

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -415,7 +415,6 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
   {
     FunctionDecl *FD = cast<FunctionDecl>(E->getDecl());
     isItypeGenericFunction = FD->isItypeGenericFunction() && E->GetTypeArgumentInfo() != nullptr;
-    //$TODO$// Unused as of now is ItypeGenericFunction. Must dump _itype_for_any function
   }
   Record.push_back(isItypeGenericFunction);
 

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -402,8 +402,21 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
   Record.push_back(E->hasTemplateKWAndArgsInfo());
   Record.push_back(E->hadMultipleCandidates());
   Record.push_back(E->refersToEnclosingVariableOrCapture());
-  bool isGenericFunction = E->GetTypeArgumentInfo() != nullptr;
+  bool isGenericFunction = false;
+  if(E->getDecl() && isa<FunctionDecl>(E->getDecl()))
+  {
+    FunctionDecl *FD = cast<FunctionDecl>(E->getDecl());
+    isGenericFunction = FD->isGenericFunction() && E->GetTypeArgumentInfo() != nullptr;
+  }
   Record.push_back(isGenericFunction);
+
+  bool isItypeGenericFunction = false;
+  if(E->getDecl() && isa<FunctionDecl>(E->getDecl()))
+  {
+    FunctionDecl *FD = cast<FunctionDecl>(E->getDecl());
+    isItypeGenericFunction = FD->isItypeGenericFunction() && E->GetTypeArgumentInfo() != nullptr;
+    //$TODO$// Unused as of now is ItypeGenericFunction. Must dump _itype_for_any function
+  }
 
   if (E->hasTemplateKWAndArgsInfo()) {
     unsigned NumTemplateArgs = E->getNumTemplateArgs();

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -403,16 +403,14 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
   Record.push_back(E->hadMultipleCandidates());
   Record.push_back(E->refersToEnclosingVariableOrCapture());
   bool isGenericFunction = false;
-  if(E->getDecl() && isa<FunctionDecl>(E->getDecl()))
-  {
+  if (E->getDecl() && isa<FunctionDecl>(E->getDecl())) {
     FunctionDecl *FD = cast<FunctionDecl>(E->getDecl());
     isGenericFunction = FD->isGenericFunction() && E->GetTypeArgumentInfo() != nullptr;
   }
   Record.push_back(isGenericFunction);
 
   bool isItypeGenericFunction = false;
-  if(E->getDecl() && isa<FunctionDecl>(E->getDecl()))
-  {
+  if (E->getDecl() && isa<FunctionDecl>(E->getDecl())) {
     FunctionDecl *FD = cast<FunctionDecl>(E->getDecl());
     isItypeGenericFunction = FD->isItypeGenericFunction() && E->GetTypeArgumentInfo() != nullptr;
   }

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -417,6 +417,7 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
     isItypeGenericFunction = FD->isItypeGenericFunction() && E->GetTypeArgumentInfo() != nullptr;
     //$TODO$// Unused as of now is ItypeGenericFunction. Must dump _itype_for_any function
   }
+  Record.push_back(isItypeGenericFunction);
 
   if (E->hasTemplateKWAndArgsInfo()) {
     unsigned NumTemplateArgs = E->getNumTemplateArgs();
@@ -428,6 +429,7 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
   if ((!E->hasTemplateKWAndArgsInfo()) && (!E->hasQualifier()) &&
       (E->getDecl() == E->getFoundDecl()) &&
       !isGenericFunction &&
+      isItypeGenericFunction &&
       nk == DeclarationName::Identifier) {
     AbbrevToUse = Writer.getDeclRefExprAbbrev();
   }
@@ -442,7 +444,7 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
     AddTemplateKWAndArgsInfo(*E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
                              E->getTrailingObjects<TemplateArgumentLoc>());
 
-  if (isGenericFunction) {
+  if (isGenericFunction || isItypeGenericFunction) {
     Record.push_back(E->GetTypeArgumentInfo()->typeArgumentss().size());
     for (DeclRefExpr::GenericInstInfo::TypeArgument tn :
          E->GetTypeArgumentInfo()->typeArgumentss()) {


### PR DESCRIPTION
Added new keyword _Itype_for_any which is a function specifier.

Pending:
1. Parsing logic of _For_any and _Itype_for_any seems to fail in linux
2. Spec needs to be updated

