### PR TITLE
Handle non-zero length nt_array_ptrs

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -124,6 +124,7 @@ namespace clang {
     Result CompareType(QualType T1, QualType T2) const;
     Result CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) const;
 
+    Result CompareAPInt(const llvm::APInt &I1, const llvm::APInt &I2) const;
     Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E);
   };
 }  // end namespace clang

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -117,6 +117,10 @@ namespace clang {
       ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
     };
 
+    // A set of all ntptrs in scope. Currently, we simply collect all ntptrs
+    // defined in the function.
+    DeclSetTy NtPtrsInScope;
+
     // BlockMapTy stores the mapping from CFGBlocks to ElevatedCFGBlocks.
     using BlockMapTy = llvm::DenseMap<const CFGBlock *, ElevatedCFGBlock *>;
     // A queue of unique ElevatedCFGBlocks to run the dataflow analysis on.
@@ -271,22 +275,11 @@ namespace clang {
     // @return Return the APInt value for E. Return APInt(0) if E is nullptr.
     const llvm::APInt GetAPIntVal(const Expr *E) const;
 
-    // Check whether there is an ntptr defined in the current block.
-    // @param[in] B is the current block.
-    DeclSetTy GetNtPtrsInBlock(const CFGBlock *B) const;
-
-    // Get the ntptrs in scope. These will be the ntptrs declared in any pred
-    // of a block as well as those passed as function parameters to the current
-    // function. This function will recurse for all preds of a block.
-    // @param[in] B is the current CFGBlock.
-    // @param[out] NtPtrsInScope is a set of all ntptrs in scope in block B.
-    // @param[in] GetNtPtrsInScope recurses for all preds of a block. But the
-    // params to the current function remain the same for all blocks in this
-    // function. So we only need to check ntptrs in the params only once. This
-    // flag is false by default and is set to true for the first time this
-    // function is invoked.
-    void GetNtPtrsInScope(const CFGBlock *B, DeclSetTy &NtPtrsInScope,
-                          bool CheckParams = false) const;
+    // Collect all ntptrs in scope. Currently, this simply collects all ntptrs
+    // defined in all blocks in the current function. This function inserts the
+    // VarDecls for the ntptrs in NtPtrsInScope.
+    // @param[in] BlockMap is the map from CFGBlock to ElevatedCFGBlock.
+    void CollectNtPtrsInScope(BlockMapTy BlockMap);
 
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -85,6 +85,10 @@ namespace clang {
   // for printing the blocks in a deterministic order.
   using OrderedBlocksTy = std::vector<const CFGBlock *>;
 
+  // ExprPairTy denotes a pair of expressions. This is used as a return type
+  // when an expression is split into a base and an offset.
+  using ExprPairTy = std::pair<const Expr *, const Expr *>;
+
   class BoundsAnalysis {
   private:
     Sema &S;
@@ -175,19 +179,15 @@ namespace clang {
     // @param[in] Dest block for the edge for which the Gen set is updated.
     void FillGenSet(Expr *E, ElevatedCFGBlock *EB, ElevatedCFGBlock *SuccEB);
 
-    // Fill Gen set for ntptr derefs.
-    // @param[in] UO is the pointer deref expr.
+    // Uniformize the expr, fill Gen set and get variables used in bounds expr
+    // for the ntptr.
+    // @param[in] E is an ntptr dereference or array subscript expr.
+    // @param[in] BE is the bounds expr for the ntptr.
     // @param[in] Source block for the edge for which the Gen set is updated.
     // @param[in] Dest block for the edge for which the Gen set is updated.
-    void HandlePointerDeref(UnaryOperator *UO, ElevatedCFGBlock *EB,
-                            ElevatedCFGBlock *SuccEB);
-
-    // Fill Gen set for ntptr subscripts.
-    // @param[in] AE is the array subscript expr.
-    // @param[in] Source block for the edge for which the Gen set is updated.
-    // @param[in] Dest block for the edge for which the Gen set is updated.
-    void HandleArraySubscript(ArraySubscriptExpr *AE, ElevatedCFGBlock *EB,
-                              ElevatedCFGBlock *SuccEB);
+    void FillGenSetAndGetBoundsVars(const Expr *E, BoundsExpr *BE,
+                                    ElevatedCFGBlock *EB,
+                                    ElevatedCFGBlock *SuccEB);
 
     // Collect all variables used in bounds expr E.
     // @param[in] E represents the bounds expr for an ntptr.
@@ -252,6 +252,19 @@ namespace clang {
     // @return Whether E is an expression containing a reference to an array
     // subscript or a pointer dereference.
     bool IsDeclOperand(const Expr *E);
+
+    // Make an expression uniform by moving all DeclRefExpr to the LHS and all
+    // IntegerLiterals to the RHS.
+    // @param[in] E is the expression which should be made uniform.
+    // @return A pair of expressions. The first contains all DeclRefExprs of E
+    // and the second contains all IntegerLiterals of E.
+    ExprPairTy SplitIntoBaseOffset(const Expr *E);
+
+    // Get the VarDecl for the ntptr from E if E is the lower bounds expr for
+    // an ntptr.
+    // @param[in] E is the expressions for the lower bounds for an ntptr.
+    // @return The VarDecl for the ntptr.
+    const VarDecl *GetNtArrayVarDecl(const Expr *E);
 
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -89,9 +89,6 @@ namespace clang {
   // when an expression is split into a base and an offset.
   using ExprPairTy = std::pair<const Expr *, const Expr *>;
 
-  // A mapping from a block to variables declared in the block.
-  using BlockDeclMapTy = llvm::DenseMap<const CFGBlock *, DeclSetTy>;
-
   class BoundsAnalysis {
   private:
     Sema &S;

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -265,16 +265,6 @@ namespace clang {
     // and the second contains all IntegerLiterals of E.
     ExprPairTy SplitIntoBaseOffset(const Expr *E);
 
-    // An IntegerLiteral can either be int, +int or -int.
-    // @param[in] E is an expression.
-    // @return Whether E contains an IntegerLiteral.
-    bool IsIntegerOperand(const Expr *E) const;
-
-    // Get the APInt value from an expression representing an IntegerLiteral.
-    // @param[in] E represents an IntegerLiteral.
-    // @return Return the APInt value for E. Return APInt(0) if E is nullptr.
-    const llvm::APInt GetAPIntVal(const Expr *E) const;
-
     // Collect all ntptrs in scope. Currently, this simply collects all ntptrs
     // defined in all blocks in the current function. This function inserts the
     // VarDecls for the ntptrs in NtPtrsInScope.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -140,7 +140,6 @@ namespace clang {
     BoundsMapTy GetWidenedBounds(const CFGBlock *B);
 
     // Pretty print the widen bounds analysis.
-    // @param[in] FD is used to extract the name of the current function for
     // printing.
     void DumpWidenedBounds();
 

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -266,6 +266,16 @@ namespace clang {
     // @return The VarDecl for the ntptr.
     const VarDecl *GetNtArrayVarDecl(const Expr *E);
 
+    // An IntegerLiteral can either be int, +int or -int.
+    // @param[in] E is an expression.
+    // @return Whether E contains an IntegerLiteral.
+    bool IsIntegerOperand(const Expr *E) const;
+
+    // Get the APInt value from an expression representing an IntegerLiteral.
+    // @param[in] E represents an IntegerLiteral.
+    // @return Return the APInt value for E. Return APInt(0) if E is nullptr.
+    const llvm::APInt GetAPIntVal(const Expr *E) const;
+
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.
     // @param[in] B is a set.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4989,6 +4989,12 @@ public:
   // will always fail.
   void WarnDynamicCheckAlwaysFails(const Expr *Condition);
 
+  // This is wrapper around CheckBoundsDeclaration::ExpandToRange. This
+  // provides an easy way to invoke this function from outside the class. Given
+  // a byte_count or count bounds expression for the VarDecl D, ExpandToRange
+  // will expand it to a range bounds expression.
+  BoundsExpr *ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B);
+
   //
   // Track variables that in-scope bounds declarations depend upon.
   // TODO: generalize this to other lvalue expressions.

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -72,7 +72,8 @@ Result Lexicographic::CompareInteger(unsigned I1, unsigned I2) const {
     return Result::Equal;
 }
 
-static Result CompareAPInt(const llvm::APInt &I1, const llvm::APInt &I2) {
+Result Lexicographic::CompareAPInt(const llvm::APInt &I1,
+                                   const llvm::APInt &I2) const {
   if (I1.slt(I2))
     return Result::LessThan;
   else if (I1.eq(I2))

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -239,6 +239,12 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
   // commutativity of operations. Exprs like "p + e" and "e + p" are considered
   // unequal.
 
+  // TODO: Currently, we iterate and re-compute info for all ntptrs in scope
+  // for each ntptr dereference. We can optimize this at the cost of space by
+  // storing the VarDecls, variables used in bounds exprs and base/offset for
+  // the declared upper bounds expr for the VarDecl. Then we simply have to
+  // look this up instead of re-computing.
+
   for (const VarDecl *V : NtPtrsInScope) {
     // In case the bounds expr for V is not a RangeBoundsExpr, invoke
     // ExpandBoundsToRange to expand it to RangeBoundsExpr.

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -141,10 +141,13 @@ bool BoundsAnalysis::IsIntegerOperand(const Expr *E) const {
     return false;
 
   // An IntegerLiteral could either be int, +int or -int.
-  if (const auto *UO = dyn_cast<UnaryOperator>(E))
+  if (const auto *UO = dyn_cast<UnaryOperator>(E)) {
+    assert(UO->getSubExpr() && "invalid UnaryOperator expression");
+
     if (UO->getOpcode() == UO_Plus ||
         UO->getOpcode() == UO_Minus)
       return isa<IntegerLiteral>(UO->getSubExpr());
+  }
   return isa<IntegerLiteral>(E);
 }
 
@@ -155,6 +158,8 @@ const llvm::APInt BoundsAnalysis::GetAPIntVal(const Expr *E) const {
   }
 
   if (const auto *UO = dyn_cast<UnaryOperator>(E)) {
+    assert(UO->getSubExpr() && "invalid UnaryOperator expression");
+
     if (UO->getOpcode() == UO_Plus)
       return dyn_cast<IntegerLiteral>(UO->getSubExpr())->getValue();
     if (UO->getOpcode() == UO_Minus)
@@ -211,8 +216,6 @@ void BoundsAnalysis::GetNtPtrsInScope(const CFGBlock *B,
   // memoizing the ntptrs in scope for all blocks so we can terminate the
   // recursion earlier.
 
-  // TODO: Currently, we cannot widen a local ntptr which overrides a global
-  // ntptr of the same name.
   for (const CFGBlock *pred : B->preds()) {
     if (SkipBlock(pred))
       continue;

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -283,7 +283,7 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
       UpperOffsetVal = Zero;
 
     // We cannot widen the bounds if the offset in the deref expr is less than
-    // the offset in the upper bounds expr. For example:
+    // the offset in the declared upper bounds expr. For example:
     // _Nt_array_ptr<T> p : bounds(p, p + i + 2); // Upper Bounds Offset (UBO) = 2.
 
     // if (*(p + i)) // Offset = 0 < UBO ==> no widening

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -216,8 +216,8 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
       !DerefOffset->isIntegerConstantExpr(DerefOffsetVal, Ctx))
     DerefOffsetVal = Zero;
 
-  // For bounds widening, the base of the deref expr and the upper bounds expr
-  // for all ntptrs in scope should be the same.
+  // For bounds widening, the base of the deref expr and the declared upper
+  // bounds expr for all ntptrs in scope should be the same.
 
   // For example:
   // _Nt_array_ptr<T> p : bounds(p, p + i);

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -309,7 +309,7 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
     return std::make_pair(BO, nullptr);
 
   // To make parsing simpler, we always try to keep BinaryOperator on the LHS.
-  if (isa<BinaryOperator>(RHS))
+  if (!isa<BinaryOperator>(LHS) && isa<BinaryOperator>(RHS))
     std::swap(LHS, RHS);
 
   // By this time the LHS should be a BinaryOperator; either because it already
@@ -323,6 +323,10 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   // Case 5: (p + j) + i
   // Case 6: (p + q) + r
   // Case 7: (p + j) + r
+
+  // TODO: Currently we assume that the RHS cannot be a BinaryOperator. So we
+  // do not handle cases like: (p + q) + (i + j).
+
   auto *BE = dyn_cast<BinaryOperator>(LHS);
 
   // Recursively, make the LHS uniform.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2600,7 +2600,103 @@ namespace {
       return CE;
     }
 
+    ImplicitCastExpr *CreateImplicitCast(QualType Target, CastKind CK,
+                                         Expr *E) {
+      return ImplicitCastExpr::Create(Context, Target, CK, E, nullptr,
+                                       ExprValueKind::VK_RValue);
+    }
+
+    // Given a byte_count or count bounds expression for the expression Base,
+    // expand it to a range bounds expression:
+    //  E : Count(C) expands to Bounds(E, E + C)
+    //  E : ByteCount(C)  expands to Bounds((array_ptr<char>) E,
+    //                                      (array_ptr<char>) E + C)
+    BoundsExpr *ExpandToRange(Expr *Base, BoundsExpr *B) {
+      assert(Base->isRValue() && "expected rvalue expression");
+      BoundsExpr::Kind K = B->getKind();
+      switch (K) {
+        case BoundsExpr::Kind::ByteCount:
+        case BoundsExpr::Kind::ElementCount: {
+          CountBoundsExpr *BC = dyn_cast<CountBoundsExpr>(B);
+          if (!BC) {
+            llvm_unreachable("unexpected cast failure");
+            return CreateBoundsInferenceError();
+          }
+          Expr *Count = BC->getCountExpr();
+          QualType ResultTy;
+          Expr *LowerBound;
+          Base = S.MakeAssignmentImplicitCastExplicit(Base);
+          if (K == BoundsExpr::ByteCount) {
+            ResultTy = Context.getPointerType(Context.CharTy,
+                                              CheckedPointerKind::Array);
+            // When bounds are pretty-printed as source code, the cast needs
+            // to appear in the source code for the code to be correct, so
+            // use an explicit cast operation.
+            //
+            // The bounds-safe interface argument is false because casts
+            // to checked pointer types are always allowed by type checking.
+            LowerBound =
+              CreateExplicitCast(ResultTy, CastKind::CK_BitCast, Base, false);
+          } else {
+            ResultTy = Base->getType();
+            LowerBound = Base;
+            if (ResultTy->isCheckedPointerPtrType()) {
+              ResultTy = Context.getPointerType(ResultTy->getPointeeType(),
+                CheckedPointerKind::Array);
+              // The bounds-safe interface argument is false because casts
+              // between checked pointer types are always allowed by type
+              // checking.
+              LowerBound =
+                CreateExplicitCast(ResultTy, CastKind::CK_BitCast, Base, false);
+            }
+          }
+          Expr *UpperBound =
+            new (Context) BinaryOperator(LowerBound, Count,
+                                          BinaryOperatorKind::BO_Add,
+                                          ResultTy,
+                                          ExprValueKind::VK_RValue,
+                                          ExprObjectKind::OK_Ordinary,
+                                          SourceLocation(),
+                                          FPOptions());
+          RangeBoundsExpr *R = new (Context) RangeBoundsExpr(LowerBound, UpperBound,
+                                               SourceLocation(),
+                                               SourceLocation());
+          return R;
+        }
+        default:
+          return B;
+      }
+    }
+
+    BoundsExpr *ExpandToRange(VarDecl *D, BoundsExpr *B) {
+      QualType QT = D->getType();
+      ExprResult ER = S.BuildDeclRefExpr(D, QT,
+                                       clang::ExprValueKind::VK_LValue, SourceLocation());
+      if (ER.isInvalid())
+        return nullptr;
+      Expr *Base = ER.get();
+      if (!QT->isArrayType())
+        Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, Base);
+      return ExpandToRange(Base, B);
+    }
+
+    // Compute bounds for a variable expression or member reference expression
+    // with an array type.
+    BoundsExpr *ArrayExprBounds(Expr *E) {
+      DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
+      assert((DR && dyn_cast<VarDecl>(DR->getDecl())) || isa<MemberExpr>(E));
+      BoundsExpr *BE = CreateBoundsForArrayType(E->getType());
+      if (BE->isUnknown())
+        return BE;
+
+      Expr *Base = CreateImplicitCast(Context.getDecayedType(E->getType()),
+                                      CastKind::CK_ArrayToPointerDecay,
+                                      E);
+      return ExpandToRange(Base, BE);
+    }
+
   // Methods for inferring bounds expressions for C expressions.
+
 
   // C has an interesting semantics for expressions that differentiates between
   // lvalue and value expressions and inserts implicit conversions from lvalues
@@ -2755,12 +2851,6 @@ namespace {
       return ExpandToRange(LowerBounds, Context.getPrebuiltCountOne());
     }
 
-    ImplicitCastExpr *CreateImplicitCast(QualType Target, CastKind CK,
-                                         Expr *E) {
-      return ImplicitCastExpr::Create(Context, Target, CK, E, nullptr,
-                                       ExprValueKind::VK_RValue);
-    }
-
     Expr *CreateTemporaryUse(CHKCBindTemporaryExpr *Binding) {
       return new (Context) BoundsValueExpr(SourceLocation(), Binding);
     }
@@ -2816,95 +2906,6 @@ namespace {
       IntegerLiteral *Lit = IntegerLiteral::Create(Context, ResultVal, Ty,
                                                    SourceLocation());
       return Lit;
-    }
-
-    // Given a byte_count or count bounds expression for the expression Base,
-    // expand it to a range bounds expression:
-    //  E : Count(C) expands to Bounds(E, E + C)
-    //  E : ByteCount(C)  expands to Bounds((array_ptr<char>) E,
-    //                                      (array_ptr<char>) E + C)
-    BoundsExpr *ExpandToRange(Expr *Base, BoundsExpr *B) {
-      assert(Base->isRValue() && "expected rvalue expression");
-      BoundsExpr::Kind K = B->getKind();
-      switch (K) {
-        case BoundsExpr::Kind::ByteCount:
-        case BoundsExpr::Kind::ElementCount: {
-          CountBoundsExpr *BC = dyn_cast<CountBoundsExpr>(B);
-          if (!BC) {
-            llvm_unreachable("unexpected cast failure");
-            return CreateBoundsInferenceError();
-          }
-          Expr *Count = BC->getCountExpr();
-          QualType ResultTy;
-          Expr *LowerBound;
-          Base = S.MakeAssignmentImplicitCastExplicit(Base);
-          if (K == BoundsExpr::ByteCount) {
-            ResultTy = Context.getPointerType(Context.CharTy,
-                                              CheckedPointerKind::Array);
-            // When bounds are pretty-printed as source code, the cast needs
-            // to appear in the source code for the code to be correct, so
-            // use an explicit cast operation.
-            //
-            // The bounds-safe interface argument is false because casts
-            // to checked pointer types are always allowed by type checking.
-            LowerBound =
-              CreateExplicitCast(ResultTy, CastKind::CK_BitCast, Base, false);
-          } else {
-            ResultTy = Base->getType();
-            LowerBound = Base;
-            if (ResultTy->isCheckedPointerPtrType()) {
-              ResultTy = Context.getPointerType(ResultTy->getPointeeType(),
-                CheckedPointerKind::Array);
-              // The bounds-safe interface argument is false because casts
-              // between checked pointer types are always allowed by type
-              // checking.
-              LowerBound =
-                CreateExplicitCast(ResultTy, CastKind::CK_BitCast, Base, false);
-            }
-          }
-          Expr *UpperBound =
-            new (Context) BinaryOperator(LowerBound, Count,
-                                          BinaryOperatorKind::BO_Add,
-                                          ResultTy,
-                                          ExprValueKind::VK_RValue,
-                                          ExprObjectKind::OK_Ordinary,
-                                          SourceLocation(),
-                                          FPOptions());
-          RangeBoundsExpr *R = new (Context) RangeBoundsExpr(LowerBound, UpperBound,
-                                               SourceLocation(),
-                                               SourceLocation());
-          return R;
-        }
-        default:
-          return B;
-      }
-    }
-
-    BoundsExpr *ExpandToRange(VarDecl *D, BoundsExpr *B) {
-      QualType QT = D->getType();
-      ExprResult ER = S.BuildDeclRefExpr(D, QT,
-                                       clang::ExprValueKind::VK_LValue, SourceLocation());
-      if (ER.isInvalid())
-        return nullptr;
-      Expr *Base = ER.get();
-      if (!QT->isArrayType())
-        Base = CreateImplicitCast(QT, CastKind::CK_LValueToRValue, Base);
-      return ExpandToRange(Base, B);
-    }
-
-    // Compute bounds for a variable expression or member reference expression
-    // with an array type.
-    BoundsExpr *ArrayExprBounds(Expr *E) {
-      DeclRefExpr *DR = dyn_cast<DeclRefExpr>(E);
-      assert((DR && dyn_cast<VarDecl>(DR->getDecl())) || isa<MemberExpr>(E));
-      BoundsExpr *BE = CreateBoundsForArrayType(E->getType());
-      if (BE->isUnknown())
-        return BE;
-
-      Expr *Base = CreateImplicitCast(Context.getDecayedType(E->getType()),
-                                      CastKind::CK_ArrayToPointerDecay,
-                                      E);
-      return ExpandToRange(Base, BE);
     }
 
     // Infer bounds for string literals.
@@ -3785,10 +3786,10 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   }
 
   if (Cfg != nullptr) {
-    BoundsAnalysis Collector(*this, Cfg.get());
+    BoundsAnalysis Collector(*this, Cfg.get(), FD);
     Collector.WidenBounds();
     if (getLangOpts().DumpWidenedBounds)
-      Collector.DumpWidenedBounds(FD);
+      Collector.DumpWidenedBounds();
   }
 
 #if TRACE_CFG
@@ -3949,4 +3950,35 @@ void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
         << Condition->getSourceRange();
     }
   }
+}
+
+// This is wrapper around CheckBoundsDeclaration::ExpandToRange. This provides
+// an easy way to invoke this function from outside the class. Given a
+// byte_count or count bounds expression for the VarDecl D, ExpandToRange will
+// expand it to a range bounds expression.
+BoundsExpr *Sema::ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B) {
+  // If the bounds expr is already a RangeBoundsExpr, simply return it.
+  if (B && isa<RangeBoundsExpr>(B))
+    return const_cast<BoundsExpr *>(B);
+
+  CheckBoundsDeclarations CBD = CheckBoundsDeclarations(*this);
+
+  if (D->getType()->isArrayType()) {
+    ExprResult ER = BuildDeclRefExpr(const_cast<VarDecl *>(D), D->getType(),
+                                     clang::ExprValueKind::VK_LValue,
+                                     SourceLocation());
+    if (ER.isInvalid())
+      return nullptr;
+    Expr *Base = ER.get();
+
+    // Declared bounds override the bounds based on the array type.
+    if (!B)
+      return CBD.ArrayExprBounds(Base);
+    Base = CBD.CreateImplicitCast(Context.getDecayedType(Base->getType()),
+                                  CastKind::CK_ArrayToPointerDecay,
+                                  Base);
+    return CBD.ExpandToRange(Base, const_cast<BoundsExpr *>(B));
+  }
+  return CBD.ExpandToRange(const_cast<VarDecl *>(D),
+                           const_cast<BoundsExpr *>(B));
 }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2697,7 +2697,6 @@ namespace {
 
   // Methods for inferring bounds expressions for C expressions.
 
-
   // C has an interesting semantics for expressions that differentiates between
   // lvalue and value expressions and inserts implicit conversions from lvalues
   // to values.  Value expressions are usually called rvalue expressions.  This

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -309,9 +309,9 @@ void f15(int i) {
   if (*(p - i)) {}
 
 // CHECK: In function: f15
-// CHECK:  [B5]
+// CHECK:  [B9]
 // CHECK:    2: *(p - i)
-// CHECK:  [B4]
+// CHECK:  [B8]
 // CHECK-NOT: upper_bound(p)
 
   _Nt_array_ptr<char> q : count(0) = "a";
@@ -319,12 +319,30 @@ void f15(int i) {
     if (*(q - 1))  // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B3]
+// CHECK:  [B7]
 // CHECK:    2: *q
-// CHECK:  [B2]
+// CHECK:  [B6]
 // CHECK:    1: *(q - 1)
 // CHECK: upper_bound(q) = 1
-// CHECK:  [B1]
+// CHECK:  [B5]
 // CHECK: upper_bound(q) = 1
 // CHECK-NOT: upper_bound(q)
+
+  _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
+  if (*(r + +1))
+  {}
+
+// CHECK:  [B4]
+// CHECK:    2: *(r + +1)
+// CHECK:  [B3]
+// CHECK: upper_bound(r) = 1
+
+  _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
+  if (*(s + -1)) // expected-error {{out-of-bounds memory access}}
+  {}
+
+// CHECK:  [B2]
+// CHECK:    2: *(s + -1)
+// CHECK:  [B1]
+// CHECK: upper_bound(s) = 1
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -439,3 +439,28 @@ void f18() {
 // CHECK:  [B1]
 // CHECK: upper_bound(s) = 1
 }
+
+void f19() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p)
+    if (*(p + 1))
+      if (*(p + 3))
+        if (*(p + 2))
+  {}
+
+// CHECK: In function: f19
+// CHECK:  [B5]
+// CHECK:    2: *p
+// CHECK:  [B4]
+// CHECK:    1: *(p + 1)
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B3]
+// CHECK:    1: *(p + 3)
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B2]
+// CHECK:    1: *(p + 2)
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B1]
+// CHECK: upper_bound(p) = 3
+}

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -316,7 +316,7 @@ void f15(int i) {
 
   _Nt_array_ptr<char> q : count(0) = "a";
   if (*q)
-    if (*(q - 1))  // expected-error {{out-of-bounds memory access}}
+    if (*(q - 1)) // expected-error {{out-of-bounds memory access}}
   {}
 
 // CHECK:  [B7]
@@ -383,9 +383,9 @@ void f17(char p _Nt_checked[] : count(1)) {
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(r) = 1
 // CHECK:  [B1]
-// CHECK: upper_bound(r) = 2
 // CHECK: upper_bound(p) = 1
 // CHECK: upper_bound(q) = 1
+// CHECK: upper_bound(r) = 2
 }
 
 void f18() {
@@ -444,9 +444,9 @@ void f19() {
   _Nt_array_ptr<char> p : count(0) = "a";
 
   if (*p)
-    if (*(p + 1))
-      if (*(p + 3))
-        if (*(p + 2))
+    if (*(p + 1))     // expected-error {{out-of-bounds memory access}}
+      if (*(p + 3))   // expected-error {{out-of-bounds memory access}}
+        if (*(p + 2)) // expected-error {{out-of-bounds memory access}}
   {}
 
 // CHECK: In function: f19

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -99,7 +99,7 @@ void f5() {
 }
 
 void f6(int i) {
-  char p _Nt_checked[] : bounds(p, p + i)  = "abc";
+  char p _Nt_checked[] : bounds(p + i, p)  = "abc";
 
   if (p[0]) {
     i = 0;

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -346,3 +346,96 @@ void f15(int i) {
 // CHECK:  [B1]
 // CHECK: upper_bound(s) = 1
 }
+
+void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
+  _Nt_array_ptr<char> q : bounds(p, p) = "a";
+  _Nt_array_ptr<char> r : bounds(p, p + 1) = "a";
+
+  if (*(p))
+    if (*(p + 1)) // expected-error {{out-of-bounds memory access}}
+  {}
+
+// CHECK: In function: f16
+// CHECK:  [B3]
+// CHECK:    3: *(p)
+// CHECK:  [B2]
+// CHECK:    1: *(p + 1)
+// CHECK: upper_bound(p) = 1
+// CHECK: upper_bound(q) = 1
+// CHECK:  [B1]
+// CHECK: upper_bound(p) = 2
+// CHECK: upper_bound(q) = 2
+// CHECK: upper_bound(r) = 1
+}
+
+void f17(char p _Nt_checked[] : count(1)) {
+  _Nt_array_ptr<char> q : bounds(p, p + 1) = "a";
+  _Nt_array_ptr<char> r : bounds(p, p) = "a";
+
+  if (*(p))
+    if (*(p + 1))
+  {}
+
+// CHECK: In function: f17
+// CHECK:  [B3]
+// CHECK:    3: *(p)
+// CHECK:  [B2]
+// CHECK:    1: *(p + 1)
+// CHECK: upper_bound(r) = 1
+// CHECK:  [B1]
+// CHECK: upper_bound(r) = 2
+// CHECK: upper_bound(p) = 1
+// CHECK: upper_bound(q) = 1
+}
+
+void f18() {
+  char p _Nt_checked[] = "a";
+  char q _Nt_checked[] = "ab";
+  char r _Nt_checked[] : count(0) = "ab";
+  char s _Nt_checked[] : count(1) = "ab";
+
+  if (p[0])
+    if (p[1])
+  {}
+
+// CHECK: In function: f18
+// CHECK:  [B12]
+// CHECK:    5: p[0]
+// CHECK:  [B11]
+// CHECK:    1: p[1]
+// CHECK:  [B10]
+// CHECK: upper_bound(p) = 1
+
+  if (q[0])
+    if (q[1])
+      if (q[2])
+  {}
+
+// CHECK:  [B9]
+// CHECK:    1: q[0]
+// CHECK:  [B8]
+// CHECK:    1: q[1]
+// CHECK:  [B7]
+// CHECK:    1: q[2]
+// CHECK:  [B6]
+// CHECK: upper_bound(q) = 1
+
+  if (r[0])
+  {}
+
+// CHECK:  [B5]
+// CHECK:    1: r[0]
+// CHECK:  [B4]
+// CHECK: upper_bound(r) = 1
+
+  if (s[0])
+    if (s[1])
+  {}
+
+// CHECK:  [B3]
+// CHECK:    1: s[0]
+// CHECK:  [B2]
+// CHECK:    1: s[1]
+// CHECK:  [B1]
+// CHECK: upper_bound(s) = 1
+}


### PR DESCRIPTION
We can do bounds-widening for nt_array_ptrs variables whose upper bound is not
just the variables itself (that is, non-zero length array_ptrs).  Consider,
nt_array_ptr p : bounds(e1, e2); where e1 and e2 are expressions and e2 is of
the form (e + k) To widen the bounds, we look for derefs of the form "*(e2 +
i)".

Example:
nt_array_ptr<T> p : bounds(p, p + i);

if (*(p + i)) // widen by 1
  if (*(p + i + 1)) // widen by 2
    if (*(p + i + 2)) // widen by 3

if (*(p + i)) // widen by 1
  if (*(p + i + 2)) // no widening

if (*p) // no widening
  if (*(p+ 1)) // no widening
    if (*(p + 2)) // no widening