### PR TITLE
Remove the WidendBounds map to optimize space [5/n]

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -102,10 +102,6 @@ namespace clang {
     ASTContext &Ctx;
     Lexicographic Lex;
 
-    // The final widened bounds will reside here. This is a map keyed by
-    // CFGBlock.
-    EdgeBoundsTy WidenedBounds;
-
     class ElevatedCFGBlock {
     public:
       const CFGBlock *Block;


### PR DESCRIPTION
Currently, in BoundsAnalysis we save the In sets of all blocks in a map called
WidenedBounds. This is really not needed as we can simply return the In set
for the block which already contains the widened bounds for that block. So we
can get rid of the WidenedBounds map.