### PR TITLE
Fix to correct handling of void pointers in itype

### DIFF
--- a/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/tools/checked-c-convert/CheckedCConvert.cpp
@@ -748,7 +748,7 @@ bool CastPlacementVisitor::VisitFunctionDecl(FunctionDecl *FD) {
         std::string scratch = "";
         raw_string_ostream declText(scratch);
         Definition->getParamDecl(i)->print(declText);
-        std::string ctype = Defn->mkString(Info.getConstraints().getVariables(), false);
+        std::string ctype = Defn->mkString(Info.getConstraints().getVariables(), false, true);
         std::string bi = declText.str() + " : itype("+ctype+") ";
         parmStrs.push_back(bi);
       } else {
@@ -779,7 +779,7 @@ bool CastPlacementVisitor::VisitFunctionDecl(FunctionDecl *FD) {
     std::string endStuff = "";
     bool anyConstrained = Defn->anyChanges(Info.getConstraints().getVariables());
     if (Defn->isLt(*Decl, Info) && anyConstrained) {
-      std::string ctype = Defn->mkString(Info.getConstraints().getVariables());
+      std::string ctype = Defn->mkString(Info.getConstraints().getVariables(), true, true);
       returnVar = Defn->getTy();
       endStuff = " : itype("+ctype+") ";
       didAny = true;

--- a/tools/checked-c-convert/ProgramInfo.cpp
+++ b/tools/checked-c-convert/ProgramInfo.cpp
@@ -245,7 +245,7 @@ void PointerVariableConstraint::print(raw_ostream &O) const {
 // variables and potentially nested function pointer declaration. Produces a 
 // string that can be replaced in the source code.
 std::string
-PointerVariableConstraint::mkString(Constraints::EnvironmentMap &E, bool emitName) {
+PointerVariableConstraint::mkString(Constraints::EnvironmentMap &E, bool emitName, bool forItype) {
   std::ostringstream ss;
   std::ostringstream pss;
   unsigned caratsToAdd = 0;
@@ -260,8 +260,10 @@ PointerVariableConstraint::mkString(Constraints::EnvironmentMap &E, bool emitNam
 
     std::map<uint32_t, Qualification>::iterator q;
     Atom::AtomKind K = C->getKind();
-
-    if (BaseType == "void")
+    
+    // if this is not an itype
+    // make this wild as it can hold any pointer type
+    if (!forItype && BaseType == "void")
       K = Atom::A_Wild;
 
     switch (K) {
@@ -596,7 +598,7 @@ void FunctionVariableConstraint::print(raw_ostream &O) const {
 }
 
 std::string
-FunctionVariableConstraint::mkString(Constraints::EnvironmentMap &E, bool emitName) {
+FunctionVariableConstraint::mkString(Constraints::EnvironmentMap &E, bool emitName, bool forItype) {
   std::string s = "";
   // TODO punting on what to do here. The right thing to do is to figure out
   // the LUB of all of the V in returnVars.

--- a/tools/checked-c-convert/ProgramInfo.h
+++ b/tools/checked-c-convert/ProgramInfo.h
@@ -71,7 +71,9 @@ public:
   // Create a "for-rewriting" representation of this ConstraintVariable.
   // The 'emitName' parameter is true when the generated string should include
   // the name of the variable, false for just the type.
-  virtual std::string mkString(Constraints::EnvironmentMap &E, bool emitName=true) = 0;
+  // The 'forIType' parameter is true when the generated string is expected
+  // to be used inside an itype
+  virtual std::string mkString(Constraints::EnvironmentMap &E, bool emitName=true, bool forItype=false) = 0;
 
   // Debug printing of the constraint variable.
   virtual void print(llvm::raw_ostream &O) const = 0;
@@ -176,7 +178,7 @@ public:
     return S->getKind() == PointerVariable;
   }
 
-  std::string mkString(Constraints::EnvironmentMap &E, bool emitName=true);
+  std::string mkString(Constraints::EnvironmentMap &E, bool emitName=true, bool forItype=false);
 
   FunctionVariableConstraint *getFV() { return FV; }
 
@@ -239,7 +241,7 @@ public:
     return paramVars.at(i);
   }
 
-  std::string mkString(Constraints::EnvironmentMap &E, bool emitName=true);
+  std::string mkString(Constraints::EnvironmentMap &E, bool emitName=true, bool forItype=false);
   void print(llvm::raw_ostream &O) const;
   void dump() const { print(llvm::errs()); }
   void constrainTo(Constraints &CS, ConstAtom *C, bool checkSkip=false);


### PR DESCRIPTION
## Problem
For `itype`, we expect the tool to use CheckedC types instead of regular `C` types. However, in the case of  `void*`, the tool emits `itype(void*)` instead of `itype(_Ptr<void>)`.

This is because, the tool considers all `void*` as wild as those pointers can be used to hold __any__ pointer types. Consequently, all `void*` types are emitted as regular `C` types. However, in the case of `itype`, we should use `itype(_Ptr<void>)`.

## Fix
The fix tries to specialize the `mkString` function, that emits the type string, to handle the cases when the function is called to be used within `itype` 