### PR TITLE
Fix duplicate messages for illegal void pointer arithmetic.

### DIFF
--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -9067,9 +9067,9 @@ static void diagnoseArithmeticOnNullPointer(Sema &S, SourceLocation Loc,
 /// \brief Diagnose invalid arithmetic on two function pointers.
 static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
                                                     Expr *LHS, Expr *RHS) {
-  // For Checked C, we can ignore checked function pointers in this method. Only
-  // _Ptrs to function types are allowed and there will be an error issued
-  // for trying pointer arithmetic on that.
+  // For Checked C, arithmetic on checked function pointers is never allowed.
+  // We don't have check for it here, though.  Only _Ptrs to function types are
+  // allowed and arithmetic on _Ptrs is disallowed by another diagnostic.
   assert(LHS->getType()->isAnyPointerType());
   assert(RHS->getType()->isAnyPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
@@ -9086,9 +9086,9 @@ static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
 /// \brief Diagnose invalid arithmetic on a function pointer.
 static void diagnoseArithmeticOnFunctionPointer(Sema &S, SourceLocation Loc,
                                                 Expr *Pointer) {
- // For Checked C, we can ignore checked function pointers in this method.  Only
-  // _Ptrs to function type are allowed and there will be an error issued
-  // for trying pointer arithmetic on that.
+  // For Checked C, arithmetic on checked function pointers is never allowed.
+  // We don't have check for it here, though.  Only _Ptrs to function types are
+  // allowed and arithmetic on _Ptrs is disallowed by another diagnostic.
   assert(Pointer->getType()->isAnyPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
                 ? diag::err_typecheck_pointer_arith_function_type
@@ -9212,8 +9212,9 @@ static bool checkArithmeticBinOpPointerOperands(Sema &S, SourceLocation Loc,
                                                                 RHSExpr);
     else diagnoseArithmeticOnTwoFunctionPointers(S, Loc, LHSExpr, RHSExpr);
 
-    // We don't have to check if the function pointers are checked. Only _Ptr to
-    // function type is allowed and pointer arithmetic is not allowed on _Ptrs.
+    // We don't have to check if the function pointers are checked. Only _Ptrs to
+    // function types are allowd and arithmetic on _Ptrs is covered by another
+    // diagnostic.
     return !S.getLangOpts().CPlusPlus;
   }
 

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -9068,8 +9068,8 @@ static void diagnoseArithmeticOnNullPointer(Sema &S, SourceLocation Loc,
 static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
                                                     Expr *LHS, Expr *RHS) {
   // For Checked C, arithmetic on checked function pointers is never allowed.
-  // We don't have check for it here, though.  Only _Ptrs to function types are
-  // allowed and arithmetic on _Ptrs is disallowed by another diagnostic.
+  // We don't have to check for it here, though. Only _Ptrs to function types
+  // are allowed and arithmetic on _Ptrs is disallowed by another diagnostic.
   assert(LHS->getType()->isAnyPointerType());
   assert(RHS->getType()->isAnyPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
@@ -9087,8 +9087,8 @@ static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
 static void diagnoseArithmeticOnFunctionPointer(Sema &S, SourceLocation Loc,
                                                 Expr *Pointer) {
   // For Checked C, arithmetic on checked function pointers is never allowed.
-  // We don't have check for it here, though.  Only _Ptrs to function types are
-  // allowed and arithmetic on _Ptrs is disallowed by another diagnostic.
+  // We don't have to check for it here, though. Only _Ptrs to function types
+  // are allowed and arithmetic on _Ptrs is disallowed by another diagnostic.
   assert(Pointer->getType()->isAnyPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
                 ? diag::err_typecheck_pointer_arith_function_type

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -9067,11 +9067,11 @@ static void diagnoseArithmeticOnNullPointer(Sema &S, SourceLocation Loc,
 /// \brief Diagnose invalid arithmetic on two function pointers.
 static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
                                                     Expr *LHS, Expr *RHS) {
+  // For Checked C, we can ignore checked function pointers in this method. Only
+  // _Ptrs to function types are allowed and there will be an error issued
+  // for trying pointer arithmetic on that.
   assert(LHS->getType()->isAnyPointerType());
   assert(RHS->getType()->isAnyPointerType());
-  // We should never get here for checked pointers. Only _Ptr to function type
-  // is allowed in Checked C.  Arithmetic isn't allowed on _Ptrs.
-  assert(!(LHS->getType()->isCheckedPointerType() || RHS->getType()->isCheckedPointerType()));
   S.Diag(Loc, S.getLangOpts().CPlusPlus
                 ? diag::err_typecheck_pointer_arith_function_type
                 : diag::ext_gnu_ptr_func_arith)
@@ -9086,10 +9086,10 @@ static void diagnoseArithmeticOnTwoFunctionPointers(Sema &S, SourceLocation Loc,
 /// \brief Diagnose invalid arithmetic on a function pointer.
 static void diagnoseArithmeticOnFunctionPointer(Sema &S, SourceLocation Loc,
                                                 Expr *Pointer) {
+ // For Checked C, we can ignore checked function pointers in this method.  Only
+  // _Ptrs to function type are allowed and there will be an error issued
+  // for trying pointer arithmetic on that.
   assert(Pointer->getType()->isAnyPointerType());
-  // We should never get here for checked pointers. Only _Ptr to function type
-  // is allowed in Checked C.  Arithmetic isn't allowed on _Ptrs.
-  assert(!Pointer->getType()->isCheckedPointerType());
   S.Diag(Loc, S.getLangOpts().CPlusPlus
                 ? diag::err_typecheck_pointer_arith_function_type
                 : diag::ext_gnu_ptr_func_arith)

--- a/test/CheckedC/regression-cases/bug_543_void_ptr_dupl_error.c
+++ b/test/CheckedC/regression-cases/bug_543_void_ptr_dupl_error.c
@@ -3,12 +3,27 @@
 // https://github.com/Microsoft/checkedc-clang/issues/543
 //
 // This test checks that we do not get duplicate error message for uses
-// of arithmetic on void pointers in bounds expressions.
+// of arithmetic on checked void pointers and checked function
+// pointers in bounds expressions.
 
 // RUN: %clang -cc1 -verify -fcheckedc-extension %s
 
+// Test checked pointers to void.
 _Array_ptr<void> f1(void) : bounds(_Return_value, _Return_value + 5);  // expected-error {{arithmetic on a pointer to void}}
 
 void f2(_Array_ptr<void> p : bounds(p, p + 5)); // expected-error {{arithmetic on a pointer to void}}
 
-void f3(_Array_ptr<void> p, _Array_ptr<void> q, _Array_ptr<int> buf : count(p - q)); // expected-error {{arithmetic on a pointers to void}}
+void f3(_Array_ptr<void> p, _Array_ptr<void> q, _Array_ptr<int> buf : count(p - q)); // expected-error {{arithmetic on pointers to void}}
+
+// Test checked function pointers.  Other error messages should prevent
+// pointer arithmetic on them in bounds.
+
+// Test _Array_ptrs.  Declaring an _Array_ptr of function type is not allowed.
+void f4(_Array_ptr<int (int)> pf, _Array_ptr<void> code : bounds(pf, pf + 1));  // expected-error {{declared as _Array_ptr to function}}
+
+void f5(_Array_ptr<int (int)> pf, _Array_ptr<int (int)> pg, _Array_ptr<void> code : count(pf - pg));  // expected-error 2 {{declared as _Array_ptr to function}}
+
+// Test _Ptr.  Declaring a _Ptr to function types is not allowed.
+void f6(_Ptr<int (int)> pf, _Ptr<void> code : bounds(pf, pf + 1)); // expected-error {{arithmetic on _Ptr type}}
+
+void f7(_Ptr<int (int)> pf, _Ptr<int (int)> pg, _Array_ptr<void> code : bounds(pf, pf + (pg - pf))); // expected-error {{arithmetic on _Ptr type}}

--- a/test/CheckedC/regression-cases/bug_543_void_ptr_dupl_error.c
+++ b/test/CheckedC/regression-cases/bug_543_void_ptr_dupl_error.c
@@ -1,0 +1,14 @@
+//
+// These is a regression test case for 
+// https://github.com/Microsoft/checkedc-clang/issues/543
+//
+// This test checks that we do not get duplicate error message for uses
+// of arithmetic on void pointers in bounds expressions.
+
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+
+_Array_ptr<void> f1(void) : bounds(_Return_value, _Return_value + 5);  // expected-error {{arithmetic on a pointer to void}}
+
+void f2(_Array_ptr<void> p : bounds(p, p + 5)); // expected-error {{arithmetic on a pointer to void}}
+
+void f3(_Array_ptr<void> p, _Array_ptr<void> q, _Array_ptr<int> buf : count(p - q)); // expected-error {{arithmetic on a pointers to void}}


### PR DESCRIPTION
The compiler was emitting duplicate error messages for void pointer arithmetic using checked pointers in bounds expressions.  The problem was that the logic for marking the expression as invalid is separate from actually emitting the diagnostic.  The logic only looked for the language being C++.  The fix is to look for the conditions related to Checked C also.  This fixes issue #543.

This caused a duplicate error messages because the expression wasn't turned into an invalid expression.  When a subsequent TreeTransform pass for bounds declaration checking ran, it emitted the diagnostic a second time when it encountered the expression again.

I noticed that we had some logic for handling pointer arithmetic involving function pointers.  This is allowed by a GCC extension.  For checked pointers, we never allow _Array_ptrs to function pointers.  We only allow _Ptrs to function pointers.  Pointer arithmetic is never allowed for _Ptrs, so we never reach this logic.  I converted the logic to an assert and added some comments.

Testing:
- I added a new Checked C clang regression test for these cases that checks hat only   one error message is emitted.
- Passed automated testing.
