### PR TITLE
Replace unnecessary dyn_cast with isa

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -848,7 +848,7 @@ namespace {
       case Expr::CHKCBindTemporaryExprClass: {
         CHKCBindTemporaryExpr *Binding = cast<CHKCBindTemporaryExpr>(E);
         Expr *SE = Binding->getSubExpr()->IgnoreParens();
-        if  (CompoundLiteralExpr *CL = dyn_cast<CompoundLiteralExpr>(SE)) {
+        if (isa<CompoundLiteralExpr>(SE)) {
           BoundsExpr *BE = CreateBoundsForArrayType(E->getType());
           QualType PtrType = Context.getDecayedType(E->getType());
           Expr *ArrLValue = CreateTemporaryUse(Binding);


### PR DESCRIPTION
The variable CL is needed only by the dyn_cast and is unused elsewhere. So we
can get rid of it by replacing dyn_cast with isa.