### PR TITLE
Traverse children in CheckVarDecl

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2566,13 +2566,15 @@ namespace {
                              SideEffects SE) {
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
+      if (SE == SideEffects::Disabled)
+        return ResultBounds;
+
+      // If there is an initializer, traverse it.  This prevents TraverseStmt
+      // from needing to traverse the children of variable declarations.
       Expr *Init = D->getInit();
       BoundsExpr *InitBounds = nullptr;
       if (Init)
         InitBounds = TraverseStmt(Init, CSS, Facts, SE);
-
-      if (SE == SideEffects::Disabled)
-        return ResultBounds;
 
       if (D->isInvalidDecl())
         return ResultBounds;


### PR DESCRIPTION
If a variable declaration has an initializer expression, traverse it in CheckVarDecl rather than traversing the children of DeclStmts in TraverseStmt.

Testing:
* No new tests or change to existing tests
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux