### PR TITLE
Add support for generic structs

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3780,7 +3780,8 @@ public:
   static RecordDecl *Create(const ASTContext &C, TagKind TK, DeclContext *DC,
                             SourceLocation StartLoc, SourceLocation IdLoc,
                             IdentifierInfo *Id, RecordDecl* PrevDecl = nullptr,
-                            ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>{ nullptr, 0 });
+                            ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>{ nullptr, 0 },
+                            ArrayRef<QualType> TypeArgs = ArrayRef<QualType>{ nullptr, (size_t)0 });
   static RecordDecl *CreateDeserialized(const ASTContext &C, unsigned ID);
 
   static RecordDecl* Instantiate(RecordDecl* Base, ArrayRef<QualType> TypeArgs);

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3772,12 +3772,12 @@ public:
 protected:
   RecordDecl(Kind DK, TagKind TK, const ASTContext &C, DeclContext *DC,
              SourceLocation StartLoc, SourceLocation IdLoc,
-             IdentifierInfo *Id, RecordDecl *PrevDecl);
+             IdentifierInfo* Id, RecordDecl* PrevDecl, ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>{ nullptr, 0 });
 
 public:
   static RecordDecl *Create(const ASTContext &C, TagKind TK, DeclContext *DC,
                             SourceLocation StartLoc, SourceLocation IdLoc,
-                            IdentifierInfo *Id, RecordDecl* PrevDecl = nullptr);
+                            IdentifierInfo *Id, RecordDecl* PrevDecl = nullptr, ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>{ nullptr, 0 });
   static RecordDecl *CreateDeserialized(const ASTContext &C, unsigned ID);
 
   RecordDecl *getPreviousDecl() {
@@ -3966,9 +3966,32 @@ public:
   /// nullptr is returned if no named data member exists.
   const FieldDecl *findFirstNamedDataMember() const;
 
+  // Checked C
+
+  /// Whether the record is generic.
+  bool isGeneric();
+
+  /// Returns the record's type parameters.
+  /// If there are no type parameters, then the array will be empty.
+  ArrayRef<TypedefDecl*> typeParams();
+
 private:
   /// Deserialize just the fields.
   void LoadFieldsFromExternalStorage() const;
+
+  // Checked C
+
+  /// Whether this record is generic.
+  bool IsGeneric;
+  /// The number of type parameters the record has.
+  size_t NumTypeParams;
+  /// New []'d array of pointers to TypedefDecls for the type
+  /// parameters of this record.  This is null if not a generic record.
+  TypedefDecl **TypeParams;
+
+  /// Sets the type parameters for the record.
+  /// This sets 'TypeParams', but also 'NumTypeParams' and 'IsGeneric'.
+  void setTypeParams(ASTContext& C, ArrayRef<TypedefDecl*> NewTypeParams);
 };
 
 class FileScopeAsmDecl : public Decl {

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3979,10 +3979,10 @@ public:
   /// If there are no type parameters, then the array will be empty.
   ArrayRef<TypedefDecl*> typeParams();
 
-  /// Whether the record is generic.
+  /// Whether the record is a (fully) instantiated generic.
   bool isInstantiated();
   /// Returns the record's type arguments.
-  /// If there are no type parameters, then the array will be empty.
+  /// If there are no type arguments, then the array will be empty.
   ArrayRef<QualType> typeArgs();
 
 private:

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3784,8 +3784,6 @@ public:
                             ArrayRef<TypeArgument> TypeArgs = ArrayRef<TypeArgument>(nullptr, (size_t)0));
   static RecordDecl *CreateDeserialized(const ASTContext &C, unsigned ID);
 
-  static RecordDecl* Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
-
   RecordDecl *getPreviousDecl() {
     return cast_or_null<RecordDecl>(
             static_cast<TagDecl *>(this)->getPreviousDecl());

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3988,6 +3988,13 @@ public:
   /// If there are no type arguments, then the array will be empty.
   ArrayRef<TypeArgument> typeArgs();
 
+  /// Whether this record represents a delayed type application.
+  /// If so, then 'isInstantiated()' will return 'true', and the type arguments will be populated.
+  /// However, the record's fields won't be set yet.
+  bool isDelayedTypeApp();
+  /// Indicate whether this record is currently a delayed type application.
+  void setDelayedTypeApp(bool IsDelayed);
+
 private:
   /// Deserialize just the fields.
   void LoadFieldsFromExternalStorage() const;
@@ -4025,6 +4032,10 @@ private:
   TypeArgument *TypeArgs;
   /// Sets the type arguments for an instantiation, as well as 'IsInstantiated' and 'NumTypeArgs'.
   void setTypeArgs(ASTContext& C, RecordDecl *BaseDecl, ArrayRef<TypeArgument> NewTypeArgs);
+
+  /// Whether this record represents a delayed type application.
+  /// A delayed type application won't contain any fields, until it is completed via 'Sema::CompleteTypeAppFields'.
+  bool IsDelayed;
 };
 
 class FileScopeAsmDecl : public Decl {

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3774,6 +3774,7 @@ protected:
              SourceLocation StartLoc, SourceLocation IdLoc,
              IdentifierInfo* Id, RecordDecl* PrevDecl,
              ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>(nullptr, (size_t)0),
+             RecordDecl *BaseDecl = nullptr,
              ArrayRef<TypeArgument> TypeArgs = ArrayRef<TypeArgument>(nullptr, (size_t)0));
 
 public:
@@ -3781,6 +3782,7 @@ public:
                             SourceLocation StartLoc, SourceLocation IdLoc,
                             IdentifierInfo *Id, RecordDecl* PrevDecl = nullptr,
                             ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>(nullptr, (size_t)0),
+                            RecordDecl *BaseDecl = nullptr,
                             ArrayRef<TypeArgument> TypeArgs = ArrayRef<TypeArgument>(nullptr, (size_t)0));
   static RecordDecl *CreateDeserialized(const ASTContext &C, unsigned ID);
 
@@ -3980,6 +3982,8 @@ public:
 
   /// Whether the record is a (fully) instantiated generic.
   bool isInstantiated();
+  /// If this is an instantiated RecordDecl, return the underlying generic RecordDecl.
+  RecordDecl *baseDecl();
   /// Returns the record's type arguments.
   /// If there are no type arguments, then the array will be empty.
   ArrayRef<TypeArgument> typeArgs();
@@ -4011,6 +4015,8 @@ private:
   /// Whether this struct is the result of instantiating a generic struct
   /// (so the current struct is fully - instantiated no longer generic).
   bool IsInstantiated;
+  /// The underlying generic RecordDecl that was instantiated.
+  RecordDecl *BaseDecl;
   /// The number of type arguments in this instantiated struct (must match the number of parameters
   /// in the underlying generic base struct).
   size_t NumTypeArgs;
@@ -4018,7 +4024,7 @@ private:
   /// isn't the result of an instantiation.
   TypeArgument *TypeArgs;
   /// Sets the type arguments for an instantiation, as well as 'IsInstantiated' and 'NumTypeArgs'.
-  void setTypeArgs(ASTContext& C, ArrayRef<TypeArgument> NewTypeArgs);
+  void setTypeArgs(ASTContext& C, RecordDecl *BaseDecl, ArrayRef<TypeArgument> NewTypeArgs);
 };
 
 class FileScopeAsmDecl : public Decl {

--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3773,18 +3773,18 @@ protected:
   RecordDecl(Kind DK, TagKind TK, const ASTContext &C, DeclContext *DC,
              SourceLocation StartLoc, SourceLocation IdLoc,
              IdentifierInfo* Id, RecordDecl* PrevDecl,
-             ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>{ nullptr, (size_t) 0 },
-             ArrayRef<QualType> TypeArgs = ArrayRef<QualType>{ nullptr, (size_t) 0 });
+             ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>(nullptr, (size_t)0),
+             ArrayRef<TypeArgument> TypeArgs = ArrayRef<TypeArgument>(nullptr, (size_t)0));
 
 public:
   static RecordDecl *Create(const ASTContext &C, TagKind TK, DeclContext *DC,
                             SourceLocation StartLoc, SourceLocation IdLoc,
                             IdentifierInfo *Id, RecordDecl* PrevDecl = nullptr,
-                            ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>{ nullptr, 0 },
-                            ArrayRef<QualType> TypeArgs = ArrayRef<QualType>{ nullptr, (size_t)0 });
+                            ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*>(nullptr, (size_t)0),
+                            ArrayRef<TypeArgument> TypeArgs = ArrayRef<TypeArgument>(nullptr, (size_t)0));
   static RecordDecl *CreateDeserialized(const ASTContext &C, unsigned ID);
 
-  static RecordDecl* Instantiate(RecordDecl* Base, ArrayRef<QualType> TypeArgs);
+  static RecordDecl* Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
 
   RecordDecl *getPreviousDecl() {
     return cast_or_null<RecordDecl>(
@@ -3984,7 +3984,7 @@ public:
   bool isInstantiated();
   /// Returns the record's type arguments.
   /// If there are no type arguments, then the array will be empty.
-  ArrayRef<QualType> typeArgs();
+  ArrayRef<TypeArgument> typeArgs();
 
 private:
   /// Deserialize just the fields.
@@ -4018,9 +4018,9 @@ private:
   size_t NumTypeArgs;
   /// New []'d array of pointers to the type arguments. This is null if this RecordDecl
   /// isn't the result of an instantiation.
-  QualType *TypeArgs;
+  TypeArgument *TypeArgs;
   /// Sets the type arguments for an instantiation, as well as 'IsInstantiated' and 'NumTypeArgs'.
-  void setTypeArgs(ASTContext& C, ArrayRef<QualType> NewTypeArgs);
+  void setTypeArgs(ASTContext& C, ArrayRef<TypeArgument> NewTypeArgs);
 };
 
 class FileScopeAsmDecl : public Decl {

--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -1061,13 +1061,6 @@ public:
   /// \brief Information for an instantiation of generic function. Stores type
   /// name list and location required to instantiate generic function.
   class GenericInstInfo {
-  public:
-    struct TypeArgument {
-      QualType typeName;
-      TypeSourceInfo *sourceInfo;
-    };
-
-  private :
     /// \brief references to generic functions in code must always be
     /// instantiated (applied to type arguments). Type arguments are stored in
     /// DeclRefExpr.
@@ -1204,7 +1197,7 @@ public:
   }
 
   void SetGenericInstInfo(ASTContext &C,
-       ArrayRef<GenericInstInfo::TypeArgument> NewTypeVariableNames) {
+       ArrayRef<TypeArgument> NewTypeVariableNames) {
     TypeArgumentInfo = GenericInstInfo::Create(C, NewTypeVariableNames);
   }
 

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -61,6 +61,7 @@ class ExtQuals;
 class QualType;
 class TagDecl;
 class Type;
+class TypeSourceInfo;
 
 enum {
   TypeAlignmentInBits = 4,
@@ -1443,6 +1444,13 @@ public:
 
   /// \brief Always write data for individual elements.
   void Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Ctx) const;
+};
+
+/// Checked C: an argument in an instantiation of a generic function
+/// or record.
+struct TypeArgument {
+  QualType typeName;
+  TypeSourceInfo* sourceInfo;
 };
 
 /// The base class of the type hierarchy.

--- a/include/clang/Basic/DiagnosticParseKinds.td
+++ b/include/clang/Basic/DiagnosticParseKinds.td
@@ -1303,6 +1303,9 @@ def err_expected_list_of_types_expr_for_generic_function : Error<
 def err_type_function_comma_or_greater_expected : Error<
   "expected , or >">;
 
+def err_num_type_args_params_mistmatch : Error<
+  "generic struct takes %0 type arguments, but instantiation provided %1">;
+
  // Checked C pragmas
 def err_pragma_checked_scope_invalid_argument : Error<
   "unexpected argument '%0' to '#pragma CHECKED_SCOPE'; "

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9990,5 +9990,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_type_args_limited : Error<
     "type arguments only supported for variables and function names right now">;
 
+  // TODO(abeln): describe cycle in error message
+  def err_expanding_cycle : Error<
+	"expanding cycle in struct definition">;
+
 } // end of Checked C Category
 } // end of sema component.

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1886,7 +1886,8 @@ private:
   ExprResult ParseBoundsCastExpression();
 
   ExprResult ParseBoundsExpression();
-  ExprResult ParseGenericTypeArgumentList(ExprResult TypeFunc, SourceLocation Loc);
+  ExprResult ParseGenericFunctionApplication(ExprResult TypeFunc, SourceLocation Loc);
+  bool ParseGenericTypeArgumentList(ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> &out, SourceLocation Loc);
 
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> &typeNames);

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1889,7 +1889,7 @@ private:
   ExprResult ParseGenericFunctionApplication(ExprResult TypeFunc, SourceLocation Loc);
 
   using TypeArgVector = SmallVector<TypeArgument, 4>;
-  std::pair<bool, TypeArgVector> ParseGenericTypeArgumentList(SourceLocation Loc);
+  std::pair<bool, TypeArgVector> ParseGenericTypeArgumentList(SourceLocation Loc, bool WithinFieldDecl=false);
 
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<TypeArgument, 4> &typeNames);
@@ -1916,7 +1916,7 @@ private:
 
   ExprResult ParseReturnValueExpression();
 
-  DeclResult ParseRecordTypeApplication(RecordDecl *base);
+  DeclResult ParseRecordTypeApplication(RecordDecl *Base, bool WithinFieldDecl);
 
   //===--------------------------------------------------------------------===//
   // clang Expressions
@@ -2192,14 +2192,16 @@ private:
       const ParsedTemplateInfo &TemplateInfo = ParsedTemplateInfo(),
       AccessSpecifier AS = AS_none,
       DeclSpecContext DSC = DeclSpecContext::DSC_normal,
-      LateParsedAttrList *LateAttrs = nullptr);
+      LateParsedAttrList *LateAttrs = nullptr,
+      bool WithinFieldDecl = false);
   bool DiagnoseMissingSemiAfterTagDefinition(
       DeclSpec &DS, AccessSpecifier AS, DeclSpecContext DSContext,
       LateParsedAttrList *LateAttrs = nullptr);
 
   void ParseSpecifierQualifierList(
       DeclSpec &DS, AccessSpecifier AS = AS_none,
-      DeclSpecContext DSC = DeclSpecContext::DSC_normal);
+      DeclSpecContext DSC = DeclSpecContext::DSC_normal,
+      bool WithinFieldDecl = false);
 
   void ParseObjCTypeQualifierList(ObjCDeclSpec &DS,
                                   DeclaratorContext Context);
@@ -2407,7 +2409,8 @@ public:
                              = DeclaratorContext::TypeNameContext,
                            AccessSpecifier AS = AS_none,
                            Decl **OwnedType = nullptr,
-                           ParsedAttributes *Attrs = nullptr);
+                           ParsedAttributes *Attrs = nullptr,
+                           bool WithinFieldDecl = false);
 
 private:
   void ParseBlockId(SourceLocation CaretLoc);
@@ -2825,7 +2828,8 @@ private:
                            DeclSpec &DS, const ParsedTemplateInfo &TemplateInfo,
                            AccessSpecifier AS, bool EnteringContext,
                            DeclSpecContext DSC,
-                           ParsedAttributesWithRange &Attributes);
+                           ParsedAttributesWithRange &Attributes,
+                           bool WithinFieldDecl = false);
   void SkipCXXMemberSpecification(SourceLocation StartLoc,
                                   SourceLocation AttrFixitLoc,
                                   unsigned TagType,

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1889,7 +1889,7 @@ private:
   ExprResult ParseGenericFunctionApplication(ExprResult TypeFunc, SourceLocation Loc);
 
   using TypeArgVector = SmallVector<TypeArgument, 4>;
-  std::pair<bool, TypeArgVector> ParseGenericTypeArgumentList(SourceLocation Loc, bool WithinFieldDecl=false);
+  std::pair<bool, TypeArgVector> ParseGenericTypeArgumentList(SourceLocation Loc);
 
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<TypeArgument, 4> &typeNames);
@@ -1916,7 +1916,7 @@ private:
 
   ExprResult ParseReturnValueExpression();
 
-  DeclResult ParseRecordTypeApplication(RecordDecl *Base, bool WithinFieldDecl);
+  DeclResult ParseRecordTypeApplication(RecordDecl *Base);
 
   //===--------------------------------------------------------------------===//
   // clang Expressions
@@ -2192,16 +2192,14 @@ private:
       const ParsedTemplateInfo &TemplateInfo = ParsedTemplateInfo(),
       AccessSpecifier AS = AS_none,
       DeclSpecContext DSC = DeclSpecContext::DSC_normal,
-      LateParsedAttrList *LateAttrs = nullptr,
-      bool WithinFieldDecl = false);
+      LateParsedAttrList *LateAttrs = nullptr);
   bool DiagnoseMissingSemiAfterTagDefinition(
       DeclSpec &DS, AccessSpecifier AS, DeclSpecContext DSContext,
       LateParsedAttrList *LateAttrs = nullptr);
 
   void ParseSpecifierQualifierList(
       DeclSpec &DS, AccessSpecifier AS = AS_none,
-      DeclSpecContext DSC = DeclSpecContext::DSC_normal,
-      bool WithinFieldDecl = false);
+      DeclSpecContext DSC = DeclSpecContext::DSC_normal);
 
   void ParseObjCTypeQualifierList(ObjCDeclSpec &DS,
                                   DeclaratorContext Context);
@@ -2409,8 +2407,7 @@ public:
                              = DeclaratorContext::TypeNameContext,
                            AccessSpecifier AS = AS_none,
                            Decl **OwnedType = nullptr,
-                           ParsedAttributes *Attrs = nullptr,
-                           bool WithinFieldDecl = false);
+                           ParsedAttributes *Attrs = nullptr);
 
 private:
   void ParseBlockId(SourceLocation CaretLoc);
@@ -2828,8 +2825,7 @@ private:
                            DeclSpec &DS, const ParsedTemplateInfo &TemplateInfo,
                            AccessSpecifier AS, bool EnteringContext,
                            DeclSpecContext DSC,
-                           ParsedAttributesWithRange &Attributes,
-                           bool WithinFieldDecl = false);
+                           ParsedAttributesWithRange &Attributes);
   void SkipCXXMemberSpecification(SourceLocation StartLoc,
                                   SourceLocation AttrFixitLoc,
                                   unsigned TagType,

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1914,6 +1914,8 @@ private:
 
   ExprResult ParseReturnValueExpression();
 
+  DeclResult ParseGenericStructInstantiation(RecordDecl *base);
+
   //===--------------------------------------------------------------------===//
   // clang Expressions
 

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1888,11 +1888,11 @@ private:
   ExprResult ParseBoundsExpression();
   ExprResult ParseGenericFunctionApplication(ExprResult TypeFunc, SourceLocation Loc);
 
-  using TypeArgVector = SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4>;
+  using TypeArgVector = SmallVector<TypeArgument, 4>;
   std::pair<bool, TypeArgVector> ParseGenericTypeArgumentList(SourceLocation Loc);
 
   QualType SubstituteTypeVariable(QualType QT,
-    SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> &typeNames);
+    SmallVector<TypeArgument, 4> &typeNames);
 
   ExprResult ParseInteropTypeAnnotation(const Declarator &D, bool IsReturn=false);
   bool ParseBoundsAnnotations(const Declarator &D,

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1887,7 +1887,9 @@ private:
 
   ExprResult ParseBoundsExpression();
   ExprResult ParseGenericFunctionApplication(ExprResult TypeFunc, SourceLocation Loc);
-  bool ParseGenericTypeArgumentList(ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> &out, SourceLocation Loc);
+
+  using TypeArgVector = SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4>;
+  std::pair<bool, TypeArgVector> ParseGenericTypeArgumentList(SourceLocation Loc);
 
   QualType SubstituteTypeVariable(QualType QT,
     SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4> &typeNames);

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -2642,7 +2642,7 @@ private:
   void ParseAtomicSpecifier(DeclSpec &DS);
   void ParseCheckedPointerSpecifiers(DeclSpec & DS);
   void ParseForanySpecifier(DeclSpec &DS);
-  bool ParseGenericFunctionSpecifierHelper(DeclSpec &DS,
+  bool ParseForanySpecifierHelper(DeclSpec &DS,
                                             Scope::ScopeFlags S);
   void ParseItypeforanySpecifier(DeclSpec &DS);
 

--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1916,7 +1916,7 @@ private:
 
   ExprResult ParseReturnValueExpression();
 
-  DeclResult ParseGenericStructInstantiation(RecordDecl *base);
+  DeclResult ParseRecordTypeApplication(RecordDecl *base);
 
   //===--------------------------------------------------------------------===//
   // clang Expressions

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -393,8 +393,8 @@ private:
 
   TypedefDecl **TypeVarInfo;
   unsigned NumTypeVars : 15;
-  bool GenericFunction : 1;
-  bool ItypeGenericFunction : 1;
+  bool GenericFunctionOrStruct : 1;
+  bool ItypeGenericFunctionOrStruct : 1;
 
 
   // Scope specifier for the type spec, if applicable.
@@ -475,8 +475,8 @@ public:
       Attrs(attrFactory),
       TypeVarInfo(nullptr),
       NumTypeVars(0),
-      GenericFunction(false),
-      ItypeGenericFunction(false),
+      GenericFunctionOrStruct(false),
+      ItypeGenericFunctionOrStruct(false),
       writtenBS(),
       ObjCQualifiers(nullptr) {
   }
@@ -624,12 +624,12 @@ public:
   SourceLocation getForanySpecLoc() const { return FS_foranyLoc; }
 
   void setTypeVars(ASTContext &C, ArrayRef<TypedefDecl *> NewTypeVarInfo, unsigned NewNumTypeVars);
-  void setGenericFunction(bool IsGeneric) { GenericFunction = IsGeneric; }
-  void setItypeGenericFunction(bool IsItypeGeneric) { ItypeGenericFunction = IsItypeGeneric; }
+  void setGenericFunctionOrStruct(bool IsGeneric) { GenericFunctionOrStruct = IsGeneric; }
+  void setItypeGenericFunctionOrStruct(bool IsItypeGeneric) { ItypeGenericFunctionOrStruct = IsItypeGeneric; }
   void setNumTypeVars(unsigned NewNumTypeVars) { NumTypeVars = NewNumTypeVars; }
   unsigned getNumTypeVars(void) const { return NumTypeVars; }
-  bool isGenericFunction(void) const { return GenericFunction; }
-  bool isItypeGenericFunction(void) const { return ItypeGenericFunction; }
+  bool isGenericFunctionOrStruct(void) const { return GenericFunctionOrStruct; }
+  bool isItypeGenericFunctionOrStruct(void) const { return ItypeGenericFunctionOrStruct; }
 
   ArrayRef<TypedefDecl *> typeVariables() const {
     return { TypeVarInfo, getNumTypeVars() };
@@ -778,9 +778,9 @@ public:
                               const char *&PrevSpec, unsigned &DiagID);
   bool setFunctionSpecUnchecked(SourceLocation Loc, const char *&PrevSpec,
                                 unsigned &DiagID);
-  bool setFunctionSpecForany(SourceLocation Loc, const char *&PrevSpec,
+  bool setSpecForany(SourceLocation Loc, const char *&PrevSpec,
                                 unsigned &DiagID);
-  bool setFunctionSpecItypeforany(SourceLocation Loc, const char *&PrevSpec,
+  bool setSpecItypeforany(SourceLocation Loc, const char *&PrevSpec,
                                     unsigned &DiagID);
   bool SetFriendSpec(SourceLocation Loc, const char *&PrevSpec,
                      unsigned &DiagID);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4876,7 +4876,7 @@ public:
   ExprResult ActOnFunctionTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
                      ArrayRef<TypeArgument> Args);
 
-  RecordDecl* ActOnRecordTypeApplication(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs, bool WithinFieldDecl);
+  RecordDecl* ActOnRecordTypeApplication(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
 
   /// Complete a delayed type application by populating the record's fields with the right types.
   /// Should only be called once per delayed 'RecordDecl'.
@@ -4922,8 +4922,7 @@ public:
   //      GetAsGenericRecordDecl(struct Bar) -> nullptr
   RecordDecl *GetAsGenericRecordDecl(const Type *Type);
 
-  QualType SubstituteTypeArgs(QualType QT,
-                ArrayRef<TypeArgument> TypeArgs, bool WithinFieldDecl);
+  QualType SubstituteTypeArgs(QualType QT, ArrayRef<TypeArgument> TypeArgs);
 
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -2249,7 +2249,8 @@ public:
                  bool &IsDependent, SourceLocation ScopedEnumKWLoc,
                  bool ScopedEnumUsesClassTag, TypeResult UnderlyingType,
                  bool IsTypeSpecifier, bool IsTemplateParamOrArg,
-                 SkipBodyInfo *SkipBody = nullptr);
+                 SkipBodyInfo *SkipBody = nullptr,
+                 ArrayRef<TypedefDecl*> TypeParams = ArrayRef<TypedefDecl*> { nullptr, 0} );
 
   Decl *ActOnTemplatedFriendTag(Scope *S, SourceLocation FriendLoc,
                                 unsigned TagSpec, SourceLocation TagLoc,

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4876,6 +4876,8 @@ public:
   ExprResult ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
                      ArrayRef<TypeArgument> Args);
 
+  RecordDecl* Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
+
   QualType SubstituteTypeArgs(QualType QT,
                 ArrayRef<TypeArgument> TypeArgs);
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4874,10 +4874,10 @@ public:
   BoundsExpr *CheckNonModifyingBounds(BoundsExpr *Bounds, Expr *E);
 
   ExprResult ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
-                     ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> Args);
+                     ArrayRef<TypeArgument> Args);
 
   QualType SubstituteTypeArgs(QualType QT,
-                ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> TypeArgs);
+                ArrayRef<TypeArgument> TypeArgs);
 
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4883,9 +4883,37 @@ public:
   void CompleteTypeAppFields(RecordDecl *Incomplete);
 
   // Determine whether the given 'RecordDecl' is part of an 'expanding cycle'.
-  // For the definition of expanding cycle, see 'ECMA 335 Common Language Infrastructure (CLI) Partitions I to VI'.
+  // Generic records that form part of an expanding cycle can't be instantiated because they
+  // produce an infinite number of type applications (because we construct the transitive closure
+  // of type applications eagerly).
+  //
+  // Consider the graph of type parameter dependencies as defined below. An expanding cycle
+  // is a cycle in the graph that contains at least one expanding edge.
+  //
+  // We show how the graph is built via an example. Suppose we have three generic structs A<T>, B<U>, C<V>:
+  //
+  //   struct A _For_any(T) { struct A<T>* a; struct B<T> *b; }
+  //   struct B _For_any(U) { struct C<struct C<U> > *c; }
+  //   struct C _For_any(V) { struct A<V>* a; }
+  //
+  // The vertices of the graph are T, U, and V (the type parameter, alpha re-named if needed).
+  // There is an edge between nodes N1 and N2 if N2 is used in a field anywhere in the position of N1.
+  // If N2 appears at the "top-level" replacing N1, then the resulting edge is "non-expanding".
+  // Otheriwse, if N2 appears nested within the argument that replaces N1, then the edge is "expanding".
+  //
+  // In our example the edges are:
+  //
+  //   non-expanding: T -> T, T -> U, V -> T, U -> V
+  //   expanding: U => V
+  //
+  // T -> U, U => V, V -> T is an expanding cycle because it contains the expanding edge U => V
+  //
+  // The cycle will be detected when C is processed (because C is defined last). If we tried to instantiate C, we would
+  // end up performing the following type applications:
+  //   A<V>, B<V>, C<C<V>>, A<C<V>>, B<C<V>>, C<C<C<V>>>, ...
+  //
+  // The definition of expanding cycle is adapted from the 'ECMA 335 Common Language Infrastructure (CLI) Partitions I to VI' standard.
   // Specifically, Partition II, section II.9.2 'Generics and recursive inheritance graphs'.
-  // TODO(abeln): add larger comment describing the algorithm.
   bool DiagnoseExpandingCycles(RecordDecl *Base, SourceLocation Loc);
 
   // Like 'Type::getAsRecordDecl', but for generic records. Additionally, it unwraps pointer types multiple times, if necessary.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4882,6 +4882,12 @@ public:
   /// Should only be called once per delayed 'RecordDecl'.
   void CompleteTypeAppFields(RecordDecl *Incomplete);
 
+  // Determine whether the given 'RecordDecl' is part of an 'expanding cycle'.
+  // For the definition of expanding cycle, see 'ECMA 335 Common Language Infrastructure (CLI) Partitions I to VI'.
+  // Specifically, Partition II, section II.9.2 'Generics and recursive inheritance graphs'.
+  // TODO(abeln): add larger comment describing the algorithm.
+  bool DiagnoseExpandingCycles(RecordDecl *Base, SourceLocation Loc);
+
   QualType SubstituteTypeArgs(QualType QT,
                 ArrayRef<TypeArgument> TypeArgs, bool WithinFieldDecl);
 

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4873,10 +4873,10 @@ public:
 
   BoundsExpr *CheckNonModifyingBounds(BoundsExpr *Bounds, Expr *E);
 
-  ExprResult ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
+  ExprResult ActOnFunctionTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
                      ArrayRef<TypeArgument> Args);
 
-  RecordDecl* Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
+  RecordDecl* ActOnRecordTypeApplication(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
 
   QualType SubstituteTypeArgs(QualType QT,
                 ArrayRef<TypeArgument> TypeArgs);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4876,10 +4876,14 @@ public:
   ExprResult ActOnFunctionTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
                      ArrayRef<TypeArgument> Args);
 
-  RecordDecl* ActOnRecordTypeApplication(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs);
+  RecordDecl* ActOnRecordTypeApplication(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs, bool WithinFieldDecl);
+
+  /// Complete a delayed type application by populating the record's fields with the right types.
+  /// Should only be called once per delayed 'RecordDecl'.
+  void CompleteTypeAppFields(RecordDecl *Incomplete);
 
   QualType SubstituteTypeArgs(QualType QT,
-                ArrayRef<TypeArgument> TypeArgs);
+                ArrayRef<TypeArgument> TypeArgs, bool WithinFieldDecl);
 
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4888,6 +4888,12 @@ public:
   // TODO(abeln): add larger comment describing the algorithm.
   bool DiagnoseExpandingCycles(RecordDecl *Base, SourceLocation Loc);
 
+  // Like 'Type::getAsRecordDecl', but for generic records. Additionally, it unwraps pointer types multiple times, if necessary.
+  // If there's no underlying generic record, return 'nullptr'.
+  // e.g. GetAsGenericRecordDecl(struct Foo<T>**) -> struct Foo<T>
+  //      GetAsGenericRecordDecl(struct Bar) -> nullptr
+  RecordDecl *GetAsGenericRecordDecl(const Type *Type);
+
   QualType SubstituteTypeArgs(QualType QT,
                 ArrayRef<TypeArgument> TypeArgs, bool WithinFieldDecl);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -11190,10 +11190,6 @@ RecordDecl *ASTContext::getCachedTypeApp(const RecordDecl *Base, ArrayRef<const 
 }
 
 void ASTContext::addCachedTypeApp(const RecordDecl *Base, ArrayRef<const Type *> TypeArgs, RecordDecl *Inst) {
-  printf("adding to cache %s #args = %d\n", Base->getNameAsString().c_str(), TypeArgs.size());
-  for (auto TA : TypeArgs) {
-    TA->dump();
-  }
   assert((getCachedTypeApp(Base, TypeArgs) == nullptr) && "Type application is already cached");
   CachedTypeApps.insert(std::make_pair(std::make_pair(Base, TypeArgs), Inst));
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -11182,3 +11182,18 @@ APFixedPoint ASTContext::getFixedPointMin(QualType Ty) const {
   assert(Ty->isFixedPointType());
   return APFixedPoint::getMin(getFixedPointSemantics(Ty));
 }
+
+RecordDecl *ASTContext::getCachedTypeApp(const RecordDecl *Base, ArrayRef<const Type *> TypeArgs) {
+  auto it = CachedTypeApps.find(std::make_pair(Base, TypeArgs));
+  if (it == CachedTypeApps.end()) return nullptr;
+  return it->second;
+}
+
+void ASTContext::addCachedTypeApp(const RecordDecl *Base, ArrayRef<const Type *> TypeArgs, RecordDecl *Inst) {
+  printf("adding to cache %s #args = %d\n", Base->getNameAsString().c_str(), TypeArgs.size());
+  for (auto TA : TypeArgs) {
+    TA->dump();
+  }
+  assert((getCachedTypeApp(Base, TypeArgs) == nullptr) && "Type application is already cached");
+  CachedTypeApps.insert(std::make_pair(std::make_pair(Base, TypeArgs), Inst));
+}

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1567,7 +1567,7 @@ void ASTDumper::VisitCastExpr(const CastExpr *Node) {
 void ASTDumper::VisitDeclRefExpr(const DeclRefExpr *Node) {
   if (Node->GetTypeArgumentInfo() &&
       !Node->GetTypeArgumentInfo()->typeArgumentss().empty()) {
-    for (DeclRefExpr::GenericInstInfo::TypeArgument tn :
+    for (TypeArgument tn :
          Node->GetTypeArgumentInfo()->typeArgumentss()) {
       dumpTypeAsChild(tn.typeName);
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4366,29 +4366,6 @@ void RecordDecl::setTypeArgs(ASTContext& C, ArrayRef<TypeArgument> NewTypeArgs) 
   }
 }
 
-// Type Instantiation
-
-RecordDecl* RecordDecl::Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs) {
-  // TODO(abeln): populate the two 'SourceLocation' fields.
-  RecordDecl* Inst = Create(Base->getASTContext(), Base->getTagKind(), Base->getDeclContext(), SourceLocation(), SourceLocation(),
-    Base->getIdentifier(), Base->getPreviousDecl(), ArrayRef<TypedefDecl*>(nullptr, (size_t)0) /* TypeParams */, TypeArgs);
-
-  for (auto Field = Base->field_begin(); Field != Base->field_end(); Field++) {
-    // TODO(abeln): instantiate type properly
-    QualType InstType = Field->getType();
-    // TODO(abeln): populate 'SouceLocation' fields.
-    // Also make sure that TypeSouceInfo and InstType are in-sync.
-    FieldDecl* NewField = FieldDecl::Create(Field->getASTContext(), Inst, SourceLocation(), SourceLocation(),
-      Field->getIdentifier(), InstType, Field->getTypeSourceInfo(), Field->getBitWidth(), Field->isMutable(), Field->getInClassInitStyle());
-    // printf("new field %s with type\n", NewField->getNameAsString().c_str());
-    // NewField->getType()->dump();
-    Inst->addDecl(NewField);
-  }
-
-  Inst->setCompleteDefinition();
-  return Inst;
-}
-
 //===----------------------------------------------------------------------===//
 // BlockDecl Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4158,7 +4158,7 @@ RecordDecl::RecordDecl(Kind DK, TagKind TK, const ASTContext &C,
                        RecordDecl *BaseDecl,
                        ArrayRef<TypeArgument> TypeArgs)
     : TagDecl(DK, TK, C, DC, IdLoc, Id, PrevDecl, StartLoc),
-      IsGeneric(false), NumTypeParams(0), IsInstantiated(false), NumTypeArgs(0) {
+      IsGeneric(false), NumTypeParams(0), IsInstantiated(false), NumTypeArgs(0), IsDelayed(false) {
   assert(classof(static_cast<Decl *>(this)) && "Invalid Kind!");
   setHasFlexibleArrayMember(false);
   setAnonymousStructOrUnion(false);
@@ -4357,6 +4357,14 @@ RecordDecl *RecordDecl::baseDecl() {
 
 ArrayRef<TypeArgument> RecordDecl::typeArgs() {
   return { TypeArgs, NumTypeArgs };
+}
+
+bool RecordDecl::isDelayedTypeApp() {
+  return IsDelayed;
+}
+
+void RecordDecl::setDelayedTypeApp(bool IsDelayed) {
+  this->IsDelayed = IsDelayed;
 }
 
 void RecordDecl::setTypeArgs(ASTContext& C, RecordDecl *NewBaseDecl, ArrayRef<TypeArgument> NewTypeArgs) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4193,6 +4193,7 @@ RecordDecl *RecordDecl::CreateDeserialized(const ASTContext &C, unsigned ID) {
 }
 
 RecordDecl* RecordDecl::Instantiate(RecordDecl* Base, ArrayRef<QualType> TypeArgs) {
+  // TODO(abeln): implement
   return Base;
 }
 
@@ -4336,8 +4337,10 @@ ArrayRef<TypedefDecl*> RecordDecl::typeParams() {
 }
 
 void RecordDecl::setTypeParams(ASTContext& C, ArrayRef<TypedefDecl*> NewTypeParams) {
+  assert(!isGeneric() && "Can't reset type parameters for record");
   NumTypeParams = NewTypeParams.size();
   IsGeneric = NumTypeParams > 0;
+  assert(!(isGeneric() && isInstantiated()) && "Record can't be both generic and instantiated");
 
   // Zero params -> null pointer.
   if (!NewTypeParams.empty()) {
@@ -4357,8 +4360,10 @@ ArrayRef<QualType> RecordDecl::typeArgs() {
 }
 
 void RecordDecl::setTypeArgs(ASTContext& C, ArrayRef<QualType> NewTypeArgs) {
+  assert(!isInstantiated() && "Can't reset type parameters for record");
   NumTypeArgs = NewTypeArgs.size();
   IsInstantiated = NumTypeArgs > 0;
+  assert(!(isGeneric() && isInstantiated()) && "Record can't be both generic and instantiated");
 
   // Zero args -> null pointer.
   if (!NewTypeArgs.empty()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4298,9 +4298,7 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
         // Checked C: if the type of the field refers to a delayed type application,
         // then accumulate the decl for later completion.
         auto FieldTpe = Field->getType();
-        auto RDecl = Field->getType()->getAsRecordDecl();
-        // TODO(abeln): find a more-robust way to get the underlying 'RecordDecl'.
-        if (!RDecl) RDecl = FieldTpe->getPointeeType()->getAsRecordDecl();
+        auto RDecl = Actions.GetAsGenericRecordDecl(FieldTpe.getTypePtr());
         if (RDecl && RDecl->isDelayedTypeApp()) DelayedTypeApps.push_back(RDecl);
       };
 
@@ -4401,8 +4399,7 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
       // Complete the arguments to this type application, if necessary: e.g. when completing 'Box<List<int>>', need
       // to potentially complete 'List<int>'.
       for (auto TypeArg : TypeApp->typeArgs()) {
-        // TODO(abeln): add more robust logic to extract the underlying 'RecordDecl'.
-        if (auto Decl = TypeArg.typeName.getTypePtr()->getAsRecordDecl()) DelayedTypeApps.push_back(Decl);
+        if (auto Decl = Actions.GetAsGenericRecordDecl(TypeArg.typeName.getTypePtr())) DelayedTypeApps.push_back(Decl);
       }
     }
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -44,8 +44,7 @@ TypeResult Parser::ParseTypeName(SourceRange *Range,
                                  DeclaratorContext Context,
                                  AccessSpecifier AS,
                                  Decl **OwnedType,
-                                 ParsedAttributes *Attrs,
-                                 bool WithinFieldDecl) {
+                                 ParsedAttributes *Attrs) {
   DeclSpecContext DSC = getDeclSpecContextFromDeclaratorContext(Context);
   if (DSC == DeclSpecContext::DSC_normal)
     DSC = DeclSpecContext::DSC_type_specifier;
@@ -54,7 +53,7 @@ TypeResult Parser::ParseTypeName(SourceRange *Range,
   DeclSpec DS(AttrFactory);
   if (Attrs)
     DS.addAttributes(*Attrs);
-  ParseSpecifierQualifierList(DS, AS, DSC, WithinFieldDecl);
+  ParseSpecifierQualifierList(DS, AS, DSC);
 
   // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);
@@ -2495,12 +2494,11 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
 ///          type-qualifier specifier-qualifier-list[opt]
 /// [GNU]    attributes     specifier-qualifier-list[opt]
 ///
-void Parser::ParseSpecifierQualifierList(DeclSpec &DS, AccessSpecifier AS,
-                                         DeclSpecContext DSC, bool WithinFieldDecl) {
+void Parser::ParseSpecifierQualifierList(DeclSpec &DS, AccessSpecifier AS, DeclSpecContext DSC) {
   /// specifier-qualifier-list is a subset of declaration-specifiers.  Just
   /// parse declaration-specifiers and complain about extra stuff.
   /// TODO: diagnose attribute-specifiers and alignment-specifiers.
-  ParseDeclarationSpecifiers(DS, ParsedTemplateInfo(), AS, DSC, nullptr /* LateAttrs */, WithinFieldDecl);
+  ParseDeclarationSpecifiers(DS, ParsedTemplateInfo(), AS, DSC, nullptr /* LateAttrs */);
 
   // Validate declspec for type-name.
   unsigned Specs = DS.getParsedSpecifiers();
@@ -3039,8 +3037,7 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
                                         const ParsedTemplateInfo &TemplateInfo,
                                         AccessSpecifier AS,
                                         DeclSpecContext DSContext,
-                                        LateParsedAttrList *LateAttrs,
-                                        bool WithinFieldDecl) {
+                                        LateParsedAttrList *LateAttrs) {
   if (DS.getSourceRange().isInvalid()) {
     // Start the range at the current token but make the end of the range
     // invalid.  This will make the entire range invalid unless we successfully
@@ -3879,7 +3876,7 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
       // parsing class specifier.
       ParsedAttributesWithRange Attributes(AttrFactory);
       ParseClassSpecifier(Kind, Loc, DS, TemplateInfo, AS,
-                          EnteringContext, DSContext, Attributes, WithinFieldDecl);
+                          EnteringContext, DSContext, Attributes);
 
       // If there are attributes following class specifier,
       // take them over and handle them here.
@@ -4080,7 +4077,7 @@ void Parser::ParseStructDeclaration(
   DS.takeAttributesFrom(Attrs);
 
   // Parse the common specifier-qualifiers-list piece.
-  ParseSpecifierQualifierList(DS, AS_none, DeclSpecContext::DSC_normal, true /* WithinFieldDecl */);
+  ParseSpecifierQualifierList(DS, AS_none, DeclSpecContext::DSC_normal);
 
   // Checked C - mark the current scope as checked or unchecked if necessary.
   Sema::CheckedScopeRAII CheckedScopeTracker(Actions, DS);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3005,14 +3005,14 @@ static void SetupFixedPointError(const LangOptions &LangOpts,
 
 /// ParseDeclarationSpecifiers
 ///       declaration-specifiers: [C99 6.7]
-///         storage-class-specifier declaration-specifiers[opt]
-///         type-specifier declaration-specifiers[opt]
-/// [C99]   function-specifier declaration-specifiers[opt]
-/// [C11]   alignment-specifier declaration-specifiers[opt]
-/// [GNU]   attributes declaration-specifiers[opt]
-/// [Clang] '__module_private__' declaration-specifiers[opt]
-/// [ObjC1] '__kindof' declaration-specifiers[opt]
-///
+///            storage-class-specifier declaration-specifiers[opt]
+///            type-specifier declaration-specifiers[opt]
+/// [C99]      function-specifier declaration-specifiers[opt]
+/// [C11]      alignment-specifier declaration-specifiers[opt]
+/// [GNU]      attributes declaration-specifiers[opt]
+/// [Clang]    '__module_private__' declaration-specifiers[opt]
+/// [ObjC1]    '__kindof' declaration-specifiers[opt]
+/// [CheckedC] for-any-specifier declaration-specifier[opt]
 ///       storage-class-specifier: [C99 6.7.1]
 ///         'typedef'
 ///         'extern'
@@ -3028,11 +3028,12 @@ static void SetupFixedPointError(const LangOptions &LangOpts,
 /// [C++]   'virtual'
 /// [C++]   'explicit'
 /// [OpenCL] '__kernel'
+///       'friend': [C++ dcl.friend]
+///       'constexpr': [C++0x dcl.constexpr]
+///       for-any-specifier: [CheckedC]
 /// [CheckedC] '_For_any'
 /// [CheckedC] '_Itype_for_any'
 /// [CheckedC] '_Itype_for_any' and '_For_any' are mutually exclusive
-///       'friend': [C++ dcl.friend]
-///       'constexpr': [C++0x dcl.constexpr]
 void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
                                         const ParsedTemplateInfo &TemplateInfo,
                                         AccessSpecifier AS,
@@ -3142,13 +3143,13 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
     case tok::kw__Nt_checked:
       goto DoneWithDeclSpec;
     case tok::kw__For_any:
-      isInvalid = DS.setFunctionSpecForany(Loc, PrevSpec, DiagID);
+      isInvalid = DS.setSpecForany(Loc, PrevSpec, DiagID);
       if (isInvalid)
           goto DoneWithDeclSpec;
       ParseForanySpecifier(DS);
       continue;
     case tok::kw__Itype_for_any:
-      isInvalid = DS.setFunctionSpecItypeforany(Loc, PrevSpec, DiagID);
+      isInvalid = DS.setSpecItypeforany(Loc, PrevSpec, DiagID);
       if (isInvalid)
         goto DoneWithDeclSpec;
       ParseItypeforanySpecifier(DS);
@@ -7344,21 +7345,21 @@ void Parser::ParseCheckedPointerSpecifiers(DeclSpec &DS) {
 }
 
 void Parser::ParseItypeforanySpecifier(DeclSpec &DS) {
-  if(!ParseGenericFunctionSpecifierHelper(DS, Scope::ItypeforanyScope)) {
-    DS.setItypeGenericFunction(true);
+  if(!ParseForanySpecifierHelper(DS, Scope::ItypeforanyScope)) {
+    DS.setItypeGenericFunctionOrStruct(true);
   }
 }
 
 void Parser::ParseForanySpecifier(DeclSpec &DS) {
-  if(!ParseGenericFunctionSpecifierHelper(DS, Scope::ForanyScope)) {
-    DS.setGenericFunction(true);
+  if(!ParseForanySpecifierHelper(DS, Scope::ForanyScope)) {
+    DS.setGenericFunctionOrStruct(true);
   }
 }
 
-/// Parses type variables that are part of function specifiers "_For_any" and "_Itype_for_any"
+/// Parses type variables that are part of function or struct specifiers "_For_any" and "_Itype_for_any"
 /// Parameter "S" can either be "ForanyScope" or "ItypeforanyScope"
 /// Parameter "Ident" is the identifier string(_For_any or _Itype_for_any) that will be used within the parsing error messages
-bool Parser::ParseGenericFunctionSpecifierHelper(DeclSpec &DS,
+bool Parser::ParseForanySpecifierHelper(DeclSpec &DS,
                                                   Scope::ScopeFlags S) {
   assert((S == Scope::ForanyScope) || (S == Scope::ItypeforanyScope));  
 

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2047,13 +2047,14 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* base) {
   assert(base->isGeneric() && "Instantiated record must be generic");
   ExpectAndConsume(tok::less); // eat the initial '<'
-  auto typeArgs = ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument>();
-  if (ParseGenericTypeArgumentList(typeArgs, SourceLocation())) {
-    return true; // problem while parsing the type arguments (error is produced by 'ParseGenericTypeArgumentList')
+  auto ArgsRes = ParseGenericTypeArgumentList(SourceLocation());
+  if (ArgsRes.first) {
+    // Problem while parsing the type arguments (error is produced by 'ParseGenericTypeArgumentList')
+    return true;
   }
-  if (typeArgs.size() != base->typeParams().size()) {
+  if (ArgsRes.second.size() != base->typeParams().size()) {
     // TODO(abeln): add real error message
-    printf("expected %d type params but got %d\n", base->typeParams().size(), typeArgs.size());
+    printf("expected %d type params but got %d\n", base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
     return base;

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1940,15 +1940,8 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
     // Checked C: a reference to a struct can be followed by a list of type arguments,
     // if the struct is generic.
     if (!TagOrTempResult.isInvalid() && TUK == Sema::TUK_Reference) {
-      RecordDecl* Decl = llvm::dyn_cast<RecordDecl>(TagOrTempResult.get());
+      RecordDecl* Decl = llvm::dyn_cast<RecordDecl>(TagOrTempResult.get()->getCanonicalDecl());
       if (Decl && Decl->isGeneric()) {
-        // There are two cases here:
-        //   1) 'Decl' could be a reference to a fully-defined record, in which case
-        //      we want to access the underlying *definition* which contains all the fields.
-        //   2) 'Decl' could be a recursive reference to the record currently being defined.
-        //      In this case, there's no underlying definition because it's currently being built.
-        //      But that's ok, because the fields will be added eventually.
-        if (auto Def = Decl->getDefinition()) Decl = Def;
         // We're parsing a reference to a generic struct, so we need to parse
         // the type arguments before we can instantiate.
         TagOrTempResult = ParseRecordTypeApplication(Decl, WithinFieldDecl);

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1646,6 +1646,12 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
   const PrintingPolicy &Policy = Actions.getASTContext().getPrintingPolicy();
   Sema::TagUseKind TUK;
 
+  // Checked C - handle generic structs.
+  if (Tok.is(tok::kw__For_any)) {
+    // TODO(abeln): don't allow _any_ specifier, just '_For_any'.
+    ParseDeclarationSpecifiers(DS);
+  }
+
   // Checked C - checked scope keyword, possibly followed by checked scope modifier,
   // followed by '{'.   Set the kind of checked scope and consume the checked scope-related
   // keywords.

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2058,8 +2058,8 @@ DeclResult Parser::ParseRecordTypeApplication(RecordDecl* Base, bool WithinField
     return true;
   }
   if (ArgsRes.second.size() != Base->typeParams().size()) {
-    // TODO(abeln): add real error message
-    printf("expected %d type params but got %u\n", Base->typeParams().size(), ArgsRes.second.size());
+    Diag(Tok.getLocation(), diag::err_num_type_args_params_mistmatch)
+      << static_cast<unsigned int>(Base->typeParams().size()) << static_cast<unsigned int>(ArgsRes.second.size());
     return true;
   } 
   return Actions.ActOnRecordTypeApplication(Base, ArrayRef<TypeArgument>(ArgsRes.second), WithinFieldDecl);

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1943,7 +1943,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
       if (decl && decl->isGeneric()) {
         // We're parsing a reference to a generic struct, so need to parse
         // the type arguments before we can instantiate.
-        TagOrTempResult = ParseGenericStructInstantiation(decl->getDefinition());
+        TagOrTempResult = ParseRecordTypeApplication(decl->getDefinition());
       }
     }
 
@@ -2044,7 +2044,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 ///
 ///  type-name-list-suffix
 ///    ',' type-name type-name-list-suffix [opt]
-DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
+DeclResult Parser::ParseRecordTypeApplication(RecordDecl* Base) {
   assert(Base->isGeneric() && "Instantiated record must be generic");
   assert(Base->isCompleteDefinition() && "Must pass the record definition and not just a reference");
   ExpectAndConsume(tok::less); // eat the initial '<'
@@ -2055,7 +2055,7 @@ DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
   }
   if (ArgsRes.second.size() != Base->typeParams().size()) {
     // TODO(abeln): add real error message
-    printf("expected %d type params but got %d\n", Base->typeParams().size(), ArgsRes.second.size());
+    printf("expected %d type params but got %u\n", Base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
     return Actions.ActOnRecordTypeApplication(Base, ArrayRef<TypeArgument>(ArgsRes.second));

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2058,7 +2058,7 @@ DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
     printf("expected %d type params but got %d\n", Base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
-    return RecordDecl::Instantiate(Base, ArrayRef<QualType> { nullptr, (size_t)0 });
+    return RecordDecl::Instantiate(Base, ArrayRef<TypeArgument>(ArgsRes.second));
   }
 }
 

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2058,7 +2058,7 @@ DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
     printf("expected %d type params but got %d\n", Base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
-    return RecordDecl::Instantiate(Base, ArrayRef<TypeArgument>(ArgsRes.second));
+    return Actions.Instantiate(Base, ArrayRef<TypeArgument>(ArgsRes.second));
   }
 }
 

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2044,20 +2044,20 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 ///
 ///  type-name-list-suffix
 ///    ',' type-name type-name-list-suffix [opt]
-DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* base) {
-  assert(base->isGeneric() && "Instantiated record must be generic");
+DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
+  assert(Base->isGeneric() && "Instantiated record must be generic");
   ExpectAndConsume(tok::less); // eat the initial '<'
   auto ArgsRes = ParseGenericTypeArgumentList(SourceLocation());
   if (ArgsRes.first) {
     // Problem while parsing the type arguments (error is produced by 'ParseGenericTypeArgumentList')
     return true;
   }
-  if (ArgsRes.second.size() != base->typeParams().size()) {
+  if (ArgsRes.second.size() != Base->typeParams().size()) {
     // TODO(abeln): add real error message
-    printf("expected %d type params but got %d\n", base->typeParams().size(), ArgsRes.second.size());
+    printf("expected %d type params but got %d\n", Base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
-    return base;
+    return Base;
   }
 }
 

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1927,7 +1927,8 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
         DSC == DeclSpecContext::DSC_type_specifier,
         DSC == DeclSpecContext::DSC_template_param ||
             DSC == DeclSpecContext::DSC_template_type_arg,
-        &SkipBody);
+        &SkipBody,
+        DS.typeVariables());
 
     // If ActOnTag said the type was dependent, try again with the
     // less common call.

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2057,7 +2057,7 @@ DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
     printf("expected %d type params but got %d\n", Base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
-    return Base;
+    return RecordDecl::Instantiate(Base, ArrayRef<QualType> { nullptr, (size_t)0 });
   }
 }
 

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1648,8 +1648,11 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 
   // Checked C - handle generic structs.
   if (Tok.is(tok::kw__For_any)) {
-    // TODO(abeln): don't allow _any_ specifier, just '_For_any'.
-    ParseDeclarationSpecifiers(DS);
+    // TODO(abeln): add error handling here
+    unsigned DiagID;
+    const char *PrevSpec;
+    DS.setSpecForany(Tok.getLocation(), PrevSpec, DiagID);
+    ParseForanySpecifier(DS);
   }
 
   // Checked C - checked scope keyword, possibly followed by checked scope modifier,

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1943,7 +1943,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
       if (decl && decl->isGeneric()) {
         // We're parsing a reference to a generic struct, so need to parse
         // the type arguments before we can instantiate.
-        TagOrTempResult = ParseGenericStructInstantiation(decl);
+        TagOrTempResult = ParseGenericStructInstantiation(decl->getDefinition());
       }
     }
 
@@ -2046,6 +2046,7 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 ///    ',' type-name type-name-list-suffix [opt]
 DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
   assert(Base->isGeneric() && "Instantiated record must be generic");
+  assert(Base->isCompleteDefinition() && "Must pass the record definition and not just a reference");
   ExpectAndConsume(tok::less); // eat the initial '<'
   auto ArgsRes = ParseGenericTypeArgumentList(SourceLocation());
   if (ArgsRes.first) {

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -1919,9 +1919,15 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
 
     stripTypeAttributesOffDeclSpec(attrs, DS, TUK);
 
+    // Checked C: if the struct has type parameters, then they introduced a new scope, so we
+    // must make sure to add the struct to the parent scope instead.
+    // The type parameters scope is removed later in 'ParseDeclOrFunctionDefInternal'.
+    assert(getCurScope()->isForanyScope() == DS.isForanySpecified());
+    Scope* structScope = getCurScope()->isForanyScope() ? getCurScope()->getParent() : getCurScope();
+
     // Declaration or definition of a class type
     TagOrTempResult = Actions.ActOnTag(
-        getCurScope(), TagType, TUK, StartLoc, SS, Name, NameLoc, attrs, AS,
+        structScope, TagType, TUK, StartLoc, SS, Name, NameLoc, attrs, AS,
         DS.getModulePrivateSpecLoc(), TParams, Owned, IsDependent,
         SourceLocation(), false, clang::TypeResult(),
         DSC == DeclSpecContext::DSC_type_specifier,

--- a/lib/Parse/ParseDeclCXX.cpp
+++ b/lib/Parse/ParseDeclCXX.cpp
@@ -2058,7 +2058,7 @@ DeclResult Parser::ParseGenericStructInstantiation(RecordDecl* Base) {
     printf("expected %d type params but got %d\n", Base->typeParams().size(), ArgsRes.second.size());
     return true;
   } else {
-    return Actions.Instantiate(Base, ArrayRef<TypeArgument>(ArgsRes.second));
+    return Actions.ActOnRecordTypeApplication(Base, ArrayRef<TypeArgument>(ArgsRes.second));
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3260,7 +3260,7 @@ ExprResult Parser::ParseBoundsExpression() {
 // This is re-used for both generic functions and generic structs.
 // Return false if parsing succeeds, in which case the 'typeArgs' is also populated.
 // Return true if parsing fails.
-std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(SourceLocation Loc, bool WithinFieldDecl) {
+std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(SourceLocation Loc) {
   Parser::TypeArgVector typeArgumentInfos;
   auto err = std::make_pair<>(true, Parser::TypeArgVector());
   bool firstTypeArgument = true;
@@ -3278,7 +3278,7 @@ std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(Sour
       firstTypeArgument = false;
 
     // Expect to see type name.
-    TypeResult Ty = ParseTypeName(nullptr /*Range*/, DeclaratorContext::TypeNameContext, AS_none, nullptr /*OwnedType*/, nullptr /*Attrs*/, WithinFieldDecl);
+    TypeResult Ty = ParseTypeName(nullptr /*Range*/, DeclaratorContext::TypeNameContext, AS_none, nullptr /*OwnedType*/, nullptr /*Attrs*/);
     if (Ty.isInvalid()) {
       // We do not need to write an error message since ParseTypeName does.
       // We want to consume greater, but not consume semi

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3273,8 +3273,7 @@ bool Parser::ParseGenericTypeArgumentList(ArrayRef<DeclRefExpr::GenericInstInfo:
         if (Tok.getKind() == tok::greater) ConsumeToken();
         return true;
       }
-    }
-    else
+    } else
       firstTypeArgument = false;
 
     // Expect to see type name.
@@ -3287,7 +3286,7 @@ bool Parser::ParseGenericTypeArgumentList(ArrayRef<DeclRefExpr::GenericInstInfo:
       return true;
     }
 
-    TypeSourceInfo* TInfo;
+    TypeSourceInfo *TInfo;
     QualType realType = Actions.GetTypeFromParser(Ty.get(), &TInfo);
     typeArgumentInfos.push_back({ realType, TInfo });
   }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3304,7 +3304,7 @@ std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(Sour
 ExprResult Parser::ParseGenericFunctionApplication(ExprResult Res, SourceLocation Loc) {
   auto ArgRes = ParseGenericTypeArgumentList(Loc);
   if (ArgRes.first) return ExprError();
-  return Actions.ActOnTypeApplication(Res, Loc, ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument>(ArgRes.second));
+  return Actions.ActOnTypeApplication(Res, Loc, ArrayRef<TypeArgument>(ArgRes.second));
 }
 
 bool Parser::ParseRelativeBoundsClauseForDecl(ExprResult &Expr) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3304,7 +3304,7 @@ std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(Sour
 ExprResult Parser::ParseGenericFunctionApplication(ExprResult Res, SourceLocation Loc) {
   auto ArgRes = ParseGenericTypeArgumentList(Loc);
   if (ArgRes.first) return ExprError();
-  return Actions.ActOnTypeApplication(Res, Loc, ArrayRef<TypeArgument>(ArgRes.second));
+  return Actions.ActOnFunctionTypeApplication(Res, Loc, ArrayRef<TypeArgument>(ArgRes.second));
 }
 
 bool Parser::ParseRelativeBoundsClauseForDecl(ExprResult &Expr) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3260,7 +3260,7 @@ ExprResult Parser::ParseBoundsExpression() {
 // This is re-used for both generic functions and generic structs.
 // Return false if parsing succeeds, in which case the 'typeArgs' is also populated.
 // Return true if parsing fails.
-std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(SourceLocation Loc) {
+std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(SourceLocation Loc, bool WithinFieldDecl) {
   Parser::TypeArgVector typeArgumentInfos;
   auto err = std::make_pair<>(true, Parser::TypeArgVector());
   bool firstTypeArgument = true;
@@ -3278,7 +3278,7 @@ std::pair<bool, Parser::TypeArgVector> Parser::ParseGenericTypeArgumentList(Sour
       firstTypeArgument = false;
 
     // Expect to see type name.
-    TypeResult Ty = ParseTypeName();
+    TypeResult Ty = ParseTypeName(nullptr /*Range*/, DeclaratorContext::TypeNameContext, AS_none, nullptr /*OwnedType*/, nullptr /*Attrs*/, WithinFieldDecl);
     if (Ty.isInvalid()) {
       // We do not need to write an error message since ParseTypeName does.
       // We want to consume greater, but not consume semi

--- a/lib/Sema/CheckedCSubst.cpp
+++ b/lib/Sema/CheckedCSubst.cpp
@@ -19,7 +19,7 @@ using namespace clang;
 using namespace sema;
 
 ExprResult Sema::ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
-  ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> TypeArgs) {
+  ArrayRef<TypeArgument> TypeArgs) {
 
   TypeFunc = CorrectDelayedTyposInExpr(TypeFunc);
   if (!TypeFunc.isUsable())
@@ -78,7 +78,7 @@ ExprResult Sema::ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
 namespace {
 class TypeApplication : public TreeTransform<TypeApplication> {
   typedef TreeTransform<TypeApplication> BaseTransform;
-  typedef ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> TypeArgList;
+  typedef ArrayRef<TypeArgument> TypeArgList;
 
 private:
   TypeArgList TypeArgs;
@@ -104,7 +104,7 @@ public:
     } else if (TVDepth == Depth) {
       // Case 2: the type variable is bound by the type quantifier that is
       // being applied.  Substitute the appropriate type argument.
-      DeclRefExpr::GenericInstInfo::TypeArgument TypeArg = TypeArgs[TV->GetIndex()];
+      TypeArgument TypeArg = TypeArgs[TV->GetIndex()];
       TypeLoc NewTL =  TypeArg.sourceInfo->getTypeLoc();
       TLB.reserve(NewTL.getFullDataSize());
       // Run the type transform with the type argument's location information
@@ -166,7 +166,7 @@ public:
 }
 
 QualType Sema::SubstituteTypeArgs(QualType QT,
- ArrayRef<DeclRefExpr::GenericInstInfo::TypeArgument> TypeArgs) {
+ ArrayRef<TypeArgument> TypeArgs) {
    if (QT.isNull())
      return QT;
 

--- a/lib/Sema/CheckedCSubst.cpp
+++ b/lib/Sema/CheckedCSubst.cpp
@@ -18,7 +18,7 @@
 using namespace clang;
 using namespace sema;
 
-ExprResult Sema::ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
+ExprResult Sema::ActOnFunctionTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
   ArrayRef<TypeArgument> TypeArgs) {
 
   TypeFunc = CorrectDelayedTyposInExpr(TypeFunc);
@@ -77,7 +77,7 @@ ExprResult Sema::ActOnTypeApplication(ExprResult TypeFunc, SourceLocation Loc,
 
 // Type Instantiation
 
-RecordDecl* Sema::Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs) {
+RecordDecl* Sema::ActOnRecordTypeApplication(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs) {
   // TODO(abeln): populate the two 'SourceLocation' fields.
   RecordDecl* Inst = RecordDecl::Create(Base->getASTContext(), Base->getTagKind(), Base->getDeclContext(), SourceLocation(), SourceLocation(),
     Base->getIdentifier(), Base->getPreviousDecl(), ArrayRef<TypedefDecl*>(nullptr, (size_t)0) /* TypeParams */, TypeArgs);
@@ -89,8 +89,6 @@ RecordDecl* Sema::Instantiate(RecordDecl* Base, ArrayRef<TypeArgument> TypeArgs)
     // Also make sure that TypeSouceInfo and InstType are in-sync.
     FieldDecl* NewField = FieldDecl::Create(Field->getASTContext(), Inst, SourceLocation(), SourceLocation(),
       Field->getIdentifier(), InstType, Field->getTypeSourceInfo(), Field->getBitWidth(), Field->isMutable(), Field->getInClassInitStyle());
-    // printf("new field %s with type\n", NewField->getNameAsString().c_str());
-    // NewField->getType()->dump();
     Inst->addDecl(NewField);
   }
 

--- a/lib/Sema/CheckedCSubst.cpp
+++ b/lib/Sema/CheckedCSubst.cpp
@@ -319,6 +319,17 @@ bool Sema::DiagnoseExpandingCycles(RecordDecl *Base, SourceLocation Loc) {
   return false; // no cycles: can complete decls
 }
 
+RecordDecl *Sema::GetAsGenericRecordDecl(const Type *Type) {
+  while (Type != nullptr) {
+    auto AsRec = Type->getAsRecordDecl();
+    if (AsRec && AsRec->isInstantiated()) return AsRec;
+    // Assume it's a pointer and try again.
+    // Use 'getTypePtrOrNull' because 'Type' might in fact not be a pointer.
+    Type = Type->getPointeeType().getTypePtrOrNull();
+  }
+  return nullptr;
+}
+
 namespace {
 // LocRebuilderTransform is an uncustomized 'TreeTransform' that is used
 // solely for re-building 'TypeLocs' within 'TypeApplication'.

--- a/lib/Sema/DeclSpec.cpp
+++ b/lib/Sema/DeclSpec.cpp
@@ -1019,7 +1019,7 @@ bool DeclSpec::setFunctionSpecChecked(SourceLocation Loc,
   return false;
 }
 
-bool DeclSpec::setFunctionSpecForany(SourceLocation Loc,
+bool DeclSpec::setSpecForany(SourceLocation Loc,
                                         const char *&PrevSpec,
                                         unsigned &DiagID) {
   if (FS_itypeforany_specified) {
@@ -1037,7 +1037,7 @@ bool DeclSpec::setFunctionSpecForany(SourceLocation Loc,
   return false;
 }
 
-bool DeclSpec::setFunctionSpecItypeforany(SourceLocation Loc,
+bool DeclSpec::setSpecItypeforany(SourceLocation Loc,
                                               const char *&PrevSpec,
                                               unsigned &DiagID) {
   if (FS_forany_specified) {

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -15271,7 +15271,8 @@ Decl *Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK,
                      SourceLocation ScopedEnumKWLoc,
                      bool ScopedEnumUsesClassTag, TypeResult UnderlyingType,
                      bool IsTypeSpecifier, bool IsTemplateParamOrArg,
-                     SkipBodyInfo *SkipBody) {
+                     SkipBodyInfo *SkipBody,
+                     ArrayRef<TypedefDecl*> TypeParams) {
   // If this is not a definition, it must have a name.
   IdentifierInfo *OrigName = Name;
   assert((Name != nullptr || TUK == TUK_Definition) &&
@@ -16028,7 +16029,7 @@ CreateNewDecl:
         StdBadAlloc = cast<CXXRecordDecl>(New);
     } else
       New = RecordDecl::Create(Context, Kind, SearchDC, KWLoc, Loc, Name,
-                               cast_or_null<RecordDecl>(PrevDecl));
+                               cast_or_null<RecordDecl>(PrevDecl), TypeParams);
   }
 
   // C++11 [dcl.type]p3:

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -5692,7 +5692,7 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
       }
       // In an unchecked scope, pass void types as the type arguments.
       if (DeclRefExpr *DR = dyn_cast<DeclRefExpr>(Fn)) {
-        SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 4>
+        SmallVector<TypeArgument, 4>
            typeArgumentInfos;
         const FunctionProtoType *FPT = DR->getType()->getAs<FunctionProtoType>();
         unsigned count = FPT->getNumTypeVars();

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -5707,7 +5707,7 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
 
         // Substitute type arguments into function type in DeclRefExpr
         QualType NewTy =
-          SubstituteTypeArgs(DR->getType(), typeArgumentInfos);
+          SubstituteTypeArgs(DR->getType(), typeArgumentInfos, false /* WithinFieldDecl */);
         DR->setType(NewTy);
       } else {
         // There is no DeclRef to modify. Emit an error for now.

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -5707,7 +5707,7 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
 
         // Substitute type arguments into function type in DeclRefExpr
         QualType NewTy =
-          SubstituteTypeArgs(DR->getType(), typeArgumentInfos, false /* WithinFieldDecl */);
+          SubstituteTypeArgs(DR->getType(), typeArgumentInfos);
         DR->setType(NewTy);
       } else {
         // There is no DeclRef to modify. Emit an error for now.

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -5062,8 +5062,8 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         }
 
         EPI.NumTypeVars = D.getDeclSpec().getNumTypeVars();
-        EPI.GenericFunction = D.getDeclSpec().isGenericFunction();
-        EPI.ItypeGenericFunction = D.getDeclSpec().isItypeGenericFunction();
+        EPI.GenericFunction = D.getDeclSpec().isGenericFunctionOrStruct();
+        EPI.ItypeGenericFunction = D.getDeclSpec().isItypeGenericFunctionOrStruct();
 
         SmallVector<QualType, 4> Exceptions;
         SmallVector<ParsedType, 2> DynamicExceptions;

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -570,7 +570,7 @@ void ASTStmtReader::VisitDeclRefExpr(DeclRefExpr *E) {
 
   if (isGenericFunction || isItypeGenericFunction) {
     unsigned numTypeNameInfos = Record.readInt();
-    SmallVector<DeclRefExpr::GenericInstInfo::TypeArgument, 16> typeArgumentInfos;
+    SmallVector<TypeArgument, 16> typeArgumentInfos;
     for (unsigned i = 0; i < numTypeNameInfos; i++) {
       QualType tempType = Record.readType();
       TypeSourceInfo *tempSourceInfo = Record.getTypeSourceInfo();

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -495,7 +495,7 @@ void ASTStmtWriter::VisitDeclRefExpr(DeclRefExpr *E) {
 
   if (isGenericFunction || isItypeGenericFunction) {
     Record.push_back(E->GetTypeArgumentInfo()->typeArgumentss().size());
-    for (DeclRefExpr::GenericInstInfo::TypeArgument tn :
+    for (TypeArgument tn :
          E->GetTypeArgumentInfo()->typeArgumentss()) {
       Record.AddTypeRef(tn.typeName);
       Record.AddTypeSourceInfo(tn.sourceInfo);


### PR DESCRIPTION
This PR adds generic structs to Checked C.

Generic structs can be defined and then used like so
```C
struct List _For_any(T) {
  T *head;
  struct List<T> *next;
};

struct List<int> *lst;
int *h = lst->head;
lst = lst->next;
```

Here's a summary of what's in these changes:

1. Changed the parser so we can handle both type parameters and type arguments (type application).
2. Declarations and definitions of generic structs are represented as `RecordDecls` that store a list of type parameters.
3. Type applications (uses of generic structs) are also represented with `RecordDecls` containing the "base" `RecordDecl` as well as a list of type arguments (e.g. `List<int>` points to both `List` and `[int]`).
4. We eagerly instantiate type applications when possible, but sometimes we must delay instantiations to support recursive references (e.g. `List<T>` which contains a pointer to the `next`, which is another `List<T>`).
5. We rule out problematic recursive dependencies between structs by adapting the notion of "expanded cycles" used by C# for generics.

You can take a look at the accompanying PR with the tests.

What is _not_ in this PR:
1. Support for nested structs (haven't looked at those).
2. Serialization of generic structs.
3. Interop with C code (will come in new PR)