### PR TITLE
Clean up after merging latest sources

### DIFF
--- a/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -19,7 +19,7 @@ The third step is to merge your changes back into your baseline and master branc
 
 ## Create updated branches of your baseline branches
 
-First create remotes to the mirrored Github repos that contain the updates sources
+First create remotes to the mirrored GitHub repos that contain the updated sources
 for LLVM and clang. Go to your LLVM repo and do:
 
 	git remote add mirror https://github.com/llvm-mirror/llvm
@@ -43,21 +43,19 @@ LLVM has unified its projects into one repo.  However, we have not migrated our
 repos into one repo yet.   This means that our sources are being
 pulled from partial mirrors of a unifed repo.   You need to make sure that the
 changes are in sync. The pace of commits is fast enough that a change that
-causes a build break has been introduced.
+causes a build break could be introduced between syncing.
 
 
 While the LLVM ecosystem is migrating, you can look at the SVN IDs in the
-upstream git repo commits to see if you've gotten out-of-sync.
-.
-
-If the changes are not very close, for each of your branched baselines
+upstream git repo commits to see if you've gotten out-of-sync.  If the 
+changes are not very close, for each of your branched baselines
 )updated-baseline in the above example), use
 
 	git reset --hard commit-number,  where commit-number is the Git commit.
 
 ## Run testing on your branched baseline branches.
 
-You can run testing locally or push your branched baseline branches to Github
+You can run testing locally or push your branched baseline branches to GitHub
 and use automated testing.  This will show you whether there are any unexpected
 failures in your baseline branch.
 
@@ -74,12 +72,12 @@ You can now branch your baseline branches to create a new master branch:
 
 You will very likely have merge conflicts and some test failures.  The test
 failures usually stem from incorrect merges or Checked C-specific data not being
-initialized by new constructor methods.
+initialized by new or changed constructor methods.
 
 You may also need to pick up changes from LLVM/clang for fixes to any unexpected
 baseline failures.
 
-You can push your updated master branches up to Github for automated
+You can push your updated master branches up to GitHub for automated
 testing.  If you haven't cleaned the build directory as described earlier,
 make sure you do that.
 
@@ -87,7 +85,7 @@ You'll want to run automated tests on Linux and Windows x86/x64, as well as
 Linux LNT tests.  You may find in some cases that tests need to be updated
 based on new warnings or slightly different compiler behavior.
 
-## Merge your branched baseline and master.
+## Merge your branched baseline and master branches
 
 Once all testing is passing, you can merge your branches back into
 your baseline and master branches.
@@ -98,8 +96,8 @@ your baseline and master branches.
     git checkout master
     git merge updated-master
 
-## Push the updated branches to Git
+## Push the updated branches to GitHub
 
 The changes will be extensive enough that you don't want to do a pull request
-on Github.  Just push the branches up to Github.
+on GitHub.  Just push the branches up to GitHub.
 

--- a/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -4,8 +4,9 @@ We are staying in sync with the LLVM/clang mainline sources.   The baseline bran
 LLVM/clang sources.  We periodically update the baseline branch and then push the changes to other branches
 
 The first step is to create updated baseline branches:
-1. Create new branches of your local baseline branche (we suggest doing this so that
-we can run automated testing.  To run automated testing, we need new branches to test).
+1. Create new branches of your local baseline branches (we suggest creating new
+branches so that you can run automated testing. You'll need new branches
+that you can push to GitHub).
 2. Update those branches to the latest sources.
 3. Run testing on those branches to make sure things are stable.
 

--- a/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -1,69 +1,105 @@
 # Instructions for updating to the latest LLVM/clang sources
 
-We are staying in sync with the LLVM/clang mainline sources.   The baseline branch is a pristine copy of  clang/LLVM sources. 
-We periodically update the baseline branch and then push the changes to other branches
+We are staying in sync with the LLVM/clang mainline sources.   The baseline branch is a pristine copy of
+clang/LLVM sources.  We periodically update the baseline branch and then push the changes to other branches
 
-## Update your local baseline branches to the latest sources
-To update the baseline branch to the latest sourcess, make sure you have personal forks of the Checked C LLVM and clang repos.
-Clone these forks to your local machine.   Then create remotes to the mirrored Github repos that contain the updates sources 
+The first step is to create updated baseline branches:
+1. Create new branches of your local baseline branches.
+2. Update those branches to the latest sources.
+3. Run testing on those branches to make sure things are stable (we suggest used automated
+  testing, which is why you branch the existing baseline branch, not just update it directly).
+
+  The second step is to create updated master branches:
+  1. Create branches of your updated baseline branches.
+  2. Merge changes from the Checked C master branches into those branches.
+  3. Fix merge conflicts and run testing.  You will likely need to fix some issues
+     and re-run testing until all issues are fixed.
+
+The third step is to merge your changes back into your baseline and master branches.
+
+## Create updated branches of your baseline branches
+
+First create remotes to the mirrored Github repos that contain the updates sources
 for LLVM and clang. Go to your LLVM repo and do:
 
 	git remote add mirror https://github.com/llvm-mirror/llvm
 
-Set the upstream branch to the master llvm branch:
+Then branch your baseline branch and merge changes into it:
 
-	git branch --set-upstream baseline mirror/llvm
-
-You can then pull changes from the main repo into your local repo:
-
-	git pull mirror baseline
+    git checkout baseline
+    git checkout -b updated-baseline
+    git pull mirror master
 
 Repeat the process for your clang repo:
 
 	git remote add mirror https://github.com/llvm-mirror/clang
-	git branch --set-upstream baseline mirror/clang
-	git pull mirror  baseline
-
+    git checkout baseline
+    git checkout -b updated-baseline
+    git pull mirror master
 
 ## Ensure the clang and LLVM sources are synchronized
-The sources are being pulled from multiple repos that are mirrors of SVN repositories.  
-The sources need for LLVM and clang may be out of sync - for example, the mirrors may not be in sync or a change may 
-be checked in after pulling from one of the repos.
 
-You need to make sure that source are in sync.   The Git mirror commits have the SVN change number embedded in them and the 
-SVN change number is consistent across SVN repos for clang and LLVM.   You can examine that recent change log for clang and LLVM and find changes that are in
-sync according to the SVN number  (there may be gaps in the numbering because a change may only affect on repo).     For each Git repo, note the Git commit (the first 8 or so digits of the hash)
+LLVM has unified its projects into one repo.  However, we have not migrated our
+repos into one repo yet.   This means that our sources are being
+pulled from partial mirrors of a unifed repo.   You need to make sure that the
+changes are in sync. The pace of commits is fast enough that a change that
+causes a build break has been introduced.
 
-For each Git repo, make *sure* that you change to the baseline branch:
 
-	git checkout baseline
+While the LLVM ecosystem is migrating, you can look at the SVN IDs in the
+upstream git repo commits to see if you've gotten out-of-sync.
+.
 
-Then do
+If the changes are not very close, for each of your branched baselines
+)updated-baseline in the above example), use
 
 	git reset --hard commit-number,  where commit-number is the Git commit.
 
-## Update the baseline branch on Github
+## Run testing on your branched baseline branches.
 
-You will then need to build and run tests to establish test baselines.   Assuming that the tests  results are good, 
-you can push them to your personal Github forks:
+You can run testing locally or push your branched baseline branches to Github
+and use automated testing.  This will show you whether there are any unexpected
+failures in your baseline branch.
 
-	git push origin baseline
+If you use automated testing, make sure to clean the build directory first.
+Enough changes will likely have accumulated that things may go wrong without doing
+that first.
 
-You can then issue pull requests to pull the changes into the Microsift Github repos.
+## Branch your new baseline branches and merge master changes
 
-## Update the master branch.
+You can now branch your baseline branches to create a new master branch:
 
-After you have updated the baseline branch, you can update the master branch. Change to each repo and then do:
+	git checkout -b updated-master
+    git merge master
 
-	git checkout master
-	git merge baseline
+You will very likely have merge conflicts and some test failures.  The test
+failures usually stem from incorrect merges or Checked C-specific data not being
+initialized by new constructor methods.
 
-Set up the build system and compile.  Fix any issues that you encounter.  
+You may also need to pick up changes from LLVM/clang for fixes to any unexpected
+baseline failures.
 
-Then run tests.  We have added tests for Checked C to the clang master branch, so these additional tests need to be taken
-into account during testing.  Make sure the code passes the following tests:
+You can push your updated master branches up to Github for automated
+testing.  If you haven't cleaned the build directory as described earlier,
+make sure you do that.
 
-- The same tests as the baseline branch, _plus_ the Checked C specific tests for clang in the master branch.
-- The Checked C languages tests for the Checked C project.
+You'll want to run automated tests on Linux and Windows x86/x64, as well as
+Linux LNT tests.  You may find in some cases that tests need to be updated
+based on new warnings or slightly different compiler behavior.
 
-Once the tests are passing, push the changes up to a personal Github fork and issue a pull request.
+## Merge your branched baseline and master.
+
+Once all testing is passing, you can merge your branches back into
+your baseline and master branches.
+
+
+    git checkout baseline
+    git merge updated-baseline
+    git checkout master
+    git merge updated-master
+
+## Push the updated branches to Git
+
+The changes will be extensive enough that you don't want to do a pull request
+on Github.  Just push the branches up to Github.
+

--- a/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -1,15 +1,15 @@
 # Instructions for updating to the latest LLVM/clang sources
 
 We are staying in sync with the LLVM/clang mainline sources.   The baseline branch is a pristine copy of
-clang/LLVM sources.  We periodically update the baseline branch and then push the changes to other branches
+LLVM/clang sources.  We periodically update the baseline branch and then push the changes to other branches
 
 The first step is to create updated baseline branches:
-1. Create new branches of your local baseline branches.
+1. Create new branches of your local baseline branche (we suggest doing this so that
+we can run automated testing.  To run automated testing, we need new branches to test).
 2. Update those branches to the latest sources.
-3. Run testing on those branches to make sure things are stable (we suggest used automated
-  testing, which is why you branch the existing baseline branch, not just update it directly).
+3. Run testing on those branches to make sure things are stable.
 
-  The second step is to create updated master branches:
+The second step is to create updated master branches:
   1. Create branches of your updated baseline branches.
   2. Merge changes from the Checked C master branches into those branches.
   3. Fix merge conflicts and run testing.  You will likely need to fix some issues

--- a/include/clang/AST/TypeLoc.h
+++ b/include/clang/AST/TypeLoc.h
@@ -1201,8 +1201,16 @@ public:
     this->getLocalData()->StarLoc = Loc;
   }
 
+  SourceLocation getRightSymLoc() const {
+      return this->getLocalData()->RightSymLoc;
+  }
+
   void setRightSymLoc(SourceLocation Loc) {
     this->getLocalData()->RightSymLoc = Loc;
+  }
+
+  SourceLocation getKWLoc() const {
+      return this->getLocalData()->KWLoc;
   }
 
   void setKWLoc(SourceLocation Loc) {
@@ -1242,38 +1250,12 @@ public:
     setKWLoc(Loc);
   }
 
-  SourceLocation getKWLoc() const {
-      return this->getLocalData()->KWLoc;
-  }
-  void setKWLoc(SourceLocation Loc) {
-      this->getLocalData()->KWLoc = Loc;
-  }
-
   SourceLocation getLeftSymLoc() const {
-      return this->getLocalData()->StarLoc;
+      return getSigilLoc();
   }
 
   void setLeftSymLoc(SourceLocation Loc) {
-      this->getLocalData()->StarLoc = Loc;
-  }
-
-  SourceLocation getRightSymLoc() const {
-      return this->getLocalData()->RightSymLoc;
-  }
-
-  void setRightSymLoc(SourceLocation Loc) {
-      this->getLocalData()->RightSymLoc = Loc;
-  }
-
-  // CheckedC : do we need this?
-  SourceRange getBracketsRange() const {
-      return SourceRange(getLeftSymLoc(), getRightSymLoc());
-  }
-
-  // CheckedC : do we need this?
-  void setParensRange(SourceRange Range) {
-      setLeftSymLoc(Range.getBegin());
-      setRightSymLoc(Range.getEnd());
+    setSigilLoc(Loc);
   }
 
   SourceRange getLocalSourceRange() const {

--- a/lib/CodeGen/CGBuiltin.cpp
+++ b/lib/CodeGen/CGBuiltin.cpp
@@ -26,7 +26,6 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CGFunctionInfo.h"
 #include "llvm/ADT/SmallPtrSet.h"
-// #include "clang/Sema/SemaDiagnostic.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/CallSite.h"
 #include "llvm/IR/DataLayout.h"

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -876,7 +876,7 @@ namespace {
                                           ArrLValue);
           return ExpandToRange(Base, CBE);
         } else
-          CreateBoundsAlwaysUnknown();
+          return CreateBoundsAlwaysUnknown();
       }
       default:
         return CreateBoundsAlwaysUnknown();

--- a/tools/libclang/CXCursor.cpp
+++ b/tools/libclang/CXCursor.cpp
@@ -711,6 +711,7 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
     break;
   case Stmt::OMPTargetTeamsDistributeSimdDirectiveClass:
     K = CXCursor_OMPTargetTeamsDistributeSimdDirective;
+    break;
 
   // For now, do not expose Checked C extensions.
   case Stmt::PositionalParameterExprClass:


### PR DESCRIPTION
This addresses issue #601.
- Clean up PointerTypeLoc class.   The merge introduced a new base class.  We had redundant methods on the subclass and some methods on the subclass that needed to be moved to the base class.
- Fix compiler warnings about fall-through.
- Remove some commented out code that was left behind.
- Update directions for merging latest sources.
