### PR TITLE
Fix compiler assertion when subscripting a call expression.

### DIFF
--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -807,7 +807,7 @@ public:
     if (E->getKind() == BoundsValueExpr::Kind::Temporary) {
       CHKCBindTemporaryExpr *Temp = E->getTemporaryBinding();
       assert(!Temp->getSubExpr()->isLValue());
-      Result = CGF.getBoundsTemporaryLValueMapping(Temp).getPointer();
+      Result = CGF.getBoundsTemporaryRValueMapping(Temp).getScalarVal();
     } else
        llvm_unreachable("unexpected bounds value expr");
     assert(Result);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2113,9 +2113,9 @@ public:
     return it->second;
   }
 
-  /// getBoundsTemporaryLValueMapping - Given a bounds temporary (which
+  /// getBoundsTemporaryRValueMapping - Given a bounds temporary (which
   /// must be mapped to an l-value), return its mapping.
-  const RValue &getBoundsTemporaryRValueMapping(const CHKCBindTemporaryExpr *e) {
+  RValue getBoundsTemporaryRValueMapping(const CHKCBindTemporaryExpr *e) {
     assert (!e->getSubExpr()->isLValue());
 
     llvm::DenseMap<const CHKCBindTemporaryExpr *,RValue>::iterator


### PR DESCRIPTION
We introduce temporary variables to hold the results of calls to functions that return pointers with bounds.  This lets us express the bounds of the result of the call in the IR, so that we can generate a bounds check.  There is an assertion failure during code generation.  The wrong map is being used to look up the LLVM value for the temporary variable for an rvalue.  Use the right map.

Testing:
- Passes tests of subscripting call expressions.