### PR TITLE
Move IgnoreValuePreservingOperations into Lexicographic class [NFC]

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -123,6 +123,8 @@ namespace clang {
     Result CompareDecl(const NamedDecl *D1, const NamedDecl *D2) const;
     Result CompareType(QualType T1, QualType T2) const;
     Result CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) const;
+
+    Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E);
   };
 }  // end namespace clang
 


### PR DESCRIPTION
IgnoreValuePreservingOperations is currently a static function inside
AST/CanonBounds.cpp. So invoking this function from outside becomes difficult.
Lexicographic class is defined in AST/CanonBounds.cpp. Making this function a
member of this class would make it easy to invoke it from other classes.