### PR TITLE
Use llvm::APSInt::compareValues instead of directly comparing integer constants

### DIFF
--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -391,7 +391,7 @@ ExprIntPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
     // Expr is Case 4. ie: The BinaryOperator expr does not have an
     // IntegerLiteral on the RHS.
     // (p + q) + i ==> return (p + q, i)
-    if (BinOpRHS == Zero)
+    if (llvm::APSInt::compareValues(BinOpRHS, Zero) == 0)
       return std::make_pair(BE, IntVal);
 
     // Expr is Case 5. ie: The BinaryOperator expr has an IntegerLiteral on
@@ -410,7 +410,7 @@ ExprIntPairTy BoundsAnalysis::SplitIntoBaseOffset(const Expr *E) {
   // Expr is Case 6. ie: The BinaryOperator expr does not have an
   // IntegerLiteral on the RHS.
   // (p + q) + r ==> return (p + q + r, nullptr)
-  if (BinOpRHS == Zero)
+  if (llvm::APSInt::compareValues(BinOpRHS, Zero) == 0)
     return std::make_pair(BO, Zero);
 
   // Expr is Case 7. ie: The BinaryOperator expr has an IntegerLiteral on


### PR DESCRIPTION
llvm::APSInt::compareValues correctly account for signedness/unsignedness of integer when comparing them. So it is good to use this method instead of directly comparing integer constants.