### PR TITLE
Implemented the "*" operator for _MMSafe_ptr.

### DIFF
--- a/lib/CodeGen/Address.h
+++ b/lib/CodeGen/Address.h
@@ -25,11 +25,41 @@ namespace CodeGen {
 class Address {
   llvm::Value *Pointer;
   CharUnits Alignment;
+
+private:
+  bool _containMMSafePtr;
+  llvm::Type *originalPointerTy;
+  llvm::Type *rawPointerTy;  // The inner pointer type of a _MMSafe_ptr.
+
 public:
   Address(llvm::Value *pointer, CharUnits alignment)
       : Pointer(pointer), Alignment(alignment) {
     assert((!alignment.isZero() || pointer == nullptr) &&
            "creating valid address with invalid alignment");
+    if (pointer) {
+      // Backup the original _MMSafe_ptr type.
+      originalPointerTy = pointer->getType();
+
+      // Checked C: for _MMSafe_ptr, reset the poitner type.
+      if (pointer->getType()->isMMSafePointerTy()) {
+        _containMMSafePtr = true;
+        rawPointerTy = pointer->getType()->getInnerPtrFromMMSafePtr();
+        pointer->mutateType(rawPointerTy);
+      }
+    }
+  }
+
+  // Return true if this Address contains a _MMSafe_ptr.
+  bool containMMSafePtr() const { return _containMMSafePtr; }
+
+  //  Set the pointer type to be the inner pointer type of a _MMSafe_ptr.
+  void mutatePointerType() {
+    if (containMMSafePtr()) Pointer->mutateType(rawPointerTy);
+  }
+
+  // Restore the original _MMSafe_ptr type.
+  void restoreMMSafePtrType() {
+    if (containMMSafePtr()) Pointer->mutateType(originalPointerTy);
   }
 
   static Address invalid() { return Address(nullptr, CharUnits()); }

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -2623,6 +2623,10 @@ LValue CodeGenFunction::EmitUnaryOpLValue(const UnaryOperator *E) {
     EmitDynamicNonNullCheck(Addr, BaseTy);
     EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), E->getBoundsCheckKind(),
                            nullptr);
+
+    // Checked C: Check for Struct ID matching.
+    EmitDynamicStructIDCheck(E->getSubExpr());
+
     // We should not generate __weak write barrier on indirect reference
     // of a pointer to object; as in void foo (__weak id *param); *param = 0;
     // But, we continue to generate __strong write barrier on indirect write

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2938,6 +2938,7 @@ public:
                                   const BoundsExpr *CastBounds,
                                   const BoundsExpr *SubExprBounds);
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
+  void EmitDynamicStructIDCheck(const Expr *E);
   llvm::BasicBlock *EmitDynamicCheckFailedBlock();
   llvm::BasicBlock *EmitNulltermWriteAdditionalCheck(const Address PtrAddr,
                                                      const Address Upper,


### PR DESCRIPTION
When a mmsafe_ptr is dereferenced by the "*" operator and after the
null pointer checking is done, the compiler inserts a
DynamicStructIDCheck() function to check if the ID of the mmsafe_ptr
matches the ID of the pointee (a struct).

The algorithm is straightforward:

1. Extract the ID from the mmsafe_ptr.
2. Extract the ID from the struct (always the first field)
3. Insert an integer comparison instruction (ICmpInst) to compare the
   two IDs.
4. Continue executing if the IDs match; otherwise abort the program.

We also implemented a customized memory allocator and a deallocator,
and added tests for this commit. The customized allocator/deallocator
and the tests are in the checkedc repo:
https://github.com/microsoft/checkedc/commit/e4e3036386b82d848f82091bebddbdaa5b46d8b7