### PR TITLE
Improve equivalence checking of pointer arithmetic expressions

### DIFF
--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2074,8 +2074,8 @@ namespace {
     static bool CreateStandardForm(ASTContext &Ctx, Expr *Base, Expr *Offset, llvm::APSInt &ConstantPart, bool &IsOpSigned, Expr *&VariablePart) {
       bool Overflow;
       uint64_t PointerWidth = Ctx.getTargetInfo().getPointerWidth(0);
-      //if (!Base->getType()->isPointerType())
-        //return false;
+      if (!Base->getType()->isPointerType())
+        return false;
       if (Base->getType()->getPointeeOrArrayElementType()->isCharType()) {
         if (BinaryOperator *BO = dyn_cast<BinaryOperator>(Offset)) {
           if (BO->getRHS()->isIntegerConstantExpr(ConstantPart, Ctx))
@@ -2138,22 +2138,6 @@ namespace {
 
       bool CreatedStdForm1 = CreateStandardForm(Ctx, Base1, Offset1, ConstantPart1, IsOpSigned1, VariablePart1);
       bool CreatedStdForm2 = CreateStandardForm(Ctx, Base2, Offset2, ConstantPart2, IsOpSigned2, VariablePart2);
-      
-      llvm::outs() << "STANDARD FORMS:\n";
-      llvm::outs() << "CreatedStdForm1: " << CreatedStdForm1 << "\n";
-      llvm::outs() << "Std form 1:\n";
-      llvm::outs() << "ConstantPart = " << ConstantPart1.getExtValue() << "\n";
-      llvm::outs() << "IsOpSigned = " << IsOpSigned1 << "\n";
-      llvm::outs() << "VariablePart = ";
-      VariablePart1->dumpPretty(Ctx);
-      llvm::outs() << "\n\n";
-            llvm::outs() << "Std form 2:\n";
-            llvm::outs() << "CreatedStdForm2: " << CreatedStdForm2 << "\n";
-      llvm::outs() << "ConstantPart = " << ConstantPart2.getExtValue() << "\n";
-      llvm::outs() << "IsOpSigned = " << IsOpSigned2 << "\n";
-      llvm::outs() << "VariablePart = ";
-      VariablePart2->dumpPretty(Ctx);
-      llvm::outs() << "\n================\n";
       
       if (!CreatedStdForm1 || !CreatedStdForm2)
         return false;

--- a/test/CheckedC/static-checking/bounds-decl-checking-cs.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking-cs.c
@@ -7,3 +7,4 @@
 #pragma CHECKED_SCOPE ON
 
 #include "bounds-decl-checking.c"
+

--- a/test/CheckedC/static-checking/bounds-decl-checking-cs.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking-cs.c
@@ -2,9 +2,8 @@
 // produces warnings about bounds declarations that are not provably
 // true or false.
 //
-// RUN: %clang -cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
 
 #pragma CHECKED_SCOPE ON
 
 #include "bounds-decl-checking.c"
-

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -460,7 +460,19 @@ struct s2 {
 };
 
 void a_f_1(int num1, int num2) {
-  int n = num1/num2;
+  short n = num1/num2;
+  _Array_ptr<long> v : count(n) = 0;
+  _Array_ptr<int> v2 : count(n) = 0;
+  v = simulate_calloc<long>(n, sizeof(long));           // expected-warning {{cannot prove declared bounds for v are valid after assignment}} \
+                                                        // expected-note {{(expanded) declared bounds are 'bounds(v, v + n)'}} \
+                                                        // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, sizeof(long)), (_Array_ptr<char>)value of simulate_calloc(n, sizeof(long)) + (size_t)n * sizeof(long))'}}
+  v = simulate_calloc<long>(n, sizeof(unsigned long));  // expected-warning {{cannot prove declared bounds for v are valid after assignment}} \
+                                                        // expected-note {{(expanded) declared bounds are 'bounds(v, v + n)'}} \
+                                                        // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long)), (_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long)) + (size_t)n * sizeof(unsigned long))'}}
+}
+
+void a_f_1_size_t(int num1, int num2) {
+  size_t n = num1/num2;
   _Array_ptr<long> v : count(n) = 0;
   _Array_ptr<int> v2 : count(n) = 0;
   v = simulate_calloc<long>(n, sizeof(long));
@@ -468,7 +480,6 @@ void a_f_1(int num1, int num2) {
 }
 
 static size_t k = 0;
-//static unsigned int k_u = 0;
 
 extern _Array_ptr<long> v2 : count(k + 1);
 void a_f_2(void) {
@@ -546,7 +557,15 @@ int v33;
 t2 v = 0, v22 = 0;
 _Array_ptr<struct s4> v24 : count(v33) = 0;
 void a_f_11(void) {
-  v24 = simulate_calloc<struct s4>(v33, sizeof(*v22));
+  v24 = simulate_calloc<struct s4>(v33, sizeof(*v22)); // expected-warning {{cannot prove declared bounds for v24 are valid after assignment}} \
+                                                       // expected-note {{(expanded) declared bounds are 'bounds(v24, v24 + v33)'}} \
+                                                       // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(v33, sizeof (*v22)), (_Array_ptr<char>)value of simulate_calloc(v33, sizeof (*v22)) + (size_t)v33 * sizeof (*v22))'}}
+}
+
+size_t v34;
+_Array_ptr<struct s4> v25 : count(v34) = 0;
+void a_f_11_u(void) {
+  v25 = simulate_calloc<struct s4>(v34, sizeof(*v22));
 }
 
 static _Array_ptr<char> x1 : count(k);
@@ -563,6 +582,12 @@ typedef struct ts1 {
 } ts1;
 
 void a_f_13(int n) {
+  _Array_ptr<_Ptr<ts1>> v22 : count(n) = simulate_calloc<_Ptr<ts1>>(n, (sizeof(_Ptr<ts1>))); // expected-warning {{cannot prove declared bounds for 'v22' are valid after initialization}} \
+                                                                                             // expected-note {{(expanded) declared bounds are 'bounds(v22, v22 + n)'}} \
+                                                                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, (sizeof(_Ptr<ts1>))), (_Array_ptr<char>)value of simulate_calloc(n, (sizeof(_Ptr<ts1>))) + (size_t)n * (sizeof(_Ptr<ts1>)))'}}
+}
+
+void a_f_13_u(size_t n) {
   _Array_ptr<_Ptr<ts1>> v22 : count(n) = simulate_calloc<_Ptr<ts1>>(n, (sizeof(_Ptr<ts1>)));
 }
 

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -491,21 +491,21 @@ extern _Array_ptr<long> v10 : count(k + 1);
 void a_f_3(void) {
   v10 = simulate_malloc<long>((k + 1) * -1); // expected-warning {{cannot prove declared bounds for v10 are valid after assignment}} \
                                              // expected-note {{(expanded) declared bounds are 'bounds(v10, v10 + k + 1)'}} \
-                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((k + 1) * -1), (_Array_ptr<char>)value of simulate_malloc((k + 1) * -1) + (size_t)(k + 1) * -1)'}}
+                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((k + 1) * -1), (_Array_ptr<char>)value of simulate_malloc((k + 1) * -1) + (k + 1) * -1)'}}
 }
 
 extern _Array_ptr<long> v11 : count(k);
 void a_f_4(void) {
   v11 = simulate_malloc<long>(k * 1); // expected-warning {{cannot prove declared bounds for v11 are valid after assignment}} \
                                       // expected-note {{(expanded) declared bounds are 'bounds(v11, v11 + k)'}} \
-                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * 1), (_Array_ptr<char>)value of simulate_malloc(k * 1) + (size_t)k * 1)'}}
+                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * 1), (_Array_ptr<char>)value of simulate_malloc(k * 1) + k * 1)'}}
 }
 
 extern _Array_ptr<long> v12 : count(k);
 void a_f_5(void) {
   v12 = simulate_malloc<long>(k); // expected-warning {{cannot prove declared bounds for v12 are valid after assignment}} \
                                   // expected-note {{(expanded) declared bounds are 'bounds(v12, v12 + k)'}} \
-                                  // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k), (_Array_ptr<char>)value of simulate_malloc(k) + (size_t)k)'}}
+                                  // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k), (_Array_ptr<char>)value of simulate_malloc(k) + k)'}}
 }
 
 extern _Array_ptr<long> v25_l : count(k);

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -467,7 +467,9 @@ void a_f_1(int num1, int num2) {
   v = simulate_calloc<long>(n, sizeof(unsigned long));
 }
 
-static int k = 0;
+static size_t k = 0;
+//static unsigned int k_u = 0;
+
 extern _Array_ptr<long> v2 : count(k + 1);
 void a_f_2(void) {
   v2 = simulate_malloc<long>((k + 1) * sizeof(long));

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -200,6 +200,7 @@ struct S2 {
   int x;
   int y;
   int z;
+  unsigned long long p;
 };
 
 void test_cast(_Ptr<struct S1> s1, _Ptr<struct S2> s2) {
@@ -461,11 +462,9 @@ struct s2 {
 void a_f_1(int num1, int num2) {
   int n = num1/num2;
   _Array_ptr<long> v : count(n) = 0;
+  _Array_ptr<int> v2 : count(n) = 0;
   v = simulate_calloc<long>(n, sizeof(long));
   v = simulate_calloc<long>(n, sizeof(unsigned long));
-  v = simulate_calloc<long>(n, sizeof(unsigned long long)); // expected-warning {{cannot prove declared bounds for v are valid after assignment}} \
-                                                            // expected-note {{(expanded) declared bounds are 'bounds(v, v + n)'}} \
-                                                            // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long long)), (_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long long)) + (size_t)n * sizeof(unsigned long long))'}}
 }
 
 static int k = 0;
@@ -518,16 +517,16 @@ void a_f_8(void) {
 
 extern _Array_ptr<struct s2> v4 : count(k);
 void a_f_9(void) {
-  v4 = simulate_malloc<struct s2>(k * sizeof(long)); // expected-warning {{cannot prove declared bounds for v4 are valid after assignment}} \
-                                                     // expected-note {{(expanded) declared bounds are 'bounds(v4, v4 + k)'}} \
-                                                     // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(long)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(long)) + k * sizeof(long))'}}
+  v4 = simulate_malloc<struct s2>(k * sizeof(int)); // expected-warning {{cannot prove declared bounds for v4 are valid after assignment}} \
+                                                    // expected-note {{(expanded) declared bounds are 'bounds(v4, v4 + k)'}} \
+                                                    // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(int)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(int)) + k * sizeof(int))'}}
 }
 
-extern _Array_ptr<long> v20 : count(k);
+extern _Array_ptr<int> v20 : count(k);
 void a_f_10(void) {
-  v20 = simulate_malloc<long>(k * sizeof(struct s2)); // expected-warning {{cannot prove declared bounds for v20 are valid after assignment}} \
-                                                      // expected-note {{(expanded) declared bounds are 'bounds(v20, v20 + k)'}} \
-                                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(struct s2)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(struct s2)) + k * sizeof(struct s2))'}}
+  v20 = simulate_malloc<int>(k * sizeof(unsigned long long)); // expected-warning {{cannot prove declared bounds for v20 are valid after assignment}} \
+                                                              // expected-note {{(expanded) declared bounds are 'bounds(v20, v20 + k)'}} \
+                                                              // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(unsigned long long)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(unsigned long long)) + k * sizeof(unsigned long long))'}}
 }
 
 typedef _Ptr<struct s1> t1;

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -462,19 +462,24 @@ void a_f_1(int num1, int num2) {
   int n = num1/num2;
   _Array_ptr<long> v : count(n) = 0;
   v = simulate_calloc<long>(n, sizeof(long));
+  v = simulate_calloc<long>(n, sizeof(unsigned long));
+  v = simulate_calloc<long>(n, sizeof(unsigned long long)); // expected-warning {{cannot prove declared bounds for v are valid after assignment}} \
+                                                            // expected-note {{(expanded) declared bounds are 'bounds(v, v + n)'}} \
+                                                            // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long long)), (_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long long)) + (size_t)n * sizeof(unsigned long long))'}}
 }
 
 static int k = 0;
 extern _Array_ptr<long> v2 : count(k + 1);
 void a_f_2(void) {
   v2 = simulate_malloc<long>((k + 1) * sizeof(long));
+  v2 = simulate_malloc<long>(sizeof(long) * (k + 1));
 }
 
 extern _Array_ptr<long> v10 : count(k + 1);
 void a_f_3(void) {
-  v10 = simulate_malloc<long>((k + 1) * sizeof(int)); // expected-warning {{cannot prove declared bounds for v10 are valid after assignment}} \
-                                                      // expected-note {{(expanded) declared bounds are 'bounds(v10, v10 + k + 1)'}} \
-                                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((k + 1) * sizeof(int)), (_Array_ptr<char>)value of simulate_malloc((k + 1) * sizeof(int)) + (k + 1) * sizeof(int))'}}
+  v10 = simulate_malloc<long>((k + 1) * -1); // expected-warning {{cannot prove declared bounds for v10 are valid after assignment}} \
+                                             // expected-note {{(expanded) declared bounds are 'bounds(v10, v10 + k + 1)'}} \
+                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((k + 1) * -1), (_Array_ptr<char>)value of simulate_malloc((k + 1) * -1) + (size_t)(k + 1) * -1)'}}
 }
 
 extern _Array_ptr<long> v11 : count(k);
@@ -544,10 +549,12 @@ void a_f_11(void) {
 }
 
 static _Array_ptr<char> x1 : count(k);
+static _Array_ptr<char> x2 : count(3);
 void a_f_12(void) {
   x1 = simulate_calloc<char>(32768, sizeof(char)); // expected-warning {{cannot prove declared bounds for x1 are valid after assignment}} \
                                                    // expected-note {{(expanded) declared bounds are 'bounds(x1, x1 + k)'}} \
                                                    // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)), (_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)) + (size_t)32768 * sizeof(char))'}}
+  x2 = simulate_calloc<char>(3, sizeof(char));
 }
 
 typedef struct ts1 {

--- a/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -3,7 +3,9 @@
 // mostly unimplemented, we only issue warnings when bounds declarations
 // cannot be provided to hold.
 //
-// RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
+// RUN: %clang_cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
+
+#include <stddef.h>
 
 // Initialization by null - no warning.
 void f1(_Array_ptr<int> p : bounds(p, p + x), int x) {
@@ -432,4 +434,146 @@ _Array_ptr<int> f59(unsigned num) {
 _Nt_array_ptr<int> f60(unsigned num) {
   _Nt_array_ptr<int> p : count(0) = test_f56(num); // expected-error {{initializing '_Nt_array_ptr<int>' with an expression of incompatible type '_Ptr<int>'}}
   return p;
+}
+
+//
+
+// Test pointer artihmetic equivalence
+
+//
+
+_Itype_for_any(T) void *simulate_calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+_Itype_for_any(T) void *simulate_malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+#pragma CHECKED_SCOPE OFF
+
+struct s1 {
+  _Ptr<struct s1> next;
+};
+
+#pragma CHECKED_SCOPE ON
+
+struct s2 {
+  int s2a;
+  int s2b;
+};
+
+void a_f_1(int num1, int num2) {
+  int n = num1/num2;
+  _Array_ptr<long> v : count(n) = 0;
+  v = simulate_calloc<long>(n, sizeof(long));
+}
+
+static int k = 0;
+extern _Array_ptr<long> v2 : count(k + 1);
+void a_f_2(void) {
+  v2 = simulate_malloc<long>((k + 1) * sizeof(long));
+}
+
+extern _Array_ptr<long> v10 : count(k + 1);
+void a_f_3(void) {
+  v10 = simulate_malloc<long>((k + 1) * sizeof(int)); // expected-warning {{cannot prove declared bounds for v10 are valid after assignment}} \
+                                                      // expected-note {{(expanded) declared bounds are 'bounds(v10, v10 + k + 1)'}} \
+                                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((k + 1) * sizeof(int)), (_Array_ptr<char>)value of simulate_malloc((k + 1) * sizeof(int)) + (k + 1) * sizeof(int))'}}
+}
+
+extern _Array_ptr<long> v11 : count(k);
+void a_f_4(void) {
+  v11 = simulate_malloc<long>(k * 1); // expected-warning {{cannot prove declared bounds for v11 are valid after assignment}} \
+                                      // expected-note {{(expanded) declared bounds are 'bounds(v11, v11 + k)'}} \
+                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * 1), (_Array_ptr<char>)value of simulate_malloc(k * 1) + (size_t)k * 1)'}}
+}
+
+extern _Array_ptr<long> v12 : count(k);
+void a_f_5(void) {
+  v12 = simulate_malloc<long>(k); // expected-warning {{cannot prove declared bounds for v12 are valid after assignment}} \
+                                  // expected-note {{(expanded) declared bounds are 'bounds(v12, v12 + k)'}} \
+                                  // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k), (_Array_ptr<char>)value of simulate_malloc(k) + (size_t)k)'}}
+}
+
+extern _Array_ptr<long> v25_l : count(k);
+void a_f_6_l(void) {
+  v25_l = simulate_malloc<long>(k * __SIZEOF_LONG__);
+}
+
+extern _Array_ptr<long> v25_r : count(k);
+void a_f_6_r(void) {
+  v25_r = simulate_malloc<long>(__SIZEOF_LONG__ * k);
+}
+
+extern _Array_ptr<struct s2> v3 : count(k);
+void a_f_7(void) {
+  v3 = simulate_malloc<struct s2>(k * sizeof(struct s2));
+}
+
+extern _Array_ptr<struct s2> v32 : count(k);
+void a_f_8(void) {
+  v32 = simulate_malloc<struct s2>(sizeof(struct s2) * k);
+}
+
+extern _Array_ptr<struct s2> v4 : count(k);
+void a_f_9(void) {
+  v4 = simulate_malloc<struct s2>(k * sizeof(long)); // expected-warning {{cannot prove declared bounds for v4 are valid after assignment}} \
+                                                     // expected-note {{(expanded) declared bounds are 'bounds(v4, v4 + k)'}} \
+                                                     // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(long)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(long)) + k * sizeof(long))'}}
+}
+
+extern _Array_ptr<long> v20 : count(k);
+void a_f_10(void) {
+  v20 = simulate_malloc<long>(k * sizeof(struct s2)); // expected-warning {{cannot prove declared bounds for v20 are valid after assignment}} \
+                                                      // expected-note {{(expanded) declared bounds are 'bounds(v20, v20 + k)'}} \
+                                                      // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(struct s2)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(struct s2)) + k * sizeof(struct s2))'}}
+}
+
+typedef _Ptr<struct s1> t1;
+struct s3 {
+  _Array_ptr<t1> array : count(size);
+  int size;
+};
+
+struct s4 {
+  _Ptr<struct s4> next;
+};
+
+typedef _Ptr<struct s4> t2;
+int v33;
+t2 v = 0, v22 = 0;
+_Array_ptr<struct s4> v24 : count(v33) = 0;
+void a_f_11(void) {
+  v24 = simulate_calloc<struct s4>(v33, sizeof(*v22));
+}
+
+static _Array_ptr<char> x1 : count(k);
+void a_f_12(void) {
+  x1 = simulate_calloc<char>(32768, sizeof(char)); // expected-warning {{cannot prove declared bounds for x1 are valid after assignment}} \
+                                                   // expected-note {{(expanded) declared bounds are 'bounds(x1, x1 + k)'}} \
+                                                   // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)), (_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)) + (size_t)32768 * sizeof(char))'}}
+}
+
+typedef struct ts1 {
+  _Ptr<struct ts1> next;
+} ts1;
+
+void a_f_13(int n) {
+  _Array_ptr<_Ptr<ts1>> v22 : count(n) = simulate_calloc<_Ptr<ts1>>(n, (sizeof(_Ptr<ts1>)));
+}
+
+void a_f_14(void) {
+  long i;
+  _Array_ptr<long> v21 : count(i + 1) = simulate_malloc<long>((i + 1) * (i + 1) * sizeof(long)); // expected-warning {{cannot prove declared bounds for 'v21' are valid after initialization}} \
+                                                                                                 // expected-note {{(expanded) declared bounds are 'bounds(v21, v21 + i + 1)'}} \
+                                                                                                 // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((i + 1) * (i + 1) * sizeof(long)), (_Array_ptr<char>)value of simulate_malloc((i + 1) * (i + 1) * sizeof(long)) + (i + 1) * (i + 1) * sizeof(long))'}}
+}
+
+void a_f_15(void) {
+  long i, j;
+  _Array_ptr<long> v : count(j + 1) = simulate_malloc<long>((i + 1) * sizeof(long)); // expected-warning {{cannot prove declared bounds for 'v' are valid after initialization}} \
+                                                                                     // expected-note {{(expanded) declared bounds are 'bounds(v, v + j + 1)'}} \
+                                                                                     // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((i + 1) * sizeof(long)), (_Array_ptr<char>)value of simulate_malloc((i + 1) * sizeof(long)) + (i + 1) * sizeof(long))'}}
+}
+
+static _Array_ptr<char> v23 : count(32768);
+static _Array_ptr<void> a_f_16(int size) : byte_count(size) {
+  v23 = simulate_calloc<char>(32768, sizeof(char));
+  return v23;
 }


### PR DESCRIPTION
A new equivalence checking function has been added in this change
(EqualPointerArithOffset). This function is used for comparing two
bounds (i.e., Base + Offset) where one bound is following pointer
arithmetic form and the other one is in bytewise arithmetic form.
The assumption is that overflow checking is performed inside the *alloc function.

This pull request also contains new tests.