### PR TITLE
Unary operator: combine bounds inference and checking

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13945,7 +13945,8 @@ void Sema::CheckArgumentWithTypeTag(const ArgumentWithTypeTagAttr *Attr,
 
 void Sema::AddPotentialMisalignedMembers(Expr *E, RecordDecl *RD, ValueDecl *MD,
                                          CharUnits Alignment) {
-  MisalignedMembers.emplace_back(E, RD, MD, Alignment);
+  if (!DisableSubstitionDiagnostics)
+    MisalignedMembers.emplace_back(E, RD, MD, Alignment);
 }
 
 void Sema::DiagnoseMisalignedMembers() {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14177,8 +14177,14 @@ QualType Sema::ValidateBoundsExprArgument(Expr *Arg) {
   // we do see them.
   Qualifiers ArgTypeQuals = ArgTypePointee.getQualifiers();
   ArgTypeQuals.removeCVRQualifiers();
-  assert(!ArgTypeQuals.hasQualifiers() &&
+
+  if (ArgTypeQuals.hasQualifiers()) {
+    if (!DisableSubstitionDiagnostics)
+      assert(!ArgTypeQuals.hasQualifiers() &&
          "unexpected non-CVR qualifiers on type");
+    else
+      return ArgTypePointee;
+  }
 
   if (!ArgTypePointee->isIncompleteOrObjectType()) {
     Diag(Arg->getBeginLoc(), diag::err_typecheck_bounds_expr) << ArgType;


### PR DESCRIPTION
#### Overview
This pull request is the first step in refactoring the CheckBoundsDeclarations class to combine bounds inference and bounds checking in the same methods. The first step adds a SideEffects argument to suppress any side effects that occur as a result of bounds checking (to prevent duplicate side effects that can otherwise occur from calling, e.g. LValueBounds on an expression). It also replaces the former VisitUnaryOperator method (which performed bounds checking on a unary operator) with the CheckUnaryOperator method (which performs both bounds inference and, if enabled, bounds checking on a unary operator).

#### Preventing unwanted errors, asserts, and unreachables
This change allows bounds inference methods such as LValueBounds and PruneTemporaryBindings to be called on a wider variety of expressions than before. Since bounds inference is performed at the same time as bounds checking, bounds inference is now done on all unary operators that are visited by TraverseStmt. These means that some asserts, unreachables, and error messages are now removed or suppressed to avoid unwanted side effects and test failures (see comments below for details).

#### Testing:
* No new tests or changes to existing tests
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux

#### Future work:
* Convert remaining Visit* methods to Check* methods that combine bounds inference and checking
* Modify TraverseStmt to only check substatements if the called Check* method did not check subexpressions
* Remove RValueBounds method (replace with calls to TraverseStmt)