### PR TITLE
Update directory location in automation for code signing.

### DIFF
--- a/clang/automation/Windows/setup-files.bat
+++ b/clang/automation/Windows/setup-files.bat
@@ -66,7 +66,7 @@ if ERRORLEVEL 1 (goto cmdfailed)
 
 rem Set up sources for scripts for signing installer
 if "%SIGN_INSTALLER%" NEQ "No" (
-    cd %BUILD_SOURCESDIRECTORY%\automation\Windows\sign
+    cd %BUILD_SOURCESDIRECTORY%\clang\automation\Windows\sign
     if ERRORLEVEL 1 (goto cmdfailed)
     git -c http.extraheader="Authorization: bearer %SYSTEM_ACCESSTOKEN%" fetch origin
     if ERRORLEVEL 1 (goto cmdfailed)


### PR DESCRIPTION
When we moved to a monorepo, we adjusted the location of automation scripts to be clang\automation instead of automation.  We missed updating a path for sync'ing a repo that contain a scripts for code signing.  This worked on existing ADO pipelines because the old copy of the repo was still there.  The sync'ing did not have the intended effect, but the operations did not fail.  When I cloned an ADO pipeline for some experimentation, the sync'ing failed because there is no old copy of the repo.