### PR TITLE
Avoid duplicate runtime behavior diagnostics in bounds checking

### DIFF
--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -16840,6 +16840,9 @@ void Sema::MarkDeclarationsReferencedInExpr(Expr *E,
 /// during overload resolution or within sizeof/alignof/typeof/typeid.
 bool Sema::DiagRuntimeBehavior(SourceLocation Loc, const Stmt *Statement,
                                const PartialDiagnostic &PD) {
+  if (DisableSubstitionDiagnostics)
+    return false;
+
   switch (ExprEvalContexts.back().Context) {
   case ExpressionEvaluationContext::Unevaluated:
   case ExpressionEvaluationContext::UnevaluatedList:

--- a/test/CheckedC/static-checking/memory-access-checking.c
+++ b/test/CheckedC/static-checking/memory-access-checking.c
@@ -65,10 +65,7 @@ void f4(void) {
 struct S { int i;  int j; };
 struct S global_arr2 _Checked[10];
 void f5(_Array_ptr<struct S> param_arr : count(10)) {
-  _Ptr<int> p = &(global_arr2[11].i); // expected-warning {{out-of-bounds memory access}} \
-                                      // expected-warning {{array index 11 is past the end of the array}} \
-                                      // expected-warning {{array index 11 is past the end of the array}}
-                                      // TODO: GitHub issue #696: this warning should not be issued twice.
+  _Ptr<int> p = &(global_arr2[11].i); // expected-warning {{out-of-bounds memory access}} expected-warning {{array index 11 is past the end of the array}}
                                       // TODO: generate better error message for this situation
   p = &((global_arr2 + 11)->i); // expected-warning {{out-of-bounds base value}}
   p = &(param_arr[11].i); // expected-warning {{out-of-bounds memory access}}  


### PR DESCRIPTION
Issue #696 describes a duplicate "array index exceeds bounds" warning emitted due to a call to PruneTemporaryBindings. PruneTemporaryBindings suppresses diagnostics via an ExprSubstitutionScope, but Sema::DiagRuntimeBehavior emitted diagnostics regardless. This PR prevents DiagRuntimeBehavior from emitting diagnostics when substitution diagnostics are disabled.

Testing:
* Removed the expected duplicate warning from memory-access-checking.c.
* Passed local testing on Windows.
* Passed automated testing on Windows and Linux.