### PR TITLE
Implement bounds widening for _Nt_array_ptr's

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -1,0 +1,61 @@
+//===---------- BoundsAnalysis.h - collect comparison facts ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the interface for a dataflow analysis for bounds
+//  widening.
+//
+//  The analysis has the following characteristics: 1. forward dataflow
+//  analysis, 2. conservative, 3. intra-procedural, and 4. path-sensitive.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_BOUNDS_ANALYSIS_H
+#define LLVM_CLANG_BOUNDS_ANALYSIS_H
+
+#include "clang/Analysis/Analyses/PostOrderCFGView.h"
+#include "clang/Analysis/CFG.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Sema/Sema.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SetOperations.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace llvm;
+
+namespace clang {
+  using BoundsSet = SmallPtrSet<const Expr *, 4>;
+
+  class BoundsAnalysis {
+  private:
+    Sema &S;
+    CFG *Cfg;
+
+    class ElevatedCFGBlock {
+    public:
+      const CFGBlock *Block;
+      BoundsSet In, Out, Gen, Kill;
+
+      ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
+    };
+
+  public:
+    BoundsAnalysis(Sema &S, CFG *Cfg) : S(S), Cfg(Cfg) {}
+
+    void Analyze();
+
+  private:
+    bool IsPointerDerefLValue(const Expr *E);
+    bool ContainsPointerDeref(const Expr *E);
+  };
+}
+
+#endif

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -1,0 +1,96 @@
+//===-------- BoundsAnalysis.cpp - collect comparison facts -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements a dataflow analysis for bounds widening.
+//
+//  The analysis has the following characteristics: 1. forward dataflow
+//  analysis, 2. conservative, 3. intra-procedural, and 4. path-sensitive.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Sema/BoundsAnalysis.h"
+
+namespace clang {
+class Sema;
+
+void BoundsAnalysis::Analyze() {
+  assert(Cfg && "expected CFG to exist");
+
+  SetVector<ElevatedCFGBlock *> Worklist;
+  DenseMap<const CFGBlock *, ElevatedCFGBlock *> BlockMap;
+
+  for (const auto *B : PostOrderCFGView(Cfg)) {
+    auto EB = new ElevatedCFGBlock(B);
+    Worklist.insert(EB);
+    BlockMap[B] = EB;    
+  }
+
+  // Compute Gen and Kill sets.
+  for (auto B : Worklist) {
+    if (const Stmt *Term = B->Block->getTerminator()) {
+      if (const auto *IS = dyn_cast<IfStmt>(Term)) {
+        auto *E = IS->getCond();
+        // If the if condition derefences a pointer.
+        if (ContainsPointerDeref(E)) {
+          B->Gen.insert(E);
+
+          if (B->In.count(E))
+            B->Kill.insert(E);
+        }
+      }
+    }
+  }
+
+  // Iterative worklist algorithm.
+  while (!Worklist.empty()) {
+    auto *CurrentBlock = Worklist.back();
+    Worklist.pop_back();
+
+    // Update In set.
+    BoundsSet Intersections;
+    bool FirstIteration = true;
+    for (const auto B : CurrentBlock->Block->preds()) {
+      auto EB = BlockMap[B];
+      if (FirstIteration) {
+        Intersections = EB->Out;
+        FirstIteration = false;
+      } else
+        set_intersect(Intersections, EB->Out);
+    }
+    CurrentBlock->In = Intersections;
+
+    // Update Out set.
+    auto OldOut = CurrentBlock->Out;
+    CurrentBlock->Out = set_difference(CurrentBlock->In, CurrentBlock->Kill);
+    set_union(CurrentBlock->Out, CurrentBlock->Gen);
+
+    // Add the changed blocks to the worklist.
+    set_intersect(OldOut, CurrentBlock->Out);
+    if (OldOut.size() != CurrentBlock->Out.size())
+      for (const auto B : CurrentBlock->Block->succs())
+        Worklist.insert(BlockMap[B]);
+  }
+}
+
+bool BoundsAnalysis::IsPointerDerefLValue(const Expr *E) {
+  if (const auto *UO = dyn_cast<UnaryOperator>(E))
+    return UO->getOpcode() == UO_Deref;
+  return false;
+}
+
+bool BoundsAnalysis::ContainsPointerDeref(const Expr *E) {
+  if (const auto *CE = dyn_cast<CastExpr>(E)) {
+    if (CE->getCastKind() != CastKind::CK_LValueToRValue)
+      return false;
+    return IsPointerDerefLValue(CE->getSubExpr());
+  }
+  return false;
+}
+
+} // end namspace clang

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 add_clang_library(clangSema
   AnalysisBasedWarnings.cpp
   AvailableFactsAnalysis.cpp
+  BoundsAnalysis.cpp
   CheckedCAlias.cpp
   CheckedCInterop.cpp
   CheckedCSubst.cpp


### PR DESCRIPTION
Strings in Checked C are declared as _Nt_array_ptr which means they are
terminated by a null terminator. If we determine that the dereference of an
_Nt_array_ptr is non-null then we can widen the bounds of the pointer by 1
because there will always be at least the null terminator in the string.

Formally we can state the problem as:
∀ p | p ∈ _Nt_array_ptr & bounds(p) = [l, u)
*p != 0 => bounds(p) = [l, u + 1)

Example:
_Nt_array_ptr<char> p : count(0) = "abc"; // bounds = [0, 0]
if (*p) { // bounds = [0, 1) }