### PR TITLE
Fix a few build warnings

### DIFF
--- a/lib/Sema/AvailableFactsAnalysis.cpp
+++ b/lib/Sema/AvailableFactsAnalysis.cpp
@@ -293,7 +293,7 @@ bool AvailableFactsAnalysis::ContainsPointerAssignment(const Expr *E) {
     if (UO->isIncrementDecrementOp())
       if (IsPointerDerefLValue(UO->getSubExpr()))
         return true;
-  if (const CallExpr *CE = dyn_cast<CallExpr>(E))
+  if (isa<CallExpr>(E))
     return true;
   for (auto Child : E->children())
     if (const Expr *EChild = dyn_cast<Expr>(Child))
@@ -319,7 +319,7 @@ bool AvailableFactsAnalysis::IsPointerDerefLValue(const Expr *E) {
     else
       return IsPointerDerefLValue(ME->getBase());
   }
-  if (const ArraySubscriptExpr *AE = dyn_cast<ArraySubscriptExpr>(E))
+  if (isa<ArraySubscriptExpr>(E))
     return true;
   if (const ParenExpr *PE = dyn_cast<ParenExpr>(E))
     return IsPointerDerefLValue(PE->getSubExpr());

--- a/lib/Sema/CheckedCSubst.cpp
+++ b/lib/Sema/CheckedCSubst.cpp
@@ -550,7 +550,7 @@ public:
   QualType TransformTypedefType(TypeLocBuilder &TLB, TypedefTypeLoc TL) {
     // TODO: doing two recursive calls is potentially slow. Figure out a way to do this
     // with just one call.
-    QualType TransformedType = TransformType(TL.getTypePtr()->desugar());
+    TransformType(TL.getTypePtr()->desugar());
     return BaseTransform::TransformTypedefType(TLB, TL);
   }
 

--- a/tools/checked-c-convert/ConstraintVariables.cpp
+++ b/tools/checked-c-convert/ConstraintVariables.cpp
@@ -24,7 +24,7 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, Constra
                                                      DeclaratorDecl *D, std::string N, Constraints &CS,
                                                      const ASTContext &C, bool partOfFunc) :
         ConstraintVariable(ConstraintVariable::PointerVariable,
-                           tyToStr(QT.getTypePtr()),N), partOFFuncPrototype(partOfFunc), FV(nullptr)
+                           tyToStr(QT.getTypePtr()),N), FV(nullptr), partOFFuncPrototype(partOfFunc)
 {
   QualType QTy = QT;
   const Type *Ty = QTy.getTypePtr();


### PR DESCRIPTION
Fixed the following build warnings:
```
1.
lib/Sema/AvailableFactsAnalysis.cpp:296:23: warning: unused variable ‘CE’ [-Wunused-variable]
   if (const CallExpr *CE = dyn_cast<CallExpr>(E))

2.
lib/Sema/AvailableFactsAnalysis.cpp:322:33: warning: unused variable ‘AE’ [-Wunused-variable]
   if (const ArraySubscriptExpr *AE = dyn_cast<ArraySubscriptExpr>(E))

3.
lib/Sema/CheckedCSubst.cpp:553:14: warning: variable ‘TransformedType’ set but not used [-Wunused-but-set-variable]
     QualType TransformedType = TransformType(TL.getTypePtr()->desugar());

4.
tools/checked-c-convert/ConstraintVariables.h:162:8: warning: ‘PointerVariableConstraint::partOFFuncPrototype’ will be initialized after [-Wreorder]
   bool partOFFuncPrototype;
        ^
tools/checked-c-convert/ConstraintVariables.h:138:31: warning:   ‘FunctionVariableConstraint* PointerVariableConstraint::FV’ [-Wreorder]
   FunctionVariableConstraint *FV;
                               ^
tools/checked-c-convert/ConstraintVariables.cpp:23:1: warning:   when initialized here [-Wreorder]
 PointerVariableConstraint::PointerVariableConstraint(const QualType &QT, ConstraintKey &K,
```