### PR TITLE
CheckTemporaryBinding, CheckBoundsValueExpr, CheckConditionalOperator

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2194,8 +2194,9 @@ namespace {
     // e is an rvalue.
     BoundsExpr *CheckCallExpr(CallExpr *E, CheckedScopeSpecifier CSS,
                               std::pair<ComparisonSet, ComparisonSet>& Facts,
-                              SideEffects SE) {
-      BoundsExpr *ResultBounds = CallExprBounds(E, nullptr);
+                              SideEffects SE,
+                              CHKCBindTemporaryExpr *Binding = nullptr) {
+      BoundsExpr *ResultBounds = CallExprBounds(E, Binding);
 
       if (SE == SideEffects::Disabled)
         return ResultBounds;


### PR DESCRIPTION
Add CheckTemporaryBinding, CheckBoundsValueExpr, and CheckConditionalOperator methods that do their own bounds inference/checking and subexpression traversal.

Testing:
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux