### PR TITLE
Fix a build warning with checked-c-convert

### DIFF
--- a/tools/checked-c-convert/Utils.cpp
+++ b/tools/checked-c-convert/Utils.cpp
@@ -120,12 +120,11 @@ bool isDeclarationParam(clang::Decl *param) {
 
 static std::string storageClassToString(StorageClass SC) {
   switch (SC) {
+    default: return "";
     case StorageClass::SC_Static: return "static ";
     case StorageClass::SC_Extern: return "extern ";
     case StorageClass::SC_Register: return "register ";
-    // no default class, we do not care.
   }
-  return "";
 }
 
 // this method gets the storage qualifier for the provided declaration


### PR DESCRIPTION
Fixed the following build warning:

```
clang/tools/checked-c-convert/Utils.cpp: In function ‘std::__cxx11::string storageClassToString(clang::StorageClass)’:
tools/clang/tools/checked-c-convert/Utils.cpp:122:10: warning: enumeration value ‘SC_None’ not handled in switch [-Wswitch]
   switch (SC) {
          ^
clang/tools/checked-c-convert/Utils.cpp:122:10: warning: enumeration value ‘SC_PrivateExtern’ not handled in switch [-Wswitch]
clang/tools/checked-c-convert/Utils.cpp:122:10: warning: enumeration value ‘SC_Auto’ not handled in switch [-Wswitch]
```