### PR TITLE
Replace ExprPairTy to ExprIntPairTy [NFC]

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -85,9 +85,10 @@ namespace clang {
   // for printing the blocks in a deterministic order.
   using OrderedBlocksTy = std::vector<const CFGBlock *>;
 
-  // ExprPairTy denotes a pair of expressions. This is used as a return type
-  // when an expression is split into a base and an offset.
-  using ExprPairTy = std::pair<const Expr *, const Expr *>;
+  // ExprIntPairTy denotes a pair of an expression and an integer constant.
+  // This is used as a return type when an expression is split into a base and
+  // an offset.
+  using ExprIntPairTy = std::pair<const Expr *, llvm::APSInt>;
 
   class BoundsAnalysis {
   private:
@@ -260,9 +261,10 @@ namespace clang {
     // Make an expression uniform by moving all DeclRefExpr to the LHS and all
     // IntegerLiterals to the RHS.
     // @param[in] E is the expression which should be made uniform.
-    // @return A pair of expressions. The first contains all DeclRefExprs of E
-    // and the second contains all IntegerLiterals of E.
-    ExprPairTy SplitIntoBaseOffset(const Expr *E);
+    // @return A pair of an expression and an integer constant. The expression
+    // contains all DeclRefExprs of E and the integer constant contains all
+    // IntegerLiterals of E.
+    ExprIntPairTy SplitIntoBaseOffset(const Expr *E);
 
     // Collect all ntptrs in scope. Currently, this simply collects all ntptrs
     // defined in all blocks in the current function. This function inserts the

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -204,17 +204,11 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
   // p + i + j ==> (p, i + j)
   // i + p + j + q ==> (p + q, i + j)
 
-  ExprPairTy DerefExprPair = SplitIntoBaseOffset(E);
-  const Expr *DerefBase = DerefExprPair.first;
-  const Expr *DerefOffset = DerefExprPair.second;
+  ExprIntPairTy DerefExprIntPair = SplitIntoBaseOffset(E);
+  const Expr *DerefBase = DerefExprIntPair.first;
   if (!DerefBase)
     return;
-
-  llvm::APSInt Zero (Ctx.getTypeSize(Ctx.IntTy), 0);
-  llvm::APSInt DerefOffsetVal;
-  if (!DerefOffset ||
-      !DerefOffset->isIntegerConstantExpr(DerefOffsetVal, Ctx))
-    DerefOffsetVal = Zero;
+  llvm::APSInt DerefOffset = DerefExprIntPair.second;
 
   // For bounds widening, the base of the deref expr and the declared upper
   // bounds expr for all ntptrs in scope should be the same.
@@ -273,20 +267,15 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
 
     // Split the upper bounds expr into base and offset for matching with the
     // DerefBase.
-    ExprPairTy UpperExprPair = SplitIntoBaseOffset(UE);
-    const Expr *UpperBase = UpperExprPair.first;
-    const Expr *UpperOffset = UpperExprPair.second;
+    ExprIntPairTy UpperExprIntPair = SplitIntoBaseOffset(UE);
+    const Expr *UpperBase = UpperExprIntPair.first;
     if (!UpperBase)
       continue;
+    llvm::APSInt UpperOffset = UpperExprIntPair.second;
 
     if (Lex.CompareExpr(DerefBase, UpperBase) !=
         Lexicographic::Result::Equal)
       continue;
-
-    llvm::APSInt UpperOffsetVal;
-    if (!UpperOffset ||
-        !UpperOffset->isIntegerConstantExpr(UpperOffsetVal, Ctx))
-      UpperOffsetVal = Zero;
 
     // We cannot widen the bounds if the offset in the deref expr is less than
     // the offset in the declared upper bounds expr. For example:
@@ -308,7 +297,7 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
     // We widen p by 1 only if the bounds of p in (In - Kill) == Gen[p].
     // See the comments in ComputeOutSets for more details.
 
-    if (Lex.CompareAPInt(DerefOffsetVal, UpperOffsetVal) ==
+    if (Lex.CompareAPInt(DerefOffset, UpperOffset) ==
         Lexicographic::Result::LessThan)
       continue;
 
@@ -316,30 +305,35 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
     // relative to the declared upper bound expression. This offset is used in
     // the widening computation in ComputeOutSets.
 
-    // TODO: Check to see if that difference overflows/underflows.
-    llvm::APInt OffsetDiff = DerefOffsetVal - UpperOffsetVal;
+    // We need to check to see if the offset overflows.
+    bool Overflow;
+    llvm::APInt Offset = DerefOffset.ssub_ov(UpperOffset, Overflow);
+    if (Overflow)
+      continue;
 
-    EB->Gen[SuccEB->Block][V] = OffsetDiff.getLimitedValue();
+    EB->Gen[SuccEB->Block][V] = Offset.getLimitedValue();
   }
 }
 
-ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
+ExprIntPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   // In order to make an expression uniform, we want to keep all DeclRefExprs
   // on the LHS and all IntegerLiterals on the RHS.
 
+  llvm::APSInt Zero (Ctx.getTypeSize(Ctx.IntTy), 0);
+
   if (!E)
-    return std::make_pair(nullptr, nullptr);
+    return std::make_pair(nullptr, Zero);;
 
   if (IsDeclOperand(E))
-    return std::make_pair(GetDeclOperand(E), nullptr);
+    return std::make_pair(GetDeclOperand(E), Zero);
 
   if (!isa<BinaryOperator>(E))
-    return std::make_pair(nullptr, nullptr);
+    return std::make_pair(nullptr, Zero);;
 
   const BinaryOperator *BO = dyn_cast<BinaryOperator>(E);
   // TODO: Currently we only handle exprs containing additive operations.
   if (BO->getOpcode() != BO_Add)
-    return std::make_pair(nullptr, nullptr);
+    return std::make_pair(nullptr, Zero);;
 
   Expr *LHS = BO->getLHS()->IgnoreParens();
   Expr *RHS = BO->getRHS()->IgnoreParens();
@@ -354,20 +348,20 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   llvm::APSInt IntVal;
 
   if (IsDeclOperand(LHS) && RHS->isIntegerConstantExpr(IntVal, Ctx))
-    return std::make_pair(GetDeclOperand(LHS), RHS);
+    return std::make_pair(GetDeclOperand(LHS), IntVal);
 
   // Case 2: LHS is IntegerLiteral and RHS is DeclRefExpr. We simply need to
   // swap LHS and RHS to make expr uniform.
   // i + p ==> return (p, i)
   if (LHS->isIntegerConstantExpr(IntVal, Ctx) && IsDeclOperand(RHS))
-    return std::make_pair(GetDeclOperand(RHS), LHS);
+    return std::make_pair(GetDeclOperand(RHS), IntVal);
 
   // Case 3: LHS and RHS are both DeclRefExprs. This means there is no
   // IntegerLiteral in the expr. In this case, we return the incoming
   // BinaryOperator expr with a nullptr for the RHS.
   // p + q ==> return (p + q, nullptr)
   if (IsDeclOperand(LHS) && IsDeclOperand(RHS))
-    return std::make_pair(BO, nullptr);
+    return std::make_pair(BO, Zero);
 
   // To make parsing simpler, we always try to keep BinaryOperator on the LHS.
   if (!isa<BinaryOperator>(LHS) && isa<BinaryOperator>(RHS))
@@ -377,7 +371,7 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   // was a BinaryOperator, or because the RHS was a BinaryOperator and was
   // swapped with the LHS.
   if (!isa<BinaryOperator>(LHS))
-    return std::make_pair(nullptr, nullptr);
+    return std::make_pair(nullptr, Zero);;
 
   // If we reach here, the expr is one of these:
   // Case 4: (p + q) + i
@@ -391,9 +385,9 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   auto *BE = dyn_cast<BinaryOperator>(LHS);
 
   // Recursively, make the LHS uniform.
-  ExprPairTy ExprPair = SplitIntoBaseOffset(BE);
-  const Expr *BinOpLHS = ExprPair.first;
-  const Expr *BinOpRHS = ExprPair.second;
+  ExprIntPairTy ExprIntPair = SplitIntoBaseOffset(BE);
+  const Expr *BinOpLHS = ExprIntPair.first;
+  llvm::APSInt BinOpRHS = ExprIntPair.second;
 
   // Expr is either Case 4 or Case 5 from above. ie: LHS is BinaryOperator
   // and RHS is IntegerLiteral.
@@ -403,22 +397,21 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
     // Expr is Case 4. ie: The BinaryOperator expr does not have an
     // IntegerLiteral on the RHS.
     // (p + q) + i ==> return (p + q, i)
-    if (!BinOpRHS)
-      return std::make_pair(BE, RHS);
+    if (BinOpRHS == Zero)
+      return std::make_pair(BE, IntVal);
 
     // Expr is Case 5. ie: The BinaryOperator expr has an IntegerLiteral on
     // the RHS.
     // (p + j) + i ==> return (p, j + i)
-    Expr::EvalResult R1, R2;
-    RHS->EvaluateAsInt(R1, Ctx);
-    BinOpRHS->EvaluateAsInt(R2, Ctx);
 
-    // TODO: Since we are reasociating integers here, check if the value
-    // overflows/underflows.
-    llvm::APInt Val = R1.Val.getInt() + R2.Val.getInt();
+    // Since we are reassociating integers here, we need to check if the value
+    // overflows.
+    bool Overflow;
+    IntVal = IntVal.sadd_ov(BinOpRHS, Overflow);
+    if (Overflow)
+      return std::make_pair(nullptr, Zero);;
 
-    auto *I = new (Ctx) IntegerLiteral(Ctx, Val, Ctx.IntTy, SourceLocation());
-    return std::make_pair(BinOpLHS, I);
+    return std::make_pair(BinOpLHS, IntVal);
   }
 
   // If we are here it means expr is either Case 6 or Case 7 from above. ie:
@@ -428,8 +421,8 @@ ExprPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   // Expr is Case 6. ie: The BinaryOperator expr does not have an
   // IntegerLiteral on the RHS.
   // (p + q) + r ==> return (p + q + r, nullptr)
-  if (!BinOpRHS)
-    return std::make_pair(BO, nullptr);
+  if (BinOpRHS == Zero)
+    return std::make_pair(BO, Zero);
 
   // Expr is Case 7. ie: The BinaryOperator expr has an IntegerLiteral on
   // the RHS.


### PR DESCRIPTION
We use ExprPairTy as a return type when we split an Expr into a base and an
offset. We return the offset as an Expr and then extract the integer constant
from it. But while computing the offset we already have the integer constant
available. We can make use of this instead of re-computing. In case, the offset
is not an integer constant we return a zero integer.