### PR TITLE
Fix compiler assert.

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1668,9 +1668,6 @@ namespace {
     if (CXXBindTemporaryExpr *Binder = dyn_cast<CXXBindTemporaryExpr>(expr))
       expr = Binder->getSubExpr();
 
-    if (CHKCBindTemporaryExpr *Temp = dyn_cast<CHKCBindTemporaryExpr>(expr))
-      expr = Temp->getSubExpr();
-
     return expr;
   }
 }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -423,6 +423,7 @@ namespace {
   };
 
   Expr *PruneTemporaryBindings(Sema &SemaRef, Expr *E) {
+    Sema::ExprSubstitutionScope Scope(SemaRef); // suppress diagnostics
     ExprResult R = PruneTemporaryHelper(SemaRef).TransformExpr(E);
     assert(!R.isInvalid());
     return R.get();

--- a/test/CheckedC/regression-cases/bug_575_string_literal.c
+++ b/test/CheckedC/regression-cases/bug_575_string_literal.c
@@ -1,15 +1,14 @@
-//
-// These is a regression test case for 
+// This is a regression test case for 
 // https://github.com/Microsoft/checkedc-clang/issues/575
 //
-// This test checks that we do not get duplicate error message for uses
-// of arithmetic on checked void pointers and checked function
-// pointers in bounds expressions.
-
+// This test checks that the compiler does not crash on a dynamic bounds
+// cast whose argument is a string literal.
+//
 // RUN: %clang -cc1 -verify -fcheckedc-extension %s
 // expected-no-diagnostics
 
 int main(void) {
-     _Nt_array_ptr<const char> str_with_len : count(2) = _Dynamic_bounds_cast<_Nt_array_ptr<const char>>(("\n"), count(2));
-    return 0;
+  _Nt_array_ptr<const char> str_with_len : count(2) = 
+    _Dynamic_bounds_cast<_Nt_array_ptr<const char>>(("\n"), count(2));
+  return 0;
 }

--- a/test/CheckedC/regression-cases/bug_575_string_literal.c
+++ b/test/CheckedC/regression-cases/bug_575_string_literal.c
@@ -1,0 +1,15 @@
+//
+// These is a regression test case for 
+// https://github.com/Microsoft/checkedc-clang/issues/575
+//
+// This test checks that we do not get duplicate error message for uses
+// of arithmetic on checked void pointers and checked function
+// pointers in bounds expressions.
+
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+// expected-no-diagnostics
+
+int main(void) {
+     _Nt_array_ptr<const char> str_with_len : count(2) = _Dynamic_bounds_cast<_Nt_array_ptr<const char>>(("\n"), count(2));
+    return 0;
+}


### PR DESCRIPTION
This change fixes the compiler assert reported in Github issue #575. We are inserting temporary variables for strings so that we can describe their bounds.  The assert was checking that we don't compute a temporary variable more than once in an expression.

The problem is that we are  copying the expression that creates and binds the temporary into the bounds.   The bounds is used at runtime in the dynamic_bounds_cast.  This causes the temporary to be computed twice, which is what the assert is protecting against.  Since we've already computed the value
into a temporary, the fix is to replace the binding with a read of the temporary.

Testing:
- Added simple repro case that caused a compiler crash.
- Added a runtime test that will be covered by a PR to the Checked C repo
- Passed testing locally for Window x64.
- Passed automated testing for Linux.
