### PR TITLE
Pass FunctionDecl as a parameter to BoundsAnalysis functions [2/n]

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -95,7 +95,6 @@ namespace clang {
     Sema &S;
     CFG *Cfg;
     ASTContext &Ctx;
-    FunctionDecl *FD;
     Lexicographic Lex;
 
     // The final widened bounds will reside here. This is a map keyed by
@@ -132,12 +131,13 @@ namespace clang {
     DeclSetTy NtPtrsInScope;
 
   public:
-    BoundsAnalysis(Sema &S, CFG *Cfg, FunctionDecl *FD) :
-      S(S), Cfg(Cfg), Ctx(S.Context), FD(FD),
+    BoundsAnalysis(Sema &S, CFG *Cfg) :
+      S(S), Cfg(Cfg), Ctx(S.Context),
       Lex(Lexicographic(Ctx, nullptr)) {}
 
     // Run the dataflow analysis to widen bounds for ntptr's.
-    void WidenBounds();
+    // @param[in] FD is the current function.
+    void WidenBounds(FunctionDecl *FD);
 
     // Get the widened bounds for block B.
     // @param[in] B is the block for which the widened bounds are needed.
@@ -146,7 +146,8 @@ namespace clang {
 
     // Pretty print the widen bounds analysis.
     // printing.
-    void DumpWidenedBounds();
+    // @param[in] FD is the current function.
+    void DumpWidenedBounds(FunctionDecl *FD);
 
   private:
     // Compute Gen set for each edge in the CFG. If there is an edge B1->B2 and
@@ -262,7 +263,8 @@ namespace clang {
     // Collect all ntptrs in scope. Currently, this simply collects all ntptrs
     // defined in all blocks in the current function. This function inserts the
     // VarDecls for the ntptrs in NtPtrsInScope.
-    void CollectNtPtrsInScope();
+    // @param[in] FD is the current function.
+    void CollectNtPtrsInScope(FunctionDecl *FD);
 
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -15,7 +15,7 @@
 
 namespace clang {
 
-void BoundsAnalysis::WidenBounds() {
+void BoundsAnalysis::WidenBounds(FunctionDecl *FD) {
   assert(Cfg && "expected CFG to exist");
 
   WorkListTy WorkList;
@@ -50,7 +50,7 @@ void BoundsAnalysis::WidenBounds() {
   }
 
   // Collect all ntptrs in scope.
-  CollectNtPtrsInScope();
+  CollectNtPtrsInScope(FD);
 
   // Compute Gen and Kill sets.
   ComputeGenSets();
@@ -145,7 +145,7 @@ bool BoundsAnalysis::IsDeclOperand(const Expr *E) {
   return false;
 }
 
-void BoundsAnalysis::CollectNtPtrsInScope() {
+void BoundsAnalysis::CollectNtPtrsInScope(FunctionDecl *FD) {
   // TODO: Currently, we simply collect all ntptrs defined in the current
   // function. Ultimately, we need to do a liveness analysis of what ntptrs are
   // in scope for a block.
@@ -713,7 +713,7 @@ OrderedBlocksTy BoundsAnalysis::GetOrderedBlocks() {
   return OrderedBlocks;
 }
 
-void BoundsAnalysis::DumpWidenedBounds() {
+void BoundsAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
   llvm::outs() << "--------------------------------------\n";
   llvm::outs() << "In function: " << FD->getName() << "\n";
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3915,10 +3915,10 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   }
 
   if (Cfg != nullptr) {
-    BoundsAnalysis Collector(*this, Cfg.get(), FD);
-    Collector.WidenBounds();
+    BoundsAnalysis Collector(*this, Cfg.get());
+    Collector.WidenBounds(FD);
     if (getLangOpts().DumpWidenedBounds)
-      Collector.DumpWidenedBounds();
+      Collector.DumpWidenedBounds(FD);
   }
 
 #if TRACE_CFG


### PR DESCRIPTION
Currently, FunctionDecl (FD) is a member of BoundsAnalysis class. As a result,
we need to pass FD while instantiating a BoundsAnalysis object. We plan to add
a BoundsAnalysis object to CheckBoundsDeclaration class but we do not have a
FunctionDecl in the CheckBoundsDeclaration constructor. So we would not be able
to add the BoundsAnalysis object as long as FD is a member of BoundsAnalysis
class. So we need to decouple FD from BoundsAnalysis. We would pass FD only to
methods which need FD.

This is the second PR in a series of PRs to integrate the results of bounds-widening with bounds inference/checking.