### PR TITLE
Add #pragma CHECKED_SCOPE functionality.

### DIFF
--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1216,4 +1216,9 @@ def err_type_list_and_type_variable_num_mismatch : Error<
 def note_type_variables_declared_at : Note<
   "type variable(s) declared here">;
 
+ // Checked C pragmas
+def err_pragma_checked_scope_invalid_argument : Error<
+  "unexpected argument '%0' to '#pragma CHECKED_SCOPE'; "
+  "expected 'on','off', '_Bounds_only', 'push', or 'pop'">;
+
 } // end of Parser diagnostics

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9678,6 +9678,12 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_checked_on_non_function : Error<
   "%select{'_Unchecked'|'_Checked _Bounds_only|'_Checked'}0 can only appear on functions">;
 
+  def err_pragma_pop_checked_scope_mismatch : Error<
+  "#pragma CHECKED_SCOPE pop with no matching #pragma CHECKED_SCOPE push">;
+
+  def err_pragma_checked_scope_no_pop_eof : Error<"unterminated "
+    "'#pragma CHECKED_SCOPE push' at end of file">;
+
   def err_bounds_cast_expected_ptr_or_unchecked : Error<
     "expected _Ptr or * type">;
 

--- a/lib/Sema/Sema.cpp
+++ b/lib/Sema/Sema.cpp
@@ -905,6 +905,7 @@ void Sema::ActOnEndOfTranslationUnit() {
 
   DiagnoseUnterminatedPragmaPack();
   DiagnoseUnterminatedPragmaAttribute();
+  DiagnoseUnterminatedCheckedScope();
 
   // All delayed member exception specs should be checked or we end up accepting
   // incompatible declarations.

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -11542,21 +11542,28 @@ void Sema::ActOnUninitializedDecl(Decl *RealDecl) {
         Diag(Var->getLocation(), diag::err_initializer_expected_with_bounds)
           << Var;
 
-      // An unchecked pointer in a checked scope with a bounds expression must be initialized
-      if (Ty->isUncheckedPointerType() && InCheckedScope && Var->hasBoundsExpr())
-        Diag(Var->getLocation(), diag::err_initializer_expected_for_unchecked_pointer_in_checked_scope_with_bounds_expr)
+      // An unchecked pointer in a checked scope with a bounds expression must
+      // be initialized
+      if (Ty->isUncheckedPointerType() && InCheckedScope &&
+          Var->hasBoundsExpr())
+        Diag(Var->getLocation(),
+             diag::err_initializer_expected_for_unchecked_pointer_in_checked_scope_with_bounds_expr)
           << Var;
 
       // An integer with a bounds expression must be initialized
       if (Ty->isIntegerType() && Var->hasBoundsExpr())
-        Diag(Var->getLocation(), diag::err_initializer_expected_for_integer_with_bounds_expr)
+        Diag(Var->getLocation(),
+              diag::err_initializer_expected_for_integer_with_bounds_expr)
           << Var;
 
-      // struct/union and array with checked pointer members must have initializers 
+      // struct/union and array with checked pointer members must have
+      // initializers.
       // array with checked ptr element
       if (Ty->isArrayType()) {
-        // if this is an array type, check the element type of the array, potentially with type qualifiers missing
-        if (Type::HasCheckedValue == Ty->getPointeeOrArrayElementType()->containsCheckedValue(InCheckedScope))
+        // if this is an array type, check the element type of the array,
+        // potentially with type qualifiers missing
+        if (Type::HasCheckedValue == Ty->getPointeeOrArrayElementType()->
+                                      containsCheckedValue(InCheckedScope))
           Diag(Var->getLocation(), diag::err_initializer_expected_for_array)
           << Var;
       }
@@ -11564,23 +11571,26 @@ void Sema::ActOnUninitializedDecl(Decl *RealDecl) {
       if (Ty->isRecordType()) {
         const RecordType *RT = Ty->getAs<RecordType>();
         switch (RT->containsCheckedValue(InCheckedScope)) {
-        default: 
-          break;  
-        case Type::HasCheckedValue: {
-          Diag(Var->getLocation(), diag::err_initializer_expected_for_record_with_checked_value)
-          << RT->getDecl()->getTagKind() << Var;
-          break;
-        }
-        case Type::HasIntWithBounds: {
-          Diag(Var->getLocation(), diag::err_initializer_expected_for_record_with_integer_member_with_bounds_expr)
-          << RT->getDecl()->getTagKind() << Var;
-          break;
-        }
-        case Type::HasUncheckedPointer: {
-          Diag(Var->getLocation(), diag::err_initializer_expected_for_record_with_unchecked_pointer_in_checked_scope)
-          << RT->getDecl()->getTagKind() << Var;       
-          break;
-        }       
+          default:
+            break;
+          case Type::HasCheckedValue: {
+            Diag(Var->getLocation(),
+                  diag::err_initializer_expected_for_record_with_checked_value)
+            << RT->getDecl()->getTagKind() << Var;
+            break;
+          }
+          case Type::HasIntWithBounds: {
+            Diag(Var->getLocation(),
+                  diag::err_initializer_expected_for_record_with_integer_member_with_bounds_expr)
+            << RT->getDecl()->getTagKind() << Var;
+            break;
+          }
+          case Type::HasUncheckedPointer: {
+            Diag(Var->getLocation(),
+                 diag::err_initializer_expected_for_record_with_unchecked_pointer_in_checked_scope)
+            << RT->getDecl()->getTagKind() << Var;
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
Add new functionality to #pragma CHECKED_SCOPE:
- Creation of _Bounds_only checked scopes.  The syntax is
  #pragma CHECKED_SCOPE _Bounds_only.
- Saving/restoring the checked scope state. The syntax is
  #pragma CHECKED_SCOPE push and #pragma CHECKED_SCOPE pop.
- Allow lower-case on/off directives for CHECKED_SCOPE.

Also includes an unrelated fix for formatting issues in SemaDecl.cpp.

Testing:
- Add tests of the new functionality to the checkedc repo.
- Passes new tests and automated testing.
