### PR TITLE
Disallow some implicit void pointer conversions in checked scopes

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9413,8 +9413,8 @@ def err_typecheck_ptr_subscript : Error<
   "subscript of %0">;
 
 def err_checkedc_void_pointer_assign : Error<
-  "implicit conversion not permitted in checked scope between between void pointer "
-  "and pointer to data containing checked pointers (%0 and %1)">;
+  "implicit conversion between %0 and %1 is not allowed in a checked scope "
+  "because %2 contains or is a checked pointer">;
 
 def err_typecheck_cond_incompatible_checked_pointer : Error<
   "pointer type mismatch%diff{ ($ and $)|}0,1">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9416,6 +9416,10 @@ def err_checkedc_void_pointer_assign : Error<
   "implicit conversion between %0 and %1 is not allowed in a checked scope "
   "because %2 contains or is a checked pointer">;
 
+def err_checkedc_void_pointer_cond : Error<
+  "implicit conversion from %0 to %1 not allowed in a checked scope "
+  "because %2 contains or is a checked pointer">;
+
 def err_typecheck_cond_incompatible_checked_pointer : Error<
   "pointer type mismatch%diff{ ($ and $)|}0,1">;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9412,6 +9412,10 @@ def err_bounds_safe_interface_type_annotation_local_variable : Error<
 def err_typecheck_ptr_subscript : Error<
   "subscript of %0">;
 
+def err_checkedc_void_pointer_assign : Error<
+  "implicit conversion not permitted in checked scope between between void pointer "
+  "and pointer to data containing checked pointers (%0 and %1)">;
+
 def err_typecheck_cond_incompatible_checked_pointer : Error<
   "pointer type mismatch%diff{ ($ and $)|}0,1">;
 
@@ -9465,7 +9469,6 @@ def err_typecheck_void_pointer_count_bounds_cast : Error<
 
 def err_typecheck_non_count_bounds_decl : Error<
   "expected %0 to have a pointer, array, or integer type">;
-
 def err_typecheck_non_count_return_bounds : Error<
   "bounds declaration only allowed for a pointer or integer return type">;
 

--- a/include/clang/Basic/Specifiers.h
+++ b/include/clang/Basic/Specifiers.h
@@ -335,7 +335,7 @@ namespace clang {
 
     /// Check properties for bounds safety and preventing type confusion.
     /// Corresponds to _Bounds
-    CSS_BoundsAndTypes = 0x3
+    CSS_Memory = 0x3
   };
 
 } // end namespace clang

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -335,7 +335,7 @@ public:
   static const CSS CSS_None = clang::CSS_None;
   static const CSS CSS_Unchecked = clang::CSS_Unchecked;
   static const CSS CSS_Bounds = clang::CSS_Bounds;
-  static const CSS CSS_BoundsAndTypes = clang::CSS_BoundsAndTypes;
+  static const CSS CSS_Memory = clang::CSS_Memory;
 
 
 private:

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -9901,6 +9901,11 @@ public:
     /// object with __weak qualifier.
     IncompatibleObjCWeakRef,
 
+    /// IncompatibleCheckedCVoid - Assignments to/from void pointers to pointers
+    /// to data containing checked pointers is not allowed in regular checked
+    /// scopes. It is allowed only in unchecked and checked bounds_only scopes.
+    IncompatibleCheckedCVoid,
+
     /// Incompatible - We reject this conversion outright, it is invalid to
     /// represent it in the AST.
     Incompatible

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1204,7 +1204,7 @@ void ASTDumper::VisitFunctionDecl(const FunctionDecl *D) {
   switch (D->getWrittenCheckedSpecifier()) {
     case CSS_None: break;
     case CSS_Bounds: OS << " checked bounds_only"; break;
-    case CSS_BoundsAndTypes: OS << " checked"; break;
+    case CSS_Memory: OS << " checked"; break;
     case CSS_Unchecked: OS << " unchecked"; break;
   }
 
@@ -2056,7 +2056,7 @@ void ASTDumper::VisitCompoundStmt(const CompoundStmt *Node) {
     case CSS_None: break;
     case CSS_Unchecked: OS << " _Unchecked "; break;
     case CSS_Bounds: OS <<  " _Checked _Bounds_only "; break;
-    case CSS_BoundsAndTypes: OS << " _Checked "; break;
+    case CSS_Memory: OS << " _Checked "; break;
   }
 
 

--- a/lib/AST/DeclPrinter.cpp
+++ b/lib/AST/DeclPrinter.cpp
@@ -503,7 +503,7 @@ void DeclPrinter::VisitFunctionDecl(FunctionDecl *D) {
       case CSS_None: break;
       case CSS_Unchecked: Out << "_Unchecked "; break;
       case CSS_Bounds: Out << "_Checked _Bounds_only"; break;
-      case CSS_BoundsAndTypes: Out << "_Checked "; break;
+      case CSS_Memory: Out << "_Checked "; break;
     }
     if (D->isInlineSpecified())  Out << "inline ";
     if (D->isVirtualAsWritten()) Out << "virtual ";

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -122,7 +122,7 @@ void StmtPrinter::PrintRawCompoundStmt(CompoundStmt *Node) {
       case CSS_None: break;
       case CSS_Unchecked: OS << "_Unchecked "; break;
       case CSS_Bounds: OS << "_Checked _Bounds_only "; break;
-      case CSS_BoundsAndTypes: OS << "_Checked "; break;
+      case CSS_Memory: OS << "_Checked "; break;
   }
   OS << "{\n";
   for (auto *I : Node->body())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3080,7 +3080,7 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
             CSS = CSS_Bounds;
             ConsumeToken();
            } else
-            CSS = CSS_BoundsAndTypes;
+            CSS = CSS_Memory;
         }
         isInvalid = DS.setFunctionSpecChecked(Loc, CSS, PrevSpec, DiagID);
         break;

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1625,7 +1625,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
   // keywords.
   CheckedScopeSpecifier CSS = CSS_None;
   if (Tok.is(tok::kw__Checked) && NextToken().is(tok::l_brace)) {
-    CSS = CSS_BoundsAndTypes;
+    CSS = CSS_Memory;
     ConsumeToken();
   } else if (Tok.is(tok::kw__Checked) && NextToken().is(tok::kw__Bounds_only) &&
     GetLookAheadToken(2).is(tok::l_brace)) {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -894,7 +894,7 @@ StmtResult Parser::ParseCompoundStatement(bool isStmtExpr, unsigned ScopeFlags) 
   SourceLocation CSSLoc;
   SourceLocation CSMLoc;
   if (Tok.is(tok::kw__Checked)) {
-    CSS = CSS_BoundsAndTypes;
+    CSS = CSS_Memory;
     CSSLoc = ConsumeToken();
     if (Tok.is(tok::kw__Bounds_only)) {
       CSS = CSS_Bounds;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1089,7 +1089,7 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
 
   CheckedScopeSpecifier CSS = CSS_None;
   if (Tok.is(tok::kw__Checked) && NextToken().is(tok::l_brace)) {
-    CSS = CSS_BoundsAndTypes;
+    CSS = CSS_Memory;
     ConsumeToken();
   } else if (Tok.is(tok::kw__Checked) && NextToken().is(tok::kw__Bounds_only) &&
     GetLookAheadToken(2).is(tok::l_brace)) {

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -961,7 +961,7 @@ bool DeclSpec::setFunctionSpecChecked(SourceLocation Loc,
       case CSS_None: PrevSpec = ""; break;
       case CSS_Unchecked: PrevSpec = "_Unchecked"; break;
       case CSS_Bounds: PrevSpec = "_Checked _Bounds_only"; break;
-      case CSS_BoundsAndTypes: PrevSpec = "_Checked"; break;
+      case CSS_Memory: PrevSpec = "_Checked"; break;
     }
     return true;
   }

--- a/lib/Sema/SemaAttr.cpp
+++ b/lib/Sema/SemaAttr.cpp
@@ -690,7 +690,7 @@ void Sema::ActOnPragmaOptimize(bool On, SourceLocation PragmaLoc) {
 void Sema::ActOnPragmaCheckedScope(PragmaCheckedScopeKind Kind,
                                    SourceLocation Loc) {
   switch (Kind) {
-    case PCSK_On: SetCheckedScopeInfo(CSS_BoundsAndTypes); break;
+    case PCSK_On: SetCheckedScopeInfo(CSS_Memory); break;
     case PCSK_BoundsOnly: SetCheckedScopeInfo(CSS_Bounds); break;
     case PCSK_Off: SetCheckedScopeInfo(CSS_Unchecked); break;
     case PCSK_Push: PushCheckedScopeInfo(Loc); break;


### PR DESCRIPTION
In memory-safe checked scopes, disallow implicit conversions to and from void pointer types when the non-void pointer type points to data that contains a checked pointer.   Disallow these conversions at assignments, call arguments, return statements, and arms of conditional expressions.   Memory-safe checked scopes are currently the default kind of checked scopes.   This addresses part of issue #571.

Also do some cleanup within the compiler.  Rename the checked scope specifier for the default checked scope from "BoundsAndTypes" to "Memory".   The original name is incorrect for the kind of safety that will be provided.

Testing:
- Add new tests to the Checked C repo for these cases.
- Passed automated testing on Windows and Linux.

