### PR TITLE
Fix windows automation for move to monorepo.

### DIFF
--- a/clang/automation/Windows/run-cmake.bat
+++ b/clang/automation/Windows/run-cmake.bat
@@ -23,7 +23,7 @@ set OLD_DIR=%CD%
 cd %LLVM_OBJ_DIR%
 rem  This generates a build system that supports multiple configurations.  Don't try setting CMAKE_BUILD_TYPE here 
 rem because it is ignored.
-cmake %CMAKE_GENERATOR% -T "host=x64" %EXTRA_FLAGS% -DLLVM_ENABLE_PROJECTS=clang -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON %BUILD_SOURCESDIRECTORY%\llvm
+cmake %CMAKE_GENERATOR% -T "host=x64" %EXTRA_FLAGS% -DLLVM_ENABLE_PROJECTS=clang -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON %BUILD_SOURCESDIRECTORY%\checkedc-clang\llvm
 if ERRORLEVEL 1 (goto cmdfailed)
 
 :succeeded

--- a/clang/automation/Windows/setup-files.bat
+++ b/clang/automation/Windows/setup-files.bat
@@ -14,12 +14,12 @@ if "%BUILD_CHECKEDC_CLEAN%"=="Yes" (
 )
  
 if not exist %BUILD_SOURCESDIRECTORY%\.git (
-  git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-clang %BUILD_SOURCESDIRECTORY%
+  git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-clang %BUILD_SOURCESDIRECTORY%/checkedc-clang
   if ERRORLEVEL 1 (goto cmdfailed)
 )
 
-if not exist %BUILD_SOURCESDIRECTORY%\llvm\projects\checkedc-wrapper\checkedc\.git (
-  git clone https://github.com/Microsoft/checkedc %BUILD_SOURCESDIRECTORY%\llvm\projects\checkedc-wrapper\checkedc
+if not exist %BUILD_SOURCESDIRECTORY%\checkedc-clang\llvm\projects\checkedc-wrapper\checkedc\.git (
+  git clone https://github.com/Microsoft/checkedc %BUILD_SOURCESDIRECTORY%\checkedc-clang\llvm\projects\checkedc-wrapper\checkedc
   if ERRORLEVEL 1 (goto cmdfailed)
 )
 
@@ -34,7 +34,7 @@ if "%SIGN_INSTALLER%" NEQ "No" (
 )
 
 rem Set up clang sources
-cd %BUILD_SOURCESDIRECTORY%
+cd %BUILD_SOURCESDIRECTORY%\checkedc-clang
 if ERRORLEVEL 1 (goto cmdfailed)
 git fetch origin
 if ERRORLEVEL 1 (goto cmdfailed)
@@ -52,7 +52,7 @@ if not exist %LLVM_OBJ_DIR% (
 )
 
 rem set up Checked C sources
-cd %BUILD_SOURCESDIRECTORY%\llvm\projects\checkedc-wrapper\checkedc
+cd %BUILD_SOURCESDIRECTORY%\checkedc-clang\llvm\projects\checkedc-wrapper\checkedc
 if ERRORLEVEL 1 (goto cmdfailed)
 git fetch origin
 if ERRORLEVEL 1 (goto cmdfailed)

--- a/clang/automation/Windows/setup-files.bat
+++ b/clang/automation/Windows/setup-files.bat
@@ -13,7 +13,7 @@ if "%BUILD_CHECKEDC_CLEAN%"=="Yes" (
   )
 )
  
-if not exist %BUILD_SOURCESDIRECTORY%\.git (
+if not exist %BUILD_SOURCESDIRECTORY%\checkedc-clang\.git (
   git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-clang %BUILD_SOURCESDIRECTORY%\checkedc-clang
   if ERRORLEVEL 1 (goto cmdfailed)
 )

--- a/clang/automation/Windows/setup-files.bat
+++ b/clang/automation/Windows/setup-files.bat
@@ -14,7 +14,7 @@ if "%BUILD_CHECKEDC_CLEAN%"=="Yes" (
 )
  
 if not exist %BUILD_SOURCESDIRECTORY%\.git (
-  git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-clang %BUILD_SOURCESDIRECTORY%/checkedc-clang
+  git clone -c core.autocrlf=false https://github.com/Microsoft/checkedc-clang %BUILD_SOURCESDIRECTORY%\checkedc-clang
   if ERRORLEVEL 1 (goto cmdfailed)
 )
 


### PR DESCRIPTION
When we run automated tests, Azure DevOps first clones the checked-clang repo.  We then run scripts for automation from that clone.   The automation scripts then go and clone copies of the checked-clang repo and the checked repo.

The scripts weren't properly cloning the nested repo.   The testing was also running from the repo cloned by Azure DevOps.   This is incorrect given the way the scripts are written: tests would run on the wrong branch, for example.   The cloning done by Azure DevOps "GetSources" task also uses Windows-style line endings.  There are some clang tests that require UNIX-style line endings.  Those tests failed for Windows.

The fix is to have the scripts properly clone the nested the checkedc-clang repo and then run cmake on that repo.   This is fixed by inserting checkedc-clang into various paths..