### PR TITLE
Cast expression: combine bounds inference and checking

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5082,11 +5082,12 @@ public:
     Sema &SemaRef;
     bool PrevDisableSubstitionDiagnostics;
   public:
-    explicit ExprSubstitutionScope(Sema &SemaRef)
+    explicit ExprSubstitutionScope(Sema &SemaRef,
+                                   bool DisableDiagnostics = true)
         : SemaRef(SemaRef),
           PrevDisableSubstitionDiagnostics(
             SemaRef.DisableSubstitionDiagnostics) {
-      SemaRef.DisableSubstitionDiagnostics = true;
+      SemaRef.DisableSubstitionDiagnostics = DisableDiagnostics;
     }
     ~ExprSubstitutionScope() {
       SemaRef.DisableSubstitionDiagnostics =

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1967,6 +1967,9 @@ namespace {
     // e is an rvalue.
     BoundsExpr *CheckBinaryOperator(BinaryOperator *E, CheckedScopeSpecifier CSS,
               std::pair<ComparisonSet, ComparisonSet>& Facts, SideEffects SE) {
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
+
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
       BinaryOperatorKind Op = E->getOpcode();
@@ -2381,6 +2384,9 @@ namespace {
     BoundsExpr *CheckUnaryOperator(UnaryOperator *E, CheckedScopeSpecifier CSS,
                                    std::pair<ComparisonSet, ComparisonSet>& Facts,
                                    SideEffects SE) {
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
+
       UnaryOperatorKind Op = E->getOpcode();
       Expr *SubExpr = E->getSubExpr();
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2298,7 +2298,7 @@ namespace {
         CHKCBindTemporaryExpr *TempExpr = dyn_cast<CHKCBindTemporaryExpr>(SubExpr);
         assert(TempExpr);
 
-        // These bounds will be computed and tested at runtime.  Don't
+        // These bounds may be computed and tested at runtime.  Don't
         // recompute any expressions computed to temporaries already.
         Expr *TempUse = CreateTemporaryUse(TempExpr);
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2598,9 +2598,22 @@ namespace {
     /// Infer a bounds expression for an rvalue.
     /// The bounds determine whether the rvalue to which an
     /// expression evaluates is in range.
+    ///
+    /// IncludeNullTerm controls whether a null terminator
+    /// for an nt_array is included in the bounds (it gives
+    /// us physical bounds, not logical bounds).
+    ///
+    /// ExistingBounds prevents duplicate calls to RValueBounds
+    /// in case the rvalue bounds have already been computed for e.
     BoundsExpr *InferRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
-                                  std::pair<ComparisonSet, ComparisonSet>& Facts) {
-      BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SideEffects::Disabled);
+                                  std::pair<ComparisonSet, ComparisonSet>& Facts,
+                                  bool IncludeNullTerm = false,
+                                  BoundsExpr *ExistingBounds = nullptr) {
+      bool PrevIncludeNullTerminator = IncludeNullTerminator;
+      IncludeNullTerminator = IncludeNullTerm;
+      BoundsExpr *Bounds = ExistingBounds ? ExistingBounds :
+                           RValueBounds(E, CSS, Facts, SideEffects::Disabled);
+      IncludeNullTerminator = PrevIncludeNullTerminator;
       return S.CheckNonModifyingBounds(Bounds, E);
     }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2376,6 +2376,9 @@ namespace {
     BoundsExpr *CheckMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS,
                                 std::pair<ComparisonSet, ComparisonSet>& Facts,
                                 SideEffects SE) {
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
+
       if (SE == SideEffects::Disabled)
         return CreateBoundsEmpty();
 
@@ -2508,6 +2511,9 @@ namespace {
 
     BoundsExpr *CheckReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS,
                                 SideEffects SE) {
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
+
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
       if (SE == SideEffects::Disabled)
         return ResultBounds;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2604,19 +2604,24 @@ namespace {
       return S.CheckNonModifyingBounds(Bounds, E);
     }
 
-    /// Infer a bounds expression for an rvalue.
-    /// The bounds determine whether the rvalue to which an
-    /// expression evaluates is in range.
+    /// Infer the bounds of a cast operation that produces an rvalue.
     ///
     /// IncludeNullTerm controls whether a null terminator
     /// for an nt_array is included in the bounds (it gives
     /// us physical bounds, not logical bounds).
-    BoundsExpr *NullTermRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
-                                     std::pair<ComparisonSet, ComparisonSet>& Facts,
-                                     SideEffects SE, bool IncludeNullTerm) {
+    ///
+    /// OutRValueBounds saves the result of any call made to RValueBounds
+    /// to prevent unnecessary calls to RValueBounds for e.
+    BoundsExpr *InferRValueCastBounds(CastKind CK, Expr *E,
+                                      std::pair<ComparisonSet, ComparisonSet>& Facts,
+                                      CheckedScopeSpecifier CSS,
+                                      bool IncludeNullTerm,
+                                      BoundsExpr *&OutRValueBounds) {
       bool PrevIncludeNullTerminator = IncludeNullTerminator;
       IncludeNullTerminator = IncludeNullTerm;
-      BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SE);
+      BoundsExpr *Bounds = RValueCastBounds(CK, E, Facts, CSS,
+                                            SideEffects::Disabled,
+                                            OutRValueBounds);
       IncludeNullTerminator = PrevIncludeNullTerminator;
       return Bounds;
     }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2234,6 +2234,9 @@ namespace {
     BoundsExpr *CheckCastExpr(CastExpr *E, CheckedScopeSpecifier CSS,
                               std::pair<ComparisonSet, ComparisonSet>& Facts,
                               SideEffects SE) {
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
+
       if (SE == SideEffects::Enabled)
         CheckDisallowedFunctionPtrCasts(E);
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3182,14 +3182,14 @@ namespace {
     }
 
     // Compute the bounds of a cast operation that produces an rvalue.
-    // ExistingRValueBounds avoids unnecessary calls to RValueBounds
-    // in cases where the rvalue bounds for an expression have already
-    // been computed.
+    //
+    // OutRValueBounds saves the result of the call to RValueBounds (if any)
+    // to prevent unnecessary calls to RValueBounds for e.
     BoundsExpr *RValueCastBounds(CastKind CK, Expr *E,
                                  std::pair<ComparisonSet, ComparisonSet>& Facts,
                                  CheckedScopeSpecifier CSS,
                                  SideEffects SE,
-                                 BoundsExpr *ExistingRValueBounds = nullptr) {
+                                 BoundsExpr *&OutRValueBounds) {
       switch (CK) {
         case CastKind::CK_BitCast:
         case CastKind::CK_NoOp:
@@ -3199,9 +3199,10 @@ namespace {
         case CastKind::CK_PointerToIntegral:
         case CastKind::CK_IntegralCast:
         case CastKind::CK_IntegralToBoolean:
-        case CastKind::CK_BooleanToSignedIntegral:
-          return ExistingRValueBounds != nullptr ?
-                  ExistingRValueBounds : RValueBounds(E, CSS, Facts, SE);
+        case CastKind::CK_BooleanToSignedIntegral: {
+          OutRValueBounds = RValueBounds(E, CSS, Facts, SE);
+          return OutRValueBounds;
+        }
         case CastKind::CK_LValueToRValue:
           return LValueTargetBounds(E, CSS);
         case CastKind::CK_ArrayToPointerDecay:

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2554,18 +2554,27 @@ namespace {
     /// Infer a bounds expression for an rvalue.
     /// The bounds determine whether the rvalue to which an
     /// expression evaluates is in range.
+    BoundsExpr *InferRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
+                                  std::pair<ComparisonSet, ComparisonSet>& Facts) {
+      BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SideEffects::Disabled);
+      return S.CheckNonModifyingBounds(Bounds, E);
+    }
+
+    /// Infer a bounds expression for an rvalue.
+    /// The bounds determine whether the rvalue to which an
+    /// expression evaluates is in range.
     ///
     /// IncludeNullTerm controls whether a null terminator
     /// for an nt_array is included in the bounds (it gives
     /// us physical bounds, not logical bounds).
-    BoundsExpr *InferRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
-                                  std::pair<ComparisonSet, ComparisonSet>& Facts,
-                                  bool IncludeNullTerm = false) {
+    BoundsExpr *NullTermRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
+                                     std::pair<ComparisonSet, ComparisonSet>& Facts,
+                                     SideEffects SE, bool IncludeNullTerm) {
       bool PrevIncludeNullTerminator = IncludeNullTerminator;
       IncludeNullTerminator = IncludeNullTerm;
-      BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SideEffects::Disabled);
+      BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SE);
       IncludeNullTerminator = PrevIncludeNullTerminator;
-      return S.CheckNonModifyingBounds(Bounds, E);
+      return Bounds;
     }
 
     BoundsExpr *CreateBoundsUnknown() {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3129,9 +3129,14 @@ namespace {
     }
 
     // Compute the bounds of a cast operation that produces an rvalue.
+    // ExistingRValueBounds avoids unnecessary calls to RValueBounds
+    // in cases where the rvalue bounds for an expression have already
+    // been computed.
     BoundsExpr *RValueCastBounds(CastKind CK, Expr *E,
                                  std::pair<ComparisonSet, ComparisonSet>& Facts,
-                                 CheckedScopeSpecifier CSS) {
+                                 CheckedScopeSpecifier CSS,
+                                 SideEffects SE,
+                                 BoundsExpr *ExistingRValueBounds = nullptr) {
       switch (CK) {
         case CastKind::CK_BitCast:
         case CastKind::CK_NoOp:
@@ -3142,7 +3147,8 @@ namespace {
         case CastKind::CK_IntegralCast:
         case CastKind::CK_IntegralToBoolean:
         case CastKind::CK_BooleanToSignedIntegral:
-          return RValueBounds(E, CSS, Facts, SideEffects::Disabled);
+          return ExistingRValueBounds != nullptr ?
+                  ExistingRValueBounds : RValueBounds(E, CSS, Facts, SE);
         case CastKind::CK_LValueToRValue:
           return LValueTargetBounds(E, CSS);
         case CastKind::CK_ArrayToPointerDecay:

--- a/clang/test/CheckedC/inferred-bounds/calls.c
+++ b/clang/test/CheckedC/inferred-bounds/calls.c
@@ -346,8 +346,7 @@ void f20(int* a, int* b) {
 
 void f21(int* a, int* b) {
     _Array_ptr<int> c : bounds(a, a+1) = f_boundsi(b++, a); // \
-    // TODO: this error should only be emitted once, when bounds inference is done once per expression. \
-    // expected-error2 {{expression not allowed in argument for parameter used in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -409,8 +408,7 @@ void f22(int i, int j) {
 
 void f23(int i, int j) {
     _Array_ptr<int> b : count(i) = f_counti(j++, i); // \
-    // TODO: this error should only be emitted once, when bounds inference is done once per expression. \
-    // expected-error2 {{expression not allowed in argument for parameter used in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -466,8 +464,7 @@ void f24(int i, int j) {
 
 void f25(int i, int j) {
     _Array_ptr<int> b : byte_count(i) = f_bytei(j++, i); // \
-    // TODO: this error should only be emitted once, when bounds inference is done once per expression. \
-    // expected-error2 {{expression not allowed in argument for parameter used in function return bounds}} \
+    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 

--- a/clang/test/CheckedC/inferred-bounds/calls.c
+++ b/clang/test/CheckedC/inferred-bounds/calls.c
@@ -346,7 +346,8 @@ void f20(int* a, int* b) {
 
 void f21(int* a, int* b) {
     _Array_ptr<int> c : bounds(a, a+1) = f_boundsi(b++, a); // \
-    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
+    // TODO: this error should only be emitted once, when bounds inference is done once per expression. \
+    // expected-error2 {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -408,7 +409,8 @@ void f22(int i, int j) {
 
 void f23(int i, int j) {
     _Array_ptr<int> b : count(i) = f_counti(j++, i); // \
-    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
+    // TODO: this error should only be emitted once, when bounds inference is done once per expression. \
+    // expected-error2 {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 
@@ -464,7 +466,8 @@ void f24(int i, int j) {
 
 void f25(int i, int j) {
     _Array_ptr<int> b : byte_count(i) = f_bytei(j++, i); // \
-    // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
+    // TODO: this error should only be emitted once, when bounds inference is done once per expression. \
+    // expected-error2 {{expression not allowed in argument for parameter used in function return bounds}} \
     // expected-error {{initializer expected to have bounds}}
 }
 


### PR DESCRIPTION
Convert the VisitCastExpr method (which only performed bounds checking) to the CheckCastExpr method (which performs both bounds inference and checking).

This pull request also modifies the Sema ExprSubstitutionScope RAII class to be able to optionally disable diagnostics. This scope is used in Check* methods (e.g. CheckCastExpr) to suppress diagnostics if side effects are disabled. Some methods such as CallExprBounds can emit errors while inferring bounds. Since bounds may be inferred more than once for a given expression (since TraverseStmt is not fully refactored yet and still checks all substatements of an expression), these helper methods for inferring bounds may emit errors twice for an expression. Using the ExprSubstitutionScope class to suppress diagnostics helps eliminate unwanted duplicate error messages.

Testing:
* No changes to existing tests and no new tests. 
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux, with no apparent increase in test runtimes.