### PR TITLE
Generate LLVM IR code for _MMSafe_ptr.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9751,6 +9751,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_initializer_expected_for_ptr : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
+  def err_initializer_expected_for_mmsafe_ptr : Error<
+    "automatic variable %0 with _MMSafe_ptr type must have initializer">;
+
   def err_initializer_not_null_terminated_for_nt_checked : Error<
     "null terminator expected in _Nt_checked array initializer">;
 

--- a/lib/CodeGen/Address.h
+++ b/lib/CodeGen/Address.h
@@ -42,6 +42,12 @@ public:
 
   /// Return the type of the pointer value.
   llvm::PointerType *getType() const {
+    llvm::Type *pointerTy = getPointer()->getType();
+    if (pointerTy->isMMSafePointerTy()) {
+      // Checked C: extract the inner pointer inside an _MMSafe_ptr.
+      return pointerTy->getInnerPtrFromMMSafePtr();
+    }
+
     return llvm::cast<llvm::PointerType>(getPointer()->getType());
   }
 

--- a/lib/CodeGen/CodeGenTypes.cpp
+++ b/lib/CodeGen/CodeGenTypes.cpp
@@ -547,7 +547,14 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     if (PointeeType->isVoidTy())
       PointeeType = llvm::Type::getInt8Ty(getLLVMContext());
     unsigned AS = Context.getTargetAddressSpace(ETy);
-    ResultType = llvm::PointerType::get(PointeeType, AS);
+
+    if (PTy->isCheckedPointerMMSafeType()) {
+      // Checked C: build a _MMSafe_ptr pointer.
+      ResultType = llvm::PointerType::getMMSafePtr(PointeeType,
+                                                   getLLVMContext(), AS);
+    } else {
+      ResultType = llvm::PointerType::get(PointeeType, AS);
+    }
     break;
   }
   case Type::TypeVariable: {

--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -2579,7 +2579,16 @@ void X86_64ABIInfo::classify(QualType Ty, uint64_t OffsetBase,
   }
 
   if (Ty->hasPointerRepresentation()) {
-    Current = Integer;
+    Current = Integer;  // Lo = Integer
+
+    // Checked C:
+    // _MMSafe_ptr is a pointer from the perspective of the AST, while it is
+    // implemented as a struct which contains a real pointer and a
+    // 64-bit integer as ID. So we need set the Hi (ID) to be an integer.
+    if (Ty->isCheckedPointerMMSafeType()) {
+      Hi = Integer;
+    }
+
     return;
   }
 

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -12217,6 +12217,9 @@ void Sema::ActOnUninitializedDecl(Decl *RealDecl) {
       else if (B && !B->isInvalid() && !B->isUnknown() && !Ty->isArrayType())
         Diag(Var->getLocation(), diag::err_initializer_expected_with_bounds)
           << Var;
+      else if (Ty->isCheckedPointerMMSafeType())
+        Diag(Var->getLocation(), diag::err_initializer_expected_for_ptr)
+          << Var;
 
       // An unchecked pointer in a checked scope with a bounds expression must
       // be initialized


### PR DESCRIPTION
Summary of changes: 
- Modified the LLVM IR code generator to generate IR code for a `_MMSafe_ptr` when it is 
  - declared in a function
  - an argument passed to a generic function
  - a return value from a generic function
- Added check on declaration of `_MMSafe_ptr`: it must be initialized. 
- Added `_MMSafe_ptr` support in the `getType()` function of `clang::Address` class. Now it returns the inner pointer type of a `_MMSafe_ptr`.