### PR TITLE
Add BoundsAnalysis object to CheckBoundsDeclaration class [3/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -487,6 +487,12 @@ namespace {
                               // function, if any.
     ASTContext &Context;
     std::pair<ComparisonSet, ComparisonSet> &Facts;
+
+    // Having a BoundsAnalysis object here allows us to easily invoke methods
+    // for bounds-widening and get back the bounds-widening info needed for
+    // bounds inference/checking.
+    BoundsAnalysis WidenBounds;
+
     // When this flag is set to true, include the null terminator in the
     // bounds of a null-terminated array.  This is used when calculating
     // physical sizes during casts to pointers to null-terminated arrays.
@@ -1727,6 +1733,7 @@ namespace {
       ReturnBounds(ReturnBounds),
       Context(SemaRef.Context),
       Facts(Facts),
+      WidenBounds(BoundsAnalysis(SemaRef, Cfg)),
       IncludeNullTerminator(false) {}
 
     CheckBoundsDeclarations(Sema &SemaRef, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
@@ -1737,6 +1744,7 @@ namespace {
       ReturnBounds(nullptr),
       Context(SemaRef.Context),
       Facts(Facts),
+      WidenBounds(BoundsAnalysis(SemaRef, nullptr)),
       IncludeNullTerminator(false) {}
 
     typedef llvm::SmallPtrSet<const Stmt *, 16> StmtSet;
@@ -2845,6 +2853,8 @@ namespace {
       return ExpandToRange(Base, BE);
     }
 
+    BoundsAnalysis getBoundsAnalysis() { return WidenBounds; }
+
   // Methods for inferring bounds expressions for C expressions.
 
   // C has an interesting semantics for expressions that differentiates between
@@ -3915,10 +3925,10 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   }
 
   if (Cfg != nullptr) {
-    BoundsAnalysis Collector(*this, Cfg.get());
-    Collector.WidenBounds(FD);
+    BoundsAnalysis WB = Checker.getBoundsAnalysis();
+    WB.WidenBounds(FD);
     if (getLangOpts().DumpWidenedBounds)
-      Collector.DumpWidenedBounds(FD);
+      WB.DumpWidenedBounds(FD);
   }
 
 #if TRACE_CFG

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -491,7 +491,7 @@ namespace {
     // Having a BoundsAnalysis object here allows us to easily invoke methods
     // for bounds-widening and get back the bounds-widening info needed for
     // bounds inference/checking.
-    BoundsAnalysis WidenBounds;
+    BoundsAnalysis BoundsAnalyzer;
 
     // When this flag is set to true, include the null terminator in the
     // bounds of a null-terminated array.  This is used when calculating
@@ -1733,7 +1733,7 @@ namespace {
       ReturnBounds(ReturnBounds),
       Context(SemaRef.Context),
       Facts(Facts),
-      WidenBounds(BoundsAnalysis(SemaRef, Cfg)),
+      BoundsAnalyzer(BoundsAnalysis(SemaRef, Cfg)),
       IncludeNullTerminator(false) {}
 
     CheckBoundsDeclarations(Sema &SemaRef, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
@@ -1744,7 +1744,7 @@ namespace {
       ReturnBounds(nullptr),
       Context(SemaRef.Context),
       Facts(Facts),
-      WidenBounds(BoundsAnalysis(SemaRef, nullptr)),
+      BoundsAnalyzer(BoundsAnalysis(SemaRef, nullptr)),
       IncludeNullTerminator(false) {}
 
     typedef llvm::SmallPtrSet<const Stmt *, 16> StmtSet;
@@ -2853,7 +2853,7 @@ namespace {
       return ExpandToRange(Base, BE);
     }
 
-    BoundsAnalysis getBoundsAnalysis() { return WidenBounds; }
+    BoundsAnalysis getBoundsAnalyzer() { return BoundsAnalyzer; }
 
   // Methods for inferring bounds expressions for C expressions.
 
@@ -3925,10 +3925,10 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   }
 
   if (Cfg != nullptr) {
-    BoundsAnalysis WB = Checker.getBoundsAnalysis();
-    WB.WidenBounds(FD);
+    BoundsAnalysis BA = Checker.getBoundsAnalyzer();
+    BA.WidenBounds(FD);
     if (getLangOpts().DumpWidenedBounds)
-      WB.DumpWidenedBounds(FD);
+      BA.DumpWidenedBounds(FD);
   }
 
 #if TRACE_CFG


### PR DESCRIPTION
Adding a BoundsAnalysis object to ChecBoundsDeclaration class would allow us to
easily invoke BoundsAnalysis methods without having to pass around the
BoundsAnalysis object.

This is the third PR in a series of PRs to integrate the results of
bounds-widening with bounds inference/checking.