### PR TITLE
Fix wrong use of assert

### DIFF
--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -227,7 +227,7 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) const
     return Result::Equal;
 
   if (!D1 || !D2) {
-    assert("unexpected cast failure");
+    assert(false && "unexpected cast failure");
     return Result::LessThan;
   }
 

--- a/lib/Sema/CheckedCInterop.cpp
+++ b/lib/Sema/CheckedCInterop.cpp
@@ -105,7 +105,7 @@ public:
   // Assert on trailing returning type for now, instead of handling them.
   // That's a C++ feature that we cannot test right now.
     if (T->hasTrailingReturn()) {
-      assert("Unexpected trailing return type for Checked C");
+      assert(false && "Unexpected trailing return type for Checked C");
       return QualType();
     }
 


### PR DESCRIPTION
When converting a string literal to a boolean value, it will be `true`.
This makes `assert("Foo Bar Baz")` pointless (never fails).