### PR TITLE
Fix an increase in compile time from a refactoring change.

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2012,7 +2012,7 @@ namespace {
         // `i + p` has the bounds of `p`. `p` is an RValue.
         // `i += p` has the bounds of `p`. `p` is an RValue.
         else if (LHS->getType()->isIntegerType() &&
-  q          RHS->getType()->isPointerType() &&
+            RHS->getType()->isPointerType() &&
             Op == BinaryOperatorKind::BO_Add) {
           ResultBounds = RValueBounds(RHS, CSS, Facts, SideEffects::Disabled);
         }


### PR DESCRIPTION
The refactoring of bounds declaration checking for binary operator expressions appears to have caused a significant increase in compile time.  Clang regression test time increased from 15 minutes to over an hour. 

One change that was made to always compute the rhs bounds and lhs rvalue bounds, even if those bounds are ultimately not needed.  Defer the computations of those bounds to only when they are needed, which matches previous behavior.

Testing:
- Local tests showed significantly improved compile time.
- Automated tests in progress.
