### PR TITLE
Mark test/CheckedC/dump-dataflow-facts.c as unsupported for Windows

### DIFF
--- a/clang/test/CheckedC/dump-dataflow-facts.c
+++ b/clang/test/CheckedC/dump-dataflow-facts.c
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // Tests for dumping of datafow analysis for collecting facts
 //
 // RUN: %clang_cc1 -fdump-extracted-comparison-facts %s 2>1 | FileCheck %s


### PR DESCRIPTION
AvailableFactsAnalysis.cpp uses std::set as the main data structure for storing/iterating the collected facts. The implementation of std::set is platform specific. That’s the reason the test test/CheckedC/dump-dataflow-facts.c fails on Windows (but passes on Linux). On Windows X64, there are run-to-run differences in the output order of blocks and facts when I run this test by hand.

The fix will involve rethinking about the data structures used and sorting before printing.
Issue https://github.com/microsoft/checkedc-clang/issues/756 tracks this.