### PR TITLE
Reduce build parallelism for debug builds

### DIFF
--- a/clang/automation/UNIX/config-vars.sh
+++ b/clang/automation/UNIX/config-vars.sh
@@ -120,7 +120,12 @@ fi
 
 if [ -z "$BUILD_CPU_COUNT" ]; then
   declare -i NPROC=$(nproc);
-  export BUILD_CPU_COUNT=$(($NPROC*3/4))
+  if [ "$BUILDCONFIGURATION" = "Release" ]; then
+    export BUILD_CPU_COUNT=$(($NPROC*3/4))
+  else
+    # Reduce build parallelism for debug builds.
+    export BUILD_CPU_COUNT=$(($NPROC*3/8))
+  fi
 fi
 
 if [ -z "$RUN_LOCAL" ]; then


### PR DESCRIPTION
We have started to run into frequent out-of-memory (OOM) errors on ADO when building CheckedC clang. We need to setup automation to track memory footprint for CheckedC clang. But in the meanwhile, to prevent OOM errors, we need to reduce the build parallelism on ADO debug builds.