### PR TITLE
Disallow explicit cast to nt_array_ptr in checked scopes (#391)

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9867,6 +9867,10 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_checked_scope_no_assume_bounds_casting : Error<
     "_Assume_bounds_cast not allowed in a checked scope or function">;
 
+  def err_checked_scope_no_cast_to_nt_array_ptr : Error<
+    "%0 cannot be cast to %1 in a checked scope because "
+    "%0 might not point to a null-terminated array">;
+
   def err_checked_on_non_function : Error<
   "%select{'_Unchecked'|'_Checked _Bounds_only|'_Checked'}0 "
   "can only appear on functions">;

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2703,17 +2703,14 @@ void CastOperation::CheckCStyleCast(bool IsCheckedScope) {
 
     // Disallow cast from other Checked Pointer types to nt_arary_ptr because 
     // the SrcType might not point to a NULL-terminated array.
-    if (DestType->isPointerType()) {
-      if (cast<PointerType>(DestType)->getKind() == CheckedPointerKind::NtArray) {
-        if (SrcType->isPointerType() &&
-            cast<PointerType>(SrcType)->getKind() != CheckedPointerKind::NtArray) {
+    if (DestType->isPointerType() && DestType->isCheckedPointerNtArrayType()) {
+        if (SrcType->isPointerType() && !SrcType->isCheckedPointerNtArrayType()) {
           Self.Diag(SrcExpr.get()->getExprLoc(),
               diag::err_checked_scope_no_cast_to_nt_array_ptr)
             << SrcType << DestType << SrcExpr.get()->getSourceRange();
           SrcExpr = ExprError();
           return;
         }
-      } 
     }
 
   }


### PR DESCRIPTION
Disallow cast from other checked pointer types to nt_array_ptr in
checked scopes because the source pointer might not point to a
NULL_terminated array. Casting from an unchecked pointer to a
nt_array_ptr pointer should also be prohibited; this has already been
handled as no unchecked pointers are allowed in checked scopes.

Also added a new error message in
clang/include/clang/Basic/DiagnosticSemaKinds.td for casting to
nt_array_ptr in checked scopes.

The test file tests/typechecking/checked_scope_basic.c was updated
with a new function test_cast_to_nt_array_ptr to test
casting to nt_array_ptr.

The change passed the new test code and the regression tests for
checkedc and clang.