### PR TITLE
Introduce temporary bindings to BoundsCastExprs

### DIFF
--- a/include/clang/AST/CanonBounds.h
+++ b/include/clang/AST/CanonBounds.h
@@ -62,7 +62,6 @@ namespace clang {
       const T *E1 = dyn_cast<T>(Raw1);
       const T *E2 = dyn_cast<T>(Raw2);
       if (!E1 || !E2) {
-        llvm_unreachable("dyn_cast failed");
         return Result::LessThan;
       }
       return Lexicographic::CompareImpl(E1, E2);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -4951,7 +4951,7 @@ public:
   /// InferLValueBounds - infer a bounds expression for an lvalue.
   /// The bounds determine whether the lvalue to which an
   /// expression evaluates in in range.
-  BoundsExpr *InferLValueBounds(Expr *E);
+  BoundsExpr *InferLValueBounds(Expr *E, bool InCheckedScope);
 
   /// CreateTypeBasedBounds: the bounds that can be inferred from
   /// the type alone.
@@ -4975,7 +4975,7 @@ public:
 
   /// InferLValueTargetBounds - infer the bounds for the
   /// target of an lvalue.
-  BoundsExpr *InferLValueTargetBounds(Expr *E);
+  BoundsExpr *InferLValueTargetBounds(Expr *E, bool InCheckedScope);
 
   /// InferRValueBounds - infer a bounds expression for an rvalue.
   /// The bounds determine whether the rvalue to which an
@@ -4985,6 +4985,7 @@ public:
   /// for an nt_array is included in the bounds (it gives
   /// us physical bounds, not logical bounds).
   BoundsExpr *InferRValueBounds(Expr *E,
+                                bool InCheckedScope,
                                 bool IncludeNullTerminator = false);
 
   BoundsExpr *ExpandToRange(Expr *Base, BoundsExpr *B);

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -322,27 +322,23 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
   // The use of an expression temporary is equal to the
   // value of the binding expression.
   if (BoundsValueExpr *BV1 = dyn_cast<BoundsValueExpr>(E1)) {
-	  CHKCBindTemporaryExpr *Binding = BV1->getTemporaryBinding();
+    CHKCBindTemporaryExpr *Binding = BV1->getTemporaryBinding();
     if (Binding == E2)
       return Result::Equal;
-	  if (Binding) {
-	    Expr *SubExpr = Binding->getSubExpr();
-	    if (CompareExpr(SubExpr, E2) == Result::Equal) {
-	      return Result::Equal;
-	    }
-	  }
-  }
 
+    if (Binding)
+      if (CompareExpr(Binding->getSubExpr(), E2) == Result::Equal)
+        return Result::Equal;
+  }
+  
   if (BoundsValueExpr *BV2 = dyn_cast<BoundsValueExpr>(E2)) {
-	  CHKCBindTemporaryExpr *Binding = BV2->getTemporaryBinding();
+    CHKCBindTemporaryExpr *Binding = BV2->getTemporaryBinding();
     if (Binding == E1)
       return Result::Equal;
-	  if (Binding) {
-	    Expr *SubExpr = Binding->getSubExpr();
-	    if (CompareExpr(SubExpr, E1) == Result::Equal) {
-	      return Result::Equal;
-	    }
-	  }
+
+    if (Binding)
+      if (CompareExpr(Binding->getSubExpr(), E1) == Result::Equal)
+        return Result::Equal;
   }
 
    // Compare expressions structurally, recursively invoking
@@ -460,9 +456,9 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
        // - Pointer arithmetic where the pointer referent types are the same
        //   size, checkedness is the same, and the integer types are the
        //    same size/signedness.
-
-	     if (!isa<BoundsExpr>(E1ChildExpr))
-		     Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(), E2ChildExpr->getType());
+       
+       if (!isa<BoundsExpr>(E1ChildExpr))
+         Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(), E2ChildExpr->getType());
 
        if (Cmp != Result::Equal)
          return CheckEquivExprs(Cmp, E1, E2);

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -36,8 +36,6 @@ namespace {
       case CK_ArrayToPointerDecay:
       case CK_FunctionToPointerDecay:
       case CK_NullToPointer:
-      case CK_AssumePtrBounds:
-      case CK_DynamicPtrBounds:
         return true;
       default:
         return false;
@@ -446,7 +444,9 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
        // - Pointer arithmetic where the pointer referent types are the same
        //   size, checkedness is the same, and the integer types are the
        //    same size/signedness.
-       Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(),
+
+	   if (!isa<BoundsExpr>(E1ChildExpr))
+		  Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(),
                                           E2ChildExpr->getType());
        if (Cmp != Result::Equal)
          return CheckEquivExprs(Cmp, E1, E2);

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -322,29 +322,27 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
   // The use of an expression temporary is equal to the
   // value of the binding expression.
   if (BoundsValueExpr *BV1 = dyn_cast<BoundsValueExpr>(E1)) {
-	CHKCBindTemporaryExpr *Binding = BV1->getTemporaryBinding();
-    if (Binding == E2) {
+	  CHKCBindTemporaryExpr *Binding = BV1->getTemporaryBinding();
+    if (Binding == E2)
       return Result::Equal;
-	}
-	if (Binding) {
-	  Expr *SubExpr = Binding->getSubExpr();
-	  if (CompareExpr(SubExpr, E2) == Result::Equal) {
-	    return Result::Equal;
+	  if (Binding) {
+	    Expr *SubExpr = Binding->getSubExpr();
+	    if (CompareExpr(SubExpr, E2) == Result::Equal) {
+	      return Result::Equal;
+	    }
 	  }
-	}
   }
 
   if (BoundsValueExpr *BV2 = dyn_cast<BoundsValueExpr>(E2)) {
-	CHKCBindTemporaryExpr *Binding = BV2->getTemporaryBinding();
-    if (Binding == E1) {
+	  CHKCBindTemporaryExpr *Binding = BV2->getTemporaryBinding();
+    if (Binding == E1)
       return Result::Equal;
-	}
-	if (Binding) {
-	  Expr *SubExpr = Binding->getSubExpr();
-	  if (CompareExpr(SubExpr, E1) == Result::Equal) {
-	    return Result::Equal;
+	  if (Binding) {
+	    Expr *SubExpr = Binding->getSubExpr();
+	    if (CompareExpr(SubExpr, E1) == Result::Equal) {
+	      return Result::Equal;
+	    }
 	  }
-	}
   }
 
    // Compare expressions structurally, recursively invoking
@@ -463,9 +461,9 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
        //   size, checkedness is the same, and the integer types are the
        //    same size/signedness.
 
-	   if (!isa<BoundsExpr>(E1ChildExpr))
-		  Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(),
-                                          E2ChildExpr->getType());
+	     if (!isa<BoundsExpr>(E1ChildExpr))
+		     Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(), E2ChildExpr->getType());
+
        if (Cmp != Result::Equal)
          return CheckEquivExprs(Cmp, E1, E2);
      } else

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -321,13 +321,31 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
 
   // The use of an expression temporary is equal to the
   // value of the binding expression.
-  if (BoundsValueExpr *BV1 = dyn_cast<BoundsValueExpr>(E1))
-    if (BV1->getTemporaryBinding() == E2)
+  if (BoundsValueExpr *BV1 = dyn_cast<BoundsValueExpr>(E1)) {
+	CHKCBindTemporaryExpr *Binding = BV1->getTemporaryBinding();
+    if (Binding == E2) {
       return Result::Equal;
+	}
+	if (Binding) {
+	  Expr *SubExpr = Binding->getSubExpr();
+	  if (CompareExpr(SubExpr, E2) == Result::Equal) {
+	    return Result::Equal;
+	  }
+	}
+  }
 
-  if (BoundsValueExpr *BV2 = dyn_cast<BoundsValueExpr>(E2))
-    if (BV2->getTemporaryBinding() == E1)
+  if (BoundsValueExpr *BV2 = dyn_cast<BoundsValueExpr>(E2)) {
+	CHKCBindTemporaryExpr *Binding = BV2->getTemporaryBinding();
+    if (Binding == E1) {
       return Result::Equal;
+	}
+	if (Binding) {
+	  Expr *SubExpr = Binding->getSubExpr();
+	  if (CompareExpr(SubExpr, E1) == Result::Equal) {
+	    return Result::Equal;
+	  }
+	}
+  }
 
    // Compare expressions structurally, recursively invoking
    // comparison for subcomponents.  If that fails, consult

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -457,6 +457,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
        //   size, checkedness is the same, and the integer types are the
        //    same size/signedness.
        
+       // Bounds expressions don't have types.
        if (!isa<BoundsExpr>(E1ChildExpr))
          Cmp = CompareTypeIgnoreCheckedness(E1ChildExpr->getType(), E2ChildExpr->getType());
 

--- a/lib/AST/CanonBounds.cpp
+++ b/lib/AST/CanonBounds.cpp
@@ -754,9 +754,14 @@ Lexicographic::CompareImpl(const PositionalParameterExpr *E1,
 Result
 Lexicographic::CompareImpl(const BoundsCastExpr *E1,
                            const BoundsCastExpr *E2) {
-  Result Cmp = CompareExpr(E1->getBoundsExpr(), E2->getBoundsExpr());
+  Result Cmp = CompareInteger(E1->getCastKind(), E2->getCastKind());
   if (Cmp != Result::Equal)
     return Cmp;
+
+  Cmp = CompareExpr(E1->getBoundsExpr(), E2->getBoundsExpr());
+  if (Cmp != Result::Equal)
+    return Cmp;
+
   return CompareType(E1->getType(), E2->getType());
 }
 

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1308,6 +1308,7 @@ void StmtProfiler::VisitInteropTypeExpr(
 
 void StmtProfiler::VisitBoundsCastExpr(const BoundsCastExpr *S) {
   VisitExplicitCastExpr(S);
+  ID.AddInteger(S->getCastKind());
 }
 
 void StmtProfiler::VisitPositionalParameterExpr(

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2222,7 +2222,18 @@ namespace {
     }
 
     static bool EqualValue(ASTContext &Ctx, Expr *E1, Expr *E2, EquivExprSets *EquivExprs) {
-      Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(E1, E2);
+	  // It is assumed that E1 and E2 have been successfully evaluated, so that dynamic and assume bounds casts can be treated as value preserving here.
+	  Expr* Expr1 = E1;
+	  if (BoundsCastExpr* BC1 = dyn_cast<BoundsCastExpr>(E1)) {
+		Expr1 = BC1->getSubExpr();
+	  }
+
+	  Expr *Expr2 = E2;
+	  if (BoundsCastExpr *BC2 = dyn_cast<BoundsCastExpr>(E2)) {
+		Expr2 = BC2->getSubExpr();
+	  }
+
+      Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(Expr1, Expr2);
       return R == Lexicographic::Result::Equal;
     }
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2222,16 +2222,7 @@ namespace {
     }
 
     static bool EqualValue(ASTContext &Ctx, Expr *E1, Expr *E2, EquivExprSets *EquivExprs) {
-      // It is assumed that E1 and E2 have been successfully evaluated, so that dynamic and assume bounds casts can be treated as value preserving here.
-      Expr* Expr1 = E1;
-      if (BoundsCastExpr* BC1 = dyn_cast<BoundsCastExpr>(E1))
-        Expr1 = BC1->getSubExpr();
-
-      Expr *Expr2 = E2;
-      if (BoundsCastExpr *BC2 = dyn_cast<BoundsCastExpr>(E2))
-        Expr2 = BC2->getSubExpr();
-
-      Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(Expr1, Expr2);
+      Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(E1, E2);
       return R == Lexicographic::Result::Equal;
     }
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1126,19 +1126,19 @@ namespace {
           CastExpr *CE = cast<CastExpr>(E);
           Expr *SubExpr = CE->getSubExpr();
 
-		  CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
-		  assert(TempExpr);
+		      CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
+		      assert(TempExpr);
 
-		  // These bounds will be computed and tested at runtime.  Don't
-		  // recompute any expressions computed to temporaries already.
-		  Expr *TempUse = CreateTemporaryUse(TempExpr);
+		      // These bounds will be computed and tested at runtime.  Don't
+		      // recompute any expressions computed to temporaries already.
+		      Expr *TempUse = CreateTemporaryUse(TempExpr);
 
-		  Expr *SubExprAtNewType = CreateExplicitCast(E->getType(),
+		      Expr *SubExprAtNewType = CreateExplicitCast(E->getType(),
                                                       CastKind::CK_BitCast,
                                                       TempUse, true);
 
-		  BoundsExpr *Bounds = CE->getBoundsExpr();
-		  Bounds = ExpandToRange(SubExprAtNewType, Bounds);
+		      BoundsExpr *Bounds = CE->getBoundsExpr();
+		      Bounds = ExpandToRange(SubExprAtNewType, Bounds);
           return Bounds;
         }
         case Expr::ImplicitCastExprClass:
@@ -1306,10 +1306,10 @@ namespace {
         case Expr::BinaryConditionalOperatorClass:
           // TODO: infer correct bounds for conditional operators
           return CreateBoundsAllowedButNotComputed();
-		case Expr::BoundsValueExprClass: {
-		  BoundsValueExpr *BVE = cast<BoundsValueExpr>(E);
-		  return RValueBounds(BVE->getTemporaryBinding());
-		}
+		    case Expr::BoundsValueExprClass: {
+		      BoundsValueExpr *BVE = cast<BoundsValueExpr>(E);
+		      return RValueBounds(BVE->getTemporaryBinding());
+		    }
         default:
           // All other cases are unknowable
           return CreateBoundsAlwaysUnknown();
@@ -2222,16 +2222,16 @@ namespace {
     }
 
     static bool EqualValue(ASTContext &Ctx, Expr *E1, Expr *E2, EquivExprSets *EquivExprs) {
-	  // It is assumed that E1 and E2 have been successfully evaluated, so that dynamic and assume bounds casts can be treated as value preserving here.
-	  Expr* Expr1 = E1;
-	  if (BoundsCastExpr* BC1 = dyn_cast<BoundsCastExpr>(E1)) {
-		Expr1 = BC1->getSubExpr();
-	  }
+	    // It is assumed that E1 and E2 have been successfully evaluated, so that dynamic and assume bounds casts can be treated as value preserving here.
+	    Expr* Expr1 = E1;
+	    if (BoundsCastExpr* BC1 = dyn_cast<BoundsCastExpr>(E1)) {
+		    Expr1 = BC1->getSubExpr();
+	    }
 
-	  Expr *Expr2 = E2;
-	  if (BoundsCastExpr *BC2 = dyn_cast<BoundsCastExpr>(E2)) {
-		Expr2 = BC2->getSubExpr();
-	  }
+	    Expr *Expr2 = E2;
+	    if (BoundsCastExpr *BC2 = dyn_cast<BoundsCastExpr>(E2)) {
+		    Expr2 = BC2->getSubExpr();
+	    }
 
       Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(Expr1, Expr2);
       return R == Lexicographic::Result::Equal;
@@ -2470,11 +2470,11 @@ namespace {
     }
 
     CHKCBindTemporaryExpr *GetTempBinding(Expr *E) {
-	  // Bounds casts should always have a temporary binding.
-	  if (BoundsCastExpr *BCE = dyn_cast<BoundsCastExpr>(E)) {
-		CHKCBindTemporaryExpr *Result = dyn_cast<CHKCBindTemporaryExpr>(BCE->getSubExpr());
-		return Result;
-	  }
+	    // Bounds casts should always have a temporary binding.
+	    if (BoundsCastExpr *BCE = dyn_cast<BoundsCastExpr>(E)) {
+		    CHKCBindTemporaryExpr *Result = dyn_cast<CHKCBindTemporaryExpr>(BCE->getSubExpr());
+		    return Result;
+	    }
 	  
       CHKCBindTemporaryExpr *Result =
         dyn_cast<CHKCBindTemporaryExpr>(E->IgnoreParenNoopCasts(S.getASTContext()));
@@ -3113,22 +3113,20 @@ namespace {
       if (CK == CK_DynamicPtrBounds) {
         Expr *SubExpr = E->getSubExpr();
 
-		CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
-		assert(TempExpr);
+		    CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
+		    assert(TempExpr);
 
-		// These bounds will be computed and tested at runtime.  Don't
+		    // These bounds will be computed and tested at runtime.  Don't
         // recompute any expressions computed to temporaries already.
-		Expr *TempUse = BoundsInference(S).CreateTemporaryUse(TempExpr);
+		    Expr *TempUse = BoundsInference(S).CreateTemporaryUse(TempExpr);
 
-		Expr *SubExprAtNewType = BoundsInference(S).CreateExplicitCast(E->getType(),
+		    Expr *SubExprAtNewType = BoundsInference(S).CreateExplicitCast(E->getType(),
                                                 CastKind::CK_BitCast,
                                                 TempUse, true);
         BoundsExpr *DeclaredBounds = E->getBoundsExpr();
-
-		BoundsExpr *NormalizedBounds = S.ExpandToRange(SubExprAtNewType,
+		    BoundsExpr *NormalizedBounds = S.ExpandToRange(SubExprAtNewType,
                                                        DeclaredBounds);
-		BoundsExpr *SubExprBounds = S.InferRValueBounds(TempUse);
-
+		    BoundsExpr *SubExprBounds = S.InferRValueBounds(TempUse);
         if (SubExprBounds->isUnknown()) {
           S.Diag(SubExpr->getBeginLoc(), diag::err_expected_bounds);
         }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -1096,9 +1096,9 @@ namespace {
           return LValueTargetBounds(E);
         case CastKind::CK_ArrayToPointerDecay:
           return LValueBounds(E);
-		case CastKind::CK_DynamicPtrBounds:
+        case CastKind::CK_DynamicPtrBounds:
         case CastKind::CK_AssumePtrBounds:
-		  llvm_unreachable("unexpected rvalue bounds cast");
+          llvm_unreachable("unexpected rvalue bounds cast");
         default:
           return CreateBoundsAlwaysUnknown();
       }
@@ -1125,20 +1125,20 @@ namespace {
         case Expr::BoundsCastExprClass: {
           CastExpr *CE = cast<CastExpr>(E);
           Expr *SubExpr = CE->getSubExpr();
-
-		      CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
-		      assert(TempExpr);
-
-		      // These bounds will be computed and tested at runtime.  Don't
-		      // recompute any expressions computed to temporaries already.
-		      Expr *TempUse = CreateTemporaryUse(TempExpr);
-
-		      Expr *SubExprAtNewType = CreateExplicitCast(E->getType(),
+          
+          CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
+          assert(TempExpr);
+          
+          // These bounds will be computed and tested at runtime.  Don't
+          // recompute any expressions computed to temporaries already.
+          Expr *TempUse = CreateTemporaryUse(TempExpr);
+          
+          Expr *SubExprAtNewType = CreateExplicitCast(E->getType(),
                                                       CastKind::CK_BitCast,
                                                       TempUse, true);
-
-		      BoundsExpr *Bounds = CE->getBoundsExpr();
-		      Bounds = ExpandToRange(SubExprAtNewType, Bounds);
+          
+          BoundsExpr *Bounds = CE->getBoundsExpr();
+          Bounds = ExpandToRange(SubExprAtNewType, Bounds);
           return Bounds;
         }
         case Expr::ImplicitCastExprClass:
@@ -1306,10 +1306,10 @@ namespace {
         case Expr::BinaryConditionalOperatorClass:
           // TODO: infer correct bounds for conditional operators
           return CreateBoundsAllowedButNotComputed();
-		    case Expr::BoundsValueExprClass: {
-		      BoundsValueExpr *BVE = cast<BoundsValueExpr>(E);
-		      return RValueBounds(BVE->getTemporaryBinding());
-		    }
+        case Expr::BoundsValueExprClass: {
+          BoundsValueExpr *BVE = cast<BoundsValueExpr>(E);
+          return RValueBounds(BVE->getTemporaryBinding());
+        }
         default:
           // All other cases are unknowable
           return CreateBoundsAlwaysUnknown();
@@ -2222,16 +2222,14 @@ namespace {
     }
 
     static bool EqualValue(ASTContext &Ctx, Expr *E1, Expr *E2, EquivExprSets *EquivExprs) {
-	    // It is assumed that E1 and E2 have been successfully evaluated, so that dynamic and assume bounds casts can be treated as value preserving here.
-	    Expr* Expr1 = E1;
-	    if (BoundsCastExpr* BC1 = dyn_cast<BoundsCastExpr>(E1)) {
-		    Expr1 = BC1->getSubExpr();
-	    }
+      // It is assumed that E1 and E2 have been successfully evaluated, so that dynamic and assume bounds casts can be treated as value preserving here.
+      Expr* Expr1 = E1;
+      if (BoundsCastExpr* BC1 = dyn_cast<BoundsCastExpr>(E1))
+        Expr1 = BC1->getSubExpr();
 
-	    Expr *Expr2 = E2;
-	    if (BoundsCastExpr *BC2 = dyn_cast<BoundsCastExpr>(E2)) {
-		    Expr2 = BC2->getSubExpr();
-	    }
+      Expr *Expr2 = E2;
+      if (BoundsCastExpr *BC2 = dyn_cast<BoundsCastExpr>(E2))
+        Expr2 = BC2->getSubExpr();
 
       Lexicographic::Result R = Lexicographic(Ctx, EquivExprs).CompareExpr(Expr1, Expr2);
       return R == Lexicographic::Result::Equal;
@@ -2470,12 +2468,12 @@ namespace {
     }
 
     CHKCBindTemporaryExpr *GetTempBinding(Expr *E) {
-	    // Bounds casts should always have a temporary binding.
-	    if (BoundsCastExpr *BCE = dyn_cast<BoundsCastExpr>(E)) {
-		    CHKCBindTemporaryExpr *Result = dyn_cast<CHKCBindTemporaryExpr>(BCE->getSubExpr());
-		    return Result;
-	    }
-	  
+      // Bounds casts should always have a temporary binding.
+      if (BoundsCastExpr *BCE = dyn_cast<BoundsCastExpr>(E)) {
+        CHKCBindTemporaryExpr *Result = dyn_cast<CHKCBindTemporaryExpr>(BCE->getSubExpr());
+        return Result;
+      }
+
       CHKCBindTemporaryExpr *Result =
         dyn_cast<CHKCBindTemporaryExpr>(E->IgnoreParenNoopCasts(S.getASTContext()));
       return Result;
@@ -3113,20 +3111,20 @@ namespace {
       if (CK == CK_DynamicPtrBounds) {
         Expr *SubExpr = E->getSubExpr();
 
-		    CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
-		    assert(TempExpr);
+        CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
+        assert(TempExpr);
 
-		    // These bounds will be computed and tested at runtime.  Don't
+        // These bounds will be computed and tested at runtime.  Don't
         // recompute any expressions computed to temporaries already.
-		    Expr *TempUse = BoundsInference(S).CreateTemporaryUse(TempExpr);
+        Expr *TempUse = BoundsInference(S).CreateTemporaryUse(TempExpr);
 
-		    Expr *SubExprAtNewType = BoundsInference(S).CreateExplicitCast(E->getType(),
+        Expr *SubExprAtNewType = BoundsInference(S).CreateExplicitCast(E->getType(),
                                                 CastKind::CK_BitCast,
                                                 TempUse, true);
         BoundsExpr *DeclaredBounds = E->getBoundsExpr();
-		    BoundsExpr *NormalizedBounds = S.ExpandToRange(SubExprAtNewType,
+        BoundsExpr *NormalizedBounds = S.ExpandToRange(SubExprAtNewType,
                                                        DeclaredBounds);
-		    BoundsExpr *SubExprBounds = S.InferRValueBounds(TempUse);
+        BoundsExpr *SubExprBounds = S.InferRValueBounds(TempUse);
         if (SubExprBounds->isUnknown()) {
           S.Diag(SubExpr->getBeginLoc(), diag::err_expected_bounds);
         }

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -435,32 +435,6 @@ namespace {
 }
 #endif
 
-// Convert all temporary bindings in an expression to uses of the values
-// produced by a binding.   This should be done for bounds expressions that
-// are used in runtime checks.  That way we don't try to recompute a
-// temporary multiple times in an expression.
-namespace {
-  class PruneTemporaryHelper : public TreeTransform<PruneTemporaryHelper> {
-    typedef TreeTransform<PruneTemporaryHelper> BaseTransform;
-
-
-  public:
-    PruneTemporaryHelper(Sema &SemaRef) :
-      BaseTransform(SemaRef) { }
-
-    ExprResult TransformCHKCBindTemporaryExpr(CHKCBindTemporaryExpr *E) {
-      return new (SemaRef.Context) BoundsValueExpr(SourceLocation(), E);
-    }
-  };
-
-  Expr *PruneTemporaryBindings(Sema &SemaRef, Expr *E) {
-    Sema::ExprSubstitutionScope Scope(SemaRef); // suppress diagnostics
-    ExprResult R = PruneTemporaryHelper(SemaRef).TransformExpr(E);
-    assert(!R.isInvalid());
-    return R.get();
-  }
-}
-
 namespace {
   // Class for inferring bounds expressions for C expressions.
 

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -451,13 +451,18 @@ namespace {
     ExprResult TransformCHKCBindTemporaryExpr(CHKCBindTemporaryExpr *E) {	
       return new (SemaRef.Context) BoundsValueExpr(SourceLocation(), E);	
     }	
-
-    bool AlwaysRebuild() {
-      return false;
-    }
   };	
 
-  Expr *PruneTemporaryBindings(Sema &SemaRef, Expr *E) {	
+  Expr *PruneTemporaryBindings(Sema &SemaRef, Expr *E, bool InCheckedScope) {	
+    // Account for checked scope information when transforming the expression.
+    // Assume a bounds-only checked scope for InCheckedScope=true 
+    // since it is less restrictive than memory checked scopes.
+    // TODO: GitHub issue #698: this method should take a CheckedScopeSpecifier rather than a boolean.
+    CheckedScopeSpecifier CSS = InCheckedScope ? 
+      CheckedScopeSpecifier::CSS_Bounds : 
+      CheckedScopeSpecifier::CSS_Unchecked;
+    Sema::CheckedScopeRAII CheckedScope(SemaRef, CSS);
+
     Sema::ExprSubstitutionScope Scope(SemaRef); // suppress diagnostics	
     ExprResult R = PruneTemporaryHelper(SemaRef).TransformExpr(E);	
     assert(!R.isInvalid());	
@@ -802,7 +807,7 @@ namespace {
     // The returned bounds expression may contain a modifying expression within
     // it. It is the caller's responsibility to validate that the bounds
     // expression is non-modifying.
-    BoundsExpr *LValueBounds(Expr *E) {
+    BoundsExpr *LValueBounds(Expr *E, bool InCheckedScope) {
       // E may not be an lvalue if there is a typechecking error when struct 
       // accesses member array incorrectly.
       if (!E->isLValue()) return CreateBoundsInferenceError();
@@ -841,7 +846,7 @@ namespace {
       case Expr::UnaryOperatorClass: {
         UnaryOperator *UO = cast<UnaryOperator>(E);
         if (UO->getOpcode() == UnaryOperatorKind::UO_Deref)
-          return RValueBounds(UO->getSubExpr());
+          return RValueBounds(UO->getSubExpr(), InCheckedScope);
         else {
           llvm_unreachable("unexpected lvalue unary operator");
           return CreateBoundsInferenceError();
@@ -853,7 +858,7 @@ namespace {
         // of whichever subexpression has pointer type.
         ArraySubscriptExpr *AS = cast<ArraySubscriptExpr>(E);
         // getBase returns the pointer-typed expression.
-        return RValueBounds(AS->getBase());
+        return RValueBounds(AS->getBase(), InCheckedScope);
       }
       case Expr::MemberExprClass: {
         MemberExpr *ME = cast<MemberExpr>(E);
@@ -876,15 +881,15 @@ namespace {
               Expr *Base = CreateImplicitCast(Context.getDecayedType(E->getType()),
                                               CastKind::CK_ArrayToPointerDecay,
                                               E);
-              return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, ExpandToRange(Base, B)));
+              return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, ExpandToRange(Base, B), InCheckedScope));
             } else
-              return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, B));
+              return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, B, InCheckedScope));
           }
 
           // If B is an interop type annotation, the type must be identical
           // to the declared type, modulo checkedness.  So it is OK to
           // compute the array bounds based on the original type.
-          return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, ArrayExprBounds(ME)));
+          return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, ArrayExprBounds(ME), InCheckedScope));
         }
 
         // It is an error for a member to have function type
@@ -899,7 +904,7 @@ namespace {
 
         Expr *AddrOf = CreateAddressOfOperator(ME);
         BoundsExpr* Bounds = CreateSingleElementBounds(AddrOf);
-        return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, Bounds));
+        return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, Bounds, InCheckedScope));
       }
       case Expr::ImplicitCastExprClass: {
         ImplicitCastExpr *ICE = cast<ImplicitCastExpr>(E);
@@ -908,7 +913,7 @@ namespace {
         // TODO: when we add relative alignment support, we may need
         // to adjust the relative alignment of the bounds.
         if (ICE->getCastKind() == CastKind::CK_LValueBitCast)
-          return LValueBounds(ICE->getSubExpr());
+          return LValueBounds(ICE->getSubExpr(), InCheckedScope);
          return CreateBoundsAlwaysUnknown();
       }
       case Expr::CHKCBindTemporaryExprClass: {
@@ -999,7 +1004,7 @@ namespace {
     // The returned bounds expression may contain a modifying expression within
     // it. It is the caller's responsibility to validate that the bounds
     // expression is non-modifying.
-    BoundsExpr *LValueTargetBounds(Expr *E) {
+    BoundsExpr *LValueTargetBounds(Expr *E, bool InCheckedScope) {
       if (!E->isLValue()) return CreateBoundsInferenceError();
       E = E->IgnoreParens();
       QualType QT = E->getType();
@@ -1077,7 +1082,7 @@ namespace {
             B = CreateTypeBasedBounds(M, IT->getType(),
                                          /*IsParam=*/false,
                                          /*IsInteropTypeAnnotation=*/true);
-            return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, B));
+            return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, B, InCheckedScope));
           }
             
           if (!B)
@@ -1101,12 +1106,12 @@ namespace {
             B = ExpandToRange(MemberRValue, B);
           }
 
-          return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, B));
+          return cast<BoundsExpr>(PruneTemporaryBindings(SemaRef, B, InCheckedScope));
         }
         case Expr::ImplicitCastExprClass: {
           ImplicitCastExpr *ICE = cast<ImplicitCastExpr>(E);
           if (ICE->getCastKind() == CastKind::CK_LValueBitCast)
-            return LValueTargetBounds(ICE->getSubExpr());
+            return LValueTargetBounds(ICE->getSubExpr(), InCheckedScope);
           return CreateBoundsAlwaysUnknown();
         }
         default:
@@ -1115,7 +1120,7 @@ namespace {
     }
 
     // Compute the bounds of a cast operation that produces an rvalue.
-    BoundsExpr *RValueCastBounds(CastKind CK, Expr *E) {
+    BoundsExpr *RValueCastBounds(CastKind CK, Expr *E, bool InCheckedScope) {
       switch (CK) {
         case CastKind::CK_BitCast:
         case CastKind::CK_NoOp:
@@ -1126,11 +1131,11 @@ namespace {
         case CastKind::CK_IntegralCast:
         case CastKind::CK_IntegralToBoolean:
         case CastKind::CK_BooleanToSignedIntegral:
-          return RValueBounds(E);
+          return RValueBounds(E, InCheckedScope);
         case CastKind::CK_LValueToRValue:
-          return LValueTargetBounds(E);
+          return LValueTargetBounds(E, InCheckedScope);
         case CastKind::CK_ArrayToPointerDecay:
-          return LValueBounds(E);
+          return LValueBounds(E, InCheckedScope);
         case CastKind::CK_DynamicPtrBounds:
         case CastKind::CK_AssumePtrBounds:
           llvm_unreachable("unexpected rvalue bounds cast");
@@ -1144,7 +1149,7 @@ namespace {
     // The returned bounds expression may contain a modifying expression within
     // it. It is the caller's responsibility to validate that the bounds
     // expression is non-modifying.
-    BoundsExpr *RValueBounds(Expr *E) {
+    BoundsExpr *RValueBounds(Expr *E, bool InCheckedScope) {
       if (!E->isRValue()) return CreateBoundsInferenceError();
 
       E = E->IgnoreParens();
@@ -1183,7 +1188,7 @@ namespace {
           // _Ptr is invalid, that will be diagnosed separately.
           if (E->getType()->isCheckedPointerPtrType())
             return CreateTypeBasedBounds(E, E->getType(), false, false);
-          return RValueCastBounds(CE->getCastKind(), CE->getSubExpr());
+          return RValueCastBounds(CE->getCastKind(), CE->getSubExpr(), InCheckedScope);
         }
         case Expr::UnaryOperatorClass: {
           UnaryOperator *UO = cast<UnaryOperator>(E);
@@ -1209,19 +1214,19 @@ namespace {
             if (SubExpr->getType()->isFunctionType())
               return CreateBoundsEmpty();
 
-            return LValueBounds(SubExpr);
+            return LValueBounds(SubExpr, InCheckedScope);
           }
 
           // `++e`, `e++`, `--e`, `e--` all have bounds of `e`.
           // `e` is an LValue, so its bounds are its lvalue target bounds.
           if (UnaryOperator::isIncrementDecrementOp(Op))
-            return LValueTargetBounds(SubExpr);
+            return LValueTargetBounds(SubExpr, InCheckedScope);
 
           // `+e`, `-e`, `~e` all have bounds of `e`. `e` is an RValue.
           if (Op == UnaryOperatorKind::UO_Plus ||
               Op == UnaryOperatorKind::UO_Minus ||
               Op == UnaryOperatorKind::UO_Not)
-            return RValueBounds(SubExpr);
+            return RValueBounds(SubExpr, InCheckedScope);
 
           // We cannot infer the bounds of other unary operators
           return CreateBoundsAlwaysUnknown();
@@ -1239,12 +1244,12 @@ namespace {
 
           // `e1 = e2` has the bounds of `e2`. `e2` is an RValue.
           if (Op == BinaryOperatorKind::BO_Assign)
-            return RValueBounds(RHS);
+            return RValueBounds(RHS, InCheckedScope);
 
           // `e1, e2` has the bounds of `e2`. Both `e1` and `e2`
           // are RValues.
           if (Op == BinaryOperatorKind::BO_Comma)
-            return RValueBounds(RHS);
+            return RValueBounds(RHS, InCheckedScope);
 
           // Compound Assignments function like assignments mostly,
           // except the LHS is an L-Value, so we'll use its lvalue target bounds
@@ -1263,14 +1268,14 @@ namespace {
               RHS->getType()->isIntegerType() &&
               BinaryOperator::isAdditiveOp(Op)) {
             return IsCompoundAssignment ?
-              LValueTargetBounds(LHS) : RValueBounds(LHS);
+              LValueTargetBounds(LHS, InCheckedScope) : RValueBounds(LHS, InCheckedScope);
           }
           // `i + p` has the bounds of `p`. `p` is an RValue.
           // `i += p` has the bounds of `p`. `p` is an RValue.
           if (LHS->getType()->isIntegerType() &&
               RHS->getType()->isPointerType() &&
               Op == BinaryOperatorKind::BO_Add) {
-            return RValueBounds(RHS);
+            return RValueBounds(RHS, InCheckedScope);
           }
           // `e - p` has empty bounds, regardless of the bounds of p.
           // `e -= p` has empty bounds, regardless of the bounds of p.
@@ -1298,8 +1303,8 @@ namespace {
                BinaryOperator::isBitwiseOp(Op) ||
                BinaryOperator::isShiftOp(Op))) {
             BoundsExpr *LHSBounds = IsCompoundAssignment ?
-              LValueTargetBounds(LHS) : RValueBounds(LHS);
-            BoundsExpr *RHSBounds = RValueBounds(RHS);
+              LValueTargetBounds(LHS, InCheckedScope) : RValueBounds(LHS, InCheckedScope);
+            BoundsExpr *RHSBounds = RValueBounds(RHS, InCheckedScope);
             if (LHSBounds->isUnknown() && !RHSBounds->isUnknown())
               return RHSBounds;
             if (!LHSBounds->isUnknown() && RHSBounds->isUnknown())
@@ -1335,7 +1340,7 @@ namespace {
           if (const CallExpr *CE = dyn_cast<CallExpr>(Child))
             return CallExprBounds(CE, Binding);
           else
-            return RValueBounds(Child);
+            return RValueBounds(Child, InCheckedScope);
         }
         case Expr::ConditionalOperatorClass:
         case Expr::BinaryConditionalOperatorClass:
@@ -1343,7 +1348,7 @@ namespace {
           return CreateBoundsAllowedButNotComputed();
         case Expr::BoundsValueExprClass: {
           BoundsValueExpr *BVE = cast<BoundsValueExpr>(E);
-          return RValueBounds(BVE->getTemporaryBinding());
+          return RValueBounds(BVE->getTemporaryBinding(), InCheckedScope);
         }
         default:
           // All other cases are unknowable
@@ -1480,8 +1485,8 @@ BoundsExpr *Sema::CheckNonModifyingBounds(BoundsExpr *B, Expr *E) {
     return B;
 }
 
-BoundsExpr *Sema::InferLValueBounds(Expr *E) {
-  BoundsExpr *Bounds = BoundsInference(*this).LValueBounds(E);
+BoundsExpr *Sema::InferLValueBounds(Expr *E, bool InCheckedScope) {
+  BoundsExpr *Bounds = BoundsInference(*this).LValueBounds(E, InCheckedScope);
   return CheckNonModifyingBounds(Bounds, E);
 }
 
@@ -1491,14 +1496,14 @@ BoundsExpr *Sema::CreateTypeBasedBounds(Expr *E, QualType Ty, bool IsParam,
                                                       IsBoundsSafeInterface);
 }
 
-BoundsExpr *Sema::InferLValueTargetBounds(Expr *E) {
-  BoundsExpr *Bounds = BoundsInference(*this).LValueTargetBounds(E);
+BoundsExpr *Sema::InferLValueTargetBounds(Expr *E, bool InCheckedScope) {
+  BoundsExpr *Bounds = BoundsInference(*this).LValueTargetBounds(E, InCheckedScope);
   return CheckNonModifyingBounds(Bounds, E);
 }
 
-BoundsExpr *Sema::InferRValueBounds(Expr *E, bool IncludeNullTerminator) {
+BoundsExpr *Sema::InferRValueBounds(Expr *E, bool InCheckedScope, bool IncludeNullTerminator) {
   BoundsExpr *Bounds =
-    BoundsInference(*this, IncludeNullTerminator).RValueBounds(E);
+    BoundsInference(*this, IncludeNullTerminator).RValueBounds(E, InCheckedScope);
   return CheckNonModifyingBounds(Bounds, E);
 }
 
@@ -1666,7 +1671,7 @@ namespace {
       QualType PtrType;
       if (Expr *Deref = S.GetArrayPtrDereference(E, PtrType)) {
         NeedsBoundsCheck = true;
-        BoundsExpr *LValueBounds = S.InferLValueBounds(E);
+        BoundsExpr *LValueBounds = S.InferLValueBounds(E, InCheckedScope);
         BoundsCheckKind Kind = BCK_Normal;
         // Null-terminated array pointers have special semantics for
         // bounds checks.
@@ -1714,7 +1719,7 @@ namespace {
 
       // E->F.  This is equivalent to (*E).F.
       if (Base->getType()->isCheckedPointerArrayType()) {
-        BoundsExpr *Bounds = S.InferRValueBounds(Base);
+        BoundsExpr *Bounds = S.InferRValueBounds(Base, InCheckedScope);
         if (Bounds->isUnknown()) {
           S.Diag(Base->getBeginLoc(), diag::err_expected_bounds) << Base->getSourceRange();
           Bounds = S.CreateInvalidBoundsExpr();
@@ -2967,12 +2972,12 @@ namespace {
                IsBoundsSafeInterfaceAssignment(LHSType, RHS)) {
         // Check that the value being assigned has bounds if the
         // target of the LHS lvalue has bounds.
-        LHSTargetBounds = S.InferLValueTargetBounds(LHS);
+        LHSTargetBounds = S.InferLValueTargetBounds(LHS, InCheckedScope);
         if (!LHSTargetBounds->isUnknown()) {
           if (E->isCompoundAssignmentOp())
-            RHSBounds = S.InferRValueBounds(E);
+            RHSBounds = S.InferRValueBounds(E, InCheckedScope);
           else
-            RHSBounds = S.InferRValueBounds(RHS);
+            RHSBounds = S.InferRValueBounds(RHS, InCheckedScope);
 
           if (RHSBounds->isUnknown()) {
              S.Diag(RHS->getBeginLoc(),
@@ -3055,7 +3060,7 @@ namespace {
           continue;
 
         Expr *Arg = CE->getArg(i);
-        BoundsExpr *ArgBounds = S.InferRValueBounds(Arg);
+        BoundsExpr *ArgBounds = S.InferRValueBounds(Arg, InCheckedScope);
         if (ArgBounds->isUnknown()) {
           S.Diag(Arg->getBeginLoc(),
                  diag::err_expected_bounds_for_argument) << (i + 1) <<
@@ -3150,7 +3155,7 @@ namespace {
         BoundsExpr *DeclaredBounds = E->getBoundsExpr();
         BoundsExpr *NormalizedBounds = S.ExpandToRange(SubExprAtNewType,
                                                        DeclaredBounds);
-        BoundsExpr *SubExprBounds = S.InferRValueBounds(TempUse);
+        BoundsExpr *SubExprBounds = S.InferRValueBounds(TempUse, InCheckedScope);
         if (SubExprBounds->isUnknown()) {
           S.Diag(SubExpr->getBeginLoc(), diag::err_expected_bounds);
         }
@@ -3171,7 +3176,7 @@ namespace {
         bool IncludeNullTerminator =
           E->getType()->getPointeeOrArrayElementType()->isNtCheckedArrayType();
         BoundsExpr *SubExprBounds =
-          S.InferRValueBounds(E->getSubExpr(), IncludeNullTerminator);
+          S.InferRValueBounds(E->getSubExpr(), InCheckedScope, IncludeNullTerminator);
         if (SubExprBounds->isUnknown()) {
           S.Diag(E->getSubExpr()->getBeginLoc(),
                  diag::err_expected_bounds_for_ptr_cast)
@@ -3247,7 +3252,7 @@ namespace {
      Expr *Init = D->getInit();
      if (Init && D->getType()->isScalarType()) {
        assert(D->getInitStyle() == VarDecl::InitializationStyle::CInit);
-       BoundsExpr *InitBounds = S.InferRValueBounds(Init);
+       BoundsExpr *InitBounds = S.InferRValueBounds(Init, InCheckedScope);
        if (InitBounds->isUnknown()) {
          // TODO: need some place to record the initializer bounds
          S.Diag(Init->getBeginLoc(), diag::err_expected_bounds_for_initializer)

--- a/lib/Sema/SemaBounds.cpp
+++ b/lib/Sema/SemaBounds.cpp
@@ -2459,6 +2459,12 @@ namespace {
     }
 
     CHKCBindTemporaryExpr *GetTempBinding(Expr *E) {
+	  // Bounds casts should always have a temporary binding.
+	  if (BoundsCastExpr *BCE = dyn_cast<BoundsCastExpr>(E)) {
+		CHKCBindTemporaryExpr *Result = dyn_cast<CHKCBindTemporaryExpr>(BCE->getSubExpr());
+		return Result;
+	  }
+	  
       CHKCBindTemporaryExpr *Result =
         dyn_cast<CHKCBindTemporaryExpr>(E->IgnoreParenNoopCasts(S.getASTContext()));
       return Result;

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2831,9 +2831,11 @@ ExprResult Sema::BuildBoundsCastExpr(SourceLocation OpLoc, tok::TokenKind Kind,
   if (Op.SrcExpr.isInvalid())
     return ExprError();
 
+  Expr *TempExpr = new (Context) CHKCBindTemporaryExpr(Op.SrcExpr.get());
+
   return Op.complete(
       BoundsCastExpr::Create(Context, Op.ResultType, Op.ValueKind, Op.Kind,
-                             Op.SrcExpr.get(), &Op.BasePath, CastTypeInfo,
+                             TempExpr, &Op.BasePath, CastTypeInfo,
                              OpLoc, Paren.getEnd(), AngleBrackets, bounds));
 }
 

--- a/test/CheckedC/inferred-bounds/member-arrow-reference.c
+++ b/test/CheckedC/inferred-bounds/member-arrow-reference.c
@@ -77,12 +77,12 @@ void f1(struct S1 *a1, struct S2 *b2) {
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: Initializer Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S2 *' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
 // CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue ->arr {{0x[0-9a-f]+}}
 // CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S2 *' <LValueToRValue>
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2 *' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2 *'
@@ -182,12 +182,12 @@ void f3(struct S3 *c1) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: Initializer Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S3 *' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK:   |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK:   |   `-ImplicitCastExpr {{0x[0-9a-f]+}} 'struct S3 *' <LValueToRValue>
 // CHECK:   |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S3 *' lvalue ParmVar {{0x[0-9a-f]+}} 'c1' 'struct S3 *'

--- a/test/CheckedC/inferred-bounds/member-base.c
+++ b/test/CheckedC/inferred-bounds/member-base.c
@@ -166,12 +166,12 @@ void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: RHS Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
@@ -212,14 +212,14 @@ void f3(_Array_ptr<struct S> a : bounds(a, a + 7)) {
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: RHS Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'a' '_Array_ptr<struct S>'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <LValueToRValue>
@@ -359,12 +359,12 @@ int f10a(void) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: RHS Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
@@ -405,14 +405,14 @@ int f10a(void) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: RHS Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
 // CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S _Checked[6]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'struct S _Checked[6]'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
@@ -591,12 +591,12 @@ void f22(struct S b _Checked[9]) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: RHS Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue ->f {{0x[0-9a-f]+}}
 // CHECK: |   `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |     `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
@@ -637,14 +637,14 @@ void f22(struct S b _Checked[9]) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 // CHECK: RHS Bounds:
 // CHECK:  RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 3
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>

--- a/test/CheckedC/inferred-bounds/member-reference.c
+++ b/test/CheckedC/inferred-bounds/member-reference.c
@@ -84,11 +84,11 @@ void f1(struct S1 a1, struct S2 b2) {
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: Initializer Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2':'struct S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2':'struct S2'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' '+'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>':'_Array_ptr<int>' <ArrayToPointerDecay>
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay>
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int _Checked[5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct S2':'struct S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct S2':'struct S2'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
@@ -226,11 +226,11 @@ void f10(struct Interop_S1 a1, struct Interop_S2 b2,
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: Initializer Bounds:
 // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <ArrayToPointerDecay>
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *':'int *' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *' <ArrayToPointerDecay>
 // CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
@@ -306,11 +306,11 @@ _Checked void f11(struct Interop_S1 a1, struct Interop_S2 b2,
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 // CHECK: Initializer Bounds:
  // CHECK: RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay> BoundsSafeInterface
 // CHECK: | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK: |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
-// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} 'int *':'int *' '+'
-// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} 'int *':'int *' <ArrayToPointerDecay>
+// CHECK: `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
+// CHECK:   |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' <ArrayToPointerDecay> BoundsSafeInterface
 // CHECK:   | `-MemberExpr {{0x[0-9a-f]+}} 'int [5]' lvalue .arr {{0x[0-9a-f]+}}
 // CHECK:   |   `-DeclRefExpr {{0x[0-9a-f]+}} 'struct Interop_S2':'struct Interop_S2' lvalue ParmVar {{0x[0-9a-f]+}} 'b2' 'struct Interop_S2':'struct Interop_S2'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5

--- a/test/CheckedC/inferred-bounds/ptr-cast.c
+++ b/test/CheckedC/inferred-bounds/ptr-cast.c
@@ -119,14 +119,14 @@ void f4(struct S b _Checked[9]) {
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
 // CHECK: |-Inferred SubExpr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |   |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |   |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: |   | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   |   `-ParenExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |   |     `-UnaryOperator {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue prefix '*'
 // CHECK: |   |       `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' <LValueToRValue>
 // CHECK: |   |         `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>':'_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'b' '_Array_ptr<struct S>':'_Array_ptr<struct S>'
-// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |     |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |     |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: |     | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |     |   `-ParenExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |     `-UnaryOperator {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue prefix '*'
@@ -153,7 +153,7 @@ void f5(struct S arr _Checked[][12] : count(len), int i, int j, int len) {
 // CHECK: ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int>' <BitCast>
 // CHECK: |-Inferred SubExpr Bounds
 // CHECK: | `-RangeBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE'
-// CHECK: |   |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |   |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: |   | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |   |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |   |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>
@@ -164,8 +164,8 @@ void f5(struct S arr _Checked[][12] : count(len), int i, int j, int len) {
 // CHECK: |   |     |     `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'i' 'int'
 // CHECK: |   |     `-ImplicitCastExpr {{0x[0-9a-f]+}} 'int' <LValueToRValue>
 // CHECK: |   |       `-DeclRefExpr {{0x[0-9a-f]+}} 'int' lvalue ParmVar {{0x[0-9a-f]+}} 'j' 'int'
-// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '+'
-// CHECK: |     |-UnaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' prefix '&'
+// CHECK: |   `-BinaryOperator {{0x[0-9a-f]+}} 'int *' '+'
+// CHECK: |     |-UnaryOperator {{0x[0-9a-f]+}} 'int *' prefix '&'
 // CHECK: |     | `-MemberExpr {{0x[0-9a-f]+}} 'int' lvalue .f {{0x[0-9a-f]+}}
 // CHECK: |     |   `-ArraySubscriptExpr {{0x[0-9a-f]+}} 'struct S':'struct S' lvalue
 // CHECK: |     |     |-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <ArrayToPointerDecay>

--- a/test/CheckedC/static-checking/bounds-decl-challenges.c
+++ b/test/CheckedC/static-checking/bounds-decl-challenges.c
@@ -3,18 +3,6 @@
 //
 // RUN: %clang -cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify -verify-ignore-unexpected=note %s
 
-// A function call on the rhs that returns a value with bounds.
-
-extern _Array_ptr<int> h4(void) : count(3) {
-  _Array_ptr<int> p : bounds(p, p + 3) = 0;
-  return p;
-}
-
-extern void f7(void *p) {
-  _Array_ptr<int> r : count(3) = 0;
-  r = _Assume_bounds_cast<_Array_ptr<int>>(h4(), count(3));  // expected-error {{contain a modifying expression}}
-}
-
 // Deferencing an array of nt_checked arrays.
 extern void check_assign(int val, int p[10], int q[], int r _Checked[10], int s _Checked[],
                          int s2d _Checked[10][10], int v _Nt_checked[10], int w _Nt_checked[],

--- a/test/CheckedC/static-checking/memory-access-checking.c
+++ b/test/CheckedC/static-checking/memory-access-checking.c
@@ -65,7 +65,10 @@ void f4(void) {
 struct S { int i;  int j; };
 struct S global_arr2 _Checked[10];
 void f5(_Array_ptr<struct S> param_arr : count(10)) {
-  _Ptr<int> p = &(global_arr2[11].i); // expected-warning {{out-of-bounds memory access}} expected-warning {{array index 11 is past the end of the array}}
+  _Ptr<int> p = &(global_arr2[11].i); // expected-warning {{out-of-bounds memory access}} \
+                                      // expected-warning {{array index 11 is past the end of the array}} \
+                                      // expected-warning {{array index 11 is past the end of the array}}
+                                      // TODO: GitHub issue #696: this warning should not be issued twice.
                                       // TODO: generate better error message for this situation
   p = &((global_arr2 + 11)->i); // expected-warning {{out-of-bounds base value}}
   p = &(param_arr[11].i); // expected-warning {{out-of-bounds memory access}}  


### PR DESCRIPTION
This PR adds a temporary binding expression when building a BoundsCastExpr. This helps enable dynamic and assume bounds casts expressions to be treated as non-value-preserving in CanonBounds::CompareExpr (see issue #691).

### Changes
* Introduce temporary binding expression to bounds casts.
* Adjust bounds inference and visiting cast expressions to reflect the temporary bindings.
* Account for BoundsCastExprs when getting the temporary binding of an expression.
* Account for whether the expression is in a checked scope or not in `PruneTemporaryBindings`. (A follow-up issue #698 is opened to use the `CheckedScopeSpecifier` enum rather than a boolean here.)
* ~~Consider BoundsCastExprs to be value-preserving in CheckBoundsDeclarations::EqualValue. Note: this assumes that the expressions E1 and E2 have been successfully evaluated.~~ This change has been removed. This affects the Checked C static_check_bounds_cast.c test (modified in microsoft/checkedc#385 - opened #695 to track remaining work).
* Treat bounds cast expressions as non-value-preserving.
* Consider an expression e to be lexicographically equal to the usage of a temporary binding of e.
* Remove the llvm_unreachable call if a dynamic cast fails in CanonBounds::Compare. Since bounds casts are no longer considered value-preserving, it is possible to compare, e.g. a BoundsCastExpr and an ImplicitCastExpr. An ImplicitCastExpr cannot be dynamically cast to a BoundsCastExpr.
* Account for the cast kind when profiling a BoundsCastExpr.

### Tests
* Remove the function call test from bounds-decl-challenges. With the introduction of temporaries to bounds cast expressions, this test no longer produces an error.
* Add AST tests to verify that bounds cast expressions include a temporary binding expression.
* Other tests are added to checked-c (microsoft/checkedc#385).