### PR TITLE
Prevent static variables declarations from using free type variables

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -246,7 +246,8 @@ def warn_vector_long_decl_spec_combination : Warning<
   "Use of 'long' with '__vector' is deprecated">, InGroup<Deprecated>;
 
 def err_static_decl_uses_free_type_variable : Error<
-  "type '%0' for static variable '%1' cannot use type variable '%2' that is bound by an enclosing scope">;
+  "static variable '%0' has a type that uses a type variable bound in an enclosing scope "
+  "(type is '%1' and type variable is '%2')">;
 def note_free_type_variable_declared : Note<"type variable '%0' declared here">;
 def err_redeclaration_different_type : Error<
   "redeclaration of %0 with a different type%diff{: $ vs $|}1,2">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -245,6 +245,9 @@ def err_invalid_vector_long_double_decl_spec : Error<
 def warn_vector_long_decl_spec_combination : Warning<
   "Use of 'long' with '__vector' is deprecated">, InGroup<Deprecated>;
 
+def err_static_decl_uses_free_type_variable : Error<
+  "illegal use of free type variable '%0' in declaration of static variable '%1'">;
+def note_free_type_variable_declared : Note<"free type variable '%0' declared here">;
 def err_redeclaration_different_type : Error<
   "redeclaration of %0 with a different type%diff{: $ vs $|}1,2">;
 def err_bad_variable_name : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -246,7 +246,7 @@ def warn_vector_long_decl_spec_combination : Warning<
   "Use of 'long' with '__vector' is deprecated">, InGroup<Deprecated>;
 
 def err_static_decl_uses_free_type_variable : Error<
-  "static variable '%0' cannot have type variable '%1' that is bound by an enclosing scope">;
+  "type '%0' for static variable '%1' cannot use type variable '%2' that is bound by an enclosing scope">;
 def note_free_type_variable_declared : Note<"type variable '%0' declared here">;
 def err_redeclaration_different_type : Error<
   "redeclaration of %0 with a different type%diff{: $ vs $|}1,2">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -246,8 +246,8 @@ def warn_vector_long_decl_spec_combination : Warning<
   "Use of 'long' with '__vector' is deprecated">, InGroup<Deprecated>;
 
 def err_static_decl_uses_free_type_variable : Error<
-  "illegal use of free type variable '%0' in declaration of static variable '%1'">;
-def note_free_type_variable_declared : Note<"free type variable '%0' declared here">;
+  "static variable '%0' cannot have type variable '%1' that is bound by an enclosing scope">;
+def note_free_type_variable_declared : Note<"type variable '%0' declared here">;
 def err_redeclaration_different_type : Error<
   "redeclaration of %0 with a different type%diff{: $ vs $|}1,2">;
 def err_bad_variable_name : Error<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4920,6 +4920,8 @@ public:
 
   QualType SubstituteTypeArgs(QualType QT, ArrayRef<TypeArgument> TypeArgs);
 
+  std::vector<const TypedefNameDecl *> FindFreeVariableDecls(QualType T);
+
   bool AbstractForFunctionType(BoundsAnnotations &BA,
                                ArrayRef<DeclaratorChunk::ParamInfo> Params);
   /// \brief Take a bounds expression with positional parameters from a function

--- a/clang/lib/Sema/CheckedCSubst.cpp
+++ b/clang/lib/Sema/CheckedCSubst.cpp
@@ -512,15 +512,15 @@ public:
   FreeVariablesFinder(Sema &SemaRef) : BaseTransform(SemaRef), Context(SemaRef.Context) {}
 
   /// Returns the list of free type variables referenced in the given type.
-  std::vector<const TypeVariableType *> find(QualType Tpe) {
-    getDerived().TransformType(Tpe); // Populates `FreeVars` as a side effect.
+  std::vector<const TypeVariableType *> find(QualType Ty) {
+    getDerived().TransformType(Ty); // Populates `FreeVars` as a side effect.
     return std::vector<const TypeVariableType *>(FreeVars.begin(), FreeVars.end());
   }
 
   /// Returns the list of free typedef declarations referenced in the given type.
   /// Typedef declarations enable more readable diagnostics than type variable types.
-  std::vector<const TypedefNameDecl *> findTypedefDecls(QualType Tpe) {
-    getDerived().TransformType(Tpe); // Populates `FreeTypedefDecls` as a side effect.
+  std::vector<const TypedefNameDecl *> findTypedefDecls(QualType Ty) {
+    getDerived().TransformType(Ty); // Populates `FreeTypedefDecls` as a side effect.
     return std::vector<const TypedefNameDecl *>(FreeTypedefDecls.begin(), FreeTypedefDecls.end());
   }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7754,6 +7754,21 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
   // Defer checking an 'auto' type until its initializer is attached.
   if (T->isUndeducedType())
     return;
+  
+  // Emit an error for each use of a free type variable in the declaration of a static variable.
+  if (NewVD->getStorageClass() == StorageClass::SC_Static) {
+    std::vector<const TypedefNameDecl *> FreeVarDecls = FindFreeVariableDecls(T);
+    if (FreeVarDecls.size() > 0) {
+      for (auto it = FreeVarDecls.begin(); it != FreeVarDecls.end(); ++it) {
+        const TypedefNameDecl *FreeVar = *it;
+        Diag(NewVD->getLocation(), diag::err_static_decl_uses_free_type_variable) 
+          << FreeVar->getName() << NewVD->getName();
+        Diag(FreeVar->getLocation(), diag::note_free_type_variable_declared) << FreeVar->getName();
+      }
+      NewVD->setInvalidDecl();
+      return;
+    }
+  }
 
   if (NewVD->hasAttrs())
     CheckAlignasUnderalignment(NewVD);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7763,7 +7763,7 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
       for (auto it = FreeVarDecls.begin(); it != FreeVarDecls.end(); ++it) {
         const TypedefNameDecl *FreeVar = *it;
         Diag(NewVD->getTypeSpecStartLoc(), diag::err_static_decl_uses_free_type_variable) 
-          << T.getAsString() << NewVD->getName() << FreeVar->getName();
+          << NewVD->getName() << T.getAsString() << FreeVar->getName();
         Diag(FreeVar->getLocation(), diag::note_free_type_variable_declared) << FreeVar->getName();
       }
       NewVD->setInvalidDecl();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7755,14 +7755,15 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
   if (T->isUndeducedType())
     return;
   
-  // Emit an error for each use of a free type variable in the declaration of a static variable.
+  // Emit an error for each use of a free type variable (type variable
+  // bound by an enclosing scope) in the declaration of a static variable.
   if (NewVD->getStorageClass() == StorageClass::SC_Static) {
     std::vector<const TypedefNameDecl *> FreeVarDecls = FindFreeVariableDecls(T);
     if (FreeVarDecls.size() > 0) {
       for (auto it = FreeVarDecls.begin(); it != FreeVarDecls.end(); ++it) {
         const TypedefNameDecl *FreeVar = *it;
         Diag(NewVD->getLocation(), diag::err_static_decl_uses_free_type_variable) 
-          << FreeVar->getName() << NewVD->getName();
+          << NewVD->getName() << FreeVar->getName();
         Diag(FreeVar->getLocation(), diag::note_free_type_variable_declared) << FreeVar->getName();
       }
       NewVD->setInvalidDecl();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7756,14 +7756,14 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     return;
   
   // Emit an error for each use of a free type variable (type variable
-  // bound by an enclosing scope) in the declaration of a static variable.
+  // bound by an enclosing scope) in the type of a static variable.
   if (NewVD->getStorageClass() == StorageClass::SC_Static) {
     std::vector<const TypedefNameDecl *> FreeVarDecls = FindFreeVariableDecls(T);
     if (FreeVarDecls.size() > 0) {
       for (auto it = FreeVarDecls.begin(); it != FreeVarDecls.end(); ++it) {
         const TypedefNameDecl *FreeVar = *it;
-        Diag(NewVD->getLocation(), diag::err_static_decl_uses_free_type_variable) 
-          << NewVD->getName() << FreeVar->getName();
+        Diag(NewVD->getTypeSpecStartLoc(), diag::err_static_decl_uses_free_type_variable) 
+          << T.getAsString() << NewVD->getName() << FreeVar->getName();
         Diag(FreeVar->getLocation(), diag::note_free_type_variable_declared) << FreeVar->getName();
       }
       NewVD->setInvalidDecl();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7762,7 +7762,7 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     if (FreeVarDecls.size() > 0) {
       for (auto it = FreeVarDecls.begin(); it != FreeVarDecls.end(); ++it) {
         const TypedefNameDecl *FreeVar = *it;
-        Diag(NewVD->getTypeSpecStartLoc(), diag::err_static_decl_uses_free_type_variable) 
+        Diag(NewVD->getLocation(), diag::err_static_decl_uses_free_type_variable) 
           << NewVD->getName() << T.getAsString() << FreeVar->getName();
         Diag(FreeVar->getLocation(), diag::note_free_type_variable_declared) << FreeVar->getName();
       }


### PR DESCRIPTION
(See #684) 
Emit an error for each usage of a free type variable in the declaration of a static variable. The following: 
```
struct S _For_any(T, U) { };
_For_any(T, U) void f(void) {
  static struct S<T, U> s;
}
```
will emit the following:
```
error: static variable 's' has a type that uses a type variable bound in an enclosing scope (type is 'struct S<T, U>' and type variable is 'T')
note: type variable 'T' declared here
error: static variable 's' has a type that uses a type variable bound in an enclosing scope (type is 'struct S<T, U>' and type variable is 'U')
note: type variable 'U' declared here
```
These errors are emitted at the location of the static variable. For example:
![static-free-type-variable-error-message-1](https://user-images.githubusercontent.com/6687333/68441022-a9d5ee00-0181-11ea-97cb-52471b563392.png)

Future work: disallow free type variables in assignments to static variables (see #717)

Testing:
* Added typechecking tests to Checked C to verify that static variable declarations cannot use free type variables (microsoft/checkedc#392)
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux.