### PR TITLE
Traverse children from CheckCastExpr

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2701,17 +2701,9 @@ namespace {
     /// Infer a bounds expression for an rvalue.
     /// The bounds determine whether the rvalue to which an
     /// expression evaluates is in range.
-    ///
-    /// IncludeNullTerm controls whether a null terminator
-    /// for an nt_array is included in the bounds (it gives
-    /// us physical bounds, not logical bounds).
     BoundsExpr *InferRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
-                                  std::pair<ComparisonSet, ComparisonSet>& Facts,
-                                  bool IncludeNullTerm = false) {
-      bool PrevIncludeNullTerminator = IncludeNullTerminator;
-      IncludeNullTerminator = IncludeNullTerm;
+                                  std::pair<ComparisonSet, ComparisonSet>& Facts) {
       BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SideEffects::Disabled);
-      IncludeNullTerminator = PrevIncludeNullTerminator;
       return S.CheckNonModifyingBounds(Bounds, E);
     }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2170,17 +2170,7 @@ namespace {
     BoundsExpr *CheckCallExpr(CallExpr *E, CheckedScopeSpecifier CSS,
                               std::pair<ComparisonSet, ComparisonSet>& Facts,
                               SideEffects SE) {
-
-      BoundsExpr *ResultBounds = nullptr;
-      {
-        // Suppress diagnostics that could be emitted in CallExprBounds.
-        // Since TraverseStmt still checks all subexpressions,
-        // bounds inference (including calls to CallExprBounds) may be
-        // performed multiple times on an expression.  Suppressing diagnostics
-        // here prevents duplicate diagnostic messages from being emitted.
-        Sema::ExprSubstitutionScope Scope(S);
-        ResultBounds = CallExprBounds(E, nullptr);
-      }
+      BoundsExpr *ResultBounds = CallExprBounds(E, nullptr);
 
       if (SE == SideEffects::Disabled)
         return ResultBounds;
@@ -3364,6 +3354,7 @@ namespace {
         case Expr::CompoundAssignOperatorClass:
           return CheckBinaryOperator(cast<BinaryOperator>(E), CSS, Facts, SE);
         case Expr::CallExprClass: {
+          return CheckCallExpr(cast<CallExpr>(E), CSS, Facts, SE);
           // Do not call CheckCallExpr here.  Since CheckCallExpr suppresses
           // diagnostics emitted as part of CallExprBounds (to reduce unwanted
           // duplicate diagnostics), calling CheckCallExpr here can result in

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1893,6 +1893,9 @@ namespace {
       if (!S)
         return CreateBoundsEmpty();
 
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(this->S, SE == SideEffects::Disabled);
+
       BoundsExpr *ResultBounds = CreateBoundsAlwaysUnknown();
 
       if (Expr *E = dyn_cast<Expr>(S))
@@ -2016,9 +2019,6 @@ namespace {
     // e is an rvalue.
     BoundsExpr *CheckBinaryOperator(BinaryOperator *E, CheckedScopeSpecifier CSS,
               std::pair<ComparisonSet, ComparisonSet>& Facts, SideEffects SE) {
-      // Suppress diagnostics if side effects are disabled.
-      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
-
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
       BinaryOperatorKind Op = E->getOpcode();
@@ -2304,9 +2304,6 @@ namespace {
     BoundsExpr *CheckCastExpr(CastExpr *E, CheckedScopeSpecifier CSS,
                               std::pair<ComparisonSet, ComparisonSet>& Facts,
                               SideEffects SE) {
-      // Suppress diagnostics if side effects are disabled.
-      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
-
       // If the rvalue bounds for e cannot be determined,
       // e may be an lvalue (or may have unknown rvalue bounds).
       BoundsExpr *ResultBounds = CreateBoundsUnknown();
@@ -2433,9 +2430,6 @@ namespace {
     BoundsExpr *CheckMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS,
                                 std::pair<ComparisonSet, ComparisonSet>& Facts,
                                 SideEffects SE) {
-      // Suppress diagnostics if side effects are disabled.
-      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
-
       if (SE == SideEffects::Disabled)
         return CreateBoundsEmpty();
 
@@ -2451,9 +2445,6 @@ namespace {
     BoundsExpr *CheckUnaryOperator(UnaryOperator *E, CheckedScopeSpecifier CSS,
                                    std::pair<ComparisonSet, ComparisonSet>& Facts,
                                    SideEffects SE) {
-      // Suppress diagnostics if side effects are disabled.
-      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
-
       UnaryOperatorKind Op = E->getOpcode();
       Expr *SubExpr = E->getSubExpr();
 
@@ -2581,9 +2572,6 @@ namespace {
 
     BoundsExpr *CheckReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS,
                                 SideEffects SE) {
-      // Suppress diagnostics if side effects are disabled.
-      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
-
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
       if (SE == SideEffects::Disabled)
         return ResultBounds;
@@ -3354,6 +3342,9 @@ namespace {
       if (!E->isRValue()) return CreateBoundsInferenceError();
 
       E = E->IgnoreParens();
+
+      // Suppress diagnostics if side effects are disabled.
+      Sema::ExprSubstitutionScope Scope(S, SE == SideEffects::Disabled);
 
       // Null Ptrs always have bounds(any)
       // This is the correct way to detect all the different ways that

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2242,7 +2242,7 @@ namespace {
           continue;
 
         Expr *Arg = E->getArg(i);
-        BoundsExpr *ArgBounds = InferRValueBounds(Arg, CSS, Facts); // Analogous to BoundsExpr *ArgBounds = S.InferRValueBounds(Arg, CSS) in VisitCallExpr
+        BoundsExpr *ArgBounds = InferRValueBounds(Arg, CSS, Facts);
         if (ArgBounds->isUnknown()) {
           S.Diag(Arg->getBeginLoc(),
                   diag::err_expected_bounds_for_argument) << (i + 1) <<
@@ -2705,17 +2705,12 @@ namespace {
     /// IncludeNullTerm controls whether a null terminator
     /// for an nt_array is included in the bounds (it gives
     /// us physical bounds, not logical bounds).
-    ///
-    /// ExistingBounds prevents duplicate calls to RValueBounds
-    /// in case the rvalue bounds have already been computed for e.
     BoundsExpr *InferRValueBounds(Expr *E, CheckedScopeSpecifier CSS,
                                   std::pair<ComparisonSet, ComparisonSet>& Facts,
-                                  bool IncludeNullTerm = false,
-                                  BoundsExpr *ExistingBounds = nullptr) {
+                                  bool IncludeNullTerm = false) {
       bool PrevIncludeNullTerminator = IncludeNullTerminator;
       IncludeNullTerminator = IncludeNullTerm;
-      BoundsExpr *Bounds = ExistingBounds ? ExistingBounds :
-                           RValueBounds(E, CSS, Facts, SideEffects::Disabled);
+      BoundsExpr *Bounds = RValueBounds(E, CSS, Facts, SideEffects::Disabled);
       IncludeNullTerminator = PrevIncludeNullTerminator;
       return S.CheckNonModifyingBounds(Bounds, E);
     }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3353,17 +3353,8 @@ namespace {
         case Expr::BinaryOperatorClass:
         case Expr::CompoundAssignOperatorClass:
           return CheckBinaryOperator(cast<BinaryOperator>(E), CSS, Facts, SE);
-        case Expr::CallExprClass: {
+        case Expr::CallExprClass:
           return CheckCallExpr(cast<CallExpr>(E), CSS, Facts, SE);
-          // Do not call CheckCallExpr here.  Since CheckCallExpr suppresses
-          // diagnostics emitted as part of CallExprBounds (to reduce unwanted
-          // duplicate diagnostics), calling CheckCallExpr here can result in
-          // wanted diagnostics from CallExprBounds being suppressed.
-          // Once TraverseStmt is fully refactored, calls to RValueBounds can
-          // be replaced with calls to TraverseStmt.
-          CallExpr *CE = cast<CallExpr>(E);
-          return CallExprBounds(CE, nullptr);
-        }
         case Expr::CHKCBindTemporaryExprClass: {
           CHKCBindTemporaryExpr *Binding = cast<CHKCBindTemporaryExpr>(E);
           Expr *Child = Binding->getSubExpr();


### PR DESCRIPTION
Traverse the subexpression in CheckCastExpr rather than TraverseStmt to help prevent duplicate RValueBounds calls from TraverseStmt. Clean up diagnostic suppression in case where side effects are removed by moving the ExprSubstitutionScope to TraverseStmt and RValueBounds rather than individual Check* methods.

Testing:
* No new tests or changes to existing tests
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux