### PR TITLE
Improve IR and implementation of checked scopes.

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1898,7 +1898,7 @@ protected:
         IsExplicitlyDefaulted(false), HasImplicitReturnZero(false),
         IsLateTemplateParsed(false), IsConstexpr(isConstexprSpecified),
         IsGenericFunction(false), IsItypeGenericFunction(false),
-        CheckedSpecifier(CheckedFunctionSpecifiers::CFS_None),
+        CheckedSpecifier(CheckedScopeSpecifier::CSS_None),
         InstantiationIsPending(false),
         UsesSEHTry(false), HasSkippedBody(false), WillHaveBody(false),
         EndRangeLoc(NameInfo.getEndLoc()), TemplateOrSpecialization(),
@@ -1968,9 +1968,9 @@ public:
   void setItypeGenericFunctionFlag(bool f) { IsItypeGenericFunction = f; }
   bool isItypeGenericFunction() const { return IsItypeGenericFunction; }
 
-  void setCheckedSpecifier(CheckedFunctionSpecifiers CS) { CheckedSpecifier = CS; }
-  CheckedFunctionSpecifiers getCheckedSpecifier() {
-    return (CheckedFunctionSpecifiers) CheckedSpecifier;
+  void setCheckedSpecifier(CheckedScopeSpecifier CS) { CheckedSpecifier = CS; }
+  CheckedScopeSpecifier getCheckedSpecifier() {
+    return (CheckedScopeSpecifier) CheckedSpecifier;
   }
 
   /// \brief Returns true if the function has a body (definition). The

--- a/include/clang/AST/DeclBase.h
+++ b/include/clang/AST/DeclBase.h
@@ -1941,6 +1941,8 @@ struct cast_convert_decl_context<ToTy, true> {
     return static_cast<ToTy*>(Val);
   }
 };
+
+
 } // end clang.
 
 namespace llvm {

--- a/include/clang/AST/DeclBase.h
+++ b/include/clang/AST/DeclBase.h
@@ -1941,8 +1941,6 @@ struct cast_convert_decl_context<ToTy, true> {
     return static_cast<ToTy*>(Val);
   }
 };
-
-
 } // end clang.
 
 namespace llvm {

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -21,7 +21,6 @@
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
-#include "clang/AST/Type.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SyncScope.h"

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -21,6 +21,7 @@
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SyncScope.h"

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -16,11 +16,11 @@
 
 #include "clang/AST/DeclGroup.h"
 #include "clang/AST/StmtIterator.h"
-#include "clang/AST/Type.h"
 #include "clang/Basic/CapturedStmt.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/iterator.h"
@@ -659,7 +659,7 @@ public:
   // \brief Build an empty compound statement.
   explicit CompoundStmt(EmptyShell Empty)
     : Stmt(CompoundStmtClass, Empty), Body(nullptr),
-      CSS(CSS_None), CSSLoc(), CSM(CSM_None), CSMLoc(), 
+      CSS(CSS_None), CSSLoc(), CSM(CSM_None), CSMLoc(),
       CheckedScope(CheckedScopeKind::Unchecked) {
     CompoundStmtBits.NumStmts = 0;
   }

--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -629,11 +629,13 @@ class CompoundStmt : public Stmt {
   Stmt** Body;
   SourceLocation LBraceLoc, RBraceLoc;
   CheckedScopeSpecifier CSS;
+  SourceLocation CSSLoc;
+
   CheckedSpecifierModifier CSM;
+  SourceLocation CSMLoc;
+
   CheckedScopeKind CheckedScope;  // set by semantic analysis; takes into
                                   // account inherited checking.
-  SourceLocation CSSLoc;
-  SourceLocation CSMLoc;
 
   friend class ASTStmtReader;
 
@@ -657,7 +659,8 @@ public:
   // \brief Build an empty compound statement.
   explicit CompoundStmt(EmptyShell Empty)
     : Stmt(CompoundStmtClass, Empty), Body(nullptr),
-      CSS(CSS_None), CSM(CSM_None), CheckedScope(CheckedScopeKind::Unchecked) {
+      CSS(CSS_None), CSSLoc(), CSM(CSM_None), CSMLoc(), 
+      CheckedScope(CheckedScopeKind::Unchecked) {
     CompoundStmtBits.NumStmts = 0;
   }
 

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1185,9 +1185,6 @@ def err_expected_bounds_interop_type : Error<
 def err_expected_bounds_expr_or_interop_type : Error<
   "expected bounds expression or bounds-safe interface type">;
 
-def err_expected_compound_stmt_after_checked_scope : Error<
-  "expected compound statement after checked scope keyword">;
-
 def err_single_bounds_expr_allowed : Error<
   "only one bounds expression allowed">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9675,6 +9675,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_checked_scope_no_assume_bounds_casting : Error<
     "_Assume_bounds_cast not allowed in a checked scope or function">;
 
+  def err_checked_on_non_function : Error<
+  "%select{'_Checked'|'_Unchecked'}0 can only appear on functions">;
+
   def err_bounds_cast_expected_ptr_or_unchecked : Error<
     "expected _Ptr or * type">;
 

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -320,12 +320,19 @@ namespace clang {
 
   llvm::StringRef getParameterABISpelling(ParameterABI kind);
 
-  /// Checked C - checked function specifiers
-  enum CheckedFunctionSpecifiers {
-    CFS_None = 0,
-    CFS_Checked = 1,
-    CFS_Unchecked = 2
+  /// Checked C - checked specifiers.  Used for function, structs,
+  /// and  checked compound scopes.
+  enum CheckedScopeSpecifier {
+    CSS_None = 0,
+    CSS_Checked = 1,
+    CSS_Unchecked = 2
   };
+
+  enum CheckedSpecifierModifier {
+    CSM_None = 0,
+    CSM_BoundsOnly = 1
+  };
+
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_SPECIFIERS_H

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -321,7 +321,7 @@ namespace clang {
   llvm::StringRef getParameterABISpelling(ParameterABI kind);
 
   /// Checked C - checked specifiers.  Used for function, structs,
-  /// and  checked compound scopes.
+  /// and checked compound scopes.
   enum CheckedScopeSpecifier {
     CSS_None = 0,
     CSS_Checked = 1,

--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -656,6 +656,7 @@ KEYWORD(_For_any                   , KEYCHECKEDC)
 KEYWORD(_Itype_for_any             , KEYCHECKEDC)
 KEYWORD(_Current_expr_value        , KEYCHECKEDC)
 KEYWORD(_Return_value              , KEYCHECKEDC)
+KEYWORD(_Bounds_only               , KEYCHECKEDC)
 
 // Borland Extensions which should be disabled in strict conformance mode.
 ALIAS("_pascal"      , __pascal   , KEYBORLAND)

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -179,15 +179,6 @@ class Parser : public CodeCompletionHandler {
   /// \brief Identifier for "rel_align_value"
   IdentifierInfo *Ident_rel_align_value;
 
-  enum CheckedScopeKind {
-    /// '{'
-    CSK_None,
-    /// checked '{'
-    CSK_Checked,
-    /// unchecked '{'
-    CSK_Unchecked
-  };
-
   // C++ type trait keywords that can be reverted to identifiers and still be
   // used as type traits.
   llvm::SmallDenseMap<IdentifierInfo *, tok::TokenKind> RevertibleTypeTraits;
@@ -1849,13 +1840,15 @@ private:
   StmtResult ParseCaseStatement(bool MissingCase = false,
                                 ExprResult Expr = ExprResult());
   StmtResult ParseDefaultStatement();
-  StmtResult ParseCheckedScopeStatement();
   StmtResult ParseCompoundStatement(bool isStmtExpr = false);
-  StmtResult ParseCompoundStatement(bool isStmtExpr, unsigned ScopeFlags,
-                                    CheckedScopeKind Kind = CSK_None);
+  StmtResult ParseCompoundStatement(bool isStmtExpr, unsigned ScopeFlags);
   void ParseCompoundStatementLeadingPragmas();
   StmtResult ParseCompoundStatementBody(bool isStmtExpr = false,
-                                        CheckedScopeKind Kind = CSK_None);
+                                        CheckedScopeSpecifier Kind = CSS_None,
+                                        SourceLocation CSSLoc = SourceLocation(),
+                                        CheckedSpecifierModifier = CSM_None,
+                                        SourceLocation CSMLoc = SourceLocation());
+
   bool ParseParenExprOrCondition(StmtResult *InitStmt,
                                  Sema::ConditionResult &CondResult,
                                  SourceLocation Loc,
@@ -2033,7 +2026,7 @@ private:
       const ParsedTemplateInfo &TemplateInfo = ParsedTemplateInfo(),
       ForRangeInit *FRI = nullptr);
   Decl *ParseFunctionStatementBody(Decl *Decl, ParseScope &BodyScope,
-                                   CheckedScopeKind Kind=CSK_None);
+                                   CheckedScopeSpecifier Kind = CSS_None);
   Decl *ParseFunctionTryBlock(Decl *Decl, ParseScope &BodyScope);
 
   /// \brief When in code-completion, skip parsing of the function/method body
@@ -2067,7 +2060,7 @@ private:
                           AccessSpecifier AS, DeclSpecContext DSC);
   void ParseEnumBody(SourceLocation StartLoc, Decl *TagDecl);
   void ParseStructUnionBody(SourceLocation StartLoc, unsigned TagType,
-                            Decl *TagDecl, CheckedScopeKind CSK = CSK_None);
+                            Decl *TagDecl);
 
   void ParseStructDeclaration(
       ParsingDeclSpec &DS,

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -610,6 +610,9 @@ public:
 
   bool isCheckedSpecified() const { return FS_checked_specified == CSS_Checked; }
   bool isUncheckedSpecified() const { return FS_checked_specified == CSS_Unchecked; }
+  CheckedScopeSpecifier getCheckedScopeSpecifier() const {
+    return (CheckedScopeSpecifier) FS_checked_specified;
+  }
   SourceLocation getCheckedSpecLoc() const { return FS_checkedLoc; }
 
   bool isForanySpecified() const { return FS_forany_specified; }

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -331,10 +331,10 @@ public:
     PQ_FunctionSpecifier     = 8
   };
 
-  typedef CheckedFunctionSpecifiers CFS;
-  static const CFS CFS_None = clang::CFS_None;
-  static const CFS CFS_Checked = clang::CFS_Checked;
-  static const CFS CFS_Unchecked = clang::CFS_Unchecked;
+  typedef CheckedScopeSpecifier CSS;
+  static const CSS CSS_None = clang::CSS_None;
+  static const CSS CSS_Checked = clang::CSS_Checked;
+  static const CSS CSS_Unchecked = clang::CSS_Unchecked;
 
 private:
   // storage-class-specifier
@@ -462,7 +462,7 @@ public:
       FS_explicit_specified(false),
       FS_noreturn_specified(false),
       // Checked C - checked function
-      FS_checked_specified(CFS_None),
+      FS_checked_specified(CSS_None),
       FS_forany_specified(false),
       FS_itypeforany_specified(false),
       Friend_specified(false),
@@ -608,8 +608,8 @@ public:
   bool isNoreturnSpecified() const { return FS_noreturn_specified; }
   SourceLocation getNoreturnSpecLoc() const { return FS_noreturnLoc; }
 
-  bool isCheckedSpecified() const { return FS_checked_specified == CFS_Checked; }
-  bool isUncheckedSpecified() const { return FS_checked_specified == CFS_Unchecked; }
+  bool isCheckedSpecified() const { return FS_checked_specified == CSS_Checked; }
+  bool isUncheckedSpecified() const { return FS_checked_specified == CSS_Unchecked; }
   SourceLocation getCheckedSpecLoc() const { return FS_checkedLoc; }
 
   bool isForanySpecified() const { return FS_forany_specified; }
@@ -642,7 +642,7 @@ public:
     FS_explicitLoc = SourceLocation();
     FS_noreturn_specified = false;
     FS_noreturnLoc = SourceLocation();
-    FS_checked_specified = CFS_None;
+    FS_checked_specified = CSS_None;
     FS_checkedLoc = SourceLocation();
     FS_forany_specified = false;
     FS_foranyLoc = SourceLocation();

--- a/include/clang/Sema/Scope.h
+++ b/include/clang/Sema/Scope.h
@@ -131,18 +131,11 @@ public:
     /// We are between inheritance colon and the real class/struct definition scope.
     ClassInheritanceScope = 0x800000,
 
-    /// Checked C - This scope corresponds to checked scope for checkedc.
-    /// It is inherited from parent scope.
-    CheckedScope = 0x1000000,
-
-    /// Checked C - It clears checked property & prevents checked inheritance.
-    UncheckedScope = 0x2000000,
-
     /// Checked C - _For_any Polymorphic type scopes
-    ForanyScope = 0x4000000,
+    ForanyScope = 0x1000000,
 
     /// Checked C - _Itype_for_any Polymorphic bounds safe interface type scopes
-    ItypeforanyScope = 0x8000000
+    ItypeforanyScope = 0x2000000
 
   };
 private:
@@ -459,9 +452,6 @@ public:
   bool isCompoundStmtScope() const {
     return getFlags() & Scope::CompoundStmtScope;
   }
-
-  /// \brief Determine whether this scope is a checked scope 'checked'
-  bool isCheckedScope() const { return getFlags() & Scope::CheckedScope; }
 
   /// \brief Returns if rhs has a higher scope depth than this.
   ///

--- a/include/clang/Sema/ScopeInfo.h
+++ b/include/clang/Sema/ScopeInfo.h
@@ -55,21 +55,14 @@ namespace sema {
 class CompoundScopeInfo {
 public:
   CompoundScopeInfo()
-    : HasEmptyLoopBodies(false), IsCheckedScope(false) { }
+    : HasEmptyLoopBodies(false) { }
 
   /// \brief Whether this compound stamement contains `for' or `while' loops
   /// with empty bodies.
   bool HasEmptyLoopBodies;
 
-  /// \brief Checked C, Whether this compound statement is in checked scope or not
-  bool IsCheckedScope;
-
   void setHasEmptyLoopBodies() {
     HasEmptyLoopBodies = true;
-  }
-
-  void setCheckedScope() {
-    IsCheckedScope = true;
   }
 };
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -3707,7 +3707,6 @@ public:
                            bool HasLeadingEmptyMacro = false);
 
   void ActOnStartOfCompoundStmt();
-
   void ActOnFinishOfCompoundStmt();
   StmtResult ActOnCompoundStmt(SourceLocation L, SourceLocation R,
                                ArrayRef<Stmt *> Elts, bool isStmtExpr,
@@ -4647,8 +4646,6 @@ private:
   QualType ValidateBoundsExprArgument(Expr *Arg);
 
 public:
-
-
   ExprResult ActOnNullaryBoundsExpr(SourceLocation BoundKWLoc,
                                     BoundsExpr::Kind Kind,
                                     SourceLocation RParenLoc);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2042,12 +2042,20 @@ void ASTDumper::VisitAttributedStmt(const AttributedStmt *Node) {
 
 void ASTDumper::VisitCompoundStmt(const CompoundStmt *Node) {
   VisitStmt(Node);
-  // To avoid having to change existing tests, we don't print
-  // inherited-unchecked information.  We only print information
-  // related to checked blocks or explicit declarations.
-  if (Node->isCheckedPropertyDeclared() || Node->isChecked()) {
-    OS << (Node->isCheckedPropertyDeclared() ? " declared-" : " inherited-");
-    OS << (Node->isChecked() ? "checked" : "unchecked");
+  CheckedScopeSpecifier CSS = Node->getCheckedSpecifier();
+  // To avoid having to change existing tests, we only print
+  // checked specifier and the checked specifier modifier information
+  // when it is present.
+  if (CSS != CSS_None)
+    OS << (CSS == CSS_Checked ? "_Checked " : "_Unchecked ");
+  CheckedSpecifierModifier CSM = Node->getCheckedModifier();
+  if (CSM == CSM_BoundsOnly)
+    OS << " _Bounds_only ";
+  CheckedScopeKind CSK = Node->getInferredChecking();
+  if (CSK != CheckedScopeKind::Unchecked) {
+     OS << "checking-state ";
+     OS << (CSK == CheckedScopeKind::Bounds ? "bounds" :
+            "bounds-and-types");
   }
 }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2047,7 +2047,7 @@ void ASTDumper::VisitCompoundStmt(const CompoundStmt *Node) {
   // checked specifier and the checked specifier modifier information
   // when it is present.
   if (CSS != CSS_None)
-    OS << (CSS == CSS_Checked ? "_Checked " : "_Unchecked ");
+    OS << (CSS == CSS_Checked ? " _Checked " : "_Unchecked ");
   CheckedSpecifierModifier CSM = Node->getCheckedModifier();
   if (CSM == CSM_BoundsOnly)
     OS << " _Bounds_only ";

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3974,11 +3974,16 @@ Stmt *ASTNodeImporter::VisitCompoundStmt(CompoundStmt *S) {
 
   SourceLocation ToLBraceLoc = Importer.Import(S->getLBracLoc());
   SourceLocation ToRBraceLoc = Importer.Import(S->getRBracLoc());
+  SourceLocation ToCheckedSpecifierLoc = Importer.Import(S->getCheckedSpecifierLoc());
+  SourceLocation ToSpecifierModifierLoc = Importer.Import(S->getSpecifierModifierLoc());
   return new (Importer.getToContext()) CompoundStmt(Importer.getToContext(),
                                                     ToStmts,
                                                     ToLBraceLoc, ToRBraceLoc,
-                                                    S->isChecked(),
-                                                    S->isCheckedPropertyDeclared());
+                                                    S->getInferredChecking(),
+                                                    S->getCheckedSpecifier(),
+                                                    ToCheckedSpecifierLoc,
+                                                    S->getCheckedModifier(),
+                                                    ToSpecifierModifierLoc);
 }
 
 Stmt *ASTNodeImporter::VisitCaseStmt(CaseStmt *S) {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -281,13 +281,17 @@ SourceLocation Stmt::getLocEnd() const {
 
 CompoundStmt::CompoundStmt(const ASTContext &C, ArrayRef<Stmt*> Stmts,
                            SourceLocation LB, SourceLocation RB,
-                           bool IsCheckedScope, bool CheckedPropertyDeclared)
-  : Stmt(CompoundStmtClass), LBraceLoc(LB), RBraceLoc(RB) {
+                           CheckedScopeKind InferredChecking,
+                           CheckedScopeSpecifier CSS,
+                           SourceLocation CSSLoc,
+                           CheckedSpecifierModifier CSM,
+                           SourceLocation CSMLoc)
+  : Stmt(CompoundStmtClass), LBraceLoc(LB), RBraceLoc(RB),
+    CSS(CSS), CSSLoc(CSSLoc), CSM(CSM), CSMLoc(CSMLoc),
+    CheckedScope(InferredChecking) {
   CompoundStmtBits.NumStmts = Stmts.size();
   assert(CompoundStmtBits.NumStmts == Stmts.size() &&
          "NumStmts doesn't fit in bits of CompoundStmtBits.NumStmts!");
-  CompoundStmtBits.IsCheckedScope = IsCheckedScope;
-  CompoundStmtBits.CheckedPropertyDeclared = CheckedPropertyDeclared;
 
   if (Stmts.size() == 0) {
     Body = nullptr;

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -118,8 +118,14 @@ namespace  {
 /// PrintRawCompoundStmt - Print a compound stmt without indenting the {, and
 /// with no newline after the }.
 void StmtPrinter::PrintRawCompoundStmt(CompoundStmt *Node) {
-  if (Node->isCheckedPropertyDeclared())
-    OS << (Node->isChecked() ? "_Checked " : "_Unchecked ");
+  switch (Node->getCheckedSpecifier()) {
+      case CSS_None: break;
+      case CSS_Unchecked: OS << "_Unchecked "; break;
+      case CSS_Checked: OS << "_Checked "; break;
+  }
+  if (Node->getCheckedModifier() == CSM_BoundsOnly)
+    OS << " _Bounds_only ";
+
   OS << "{\n";
   for (auto *I : Node->body())
     PrintStmt(I);

--- a/lib/Analysis/BodyFarm.cpp
+++ b/lib/Analysis/BodyFarm.cpp
@@ -133,8 +133,7 @@ BinaryOperator *ASTMaker::makeComparison(const Expr *LHS, const Expr *RHS,
 }
 
 CompoundStmt *ASTMaker::makeCompound(ArrayRef<Stmt *> Stmts) {
-  return new (C) CompoundStmt(C, Stmts, SourceLocation(), SourceLocation(),
-                              false, false);
+  return new (C) CompoundStmt(C, Stmts, SourceLocation(), SourceLocation());
 }
 
 DeclRefExpr *ASTMaker::makeDeclRefExpr(

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1998,7 +1998,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
           DS.ClearStorageClassSpecs();
         }
 
-        // Checked C - mark the current scope as checked or unchecked if 
+        // Checked C - mark the current scope as checked or unchecked if
         // necessary.
         Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
@@ -2309,10 +2309,10 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
     Actions.ActOnBoundsDecl(ThisVarDecl, Annots);
 
     // Check type restrictions on variable declarators.  We need to do this
-    // after the variable declaration has been parsed because some 
+    // after the variable declaration has been parsed because some
     // types are allowed if a bounds declaration is present.
     if (!Actions.DiagnoseCheckedDecl(ThisVarDecl))
-      ThisVarDecl->setInvalidDecl(); 
+      ThisVarDecl->setInvalidDecl();
   }
 
   // Parse declarator '=' initializer.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -57,9 +57,8 @@ TypeResult Parser::ParseTypeName(SourceRange *Range,
     DS.addAttributes(Attrs->getList());
   ParseSpecifierQualifierList(DS, AS, DSC);
 
-  // Adjust checked scope properties if _Checked or _Unchecked was
-  // specified.
-  Sema::CheckedScopeRAII CheckedScope(Actions, DS);
+  // Mark the current scope as checked/unchecked if necessary.
+  Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   if (OwnedType)
     *OwnedType = DS.isTypeSpecOwned() ? DS.getRepAsDecl() : nullptr;
@@ -1724,7 +1723,7 @@ Parser::ParseSimpleDeclaration(unsigned Context,
   DeclSpecContext DSContext = getDeclSpecContextFromDeclaratorContext(Context);
   ParseDeclarationSpecifiers(DS, ParsedTemplateInfo(), AS_none, DSContext);
 
-  Sema::CheckedScopeRAII CheckedScope(Actions, DS);
+  Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   // If we had a free-standing type definition with a missing semicolon, we
   // may get this far before the problem becomes obvious.
@@ -1998,7 +1997,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
           DS.ClearStorageClassSpecs();
         }
 
-        Sema::CheckedScopeRAII CheckedScope(Actions, DS);
+        Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
         Decl *TheDecl =
           ParseFunctionDefinition(D, ParsedTemplateInfo(), &LateParsedAttrs);
@@ -3949,9 +3948,8 @@ void Parser::ParseStructDeclaration(
   // Parse the common specifier-qualifiers-list piece.
   ParseSpecifierQualifierList(DS);
 
-  // Adjust checked scope properties if _Checked or _Unchecked was
-  // specified.
-  Sema::CheckedScopeRAII CheckedScope(Actions, DS);
+  // Mark the current scope as checked or unchecked if necessary.
+  Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   // If there are no declarators, this is a free-standing declaration
   // specifier. Let the actions module cope with it.
@@ -6629,7 +6627,8 @@ void Parser::ParseParameterDeclarationClause(
 
     ParseDeclarationSpecifiers(DS);
 
-    Sema::CheckedScopeRAII CheckedScope(Actions, DS);
+    // Mark the current scope as checked if necessary.
+    Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
     // Parse the declarator.  This is "PrototypeContext" or 
     // "LambdaExprParameterContext", because we must accept either 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -57,7 +57,7 @@ TypeResult Parser::ParseTypeName(SourceRange *Range,
     DS.addAttributes(Attrs->getList());
   ParseSpecifierQualifierList(DS, AS, DSC);
 
-  // Mark the current scope as checked/unchecked if necessary.
+  // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   if (OwnedType)
@@ -1723,6 +1723,7 @@ Parser::ParseSimpleDeclaration(unsigned Context,
   DeclSpecContext DSContext = getDeclSpecContextFromDeclaratorContext(Context);
   ParseDeclarationSpecifiers(DS, ParsedTemplateInfo(), AS_none, DSContext);
 
+  // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   // If we had a free-standing type definition with a missing semicolon, we
@@ -1997,6 +1998,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
           DS.ClearStorageClassSpecs();
         }
 
+        // Checked C - mark the current scope as checked or unchecked if 
+        // necessary.
         Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
         Decl *TheDecl =
@@ -3948,7 +3951,7 @@ void Parser::ParseStructDeclaration(
   // Parse the common specifier-qualifiers-list piece.
   ParseSpecifierQualifierList(DS);
 
-  // Mark the current scope as checked or unchecked if necessary.
+  // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   // If there are no declarators, this is a free-standing declaration
@@ -4209,8 +4212,8 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc, unsigned TagType,
   // A member declaration in a checked scope cannot use unchecked types, unless
   // there is a bounds-safe interface,
 
-  // TODO: shouldn't this be invoked by semantic checking.
-
+  // TODO: this should be invoked as part of semantic checking of struct defnitions,
+  // not directly by the parser.
   if (getLangOpts().CheckedC) {
     for (ArrayRef<Decl *>::iterator i = FieldDecls.begin(),
                                   end = FieldDecls.end();
@@ -6627,7 +6630,7 @@ void Parser::ParseParameterDeclarationClause(
 
     ParseDeclarationSpecifiers(DS);
 
-    // Mark the current scope as checked if necessary.
+    // Checked C - mark the current scope as checked or unchecked if necessary.
     Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
     // Parse the declarator.  This is "PrototypeContext" or 

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1696,7 +1696,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 
   // Adjust checked scope properties if _Checked or _Unchecked was
   // specified.
-  Sema::CheckedScopeRAII CheckedScope(Actions, DS);
+  Sema::CheckedScopeRAII CheckedScope(Actions, PCS, CSM_None);
 
   // Forbid misplaced attributes. In cases of a reference, we pass attributes
   // to caller to handle.

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1694,8 +1694,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
   } else
     TUK = Sema::TUK_Reference;
 
-  // Adjust checked scope properties if _Checked or _Unchecked was
-  // specified.
+  // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScope(Actions, PCS, CSM_None);
 
   // Forbid misplaced attributes. In cases of a reference, we pass attributes

--- a/lib/Parse/ParsePragma.cpp
+++ b/lib/Parse/ParsePragma.cpp
@@ -1437,7 +1437,7 @@ void Parser::HandlePragmaCheckedScope() {
   tok::OnOffSwitch OOS =
     static_cast<tok::OnOffSwitch>(
     reinterpret_cast<uintptr_t>(Tok.getAnnotationValue()));
-  Actions.ActOnPragmaCheckedScope(Actions.getCurScope(), OOS);
+  Actions.ActOnPragmaCheckedScope(OOS);
   ConsumeAnnotationToken(); // The annotation token.
 }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -945,7 +945,7 @@ Parser::ParseDeclOrFunctionDefInternal(ParsedAttributesWithRange &attrs,
   // Parse the common declaration-specifiers piece.
   ParseDeclarationSpecifiers(DS, ParsedTemplateInfo(), AS, DSC_top_level);
 
-  // Mark the current scope as being checked if necessary.
+  // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
   // If we had a free-standing type definition with a missing semicolon, we
@@ -1306,7 +1306,7 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
     DeclSpec DS(AttrFactory);
     ParseDeclarationSpecifiers(DS);
 
-    // Mark the current scope as checked if necessary.
+    // Checked C - mark the current scope as checked or unchecked if necessary.
     Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
     // C99 6.9.1p6: 'each declaration in the declaration list shall have at

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -945,6 +945,9 @@ Parser::ParseDeclOrFunctionDefInternal(ParsedAttributesWithRange &attrs,
   // Parse the common declaration-specifiers piece.
   ParseDeclarationSpecifiers(DS, ParsedTemplateInfo(), AS, DSC_top_level);
 
+  // Mark the current scope as being checked if necessary.
+  Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
+
   // If we had a free-standing type definition with a missing semicolon, we
   // may get this far before the problem becomes obvious.
   if (DS.hasTagDefinition() &&
@@ -1302,6 +1305,9 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
     // Parse the common declaration-specifiers piece.
     DeclSpec DS(AttrFactory);
     ParseDeclarationSpecifiers(DS);
+
+    // Mark the current scope as checked if necessary.
+    Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
 
     // C99 6.9.1p6: 'each declaration in the declaration list shall have at
     // least one declarator'.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -356,12 +356,6 @@ bool Parser::SkipUntil(ArrayRef<tok::TokenKind> Toks, SkipUntilFlags Flags) {
 
 /// EnterScope - Start a new scope.
 void Parser::EnterScope(unsigned ScopeFlags) {
-  // Checked C - inherit checked scope property from parent scope.
-  if (getCurScope() && getCurScope()->isCheckedScope())
-    ScopeFlags |= Scope::CheckedScope;
-  // UncheckedScope ScopeFlag clears checked property.
-  if (ScopeFlags & Scope::UncheckedScope)
-    ScopeFlags &= ~Scope::CheckedScope;
   if (NumCachedScopes) {
     Scope *N = ScopeCache[--NumCachedScopes];
     N->Init(getCurScope(), ScopeFlags);
@@ -1077,17 +1071,15 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
 
   // We should have either an opening brace or, in a C++ constructor,
   // we may have a colon.
-  // it is related to check function definition(isStartOfFunctionDefinition)
-  // Checked C - checked scope keyword(checked/unchecked) set checked property.
-  // It is propagated through scope.
-  // For correct parsing, it SHOULD consume checked scope keyword 
-  CheckedScopeKind CSK = CSK_None;
-  if (Tok.is(tok::kw__Checked) && NextToken().is(tok::l_brace))
-    CSK = CSK_Checked;
-  else if (Tok.is(tok::kw__Unchecked) && NextToken().is(tok::l_brace))
-    CSK = CSK_Unchecked;
-  if (CSK == CSK_Checked || CSK == CSK_Unchecked)
+  //
+  // For Checked C, the brace may be preceded with a _Checked / _Unchecked keyword.
+
+  CheckedScopeSpecifier CCS = CSS_None;
+  if ((Tok.is(tok::kw__Checked) || Tok.is(tok::kw__Unchecked)) &&
+      NextToken().is(tok::l_brace)) {
+    CCS = Tok.is(tok::kw__Checked) ? CSS_Checked : CSS_Unchecked;
     ConsumeToken();
+  }
 
   if (Tok.isNot(tok::l_brace) && 
       (!getLangOpts().CPlusPlus ||
@@ -1120,21 +1112,6 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
     }
   }
 
-  // Define function body scope flag to consider checked property.
-  // Checked C - checked property nearest to '{' decides scope checked property.
-  // Checked scope keyword can override checked function specifier.
-  // Add CheckedScope flag into function body scope to propagate property.
-  unsigned FnBodyScopeFlag = Scope::FnScope | Scope::DeclScope |
-                               Scope::CompoundStmtScope;
-  if (CSK == CSK_Checked)
-    FnBodyScopeFlag |= Scope::CheckedScope;
-  else if (CSK == CSK_Unchecked)
-    FnBodyScopeFlag |= Scope::UncheckedScope;
-  else if (D.getDeclSpec().isCheckedSpecified())
-    FnBodyScopeFlag |= Scope::CheckedScope;
-  else if (D.getDeclSpec().isUncheckedSpecified())
-    FnBodyScopeFlag |= Scope::UncheckedScope;
-
   // In delayed template parsing mode, for function template we consume the
   // tokens and store them for late parsing at the end of the translation unit.
   if (getLangOpts().DelayedTemplateParsing && Tok.isNot(tok::equal) &&
@@ -1142,8 +1119,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
       Actions.canDelayFunctionBody(D)) {
     MultiTemplateParamsArg TemplateParameterLists(*TemplateInfo.TemplateParams);
 
-    // Checked C - consider checked function definition
-    ParseScope BodyScope(this, FnBodyScopeFlag);
+    ParseScope BodyScope(this, Scope::FnScope | Scope::DeclScope |
+                                   Scope::CompoundStmtScope);
     Scope *ParentScope = getCurScope()->getParent();
 
     D.setFunctionDefinitionKind(FDK_Definition);
@@ -1173,8 +1150,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
            (Tok.is(tok::l_brace) || Tok.is(tok::kw_try) ||
             Tok.is(tok::colon)) && 
       Actions.CurContext->isTranslationUnit()) {
-    // Checked C - consider checked function definition
-    ParseScope BodyScope(this, FnBodyScopeFlag);
+    ParseScope BodyScope(this, Scope::FnScope | Scope::DeclScope |
+                                   Scope::CompoundStmtScope);
     Scope *ParentScope = getCurScope()->getParent();
 
     D.setFunctionDefinitionKind(FDK_Definition);
@@ -1192,8 +1169,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
   }
 
   // Enter a scope for the function body.
-  // Checked C - consider checked function definition
-  ParseScope BodyScope(this, FnBodyScopeFlag);
+  ParseScope BodyScope(this, Scope::FnScope | Scope::DeclScope |
+                                 Scope::CompoundStmtScope);
 
   // Tell the actions module that we have entered a function definition with the
   // specified Declarator for the function.
@@ -1282,7 +1259,7 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
   if (LateParsedAttrs)
     ParseLexedAttributeList(*LateParsedAttrs, Res, false, true);
 
-  return ParseFunctionStatementBody(Res, BodyScope, CSK);
+  return ParseFunctionStatementBody(Res, BodyScope, CCS);
 }
 
 void Parser::SkipFunctionBody() {
@@ -1315,16 +1292,8 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
 
   // Enter function-declaration scope, limiting any declarators to the
   // function prototype scope, including parameter declarators.
-  unsigned PrototypeScopeFlag = Scope::FunctionPrototypeScope |
-                                Scope::FunctionDeclarationScope |
-                                Scope::DeclScope;
-  PrototypeScopeFlag |=
-      (D.getDeclSpec().isCheckedSpecified()
-           ? Scope::CheckedScope
-           : (D.getDeclSpec().isUncheckedSpecified() ? Scope::UncheckedScope
-                                                     : 0));
-
-  ParseScope PrototypeScope(this, PrototypeScopeFlag);
+  ParseScope PrototypeScope(this, Scope::FunctionPrototypeScope |
+                            Scope::FunctionDeclarationScope | Scope::DeclScope);
 
   // Read all the argument declarations.
   while (isDeclarationSpecifier()) {

--- a/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/lib/Sema/AnalysisBasedWarnings.cpp
@@ -601,7 +601,7 @@ struct CheckFallThroughDiagnostics {
       bool isCheckedReturn = FD->getReturnType()->isCheckedPointerType();
       bool hasReturnAnnots = FD->hasBoundsAnnotations();
       CompoundStmt *CS = dyn_cast_or_null<CompoundStmt>(FD->getBody());
-      bool isCheckedFunction = CS && CS->isChecked();
+      bool isCheckedFunction = CS && CS->isCheckedScope();
       if (isCheckedReturn) {
         D.diag_MaybeFallThrough_ReturnsNonVoid =
           diag::err_maybe_falloff_function_with_checked_return;

--- a/lib/Sema/CheckedCAlias.cpp
+++ b/lib/Sema/CheckedCAlias.cpp
@@ -502,7 +502,7 @@ namespace {
 
  // Statement to traverse.  This iterates recursively over a statement
  // and all of its children statements.
- void TraverseStmt(Stmt *S, bool InCheckedScope) {
+ void TraverseStmt(Stmt *S, bool Kind) {
    if (!S)
       return;
 
@@ -510,15 +510,15 @@ namespace {
 
    switch (S->getStmtClass()) {
      case Expr::UnaryOperatorClass:
-       VisitUnaryOperator(cast<UnaryOperator>(S), InCheckedScope);
+       VisitUnaryOperator(cast<UnaryOperator>(S), Kind);
        break;
      case Expr::BinaryOperatorClass:
      case Expr::CompoundAssignOperatorClass:
-       VisitBinaryOperator(cast<BinaryOperator>(S), InCheckedScope);
+       VisitBinaryOperator(cast<BinaryOperator>(S), Kind);
        break;
      case Stmt::CompoundStmtClass: {
        CompoundStmt *CS = cast<CompoundStmt>(S);
-       InCheckedScope = CS->isChecked();
+       Kind = CS->isCheckedScope();
        NewScope = true;
        break;
      }
@@ -530,7 +530,7 @@ namespace {
          // The initializer expression is visited during the loop
          // below iterating children.
          if (VarDecl *VD = dyn_cast<VarDecl>(D))
-           VisitVarDecl(VD, InCheckedScope);
+           VisitVarDecl(VD, Kind);
        }
        break;
      }
@@ -544,7 +544,7 @@ namespace {
 
     auto Begin = S->child_begin(), End = S->child_end();
     for (auto I = Begin; I != End; ++I) {
-      TraverseStmt(*I, InCheckedScope);
+      TraverseStmt(*I, Kind);
     }
 
     if (NewScope) {

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -950,12 +950,12 @@ bool DeclSpec::setFunctionSpecNoreturn(SourceLocation Loc,
 bool DeclSpec::setFunctionSpecChecked(SourceLocation Loc,
                                       const char *&PrevSpec,
                                       unsigned &DiagID) {
-  if (FS_checked_specified == CFS_Checked) {
+  if (FS_checked_specified == CSS_Checked) {
     DiagID = diag::warn_duplicate_declspec;
     PrevSpec = "checked";
     return true;
   }
-  FS_checked_specified = CFS_Checked;
+  FS_checked_specified = CSS_Checked;
   FS_checkedLoc = Loc;
   return false;
 }
@@ -963,12 +963,12 @@ bool DeclSpec::setFunctionSpecChecked(SourceLocation Loc,
 bool DeclSpec::setFunctionSpecUnchecked(SourceLocation Loc,
                                         const char *&PrevSpec,
                                         unsigned &DiagID) {
-  if (FS_checked_specified == CFS_Unchecked) {
+  if (FS_checked_specified == CSS_Unchecked) {
     DiagID = diag::warn_duplicate_declspec;
     PrevSpec = "unchecked";
     return true;
   }
-  FS_checked_specified = CFS_Unchecked;
+  FS_checked_specified = CSS_Unchecked;
   FS_checkedLoc = Loc;
   return false;
 }
@@ -983,7 +983,7 @@ bool DeclSpec::setFunctionSpecForany(SourceLocation Loc,
   }
   if (FS_forany_specified) {
     DiagID = diag::warn_duplicate_declspec;
-    PrevSpec = "unchecked";
+    PrevSpec = "_For_any";
     return true;
   }
   FS_forany_specified = true;

--- a/lib/Sema/Scope.cpp
+++ b/lib/Sema/Scope.cpp
@@ -204,16 +204,12 @@ void Scope::dumpImpl(raw_ostream &OS) const {
     } else if (Flags & OpenMPSimdDirectiveScope) {
       OS << "OpenMPSimdDirectiveScope";
       Flags &= ~OpenMPSimdDirectiveScope;
-    } else if (Flags & CheckedScope) {
-      OS << "CheckedScope";
-      Flags &= ~CheckedScope;
-    } else if (Flags & UncheckedScope) {
-      OS << "UncheckedScope";
-      Flags &= ~UncheckedScope;
-    }
-    else if (Flags & ForanyScope) {
+    } else if (Flags & ForanyScope) {
       OS << "ForanyScope";
       Flags &= ~ForanyScope;
+    } else if (Flags & ItypeforanyScope) {
+      OS << "ITypeForanyScope";
+      Flags &= ~ItypeforanyScope;
     }
 
     if (Flags)

--- a/lib/Sema/Sema.cpp
+++ b/lib/Sema/Sema.cpp
@@ -137,7 +137,8 @@ Sema::Sema(Preprocessor &pp, ASTContext &ctxt, ASTConsumer &consumer,
       ValueWithBytesObjCTypeMethod(nullptr), NSArrayDecl(nullptr),
       ArrayWithObjectsMethod(nullptr), NSDictionaryDecl(nullptr),
       DictionaryWithObjectsMethod(nullptr), GlobalNewDeleteDeclared(false),
-      TUKind(TUKind), NumSFINAEErrors(0), BoundsExprReturnValue(QualType()),
+      TUKind(TUKind), NumSFINAEErrors(0), CheckingKind(CheckedScopeKind::Unchecked),
+      BoundsExprReturnValue(QualType()),
       DeferredBoundsParser(nullptr), DeferredBoundsParserData(nullptr),
       DisableSubstitionDiagnostics(false), AccessCheckingSFINAE(false),
       InNonInstantiationSFINAEContext(false), NonInstantiationEntries(0),
@@ -1417,12 +1418,7 @@ void Sema::PopFunctionScopeInfo(const AnalysisBasedWarnings::Policy *WP,
 }
 
 void Sema::PushCompoundScope() {
-  // Checked C - by default, it inherits the checking property of its parent
-  CompoundScopeInfo CSI;
-  if (!getCurFunction()->CompoundScopes.empty() &&
-      getCurCompoundScope().IsCheckedScope)
-    CSI.setCheckedScope();
-  getCurFunction()->CompoundScopes.push_back(CSI);
+  getCurFunction()->CompoundScopes.push_back(CompoundScopeInfo());
 }
 
 void Sema::PopCompoundScope() {

--- a/lib/Sema/SemaAttr.cpp
+++ b/lib/Sema/SemaAttr.cpp
@@ -685,21 +685,17 @@ void Sema::ActOnPragmaOptimize(bool On, SourceLocation PragmaLoc) {
     OptimizeOffPragmaLocation = PragmaLoc;
 }
 
-// Checked C - #pragma CHECKED_SCOPE action, adjust top level scope flags.
-// Adjust checked property of scope where '#pragma CHECKED_SCOPE' is set.
-void Sema::ActOnPragmaCheckedScope(Scope *S, tok::OnOffSwitch OOS) {
-  unsigned ScopeFlags = S->getFlags();
+// Checked C - #pragma CHECKED_SCOPE action, adjust the current checked
+// scope.
+void Sema::ActOnPragmaCheckedScope(tok::OnOffSwitch OOS) {
   switch (OOS) {
-  case tok::OOS_ON:
-    ScopeFlags |= Scope::CheckedScope;
-    S->setFlags(ScopeFlags);
-    break;
-  case tok::OOS_OFF:
-  case tok::OOS_DEFAULT:
-    ScopeFlags &= ~Scope::CheckedScope;
-    ScopeFlags |= Scope::UncheckedScope;
-    S->setFlags(ScopeFlags);
-    break;
+    case tok::OOS_ON:
+    case tok::OOS_DEFAULT:
+      SetCheckedScopeInfo(CheckedScopeKind::BoundsAndTypes);
+      break;
+    case tok::OOS_OFF:
+      SetCheckedScopeInfo(CheckedScopeKind::Unchecked);
+      break;
   }
 }
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2263,7 +2263,7 @@ namespace {
           CheckedStmts.insert(S);
 
       if (const CompoundStmt *CS = dyn_cast<CompoundStmt>(S))
-        InCheckedScope = CS->isChecked();
+        InCheckedScope = CS->isCheckedScope();
 
       auto Begin = S->child_begin(), End = S->child_end();
       for (auto I = Begin; I != End; ++I)
@@ -2416,7 +2416,7 @@ namespace {
           break;
         case Stmt::CompoundStmtClass: {
           CompoundStmt *CS = cast<CompoundStmt>(S);
-          InCheckedScope = CS->isChecked();
+          InCheckedScope = CS->isCheckedScope();
           break;
         }
         case Stmt::DeclStmtClass: {
@@ -3034,7 +3034,7 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
 void Sema::CheckTopLevelBoundsDecls(VarDecl *D) {
   if (!D->isLocalVarDeclOrParm()) {
     CheckBoundsDeclarations Checker(*this, nullptr, nullptr, nullptr);
-    Checker.TraverseTopLevelVarDecl(D, getCurScope()->isCheckedScope());
+    Checker.TraverseTopLevelVarDecl(D, IsCheckedScope());
   }
 }
 

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2678,7 +2678,7 @@ void CastOperation::CheckBoundsCast(tok::TokenKind kind) {
 
   // Checked C - No C-style casts to unchecked pointer/array type or variadic
   // type in a checked block.
-  if (Self.getCurScope()->isCheckedScope()) {
+  if (Self.IsCheckedScope()) {
     if (Kind == CK_AssumePtrBounds) {
       Self.Diag(OpRange.getBegin(),
                 diag::err_checked_scope_no_assume_bounds_casting);

--- a/lib/Sema/SemaChecking.cpp
+++ b/lib/Sema/SemaChecking.cpp
@@ -11974,8 +11974,13 @@ static bool DisplaysAsArrayOrPointer(QualType QT) {
 }
 
 //===--- CHECK: Checked scope -------------------------===//
-// Checked C - type restrictions on declarations in checked blocks.
+// Checked C - type restrictions on declarations in checked scope.
 bool Sema::DiagnoseCheckedDecl(const ValueDecl *Decl, SourceLocation UseLoc) {
+
+  // We're not a checked scope.
+  if (!IsCheckedScope())
+    return true;
+
   if (Decl->isInvalidDecl())
     return true;
 

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -6100,6 +6100,11 @@ void Sema::DiagnoseFunctionSpecifiers(const DeclSpec &DS) {
   if (DS.isNoreturnSpecified())
     Diag(DS.getNoreturnSpecLoc(),
          diag::err_noreturn_non_function);
+
+  if (DS.getCheckedScopeSpecifier() != CheckedScopeSpecifier::CSS_None)
+    Diag(DS.getCheckedSpecLoc(), 
+         diag::err_checked_on_non_function)
+      << ((unsigned) DS.getCheckedScopeSpecifier() - 1);
 }
 
 NamedDecl*

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -9394,8 +9394,7 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
     // Diagnose no-prototype or variadic functions declared in checked scopes or
     // with a _Checked specifier.  Do this after merging possibly prototyped
     // prior declarations to form a composite type.
-    CheckedScopeSpecifier CSS = NewFD->getCheckedSpecifier();
-    if (CSS == CheckedScopeSpecifier::CSS_Checked || (IsCheckedScope() && CSS != CheckedScopeSpecifier::CSS_Unchecked)) {
+    if (IsCheckedScope()) {
       // Disallow no prototype function declarators within a checked scope.
       //
       // This includes K&R style definitions of functions in checked scopes

--- a/lib/Sema/SemaDeclCXX.cpp
+++ b/lib/Sema/SemaDeclCXX.cpp
@@ -12272,8 +12272,7 @@ void Sema::DefineImplicitLambdaToFunctionPointerConversion(
    Stmt *Return = BuildReturnStmt(Conv->getLocation(), FunctionRef).get();
    Conv->setBody(new (Context) CompoundStmt(Context, Return,
                                             Conv->getLocation(),
-                                            Conv->getLocation(),
-                                            false, false));
+                                            Conv->getLocation()));
 
   Conv->markUsed(Context);
   Conv->setReferenced();
@@ -12336,8 +12335,7 @@ void Sema::DefineImplicitLambdaToBlockPointerConversion(
   Stmt *ReturnS = Return.get();
   Conv->setBody(new (Context) CompoundStmt(Context, ReturnS,
                                            Conv->getLocation(),
-                                           Conv->getLocation(),
-                                           false, false));
+                                           Conv->getLocation()));
   Conv->markUsed(Context);
 
   // We're done; notify the mutation listener, if any.

--- a/lib/Sema/SemaExprCXX.cpp
+++ b/lib/Sema/SemaExprCXX.cpp
@@ -6252,8 +6252,7 @@ Stmt *Sema::MaybeCreateStmtWithCleanups(Stmt *SubStmt) {
   // a new AsmStmtWithTemporaries.
   CompoundStmt *CompStmt = new (Context) CompoundStmt(Context, SubStmt,
                                                       SourceLocation(),
-                                                      SourceLocation(),
-                                                      false, false);
+                                                      SourceLocation());
   Expr *E = new (Context) StmtExpr(CompStmt, Context.VoidTy, SourceLocation(),
                                    SourceLocation());
   return MaybeCreateExprWithCleanups(E);

--- a/lib/Sema/SemaExprMember.cpp
+++ b/lib/Sema/SemaExprMember.cpp
@@ -1822,7 +1822,7 @@ Sema::BuildFieldReferenceExpr(Expr *BaseExpr, bool IsArrow,
   //
   // We skip uses of array types here.  They are handled later as part of
   // array-to-pointer decay.
-  if (getCurScope()->isCheckedScope() && !MemberType->isArrayType() && 
+  if (IsCheckedScope() && !MemberType->isArrayType() && 
       MemberType->isOrContainsUncheckedType()) {
     assert(!MemberType->isFunctionType());
     return ConvertToFullyCheckedType(ME, Field->getInteropTypeExpr(), false, VK);

--- a/lib/Sema/SemaExprMember.cpp
+++ b/lib/Sema/SemaExprMember.cpp
@@ -1822,7 +1822,7 @@ Sema::BuildFieldReferenceExpr(Expr *BaseExpr, bool IsArrow,
   //
   // We skip uses of array types here.  They are handled later as part of
   // array-to-pointer decay.
-  if (IsCheckedScope() && !MemberType->isArrayType() && 
+  if (IsCheckedScope() && !MemberType->isArrayType() &&
       MemberType->isOrContainsUncheckedType()) {
     assert(!MemberType->isFunctionType());
     return ConvertToFullyCheckedType(ME, Field->getInteropTypeExpr(), false, VK);

--- a/lib/Sema/SemaStmt.cpp
+++ b/lib/Sema/SemaStmt.cpp
@@ -379,7 +379,7 @@ StmtResult Sema::ActOnCompoundStmt(SourceLocation L, SourceLocation R,
       DiagnoseEmptyLoopBody(Elts[i], Elts[i + 1]);
   }
 
-  return new (Context) CompoundStmt(Context, Elts, L, R, GetCheckedScopeInfo(), 
+  return new (Context) CompoundStmt(Context, Elts, L, R, GetCheckedScopeInfo(),
                                     CSS, CSSLoc, CSM, CSMLoc);
 
 }

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -1247,11 +1247,12 @@ public:
                                        MultiStmtArg Statements,
                                        SourceLocation RBraceLoc,
                                        bool IsStmtExpr,
-                                       bool IsChecked,
-                                       bool CheckedPropertyDeclared) {
+                                       CheckedScopeSpecifier CSS,
+                                       SourceLocation CSSLoc,
+                                       CheckedSpecifierModifier CSM,
+                                       SourceLocation CSMLoc) {
     return getSema().ActOnCompoundStmt(LBraceLoc, RBraceLoc, Statements,
-                                       IsStmtExpr, IsChecked,
-                                       CheckedPropertyDeclared);
+                                       IsStmtExpr, CSS, CSSLoc, CSM, CSMLoc);
   }
 
   /// \brief Build a new case statement.
@@ -6663,8 +6664,8 @@ template<typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCompoundStmt(CompoundStmt *S,
                                               bool IsStmtExpr) {
-  Sema::CompoundScopeRAII CompoundScope(getSema());
-
+  Sema::CompoundScopeRAII CompoundScope(getSema(), S->getCheckedSpecifier(),
+                                        S->getCheckedModifier());
   bool SubStmtInvalid = false;
   bool SubStmtChanged = false;
   SmallVector<Stmt*, 8> Statements;
@@ -6696,8 +6697,10 @@ TreeTransform<Derived>::TransformCompoundStmt(CompoundStmt *S,
                                           Statements,
                                           S->getRBracLoc(),
                                           IsStmtExpr,
-                                          S->isChecked(),
-                                          S->isCheckedPropertyDeclared());
+                                          S->getCheckedSpecifier(),
+                                          S->getCheckedSpecifierLoc(),
+                                          S->getCheckedModifier(),
+                                          S->getCheckedSpecifierLoc());
 }
 
 template<typename Derived>

--- a/test/CheckedC/ast-dump-checked-scopes.c
+++ b/test/CheckedC/ast-dump-checked-scopes.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
 
 void f1(void) {
-  _Checked { int a = 0;  }
+  _Checked { int a = 0;  } 
   _Unchecked {}
   {}
 }
@@ -13,44 +13,41 @@ void f1(void) {
 // CHECK: FunctionDecl
 // CHECK: f1
 // CHECK-NEXT: CompoundStmt
-// For inherited-unchecked, we don't print anything to avoid breaking
-// existing tests.
-// CHECK-NOT: {{.*-checked}}
+// We don't print anyting unless the inferred checking
+// state is not _Unchecked.
+// CHECK-NOT: {{_Checked|_Unchecked|checking-state}}
 // CHECK-NEXT: CompoundStmt
-// CHECK: declared-checked
+// CHECK: _Checked checking-state bounds-and-types
 // CHECK: CompoundStmt
-// CHECK: declared-unchecked
+// CHECK: _Unchecked
 // CHECK: CompoundStmt
-// For inherited-unchecked, we don't print anything to avoid breaking
-// existing tests.
-// CHECK-NOT: {{.*-checked}}
+// CHECK-NOT: {{_Checked|_Unchecked|checking-state}}
 
 void f2(void) _Checked {}
 
 // CHECK-NEXT: FunctionDecl
 // CHECK: f2
 // CHECK-NEXT: CompoundStmt
-// CHECK: declared-checked
+// CHECK: _Checked checking-state bounds-and-types
 
 void f3(void) _Unchecked {}
 
 // CHECK-NEXT: FunctionDecl
 // CHECK: f3
 // CHECK-NEXT: CompoundStmt
-// CHECK: declared-unchecked
+// CHECK: _Unchecked
+// CHECK-NOT {{checking-state}}
 
 _Checked void f4(void) {}
 
 // CHECK-NEXT: FunctionDecl
 // CHECK: f4
 // CHECK-NEXT: CompoundStmt
-// CHECK: inherited-checked
+// CHECK: checking-state bounds-and-types
 
 _Unchecked void f5(void) {}
 
 // CHECK-NEXT: FunctionDecl
 // CHECK: f5
 // CHECK-NEXT: CompoundStmt
-// For inherited-unchecked, we don't print anything to avoid breaking
-// existing tests.
-// CHECK-NOT: {{.*-checked}}
+// CHECK-NOT: {{_Checked|_Unchecked|checking-state}}

--- a/test/CheckedC/ast-dump-checked-scopes.c
+++ b/test/CheckedC/ast-dump-checked-scopes.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
 
 void f1(void) {
-  _Checked { int a = 0;  } 
+  _Checked { int a = 0;  }
   _Unchecked {}
   {}
 }


### PR DESCRIPTION
This change updates the IR and semantic checking for  checked scopes, 
in preparation for allowing multiple kinds of checked scopes.     We
were using the clang "scope" class.  The scope class is meant to be used for
identifier lookup during parsing, not to represent properties of  a scope
during semantic checking.

In the IR, we introduce an enum for checked specifier information and
another enum for a  checked scope modifier.  We record the checked specifier
information in the source in the AST for compound statements.  We also
record the checked scope state, which combines inherited information with
any checked scope specifier on the compound statement.

The clang "scope" class wasn't the right place to store the information.   We
ended up using getCurScope(), which is only valid during parsing.  The code
specifically warns against using it during semantic checking.  Use of it
could lead to problems when re-running semantic checking.   The implementation
also had some layering violations, where parsing is doing things that are
semantic checking (and inferring whether a scope is checked or not).

During semantic checking, we now tracked the checked scope state, updating
it based on information in the AST.

Testing:
- Passed automating testing on Linux for x64 debug and release.
- Passed local testing on Windows.
