### PR TITLE
Add checked information for function declarations to AST reading and writing

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -861,6 +861,8 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
   // after everything else is read.
 
   FD->setStorageClass(static_cast<StorageClass>(Record.readInt()));
+  FD->setCheckedSpecifier(static_cast<CheckedScopeSpecifier>(Record.readInt()));
+  FD->setWrittenCheckedSpecifier(static_cast<CheckedScopeSpecifier>(Record.readInt()));
   FD->setInlineSpecified(Record.readInt());
   FD->setImplicitlyInline(Record.readInt());
   FD->setExplicitSpecified(Record.readInt());

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -161,8 +161,8 @@ void ASTStmtReader::VisitCompoundStmt(CompoundStmt *S) {
   VisitStmt(S);
   SmallVector<Stmt *, 16> Stmts;
   unsigned NumStmts = Record.readInt();
-  S->setCheckedSpecifiers((CheckedScopeSpecifier)Record.readInt());
-  S->setWrittenCheckedSpecifiers((CheckedScopeSpecifier)Record.readInt());
+  S->setCheckedSpecifiers(static_cast<CheckedScopeSpecifier>(Record.readInt()));
+  S->setWrittenCheckedSpecifiers(static_cast<CheckedScopeSpecifier>(Record.readInt()));
   while (NumStmts--)
     Stmts.push_back(Record.readSubStmt());
   S->setStmts(Stmts);

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -538,6 +538,8 @@ void ASTDeclWriter::VisitFunctionDecl(FunctionDecl *D) {
   // FunctionDecl's body is handled last at ASTWriterDecl::Visit,
   // after everything else is written.
   Record.push_back(static_cast<int>(D->getStorageClass())); // FIXME: stable encoding
+  Record.push_back(D->getCheckedSpecifier());
+  Record.push_back(D->getWrittenCheckedSpecifier());
   Record.push_back(D->isInlineSpecified());
   Record.push_back(D->isInlined());
   Record.push_back(D->isExplicitSpecified());
@@ -2130,6 +2132,8 @@ void ASTWriter::WriteDeclAbbrevs() {
   // FunctionDecl
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 11)); // IDNS
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 3)); // StorageClass
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 2)); // CheckedScopeSpecifier
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 2)); // WrittenCheckedScopeSpecifier
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // Inline
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // InlineSpecified
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // ExplicitSpecified

--- a/clang/test/CheckedC/ast-dump-pch.c
+++ b/clang/test/CheckedC/ast-dump-pch.c
@@ -34,4 +34,26 @@
 // CHECK: _Unchecked
 // CHECK-NOT {{checking-state}}
 
-// TODO: GitHub issue #704: add function declarations with checked scope specifiers
+// CHECK-NEXT: FunctionDecl
+// CHECK: f5
+// CHECK: checked
+// CHECK-NEXT: CompoundStmt
+// CHECK: checking-state bounds-and-types
+
+// CHECK-NEXT: FunctionDecl
+// CHECK: f6
+// CHECK: checked bounds_only
+// CHECK-NEXT: CompoundStmt
+// CHECK: checking-state bounds
+
+// CHECK-NEXT: FunctionDecl
+// CHECK: f7
+// CHECK: unchecked
+// CHECK-NEXT: CompoundStmt
+// CHECK-NOT: {{_Checked|_Unchecked|checking-state}}
+
+// CHECK-NEXT: FunctionDecl
+// CHECK: f8
+// CHECK: checked
+// CHECK-NEXT: CompoundStmt
+// CHECK: checking-state bounds

--- a/clang/test/CheckedC/ast-dump-pch.h
+++ b/clang/test/CheckedC/ast-dump-pch.h
@@ -13,4 +13,10 @@ void f3(void) _Checked _Bounds_only {}
 
 void f4(void) _Unchecked {}
 
-// TODO: GitHub issue #704: add function declarations with checked scope specifiers
+_Checked void f5(void) {}
+
+_Checked _Bounds_only void f6(void) {}
+
+_Unchecked void f7(void) {}
+
+_Checked void f8(void) _Checked _Bounds_only {}


### PR DESCRIPTION
(See issue #704)
Add the checked scope specifier and written checked scope specifier for function declarations to AST reading and writing, similar to the work done in #716 for compound statements. Follow-up work: move pch tests to a subdirectory (#719).

Testing:
* Modified ast-dump-pch tests to include tests for checked scope information for function declarations.
* Passed manual testing on Windows.
* Passed automated testing on Windows and Linux.