### PR TITLE
Change Kill set to be a map from a Stmt to a set of vars whose bounds are killed by the Stmt [4/n]

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -70,9 +70,7 @@ namespace clang {
   // For each edge B1->B2, EdgeBoundsTy denotes the Gen and Out sets.
   using EdgeBoundsTy = llvm::DenseMap<const CFGBlock *, BoundsMapTy>;
 
-  // For each block B, DeclSetTy denotes the Kill set. A VarDecl V is killed if:
-  // 1. V is assigned to in the block, or
-  // 2. any variable used in the bounds expr of V is assigned to in the block.
+  // DeclSetTy denotes a set of VarDecls.
   using DeclSetTy = llvm::DenseSet<const VarDecl *>;
 
   // A mapping of VarDecl V to all the variables occuring in its bounds
@@ -90,16 +88,19 @@ namespace clang {
   // an offset.
   using ExprIntPairTy = std::pair<const Expr *, llvm::APSInt>;
 
+  // StmtDeclSetTy denotes a mapping between a Stmt and a set of VarDecls. This
+  // is used to store the Kill set for a block.
+  // A VarDecl V is killed if by a Stmt S if:
+  // 1. In Stmt S, V is assigned to in, or
+  // 2. any variable used in the bounds expr of V is assigned to by S.
+  using StmtDeclSetTy = llvm::DenseMap<const Stmt *, DeclSetTy>;
+
   class BoundsAnalysis {
   private:
     Sema &S;
     CFG *Cfg;
     ASTContext &Ctx;
     Lexicographic Lex;
-
-    // The final widened bounds will reside here. This is a map keyed by
-    // CFGBlock.
-    EdgeBoundsTy WidenedBounds;
 
     class ElevatedCFGBlock {
     public:
@@ -109,7 +110,7 @@ namespace clang {
       // The Gen and Out sets for the block.
       EdgeBoundsTy Gen, Out;
       // The Kill set for the block.
-      DeclSetTy Kill;
+      StmtDeclSetTy Kill;
       // The set of all variables used in bounds expr for each ntptr in the
       // block.
       BoundsVarTy BoundsVars;
@@ -155,8 +156,9 @@ namespace clang {
     // p:i} . The actual computation of i is done in FillGenSet.
     void ComputeGenSets();
 
-    // Compute Kill set for each block in BlockMap. For a block B, a variable V
-    // is added to Kill[B] if V is assigned to in B.
+    // Compute Kill set for each block in BlockMap. For a block B, if a
+    // variable V is assigned to in B by Stmt S, then the pair S:V is added to
+    // the Kill set for the block.
     void ComputeKillSets();
 
     // Compute In set for each block in BlockMap. In[B1] = n Out[B*->B1], where
@@ -195,15 +197,6 @@ namespace clang {
     // @param[out] BoundsVars is a set of all variables used in the bounds expr
     // E.
     void CollectBoundsVars(const Expr *E, DeclSetTy &BoundsVars);
-
-    // Collect the variables assigned to in a block.
-    // @param[in] S is an assignment statement.
-    // @param[in] EB is used to access the BoundsVars for the block.
-    // @param[out] DefinedVars is the set of all ntptrs whose widened bounds
-    // are no longer valid as the ntptr has been assigned to, and hence it must
-    // be added to the Kill set of the block.
-    void CollectDefinedVars(const Stmt *S, ElevatedCFGBlock *EB,
-                            DeclSetTy &DefinedVars);
 
     // Assign the widened bounds from the ElevatedBlock to the CFG Block.
     void CollectWidenedBounds();
@@ -265,6 +258,17 @@ namespace clang {
     // VarDecls for the ntptrs in NtPtrsInScope.
     // @param[in] FD is the current function.
     void CollectNtPtrsInScope(FunctionDecl *FD);
+
+    // Get the Kill set for the current block. The Kill set is a mapping of
+    // Stmts to ntptr bounds killed by each Stmt in the block.
+    // @param[in] B is the current CFGBlock.
+    // return A mapping of Stmts and the ntptr bounds killed by each Stmt.
+    StmtDeclSetTy GetKillSet(const clang::CFGBlock *B);
+
+    // If ntptr V is killed by Stmt S in Block B, add S:V pair to EB->Kill.
+    // @param[in] EB is the ElevatedCFGBlock for the current block.
+    // @param[in] S is the current Stmt in the block.
+    void FillKillSet(ElevatedCFGBlock *EB, const Stmt *S);
 
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -154,6 +154,15 @@ namespace clang {
     // @param[in] FD is the current function.
     void DumpWidenedBounds(FunctionDecl *FD);
 
+    // Get the Kill set for the current block. The Kill set is a mapping of
+    // Stmts to variables whose bounds are killed by each Stmt in the block.
+    // Note: This method is intended to be invoked from CheckBoundsDeclaration
+    // or a similar place which does bounds inference/checking.
+    // @param[in] B is the current CFGBlock.
+    // return A mapping of Stmts to variables whose bounds are killed by the
+    // Stmt.
+    StmtDeclSetTy GetKillSet(const clang::CFGBlock *B);
+
   private:
     // Compute Gen set for each edge in the CFG. If there is an edge B1->B2 and
     // the edge condition is of the form "if (*(p + i))" then Gen[B1] = {B2,
@@ -262,12 +271,6 @@ namespace clang {
     // VarDecls for the ntptrs in NtPtrsInScope.
     // @param[in] FD is the current function.
     void CollectNtPtrsInScope(FunctionDecl *FD);
-
-    // Get the Kill set for the current block. The Kill set is a mapping of
-    // Stmts to variables whose bounds killed by each Stmt in the block.
-    // @param[in] B is the current CFGBlock.
-    // return A mapping of Stmts to variables whose bounds killed by the Stmt.
-    StmtDeclSetTy GetKillSet(const clang::CFGBlock *B);
 
     // If variable V is killed by Stmt S in Block B, add S:V pair to EB->Kill.
     // @param[in] EB is the ElevatedCFGBlock for the current block.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -90,9 +90,9 @@ namespace clang {
 
   // StmtDeclSetTy denotes a mapping between a Stmt and a set of VarDecls. This
   // is used to store the Kill set for a block.
-  // A VarDecl V is killed if by a Stmt S if:
-  // 1. In Stmt S, V is assigned to in, or
-  // 2. any variable used in the bounds expr of V is assigned to by S.
+  // A VarDecl V is killed in a Stmt S if:
+  // 1. V is assigned to in S, or
+  // 2. any variable used in the bounds expr of V is assigned to in S.
   using StmtDeclSetTy = llvm::DenseMap<const Stmt *, DeclSetTy>;
 
   class BoundsAnalysis {
@@ -101,6 +101,10 @@ namespace clang {
     CFG *Cfg;
     ASTContext &Ctx;
     Lexicographic Lex;
+
+    // The final widened bounds will reside here. This is a map keyed by
+    // CFGBlock.
+    EdgeBoundsTy WidenedBounds;
 
     class ElevatedCFGBlock {
     public:
@@ -260,12 +264,12 @@ namespace clang {
     void CollectNtPtrsInScope(FunctionDecl *FD);
 
     // Get the Kill set for the current block. The Kill set is a mapping of
-    // Stmts to ntptr bounds killed by each Stmt in the block.
+    // Stmts to variables whose bounds killed by each Stmt in the block.
     // @param[in] B is the current CFGBlock.
-    // return A mapping of Stmts and the ntptr bounds killed by each Stmt.
+    // return A mapping of Stmts to variables whose bounds killed by the Stmt.
     StmtDeclSetTy GetKillSet(const clang::CFGBlock *B);
 
-    // If ntptr V is killed by Stmt S in Block B, add S:V pair to EB->Kill.
+    // If variable V is killed by Stmt S in Block B, add S:V pair to EB->Kill.
     // @param[in] EB is the ElevatedCFGBlock for the current block.
     // @param[in] S is the current Stmt in the block.
     void FillKillSet(ElevatedCFGBlock *EB, const Stmt *S);

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -64,8 +64,6 @@ void BoundsAnalysis::WidenBounds(FunctionDecl *FD) {
     ComputeInSets(EB);
     ComputeOutSets(EB, WorkList);
   }
-
-  CollectWidenedBounds();
 }
 
 void BoundsAnalysis::ComputeGenSets() {
@@ -478,23 +476,24 @@ void BoundsAnalysis::FillGenSet(Expr *E,
 }
 
 void BoundsAnalysis::ComputeKillSets() {
-  // For a block B, a variable v is added to Kill[B] if v is assigned to in B.
+  // For a block B, a variable v is added to Kill[B][S] if v is assigned to in
+  // B by Stmt S.
 
   for (const auto item : BlockMap) {
     ElevatedCFGBlock *EB = item.second;
-    DeclSetTy DefinedVars;
 
-    for (CFGElement Elem : *(EB->Block))
-      if (Elem.getKind() == CFGElement::Statement)
-        CollectDefinedVars(Elem.castAs<CFGStmt>().getStmt(), EB, DefinedVars);
-
-    for (const VarDecl *V : DefinedVars)
-      EB->Kill.insert(V);
+    for (CFGElement Elem : *(EB->Block)) {
+      if (Elem.getKind() == CFGElement::Statement) {
+        const Stmt *S = Elem.castAs<CFGStmt>().getStmt();
+        if (!S)
+          continue;
+        FillKillSet(EB, S);
+      }
+    }
   }
 }
 
-void BoundsAnalysis::CollectDefinedVars(const Stmt *S, ElevatedCFGBlock *EB,
-                                        DeclSetTy &DefinedVars) {
+void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB, const Stmt *S) {
   if (!S)
     return;
 
@@ -512,12 +511,17 @@ void BoundsAnalysis::CollectDefinedVars(const Stmt *S, ElevatedCFGBlock *EB,
   if (E) {
     if (const auto *D = dyn_cast<DeclRefExpr>(E)) {
       if (const auto *V = dyn_cast<VarDecl>(D->getDecl())) {
-        if (IsNtArrayType(V))
-          DefinedVars.insert(V);
-        else {
 
-          // BoundsVars is a mapping from _Nt_array_ptrs to all the variables
-          // used in their bounds exprs. For example:
+        // If the variable being assigned to is an ntptr, add the Stmt:V pair
+        // to to the Kill set for the block.
+        if (IsNtArrayType(V))
+          EB->Kill[S].insert(V);
+
+        else {
+          // Else look for the variable in BoundsVars.
+
+	  // BoundsVars is a mapping from ntptrs to all the variables used in
+	  // their bounds exprs. For example:
 
           // _Nt_array_ptr<char> p : bounds(p + i, i + p + j + 10);
           // _Nt_array_ptr<char> q : bounds(i + q, i + p + q + m);
@@ -525,8 +529,13 @@ void BoundsAnalysis::CollectDefinedVars(const Stmt *S, ElevatedCFGBlock *EB,
           // EB->BoundsVars: {p: {p, i, j}, q: {i, q, p, m}}
 
           for (auto item : EB->BoundsVars) {
-            if (item.second.count(V))
-              DefinedVars.insert(item.first);
+            const VarDecl *NtPtr = item.first;
+            DeclSetTy Vars = item.second;
+
+            // If the variable exists in the bounds declaration for the NtPtr,
+            // then add the Stmt:NtPtr pair to the Kill set for the block.
+            if (Vars.count(V))
+              EB->Kill[S].insert(NtPtr);
           }
         }
       }
@@ -534,7 +543,7 @@ void BoundsAnalysis::CollectDefinedVars(const Stmt *S, ElevatedCFGBlock *EB,
   }
 
   for (const Stmt *St : S->children())
-    CollectDefinedVars(St, EB, DefinedVars);
+    FillKillSet(EB, St);
 }
 
 void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
@@ -563,7 +572,15 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
                                     WorkListTy &WorkList) {
   // Out[B1->B2] = (In[B1] - Kill[B1]) u Gen[B1->B2].
 
-  BoundsMapTy Diff = Difference(EB->In, EB->Kill);
+  // EB->Kill is a mapping from Stmt to NtPtrs. We extract just the NtPtrs for
+  // the block and then use that to compute (In - Kill).
+  DeclSetTy KilledVars;
+  for (auto item : EB->Kill) {
+    const DeclSetTy Vars = item.second;
+    KilledVars.insert(Vars.begin(), Vars.end());
+  }
+
+  BoundsMapTy Diff = Difference(EB->In, KilledVars);
   for (const CFGBlock *succ : EB->Block->succs()) {
     if (SkipBlock(succ))
       continue;
@@ -594,17 +611,14 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
   }
 }
 
-void BoundsAnalysis::CollectWidenedBounds() {
-  for (auto item : BlockMap) {
-    const CFGBlock *B = item.first;
-    ElevatedCFGBlock *EB = item.second;
-    WidenedBounds[B] = EB->In;
-    delete EB;
-  }
+StmtDeclSetTy BoundsAnalysis::GetKillSet(const CFGBlock *B) {
+  ElevatedCFGBlock *EB = BlockMap[B];
+  return EB->Kill;
 }
 
 BoundsMapTy BoundsAnalysis::GetWidenedBounds(const CFGBlock *B) {
-  return WidenedBounds[B];
+  ElevatedCFGBlock *EB = BlockMap[B];
+  return EB->In;
 }
 
 Expr *BoundsAnalysis::GetTerminatorCondition(const CFGBlock *B) const {
@@ -701,7 +715,7 @@ OrderedBlocksTy BoundsAnalysis::GetOrderedBlocks() {
   // blocks. The block IDs decrease from entry to exit. So we sort in the
   // reverse order.
   OrderedBlocksTy OrderedBlocks;
-  for (auto item : WidenedBounds) {
+  for (auto item : BlockMap) {
     // item.first is the CFGBlock.
     OrderedBlocks.push_back(item.first);
   }
@@ -721,7 +735,7 @@ void BoundsAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
     llvm::outs() << "--------------------------------------";
     B->print(llvm::outs(), Cfg, S.getLangOpts(), /* ShowColors */ true);
 
-    BoundsMapTy Vars = WidenedBounds[B];
+    BoundsMapTy Vars = GetWidenedBounds(B);
     using VarPairTy = std::pair<const VarDecl *, unsigned>;
 
     std::sort(Vars.begin(), Vars.end(), [](VarPairTy A, VarPairTy B) {


### PR DESCRIPTION
Currently, the Kill set is a set of variables killed in a block. But we have no
info on "where" exactly a variable is killed inside a block. As a result, for a
given Stmt we cannot determine if the bounds of a variable are valid after the
Stmt or not. So we change the Kill set to be a mapping between the Stmt and the
variables killed by that Stmt inside a particular block.

This info would be used by bounds inference/checking to check the widened
bounds after a given Stmt.