### PR TITLE
Do not verify alignment of load/store in unit tests

### DIFF
--- a/test/CheckedC/dynamic-checks/ptr-arith-null-check-code-gen.c
+++ b/test/CheckedC/dynamic-checks/ptr-arith-null-check-code-gen.c
@@ -9,7 +9,7 @@ array_ptr<char> q : count(3) = "abc";
 
 void f1() {
 // CHECK-LABEL: f1
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p++;
@@ -17,7 +17,7 @@ void f1() {
 
 void f2() {
 // CHECK-LABEL: f2
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   ++p;
@@ -25,7 +25,7 @@ void f2() {
 
 void f3() {
 // CHECK-LABEL: f3
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p--;
@@ -33,7 +33,7 @@ void f3() {
 
 void f4() {
 // CHECK-LABEL: f4
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   --p;
@@ -41,7 +41,7 @@ void f4() {
 
 void f5() {
 // CHECK-LABEL: f5
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p += 5;
@@ -49,7 +49,7 @@ void f5() {
 
 void f6() {
 // CHECK-LABEL: f6
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p -= 10;
@@ -57,7 +57,7 @@ void f6() {
 
 void f7() {
 // CHECK-LABEL: f7
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p = 2 + p;
@@ -65,7 +65,7 @@ void f7() {
 
 void f8() {
 // CHECK-LABEL: f8
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p = p - 100;
@@ -73,7 +73,7 @@ void f8() {
 
 void f9() {
 // CHECK-LABEL: f9
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p[1]++;
@@ -81,12 +81,12 @@ void f9() {
 
 void f10() {
 // CHECK-LABEL: f10
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
 
- // CHECK:      [[REG1:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
-// CHECK:      [[REG2:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+ // CHECK:      [[REG1:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
+// CHECK:      [[REG2:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG2]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p[1] = p[2] + (*p)++;
@@ -95,7 +95,7 @@ void f10() {
 void f11(array_ptr<char> a);
 void f12() {
 // CHECK-LABEL: f12
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG0]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   f11(++p);
@@ -103,8 +103,8 @@ void f12() {
 
 void f13() {
 // CHECK-LABEL: f13
-// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p, align 8
-// CHECK:      [[REG1:%[a-zA-Z0-9.]*]] = load i8*, i8** @q, align 8
+// CHECK:      [[REG0:%[a-zA-Z0-9.]*]] = load i8*, i8** @p
+// CHECK:      [[REG1:%[a-zA-Z0-9.]*]] = load i8*, i8** @q
 // CHECK-NEXT: [[REG_DYNN:%_Dynamic_check.non_null[a-zA-Z0-9.]*]] = icmp ne i8* [[REG1]], null
 // CHECK-NEXT: br i1 [[REG_DYNN]], label %[[LAB_DYSUC:_Dynamic_check.succeeded[a-zA-Z0-9.]*]], label %[[LAB_DYFAIL:_Dynamic_check.failed[a-zA-Z0-9.]*]]
   p[q[1]++]++;


### PR DESCRIPTION
We do not verify the alignment of any loads/stores in the IR.

Example: "%1 = load i32*, i32** @gp1, align 8"

We discard the "align 8" at the end. This is because alignment is type-size
dependent, which in turn is platform dependent. On a 64-bit system the
alignment is 8 bytes but on 32 bit systems it could be 4 bytes.  It is
better to elide these checks, because we really care about the order of
loads, checks and stores, in these tests, not their specific alignment.