### PR TITLE
Improve TreeTransform for positional parameter expressions.

### DIFF
--- a/lib/Sema/CheckedCInterop.cpp
+++ b/lib/Sema/CheckedCInterop.cpp
@@ -213,10 +213,9 @@ public:
     SmallVector<QualType, 4> ParamTypes;
     SmallVector<ParmVarDecl*, 4> ParamDecls;
     Sema::ExtParameterInfoBuilder ExtParamInfos;
-
     // ParamAnnotsStorage is pre-allocated storage that is used when updating EPI
     // in TransformExtendedParameterInfo.  Its lifetime must last until the end of
-    // the lifetimie of EPI.
+    // the lifetime of EPI.
     SmallVector<BoundsAnnotations, 4> ParamAnnotsStorage;
 
     QualType ResultType = getDerived().TransformType(TLB, ResultLoc);

--- a/lib/Sema/CheckedCInterop.cpp
+++ b/lib/Sema/CheckedCInterop.cpp
@@ -82,6 +82,7 @@ class TransformFunctionTypeToChecked :
 public:
   TransformFunctionTypeToChecked(Sema &SemaRef) : BaseTransform(SemaRef) {}
 
+  bool IsInstantiation() { return false; }
 
   QualType TransformFunctionProtoType(TypeLocBuilder &TLB,
                                       FunctionProtoTypeLoc TL) {
@@ -212,6 +213,7 @@ public:
     SmallVector<QualType, 4> ParamTypes;
     SmallVector<ParmVarDecl*, 4> ParamDecls;
     Sema::ExtParameterInfoBuilder ExtParamInfos;
+
     // ParamAnnotsStorage is pre-allocated storage that is used when updating EPI
     // in TransformExtendedParameterInfo.  Its lifetime must last until the end of
     // the lifetimie of EPI.
@@ -221,7 +223,7 @@ public:
     if (ResultType.isNull())
       return QualType();
 
-    // Places transformed data ParamTypes, ParamDecls, and ExtParamInfos.
+    // Places transformed data in ParamTypes, ParamDecls, and ExtParamInfos.
     if (getDerived().TransformFunctionTypeParams(
       TL.getBeginLoc(), TL.getParams(),
       CurrentParamTypes.begin(),
@@ -229,10 +231,10 @@ public:
       ParamTypes, &ParamDecls, ExtParamInfos))
       return QualType();
 
-    if (getDerived().TransformExtendedParameterInfo(EPI, ParamTypes, ParamAnnotsStorage,
+    if (getDerived().TransformExtendedParameterInfo(EPI, EPIChanged, ParamTypes,
+                                                    ParamAnnotsStorage,
                                                     ExtParamInfos, TL,
-                                                    TransformExceptionSpec,
-                                                    EPIChanged))
+                                                    TransformExceptionSpec))
       return QualType();
 
     // Rebuild the type if something changed.

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -1715,7 +1715,7 @@ Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
   return BuildDeclRefExpr(D, Ty, VK, NameInfo, SS);
 }
 
-/// BuildDeclRefExpr - Build an expression that references aB
+/// BuildDeclRefExpr - Build an expression that references a
 /// declaration that does not require a closure capture.
 ExprResult
 Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,

--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -119,13 +119,13 @@ protected:
   /// rather than in the subclass (e.g., lambda closure types).
   llvm::DenseMap<Decl *, Decl *> TransformedLocalDecls;
 
-
   /// \brief The set of bound temporaries that have been transformed.  This
   /// is needed so that we can keep uses in sync.
   llvm::DenseMap<CHKCBindTemporaryExpr *, CHKCBindTemporaryExpr *>
     TransformedTemporaries;
 
-  /// \brief The set of positional parameters that have been transformed.
+  /// \brief The set of parameters that have been transformed.  Used
+  /// to update positional parameter expression type information.
   llvm::SmallVector<QualType, 16> TransformedPositionalParameters;
 
 public:
@@ -664,11 +664,9 @@ public:
   /// The result vectors should be kept in sync; null entries in the
   /// variables vector are acceptable.
   ///
-  /// Inputs: Params, ParamTypes, and ParamInfos are the inputs to the
-  /// method.
+  /// Inputs: Params, ParamTypes, and ParamInfos.
   ///
-  /// Output: PTypes, PVars, and PInfos are the outputs
-  /// of the method.
+  /// Outputs: PTypes, PVars, and PInfos:
   /// - The updated parameter types are stored in PTypes.
   /// - The updated parameter variable declarations are stored in PVars.
   /// - The updated extend parameter info is stored in PInfos.
@@ -684,10 +682,8 @@ public:
       SmallVectorImpl<QualType> &PTypes, SmallVectorImpl<ParmVarDecl *> *PVars,
       Sema::ExtParameterInfoBuilder &PInfos);
 
-  /// Transform the bounds annotation Annot, updating Annot.  Set changed
-  /// to true or false depending on whether Annot changed.
-  ///
-  /// Sets Changed to true if Annot changed.
+  /// Transform the bounds annotation Annot, updating Annot. Set Changed to
+  /// true if Annot changed.
   bool TransformBoundsAnnotations(BoundsAnnotations &Annot, bool &Changed);
 
   /// \brief Transform return bounds annotations.  We provide a separate method for
@@ -5148,7 +5144,6 @@ bool TreeTransform<Derived>::TransformFunctionTypeParams(
           // Expand the function parameter pack into multiple, separate
           // parameters.
           getDerived().ExpandingFunctionParameterPack(OldParm);
-
           for (unsigned I = 0; I != *NumExpansions; ++I) {
             Sema::ArgumentPackSubstitutionIndexRAII SubstIndex(getSema(), I);
             ParmVarDecl *NewParm
@@ -12444,7 +12439,6 @@ TreeTransform<Derived>::TransformBlockExpr(BlockExpr *E) {
 
   QualType exprResultType =
       getDerived().TransformType(exprFunctionType->getReturnType());
-
 
   auto epi = exprFunctionType->getExtProtoInfo();
   epi.ExtParameterInfos = extParamInfos.getPointerOrNull(paramTypes.size());

--- a/test/CheckedC/regression-cases/bug_484_rewrite_parameter_uses.c
+++ b/test/CheckedC/regression-cases/bug_484_rewrite_parameter_uses.c
@@ -1,5 +1,5 @@
 //
-// These is a regression test case for
+// This is a regression test case for
 // https://github.com/Microsoft/checkedc-clang/issues/484
 //
 // In checked scopes, we rewrite function types with bounds-safe interfaces to

--- a/test/CheckedC/regression-cases/bug_484_rewrite_parameter_uses.c
+++ b/test/CheckedC/regression-cases/bug_484_rewrite_parameter_uses.c
@@ -1,0 +1,35 @@
+//
+// These is a regression test case for
+// https://github.com/Microsoft/checkedc-clang/issues/484
+//
+// In checked scopes, we rewrite function types with bounds-safe interfaces to
+// be fully checked. We need to rewrite declarations of parameters and uses of
+// parameters that have bounds-safe interfaces.
+//
+// The following example illustrates the problem, if wed don't do the rewrite.
+// We define 3 C typedefs:
+// 1. The first one defines an unchecked function pointer with a bounds-safe
+// interface on a parameter.
+// 2. The second one defines the bounds-safe interface type the first one.
+// 3. The third one defines a full checked version.
+//
+// If we don't rewrite the uses of parameters, the function types
+// don't match and we get a type checking error.
+// RUN: %clang -Wno-check-bounds-decls-checked-scope -c -o %t %s
+
+#pragma CHECKED_SCOPE ON
+
+typedef int (*callback_fn3)(int *a : count(n), int n);
+typedef  _Ptr<int (int *a : bounds(a, a + n), int n)> bsi_callback_fn3;
+typedef  _Ptr<int (_Array_ptr<int> a : bounds(a, a + n), int n)> checked_callback_fn3;
+
+_Checked callback_fn3 return_function_pointer(void) : itype(bsi_callback_fn3);
+
+// _Checked callback_fn3 return_function_pointer(void) : itype(_Ptr<int (int *a : bounds(a, a + n), int n)>);
+
+_Checked void test_function_pointer_return(void) {
+   checked_callback_fn3 fn = return_function_pointer();
+}
+
+
+

--- a/test/CheckedC/regression-cases/bug_484_rewrite_parameter_uses.c
+++ b/test/CheckedC/regression-cases/bug_484_rewrite_parameter_uses.c
@@ -6,12 +6,13 @@
 // be fully checked. We need to rewrite declarations of parameters and uses of
 // parameters that have bounds-safe interfaces.
 //
-// The following example illustrates the problem, if wed don't do the rewrite.
+// The following example illustrates the problem, if we don't do the rewrite.
 // We define 3 C typedefs:
 // 1. The first one defines an unchecked function pointer with a bounds-safe
 // interface on a parameter.
-// 2. The second one defines the bounds-safe interface type the first one.
-// 3. The third one defines a full checked version.
+// 2. The second one defines the bounds-safe interface type for the first
+// typedef's function pointer type.
+// 3. The third one defines a fully checked version.
 //
 // If we don't rewrite the uses of parameters, the function types
 // don't match and we get a type checking error.
@@ -24,8 +25,6 @@ typedef  _Ptr<int (int *a : bounds(a, a + n), int n)> bsi_callback_fn3;
 typedef  _Ptr<int (_Array_ptr<int> a : bounds(a, a + n), int n)> checked_callback_fn3;
 
 _Checked callback_fn3 return_function_pointer(void) : itype(bsi_callback_fn3);
-
-// _Checked callback_fn3 return_function_pointer(void) : itype(_Ptr<int (int *a : bounds(a, a + n), int n)>);
 
 _Checked void test_function_pointer_return(void) {
    checked_callback_fn3 fn = return_function_pointer();

--- a/test/CheckedC/static-checking/typechecking.c
+++ b/test/CheckedC/static-checking/typechecking.c
@@ -69,8 +69,10 @@ f304(int i, _Ptr<int(_Array_ptr<void> : byte_count(i), _Array_ptr<void> : byte_c
                                                                                                // Bounds in a function type reference parameters or locals.
 void f305(int i) {
   int j = i;
-  _Ptr<_Array_ptr<int>(void) : count(i)> p = 0; // expected-error {{out-of-scope variable for bounds}}
-  _Ptr<_Array_ptr<int>(void) : count(j)> q = 0; // expected-error {{out-of-scope variable for bounds}}
+  _Ptr<_Array_ptr<int>(void) : count(i)> p = 0;    // expected-error {{out-of-scope variable for bounds}}
+  _Ptr<_Array_ptr<int>(int k) : count(i)> q = 0; ; // expected-error {{out-of-scope variable for bounds}}
+  _Ptr<_Array_ptr<int>(void) : count(j)> r = 0;    // expected-error {{out-of-scope variable for bounds}}
+
 }
 
 // Global variable bounds are OK.


### PR DESCRIPTION
In TreeTransform.h, track the transformed types for parameters.  Use
this information to update the types for positional parameter expressions. 
This fixes issue #484, which was a typechecking error caused by different types
for uses of parameters in bounds expressions in function types.

The tracking is straightforward: we add a vector of types for parameters.
Positional parameters only occur in bounds expressions in types.  When
we transform a function prototype type, we record the transformed types for
parameters before transforming the bounds expressions in the types.

This change also contains a few clean up changes:
1. While debugging an alternative approach, I noticed that TreeTransform
had some code that is flagged as specific to template instantiation. It
was mostly code for marking uses.  The code in turn called into code that
checked for detecting references to local variables defined in other lexical
contexts (for example, block scopes).  Those checks depend on the lexical context
state for Sema.  We don't want any of this code running for the kinds
of transforms that we are doing, so I added a new method to TreeTransform.h that
can be overridden to suppress this code.
2. Clean up and improve some comments in TreeTransform.h.
3. Improve the parameters for TransformExtendedParameterInfo, marking some
as const and changing the order of parameters to group related parameters
together.

Testing:

- Added new regression test for issue 484.
- Passed local testing on Windows.
- Passed automated testing.

