### PR TITLE
Fix merging of function declarations involving bounds-safe interfaces

### DIFF
--- a/clang/test/CheckedC/ast-dump-bounds-safe.c
+++ b/clang/test/CheckedC/ast-dump-bounds-safe.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
 
 
-// No bounds-safe information
+// 1. No bounds-safe information
 void f1(int *a, int n) {
   // CHECK: FunctionDecl {{.*}} f1 'void (int *, int)'
   // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
@@ -11,7 +11,7 @@ void f1(int *a, int n) {
   // CHECK-NEXT: CompoundStmt
 }
 
-// bounds-safe information on the definition
+// 2. Bounds-safe information on the definition
 void f2(int *a : count(n), int n) {
   // CHECK: FunctionDecl {{.*}} f2 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
   // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
@@ -25,8 +25,7 @@ void f2(int *a : count(n), int n) {
   // CHECK-NEXT: CompoundStmt
 }
 
-
-// bounds-safe information on redeclaration
+// 3. Declaration with bounds-safe information
 void f3(int *a : count(n), int n);
   // CHECK: FunctionDecl {{.*}} f3 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
   // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
@@ -38,6 +37,7 @@ void f3(int *a : count(n), int n);
   // CHECK-NEXT: BuiltinType {{.*}} 'int'
   // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
 
+//    and definition without bounds-safe information
 void f3(int *a, int n) {
   // CHECK: FunctionDecl {{.*}} f3 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
   // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
@@ -50,3 +50,27 @@ void f3(int *a, int n) {
   // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
   // CHECK-NEXT: CompoundStmt
 }
+
+// 4. Declaration with bounds-safe information
+void f4(int *a : count(n), int n);
+  // CHECK: FunctionDecl {{.*}} f4 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
+  // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'n' 'int'
+  // CHECK-NEXT: InteropTypeExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: PointerType {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: BuiltinType {{.*}} 'int'
+  // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
+
+//    and redeclaration without bounds-safe information
+void f4(int *a, int n);
+  // CHECK: FunctionDecl {{.*}} f4 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
+  // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'n' 'int'
+  // CHECK-NEXT: InteropTypeExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: PointerType {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: BuiltinType {{.*}} 'int'
+  // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'

--- a/clang/test/CheckedC/ast-dump-bounds-safe.c
+++ b/clang/test/CheckedC/ast-dump-bounds-safe.c
@@ -1,0 +1,52 @@
+// Tests for dumping of ASTs of Checked C's bounds-safe information
+//
+// RUN: %clang_cc1 -ast-dump -fcheckedc-extension %s | FileCheck %s
+
+
+// No bounds-safe information
+void f1(int *a, int n) {
+  // CHECK: FunctionDecl {{.*}} f1 'void (int *, int)'
+  // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
+  // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
+  // CHECK-NEXT: CompoundStmt
+}
+
+// bounds-safe information on the definition
+void f2(int *a : count(n), int n) {
+  // CHECK: FunctionDecl {{.*}} f2 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
+  // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'n' 'int'
+  // CHECK-NEXT: InteropTypeExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: PointerType {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: BuiltinType {{.*}} 'int'
+  // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
+  // CHECK-NEXT: CompoundStmt
+}
+
+
+// bounds-safe information on redeclaration
+void f3(int *a : count(n), int n);
+  // CHECK: FunctionDecl {{.*}} f3 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
+  // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'n' 'int'
+  // CHECK-NEXT: InteropTypeExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: PointerType {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: BuiltinType {{.*}} 'int'
+  // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
+
+void f3(int *a, int n) {
+  // CHECK: FunctionDecl {{.*}} f3 'void (int * : count(arg #1) itype(_Array_ptr<int>), int)'
+  // CHECK-NEXT: ParmVarDecl {{.*}} a 'int *'
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} 'n' 'int'
+  // CHECK-NEXT: InteropTypeExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: PointerType {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: BuiltinType {{.*}} 'int'
+  // CHECK-NEXT: ParmVarDecl {{.*}} n 'int'
+  // CHECK-NEXT: CompoundStmt
+}


### PR DESCRIPTION
This fixes function merging to propagate the information to parameter declarations in the function redeclaration. This in turn allows us to check that function definitions respect their bounds-safe interface.

See the related issue #731 for more details.
