### PR TITLE
Member expression and return statement: combine bounds inference and checking

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2316,17 +2316,17 @@ namespace {
     // member points to a valid range of memory given by
     // (lvalue, lvalue + 1).   The lvalue is interpreted as a pointer to T,
     // where T is the type of the member.
-    // CheckMemberExpr returns null bounds.  e is an lvalue.
+    // CheckMemberExpr returns empty bounds.  e is an lvalue.
     BoundsExpr *CheckMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS,
                                 std::pair<ComparisonSet, ComparisonSet>& Facts,
                                 SideEffects SE) {
       if (SE == SideEffects::Disabled)
-        return nullptr;
+        return CreateBoundsEmpty();
 
       bool NeedsBoundsCheck = AddMemberBaseBoundsCheck(E, CSS, Facts);
       if (NeedsBoundsCheck && DumpBounds)
         DumpExpression(llvm::outs(), E);
-      return nullptr;
+      return CreateBoundsEmpty();
     }
 
     // If e is an rvalue, CheckUnaryOperator returns the bounds for
@@ -2449,19 +2449,20 @@ namespace {
 
     BoundsExpr *CheckReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS,
                                 SideEffects SE) {
+      BoundsExpr *ResultBounds = CreateBoundsEmpty();
       if (SE == SideEffects::Disabled)
-        return nullptr;
+        return ResultBounds;
       if (!ReturnBounds)
-        return nullptr;
+        return ResultBounds;
       Expr *RetValue = RS->getRetValue();
       if (!RetValue)
         // We already issued an error message for this case.
-        return nullptr;
+        return ResultBounds;
       // TODO: Actually check that the return expression bounds imply the 
       // return bounds.
       // TODO: Also check that any parameters used in the return bounds are
       // unmodified.
-      return nullptr;
+      return ResultBounds;
     }
 
     // Given an array type with constant dimension size, produce a count

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1927,7 +1927,7 @@ namespace {
         }
         case Stmt::ReturnStmtClass: {
           ReturnStmt *RS = cast<ReturnStmt>(S);
-          VisitReturnStmt(RS, CSS);
+          CheckReturnStmt(RS, CSS, SideEffects::Enabled);
         }
         default: 
           break;
@@ -2333,17 +2333,21 @@ namespace {
       return;
     }
 
-    void VisitReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS) {
+    BoundsExpr *CheckReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS,
+                                SideEffects SE) {
+      if (SE == SideEffects::Disabled)
+        return nullptr;
       if (!ReturnBounds)
-        return;
+        return nullptr;
       Expr *RetValue = RS->getRetValue();
       if (!RetValue)
         // We already issued an error message for this case.
-        return;
+        return nullptr;
       // TODO: Actually check that the return expression bounds imply the 
       // return bounds.
       // TODO: Also check that any parameters used in the return bounds are
       // unmodified.
+      return nullptr;
     }
 
     // Given an array type with constant dimension size, produce a count

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1897,7 +1897,7 @@ namespace {
           VisitCallExpr(cast<CallExpr>(S), CSS, Facts);
           break;
         case Expr::MemberExprClass:
-          VisitMemberExpr(cast<MemberExpr>(S), CSS);
+          CheckMemberExpr(cast<MemberExpr>(S), CSS, SideEffects::Enabled);
           break;
         case Expr::ImplicitCastExprClass:
         case Expr::CStyleCastExprClass:
@@ -2212,10 +2212,16 @@ namespace {
     // member points to a valid range of memory given by
     // (lvalue, lvalue + 1).   The lvalue is interpreted as a pointer to T,
     // where T is the type of the member.
-    void VisitMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS) {
+    // CheckMemberExpr returns null bounds.  e is an lvalue.
+    BoundsExpr *CheckMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS,
+                                SideEffects SE) {
+      if (SE == SideEffects::Disabled)
+        return nullptr;
+
       bool NeedsBoundsCheck = AddMemberBaseBoundsCheck(E, CSS);
       if (NeedsBoundsCheck && DumpBounds)
         DumpExpression(llvm::outs(), E);
+      return nullptr;
     }
 
     BoundsExpr *CheckUnaryOperator(UnaryOperator *E, CheckedScopeSpecifier CSS, SideEffects SE) {


### PR DESCRIPTION
This pull request converts VisitMemberExpr and VisitReturnStmt to CheckMemberExpr and CheckReturnStmt. Both Check methods return nullptr bounds - in future refactoring stages, this will allow TraverseStmt to recursively check the substatements.

Testing:
* No new tests or changes to existing tests
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux