### PR TITLE
Equivalent expressions [1/n]

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -42,7 +42,7 @@ namespace clang {
   class VarDecl;
 
   // List of sets of equivalent expressions.
-  typedef SmallVector<SmallVector<Expr *, 4> *, 4> EquivExprSets;
+  typedef SmallVector<SmallVector<Expr *, 4>, 4> EquivExprSets;
 
   class Lexicographic {
   public:

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -231,6 +231,7 @@ BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables
 BENIGN_LANGOPT(DumpInferredBounds, 1, 0, "dump inferred Checked C bounds for assignments and declarations")
 BENIGN_LANGOPT(DumpExtractedComparisonFacts, 1, 0, "dump extracted comparison facts")
 BENIGN_LANGOPT(DumpWidenedBounds, 1, 0, "dump widened bounds")
+BENIGN_LANGOPT(DumpEquivExprs, 1, 0, "dump equivalent expression sets during bounds checking")
 LANGOPT(InjectVerifierCalls, 1, 0, "Injects calls to VERIFIER_assume and VERIFIER_error in the bitcode")
 LANGOPT(UncheckedPointersDynamicCheck, 1, 0, "Adds dynamic checks for unchecked pointers")
 LANGOPT(NoConstantCFStrings , 1, 0, "no constant CoreFoundation strings")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -231,7 +231,7 @@ BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables
 BENIGN_LANGOPT(DumpInferredBounds, 1, 0, "dump inferred Checked C bounds for assignments and declarations")
 BENIGN_LANGOPT(DumpExtractedComparisonFacts, 1, 0, "dump extracted comparison facts")
 BENIGN_LANGOPT(DumpWidenedBounds, 1, 0, "dump widened bounds")
-BENIGN_LANGOPT(DumpEquivExprs, 1, 0, "dump equivalent expression sets during bounds checking")
+BENIGN_LANGOPT(DumpCheckingState, 1, 0, "dump the state during bounds checking")
 LANGOPT(InjectVerifierCalls, 1, 0, "Injects calls to VERIFIER_assume and VERIFIER_error in the bitcode")
 LANGOPT(UncheckedPointersDynamicCheck, 1, 0, "Adds dynamic checks for unchecked pointers")
 LANGOPT(NoConstantCFStrings , 1, 0, "no constant CoreFoundation strings")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -791,6 +791,8 @@ def fdump_extracted_comparison_facts : Flag<["-"], "fdump-extracted-comparison-f
   HelpText<"Dump extracted comparison facts">;
 def fdump_widened_bounds : Flag<["-"], "fdump-widened-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump widened bounds">;
+def fdump_equiv_exprs : Flag<["-"], "fdump-equiv-exprs">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Dump equivalent expression sets during bounds checking">;
 def fdump_inferred_bounds : Flag<["-"], "fdump-inferred-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump inferred Checked C bounds for assignments and declarations">;
 def finject_verifier_calls : Flag<["-"], "finject-verifier-calls">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -791,8 +791,8 @@ def fdump_extracted_comparison_facts : Flag<["-"], "fdump-extracted-comparison-f
   HelpText<"Dump extracted comparison facts">;
 def fdump_widened_bounds : Flag<["-"], "fdump-widened-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump widened bounds">;
-def fdump_equiv_exprs : Flag<["-"], "fdump-equiv-exprs">, Group<f_Group>, Flags<[CC1Option]>,
-  HelpText<"Dump equivalent expression sets during bounds checking">;
+def fdump_checking_state : Flag<["-"], "fdump-checking-state">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Dump the state during bounds checking">;
 def fdump_inferred_bounds : Flag<["-"], "fdump-inferred-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump inferred Checked C bounds for assignments and declarations">;
 def finject_verifier_calls : Flag<["-"], "finject-verifier-calls">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -414,8 +414,8 @@ Result Lexicographic::CheckEquivExprs(Result Current, const Expr *E1, const Expr
     bool LHSAppears = false;
     bool RHSAppears = false;
     // See if the LHS expression appears in the set.
-    SmallVector<Expr *, 4> *ExprList = *OuterList;
-    for (auto InnerList = ExprList->begin(); InnerList != ExprList->end(); ++InnerList) {
+    SmallVector<Expr *, 4> ExprList = *OuterList;
+    for (auto InnerList = ExprList.begin(); InnerList != ExprList.end(); ++InnerList) {
       if (SimpleComparer.CompareExpr(E1, *InnerList)  == Result::Equal) {
         LHSAppears = true;
         break;
@@ -425,7 +425,7 @@ Result Lexicographic::CheckEquivExprs(Result Current, const Expr *E1, const Expr
       continue;
 
     // See if the RHS expression appears in the set.
-    for (auto InnerList = ExprList->begin(); InnerList != ExprList->end(); ++InnerList) {
+    for (auto InnerList = ExprList.begin(); InnerList != ExprList.end(); ++InnerList) {
       if (SimpleComparer.CompareExpr(E2, *InnerList)  == Result::Equal) {
         RHSAppears = true;
         break;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2582,8 +2582,8 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   if (Args.hasArg(OPT_fdump_widened_bounds))
     Opts.DumpWidenedBounds = true;
 
-  if (Args.hasArg(OPT_fdump_equiv_exprs))
-    Opts.DumpEquivExprs = true;
+  if (Args.hasArg(OPT_fdump_checking_state))
+    Opts.DumpCheckingState = true;
 
   Opts.WritableStrings = Args.hasArg(OPT_fwritable_strings);
   Opts.ConstStrings = Args.hasFlag(OPT_fconst_strings, OPT_fno_const_strings,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2582,6 +2582,9 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   if (Args.hasArg(OPT_fdump_widened_bounds))
     Opts.DumpWidenedBounds = true;
 
+  if (Args.hasArg(OPT_fdump_equiv_exprs))
+    Opts.DumpEquivExprs = true;
+
   Opts.WritableStrings = Args.hasArg(OPT_fwritable_strings);
   Opts.ConstStrings = Args.hasFlag(OPT_fconst_strings, OPT_fno_const_strings,
                                    Opts.ConstStrings);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2027,6 +2027,10 @@ namespace {
         if (isa<BoundsExpr>(E))
           return ResultBounds;
 
+        // Temporary bindings are not null ptrs.
+        if (isa<CHKCBindTemporaryExpr>(E))
+          return ResultBounds;
+
         // Null ptrs always have bounds(any).
         // This is the correct way to detect all the different ways that
         // C can make a null ptr.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -476,6 +476,27 @@ namespace {
 }
 
 namespace {
+  // EqualExprTy denotes a set of expressions that produce
+  // the same value as some expression e.
+  using EqualExprTy = SmallVector<Expr *, 4>;
+
+  class CheckingState {
+    public:
+      // UEQ stores sets of expressions that are equivalent to each other
+      // after checking an expression e.
+      EquivExprSets *UEQ;
+
+      // G is a set of expressions that produce the same value
+      // as an expression e once checking of e is complete.
+      EqualExprTy *G;
+
+      CheckingState() :
+        UEQ(new EquivExprSets()),
+        G(new EqualExprTy()) {}
+  };
+}
+
+namespace {
   class CheckBoundsDeclarations {
   private:
     Sema &S;
@@ -576,16 +597,16 @@ namespace {
     }
 
     void DumpEquivalentExpressions(raw_ostream &OS, Stmt *S,
-                                   EquivExprSets *UEQ, EqualExprTy *G) {
+                                   CheckingState &State) {
       OS << "\nStatement S:\n";
       S->dump(OS);
 
       OS << "Sets of equivalent expressions after checking S:\n";
-      if (UEQ->size() == 0)
+      if (State.UEQ->size() == 0)
         OS << "{ }\n";
       else {
         OS << "{\n";
-        for (auto OuterList = UEQ->begin(); OuterList != UEQ->end(); ++OuterList) {
+        for (auto OuterList = State.UEQ->begin(); OuterList != State.UEQ->end(); ++OuterList) {
           auto ExprList = *OuterList;
           DumpEqualExpr(OS, ExprList);
         }
@@ -593,7 +614,7 @@ namespace {
       }
 
       OS << "Expressions that produce the same value as S:\n";
-      DumpEqualExpr(OS, G);
+      DumpEqualExpr(OS, State.G);
     }
 
     void DumpEqualExpr(raw_ostream &OS, EqualExprTy *G) {
@@ -1962,9 +1983,8 @@ namespace {
   public:
     BoundsExpr *Check(Stmt *S, CheckedScopeSpecifier CSS) {
       EquivExprSets EQ;
-      EquivExprSets *UEQ = new EquivExprSets();
-      EqualExprTy *G = new EqualExprTy();
-      return Check(S, CSS, EQ, UEQ, G);
+      CheckingState State;
+      return Check(S, CSS, EQ, State);
     }
 
     // If e is an rvalue, Check checks e and its children, performing any
@@ -1980,8 +2000,8 @@ namespace {
     // Check recursively checks the children of e and performs any
     // necessary side effects on e.  Check and CheckLValue work together
     // to traverse each expression in a CFG exactly once.
-    BoundsExpr *Check(Stmt *S, CheckedScopeSpecifier CSS, EquivExprSets EQ,
-                      EquivExprSets *&UEQ, EqualExprTy *&G) {
+    BoundsExpr *Check(Stmt *S, CheckedScopeSpecifier CSS,
+                      EquivExprSets EQ, CheckingState &State) {
       if (!S)
         return CreateBoundsEmpty();
 
@@ -1990,7 +2010,7 @@ namespace {
         S = E;
         if (E->isLValue()) {
           BoundsExpr *TargetBounds = nullptr;
-          CheckLValue(E, CSS, EQ, UEQ, G, TargetBounds);
+          CheckLValue(E, CSS, EQ, TargetBounds, State);
           return CreateBoundsAlwaysUnknown();
         }
       }
@@ -2000,28 +2020,28 @@ namespace {
       switch (S->getStmtClass()) {
         case Expr::UnaryOperatorClass:
           ResultBounds = CheckUnaryOperator(cast<UnaryOperator>(S),
-                                            CSS, EQ, UEQ, G);
+                                            CSS, EQ, State);
           break;
         case Expr::CallExprClass:
           ResultBounds = CheckCallExpr(cast<CallExpr>(S),
-                                       CSS, EQ, UEQ, G);
+                                       CSS, EQ, State);
           break;
         case Expr::ImplicitCastExprClass:
         case Expr::CStyleCastExprClass:
         case Expr::BoundsCastExprClass:
-          ResultBounds = CheckCastExpr(cast<CastExpr>(S), CSS, EQ, UEQ, G);
+          ResultBounds = CheckCastExpr(cast<CastExpr>(S), CSS, EQ, State);
           break;
         case Expr::BinaryOperatorClass:
         case Expr::CompoundAssignOperatorClass:
           ResultBounds = CheckBinaryOperator(cast<BinaryOperator>(S),
-                                             CSS, EQ, UEQ, G);
+                                             CSS, EQ, State);
           break;
         case Stmt::CompoundStmtClass: {
           CompoundStmt *CS = cast<CompoundStmt>(S);
           CSS = CS->getCheckedSpecifier();
           // Check may be called on a CompoundStmt if a CFG could not be
           // constructed, so check the children of a CompoundStmt.
-          CheckChildren(CS, CSS, EQ, UEQ, G);
+          CheckChildren(CS, CSS, EQ, State);
           break;
         }
         case Stmt::DeclStmtClass: {
@@ -2032,35 +2052,35 @@ namespace {
             // If an initializer expression is present, it is visited
             // during the traversal of the variable declaration.
             if (VarDecl *VD = dyn_cast<VarDecl>(D))
-              ResultBounds = CheckVarDecl(VD, CSS, EQ, UEQ, G);
+              ResultBounds = CheckVarDecl(VD, CSS, EQ, State);
           }
           break;
         }
         case Stmt::ReturnStmtClass:
-          ResultBounds = CheckReturnStmt(cast<ReturnStmt>(S), CSS, EQ, UEQ, G);
+          ResultBounds = CheckReturnStmt(cast<ReturnStmt>(S), CSS, EQ, State);
           break;
         case Stmt::CHKCBindTemporaryExprClass: {
           CHKCBindTemporaryExpr *Binding = cast<CHKCBindTemporaryExpr>(S);
-          ResultBounds = CheckTemporaryBinding(Binding, CSS, EQ, UEQ, G);
+          ResultBounds = CheckTemporaryBinding(Binding, CSS, EQ, State);
           break;
         }
         case Expr::ConditionalOperatorClass:
         case Expr::BinaryConditionalOperatorClass: {
           AbstractConditionalOperator *ACO = cast<AbstractConditionalOperator>(S);
-          ResultBounds = CheckConditionalOperator(ACO, CSS, EQ, UEQ, G);
+          ResultBounds = CheckConditionalOperator(ACO, CSS, EQ, State);
           break;
         }
         case Expr::BoundsValueExprClass:
           ResultBounds = CheckBoundsValueExpr(cast<BoundsValueExpr>(S),
-                                              CSS, EQ, UEQ, G);
+                                              CSS, EQ, State);
           break;
         default:
-          CheckChildren(S, CSS, EQ, UEQ, G);
+          CheckChildren(S, CSS, EQ, State);
           break;
       }
 
       if (DumpEquivExprs)
-        DumpEquivalentExpressions(llvm::outs(), S, UEQ, G);
+        DumpEquivalentExpressions(llvm::outs(), S, State);
 
       if (Expr *E = dyn_cast<Expr>(S)) {
         // Bounds expressions are not null ptrs.
@@ -2098,8 +2118,8 @@ namespace {
     // necessary side effects on e.  Check and CheckLValue work together
     // to traverse each expression in a CFG exactly once.
     BoundsExpr *CheckLValue(Expr *E, CheckedScopeSpecifier CSS,
-                            EquivExprSets EQ, EquivExprSets *&UEQ,
-                            EqualExprTy *&G, BoundsExpr *&OutTargetBounds) {
+                            EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                            CheckingState &State) {
       if (!E->isLValue())
         return CreateBoundsInferenceError();
 
@@ -2111,35 +2131,35 @@ namespace {
       switch (E->getStmtClass()) {
         case Expr::DeclRefExprClass:
           Bounds = CheckDeclRefExpr(cast<DeclRefExpr>(E),
-                                    CSS, EQ, UEQ, G, OutTargetBounds);
+                                    CSS, EQ, OutTargetBounds, State);
           break;
         case Expr::UnaryOperatorClass:
           Bounds = CheckUnaryLValue(cast<UnaryOperator>(E),
-                                    CSS, EQ, UEQ, G, OutTargetBounds);
+                                    CSS, EQ, OutTargetBounds, State);
           break;
         case Expr::ArraySubscriptExprClass:
           Bounds = CheckArraySubscriptExpr(cast<ArraySubscriptExpr>(E),
-                                           CSS, EQ, UEQ, G, OutTargetBounds);
+                                           CSS, EQ, OutTargetBounds, State);
           break;
         case Expr::MemberExprClass:
           Bounds = CheckMemberExpr(cast<MemberExpr>(E),
-                                   CSS, EQ, UEQ, G, OutTargetBounds);
+                                   CSS, EQ, OutTargetBounds, State);
           break;
         case Expr::ImplicitCastExprClass:
           Bounds = CheckCastLValue(cast<CastExpr>(E),
-                                   CSS, EQ, UEQ, G, OutTargetBounds);
+                                   CSS, EQ, OutTargetBounds, State);
           break;
         case Expr::CHKCBindTemporaryExprClass:
           Bounds = CheckTempBindingLValue(cast<CHKCBindTemporaryExpr>(E),
-                                          CSS, EQ, UEQ, G, OutTargetBounds);
+                                          CSS, EQ, OutTargetBounds, State);
           break;
         default:
-          CheckChildren(E, CSS, EQ, UEQ, G);
+          CheckChildren(E, CSS, EQ, State);
           break;
       }
 
       if (DumpEquivExprs)
-        DumpEquivalentExpressions(llvm::outs(), E, UEQ, G);
+        DumpEquivalentExpressions(llvm::outs(), E, State);
 
       // The type for inferring the target bounds cannot ever be an array
       // type, as these are dealt with by an array conversion, not an lvalue
@@ -2153,11 +2173,11 @@ namespace {
 
     // Recursively check and perform any side effects on the children
     // of an expression, throwing away the resulting rvalue bounds.
-    void CheckChildren(Stmt *S, CheckedScopeSpecifier CSS, EquivExprSets EQ,
-                       EquivExprSets *& UEQ, EqualExprTy *&G) {
+    void CheckChildren(Stmt *S, CheckedScopeSpecifier CSS,
+                       EquivExprSets EQ, CheckingState &State) {
       auto Begin = S->child_begin(), End = S->child_end();
       for (auto I = Begin; I != End; ++I) {
-        Check(*I, CSS, EQ, UEQ, G);
+        Check(*I, CSS, EQ, State);
       }
     }
 
@@ -2166,9 +2186,8 @@ namespace {
     void TraverseTopLevelVarDecl(VarDecl *VD, CheckedScopeSpecifier CSS) {
       ResetFacts();
       EquivExprSets EQ;
-      EquivExprSets *UEQ = new EquivExprSets();
-      EqualExprTy *G = new EqualExprTy();
-      CheckVarDecl(VD, CSS, EQ, UEQ, G);
+      CheckingState State;
+      CheckVarDecl(VD, CSS, EQ, State);
     }
 
     void ResetFacts() {
@@ -2192,18 +2211,17 @@ namespace {
     // CheckBinaryOperator returns the bounds for the value produced by e.
     // e is an rvalue.
     BoundsExpr *CheckBinaryOperator(BinaryOperator *E, CheckedScopeSpecifier CSS,
-                                    EquivExprSets EQ, EquivExprSets *&UEQ,
-                                    EqualExprTy *&G) {
+                                    EquivExprSets EQ, CheckingState &State) {
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
 
       // Infer the lvalue or rvalue bounds of the LHS.
       BoundsExpr *LHSTargetBounds, *LHSLValueBounds, *LHSBounds;
-      InferBounds(LHS, CSS, EQ, UEQ, G, LHSTargetBounds,
-                  LHSLValueBounds, LHSBounds);
+      InferBounds(LHS, CSS, EQ, LHSTargetBounds,
+                  LHSLValueBounds, LHSBounds, State);
 
       // Infer the rvalue bounds of the RHS.
-      BoundsExpr *RHSBounds = Check(RHS, CSS, EQ, UEQ, G);
+      BoundsExpr *RHSBounds = Check(RHS, CSS, EQ, State);
 
       BinaryOperatorKind Op = E->getOpcode();
 
@@ -2342,8 +2360,7 @@ namespace {
     // CheckCallExpr returns the bounds for the value produced by e.
     // e is an rvalue.
     BoundsExpr *CheckCallExpr(CallExpr *E, CheckedScopeSpecifier CSS,
-                              EquivExprSets EQ, EquivExprSets *&UEQ,
-                              EqualExprTy *&G,
+                              EquivExprSets EQ, CheckingState &State,
                               CHKCBindTemporaryExpr *Binding = nullptr) {
       BoundsExpr *ResultBounds = CallExprBounds(E, Binding);
 
@@ -2367,17 +2384,17 @@ namespace {
       // If the callee and arguments will not be checked during
       // the bounds declaration checking below, check them here.
       if (!FuncProtoTy) {
-        CheckChildren(E, CSS, EQ, UEQ, G);
+        CheckChildren(E, CSS, EQ, State);
         return ResultBounds;
       }
       if (!FuncProtoTy->hasParamAnnots()) {
-        CheckChildren(E, CSS, EQ, UEQ, G);
+        CheckChildren(E, CSS, EQ, State);
         return ResultBounds;
       }
 
       // Traverse the callee since CheckCallExpr should traverse
       // all its children.  The arguments will be traversed below.
-      Check(E->getCallee(), CSS, EQ, UEQ, G);
+      Check(E->getCallee(), CSS, EQ, State);
 
       unsigned NumParams = FuncProtoTy->getNumParams();
       unsigned NumArgs = E->getNumArgs();
@@ -2387,7 +2404,7 @@ namespace {
       for (unsigned i = 0; i < Count; i++) {
         // Check each argument.
         Expr *Arg = E->getArg(i);
-        BoundsExpr *ArgBounds = Check(Arg, CSS, EQ, UEQ, G);
+        BoundsExpr *ArgBounds = Check(Arg, CSS, EQ, State);
 
         QualType ParamType = FuncProtoTy->getParamType(i);
         // Skip checking bounds for unchecked pointer parameters, unless
@@ -2472,7 +2489,7 @@ namespace {
       // the number of function parameters.
       for (unsigned i = Count; i < NumArgs; i++) {
         Expr *Arg = E->getArg(i);
-        Check(Arg, CSS, EQ, UEQ, G);
+        Check(Arg, CSS, EQ, State);
       }
 
       return ResultBounds;
@@ -2484,8 +2501,7 @@ namespace {
     // should be called instead).
     // This includes both ImplicitCastExprs and CStyleCastExprs.
     BoundsExpr *CheckCastExpr(CastExpr *E, CheckedScopeSpecifier CSS,
-                              EquivExprSets EQ, EquivExprSets *&UEQ,
-                              EqualExprTy *&G) {
+                              EquivExprSets EQ, CheckingState &State) {
       // If the rvalue bounds for e cannot be determined,
       // e may be an lvalue (or may have unknown rvalue bounds).
       BoundsExpr *ResultBounds = CreateBoundsUnknown();
@@ -2500,8 +2516,8 @@ namespace {
 
       // Infer the lvalue or rvalue bounds of the subexpression.
       BoundsExpr *SubExprTargetBounds, *SubExprLValueBounds, *SubExprBounds;
-      InferBounds(SubExpr, CSS, EQ, UEQ, G, SubExprTargetBounds,
-                  SubExprLValueBounds, SubExprBounds);
+      InferBounds(SubExpr, CSS, EQ, SubExprTargetBounds,
+                  SubExprLValueBounds, SubExprBounds, State);
 
       IncludeNullTerminator = PreviousIncludeNullTerminator;
 
@@ -2600,15 +2616,14 @@ namespace {
     // the value produced by e.
     // If e is an lvalue, CheckUnaryLValue should be called instead.
     BoundsExpr *CheckUnaryOperator(UnaryOperator *E, CheckedScopeSpecifier CSS,
-                                   EquivExprSets EQ, EquivExprSets *&UEQ,
-                                   EqualExprTy *&G) {
+                                   EquivExprSets EQ, CheckingState &State) {
       UnaryOperatorKind Op = E->getOpcode();
       Expr *SubExpr = E->getSubExpr();
 
       // Infer the lvalue or rvalue bounds of the subexpression.
       BoundsExpr *SubExprTargetBounds, *SubExprLValueBounds, *SubExprBounds;
-      InferBounds(SubExpr, CSS, EQ, UEQ, G, SubExprTargetBounds,
-                  SubExprLValueBounds, SubExprBounds);
+      InferBounds(SubExpr, CSS, EQ, SubExprTargetBounds,
+                  SubExprLValueBounds, SubExprBounds, State);
 
       if (Op == UO_AddrOf)
         S.CheckAddressTakenMembers(E);
@@ -2656,15 +2671,14 @@ namespace {
 
     // CheckVarDecl returns empty bounds.
     BoundsExpr *CheckVarDecl(VarDecl *D, CheckedScopeSpecifier CSS,
-                             EquivExprSets EQ, EquivExprSets *&UEQ,
-                             EqualExprTy *&G) {
+                             EquivExprSets EQ, CheckingState &State) {
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
       // If there is an initializer, check it.
       Expr *Init = D->getInit();
       BoundsExpr *InitBounds = nullptr;
       if (Init)
-        InitBounds = Check(Init, CSS, EQ, UEQ, G);
+        InitBounds = Check(Init, CSS, EQ, State);
 
       if (D->isInvalidDecl())
         return ResultBounds;
@@ -2711,8 +2725,7 @@ namespace {
 
     // CheckReturnStmt returns empty bounds.
     BoundsExpr *CheckReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS,
-                                EquivExprSets EQ, EquivExprSets *&UEQ,
-                                EqualExprTy *&G) {
+                                EquivExprSets EQ, CheckingState &State) {
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
       Expr *RetValue = RS->getRetValue();
@@ -2722,7 +2735,7 @@ namespace {
         return ResultBounds;
 
       // Check the return value if it exists.
-      Check(RetValue, CSS, EQ, UEQ, G);
+      Check(RetValue, CSS, EQ, State);
 
       if (!ReturnBounds)
         return ResultBounds;
@@ -2739,33 +2752,31 @@ namespace {
     // If e is an lvalue, CheckTempBindingLValue should be called instead.
     BoundsExpr *CheckTemporaryBinding(CHKCBindTemporaryExpr *E,
                                       CheckedScopeSpecifier CSS,
-                                      EquivExprSets EQ, EquivExprSets *&UEQ,
-                                      EqualExprTy *&G) {
+                                      EquivExprSets EQ, CheckingState &State) {
       Expr *Child = E->getSubExpr();
 
       if (CallExpr *CE = dyn_cast<CallExpr>(Child))
-        return CheckCallExpr(CE, CSS, EQ, UEQ, G, E);
+        return CheckCallExpr(CE, CSS, EQ, State, E);
       else
-        return Check(Child, CSS, EQ, UEQ, G);
+        return Check(Child, CSS, EQ, State);
     }
 
     // CheckBoundsValueExpr returns the bounds for the value produced by e.
     // e is an rvalue.
     BoundsExpr *CheckBoundsValueExpr(BoundsValueExpr *E,
                                      CheckedScopeSpecifier CSS,
-                                     EquivExprSets EQ, EquivExprSets *&UEQ,
-                                     EqualExprTy *&G) {
+                                     EquivExprSets EQ, CheckingState &State) {
       Expr *Binding = E->getTemporaryBinding();
-      return Check(Binding, CSS, EQ, UEQ, G);
+      return Check(Binding, CSS, EQ, State);
     }
 
     // CheckConditionalOperator returns the bounds for the value produced by e.
     // e is an rvalue.
     BoundsExpr *CheckConditionalOperator(AbstractConditionalOperator *E,
                                          CheckedScopeSpecifier CSS,
-                                         EquivExprSets EQ, EquivExprSets *&UEQ,
-                                         EqualExprTy *&G) {
-      CheckChildren(E, CSS, EQ, UEQ, G);
+                                         EquivExprSets EQ,
+                                         CheckingState &State) {
+      CheckChildren(E, CSS, EQ, State);
       // TODO: infer correct bounds for conditional operators
       return CreateBoundsAllowedButNotComputed();
     }
@@ -2779,10 +2790,11 @@ namespace {
     // CheckDeclRefExpr returns the lvalue and target bounds of e.
     // e is an lvalue.
     BoundsExpr *CheckDeclRefExpr(DeclRefExpr *E, CheckedScopeSpecifier CSS,
-                                 EquivExprSets EQ, EquivExprSets *&UEQ,
-                                 EqualExprTy *&G, BoundsExpr *&OutTargetBounds) {
-      CheckChildren(E, CSS, EQ, UEQ, G);
-      *UEQ = EQ;
+                                 EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                 CheckingState &State) {
+      CheckChildren(E, CSS, EQ, State);
+      *State.UEQ = EQ;
+      State.G->clear();
 
       VarDecl *VD = dyn_cast<VarDecl>(E->getDecl());
       BoundsExpr *B = nullptr;
@@ -2805,13 +2817,10 @@ namespace {
         const ConstantArrayType *CAT = Context.getAsConstantArrayType(E->getType());
         if (CAT) {
           if (E->getType()->isCheckedArrayType())
-            *G = { E };
+            State.G->push_back(E);
           else if (VD->hasLocalStorage() || VD->hasExternalStorage())
-            *G = { E };
-          else
-             *G = { };
-        } else
-          *G = { };
+            State.G->push_back(E);
+        }
 
         // Declared bounds override the bounds based on the array type.
         if (B) {
@@ -2848,14 +2857,12 @@ namespace {
       if (E->getType()->isFunctionType()) {
         // Only function decl refs should have function type.
         assert(isa<FunctionDecl>(E->getDecl()));
-        // G is empty for variables with function type.
-        *G = { };
         return CreateBoundsEmpty();
       }
 
       Expr *AddrOf = CreateAddressOfOperator(E);
       // G is { &v } for variables v with array type.
-      *G = { AddrOf };
+      State.G->push_back(AddrOf);
       return CreateSingleElementBounds(AddrOf);
     }
 
@@ -2863,9 +2870,9 @@ namespace {
     // lvalue and target bounds of e.
     // If e is an rvalue, CheckUnaryOperator should be called instead.
     BoundsExpr *CheckUnaryLValue(UnaryOperator *E, CheckedScopeSpecifier CSS,
-                                 EquivExprSets EQ, EquivExprSets *&UEQ,
-                                 EqualExprTy *&G, BoundsExpr *&OutTargetBounds) {
-      BoundsExpr *SubExprBounds = Check(E->getSubExpr(), CSS, EQ, UEQ, G);
+                                 EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                 CheckingState &State) {
+      BoundsExpr *SubExprBounds = Check(E->getSubExpr(), CSS, EQ, State);
 
       if (E->getOpcode() == UnaryOperatorKind::UO_Deref) {
         // Currently, we don't know the target bounds of a pointer stored in a
@@ -2889,9 +2896,9 @@ namespace {
     // e is an lvalue.
     BoundsExpr *CheckArraySubscriptExpr(ArraySubscriptExpr *E,
                                         CheckedScopeSpecifier CSS,
-                                        EquivExprSets EQ, EquivExprSets *&UEQ,
-                                        EqualExprTy *&G,
-                                        BoundsExpr *&OutTargetBounds) {
+                                        EquivExprSets EQ,
+                                        BoundsExpr *&OutTargetBounds,
+                                        CheckingState &State) {
       // Currently, we don't know the target bounds of a pointer returned by a
       // subscripting operation, unless it is a _Ptr type or an _Nt_array_ptr.
       if (E->getType()->isCheckedPointerPtrType() ||
@@ -2904,8 +2911,8 @@ namespace {
       // the bounds of e1 + e2, which reduces to the bounds
       // of whichever subexpression has pointer type.
       // getBase returns the pointer-typed expression.
-      BoundsExpr *Bounds = Check(E->getBase(), CSS, EQ, UEQ, G);
-      Check(E->getIdx(), CSS, EQ, UEQ, G);
+      BoundsExpr *Bounds = Check(E->getBase(), CSS, EQ, State);
+      Check(E->getIdx(), CSS, EQ, State);
       return Bounds;
     }
 
@@ -2919,8 +2926,8 @@ namespace {
     // (lvalue, lvalue + 1).   The lvalue is interpreted as a pointer to T,
     // where T is the type of the member.
     BoundsExpr *CheckMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS,
-                                EquivExprSets EQ, EquivExprSets *&UEQ,
-                                EqualExprTy *&G, BoundsExpr *&OutTargetBounds) {
+                                EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                CheckingState &State) {
       // The lvalue and target bounds must be inferred before
       // performing any side effects on the base, since
       // inferring these bounds may call PruneTemporaryBindings.
@@ -2930,8 +2937,8 @@ namespace {
       // Infer the lvalue or rvalue bounds of the base.
       Expr *Base = E->getBase();
       BoundsExpr *BaseTargetBounds, *BaseLValueBounds, *BaseBounds;
-      InferBounds(Base, CSS, EQ, UEQ, G,
-                  BaseTargetBounds, BaseLValueBounds, BaseBounds);
+      InferBounds(Base, CSS, EQ, BaseTargetBounds,
+                  BaseLValueBounds, BaseBounds, State);
 
       bool NeedsBoundsCheck = AddMemberBaseBoundsCheck(E, CSS,
                                                        BaseLValueBounds,
@@ -2945,16 +2952,16 @@ namespace {
     // lvalue and target bounds of e.
     // If e is an rvalue, CheckCastExpr should be called instead.
     BoundsExpr *CheckCastLValue(CastExpr *E, CheckedScopeSpecifier CSS,
-                                EquivExprSets EQ, EquivExprSets *& UEQ,
-                                EqualExprTy *&G, BoundsExpr *&OutTargetBounds) {
+                                EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                CheckingState &State) {
       // An LValueBitCast adjusts the type of the lvalue.  The bounds are not
       // changed, except that their relative alignment may change (the bounds 
       // may only cover a partial object).  TODO: When we add relative
       // alignment support to the compiler, adjust the relative alignment.
       if (E->getCastKind() == CastKind::CK_LValueBitCast)
-        return CheckLValue(E->getSubExpr(), CSS, EQ, UEQ, G, OutTargetBounds);
+        return CheckLValue(E->getSubExpr(), CSS, EQ, OutTargetBounds, State);
 
-      CheckChildren(E, CSS, EQ, UEQ, G);
+      CheckChildren(E, CSS, EQ, State);
 
       // Cast kinds other than LValueBitCast
       // do not have lvalue or target bounds.
@@ -2967,12 +2974,12 @@ namespace {
     // If e is an rvalue, CheckTemporaryBinding should be called instead.
     BoundsExpr *CheckTempBindingLValue(CHKCBindTemporaryExpr *E,
                                        CheckedScopeSpecifier CSS,
-                                       EquivExprSets EQ, EquivExprSets *&UEQ,
-                                       EqualExprTy *&G,
-                                       BoundsExpr *&OutTargetBounds) {
+                                       EquivExprSets EQ,
+                                       BoundsExpr *&OutTargetBounds,
+                                       CheckingState &State) {
       OutTargetBounds = CreateBoundsAlwaysUnknown();
 
-      CheckChildren(E, CSS, EQ, UEQ, G);
+      CheckChildren(E, CSS, EQ, State);
 
       Expr *SubExpr = E->getSubExpr()->IgnoreParens();
 
@@ -3144,16 +3151,15 @@ namespace {
     // Sets the bounds expressions based on
     // whether e is an lvalue or an rvalue.
     void InferBounds(Expr *E, CheckedScopeSpecifier CSS, EquivExprSets EQ,
-                     EquivExprSets *&UEQ, EqualExprTy *&G,
                      BoundsExpr *&TargetBounds, BoundsExpr *&LValueBounds,
-                     BoundsExpr *&RValueBounds) {
+                     BoundsExpr *&RValueBounds, CheckingState &State) {
       TargetBounds = CreateBoundsUnknown();
       LValueBounds = CreateBoundsUnknown();
       RValueBounds = CreateBoundsUnknown();
       if (E->isLValue())
-        LValueBounds = CheckLValue(E, CSS, EQ, UEQ, G, TargetBounds);
+        LValueBounds = CheckLValue(E, CSS, EQ, TargetBounds, State);
       else if (E->isRValue())
-        RValueBounds = Check(E, CSS, EQ, UEQ, G);
+        RValueBounds = Check(E, CSS, EQ, State);
     }
 
     BoundsExpr *CreateBoundsUnknown() {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1999,7 +1999,7 @@ namespace {
     // necessary side effects on e.  Check and CheckLValue work together
     // to traverse each expression in a CFG exactly once.
     BoundsExpr *Check(Stmt *S, CheckedScopeSpecifier CSS,
-                      EquivExprSets EQ, CheckingState &State) {
+                      const EquivExprSets EQ, CheckingState &State) {
       if (!S)
         return CreateBoundsEmpty();
 
@@ -2116,7 +2116,8 @@ namespace {
     // necessary side effects on e.  Check and CheckLValue work together
     // to traverse each expression in a CFG exactly once.
     BoundsExpr *CheckLValue(Expr *E, CheckedScopeSpecifier CSS,
-                            EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                            const EquivExprSets EQ,
+                            BoundsExpr *&OutTargetBounds,
                             CheckingState &State) {
       if (!E->isLValue())
         return CreateBoundsInferenceError();
@@ -2172,7 +2173,7 @@ namespace {
     // Recursively check and perform any side effects on the children
     // of an expression, throwing away the resulting rvalue bounds.
     void CheckChildren(Stmt *S, CheckedScopeSpecifier CSS,
-                       EquivExprSets EQ, CheckingState &State) {
+                       const EquivExprSets EQ, CheckingState &State) {
       auto Begin = S->child_begin(), End = S->child_end();
       for (auto I = Begin; I != End; ++I) {
         Check(*I, CSS, EQ, State);
@@ -2208,8 +2209,10 @@ namespace {
   private:
     // CheckBinaryOperator returns the bounds for the value produced by e.
     // e is an rvalue.
-    BoundsExpr *CheckBinaryOperator(BinaryOperator *E, CheckedScopeSpecifier CSS,
-                                    EquivExprSets EQ, CheckingState &State) {
+    BoundsExpr *CheckBinaryOperator(BinaryOperator *E,
+                                    CheckedScopeSpecifier CSS,
+                                    const EquivExprSets EQ,
+                                    CheckingState &State) {
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
 
@@ -2358,7 +2361,7 @@ namespace {
     // CheckCallExpr returns the bounds for the value produced by e.
     // e is an rvalue.
     BoundsExpr *CheckCallExpr(CallExpr *E, CheckedScopeSpecifier CSS,
-                              EquivExprSets EQ, CheckingState &State,
+                              const EquivExprSets EQ, CheckingState &State,
                               CHKCBindTemporaryExpr *Binding = nullptr) {
       BoundsExpr *ResultBounds = CallExprBounds(E, Binding);
 
@@ -2499,7 +2502,7 @@ namespace {
     // should be called instead).
     // This includes both ImplicitCastExprs and CStyleCastExprs.
     BoundsExpr *CheckCastExpr(CastExpr *E, CheckedScopeSpecifier CSS,
-                              EquivExprSets EQ, CheckingState &State) {
+                              const EquivExprSets EQ, CheckingState &State) {
       // If the rvalue bounds for e cannot be determined,
       // e may be an lvalue (or may have unknown rvalue bounds).
       BoundsExpr *ResultBounds = CreateBoundsUnknown();
@@ -2614,7 +2617,8 @@ namespace {
     // the value produced by e.
     // If e is an lvalue, CheckUnaryLValue should be called instead.
     BoundsExpr *CheckUnaryOperator(UnaryOperator *E, CheckedScopeSpecifier CSS,
-                                   EquivExprSets EQ, CheckingState &State) {
+                                   const EquivExprSets EQ,
+                                   CheckingState &State) {
       UnaryOperatorKind Op = E->getOpcode();
       Expr *SubExpr = E->getSubExpr();
 
@@ -2669,7 +2673,7 @@ namespace {
 
     // CheckVarDecl returns empty bounds.
     BoundsExpr *CheckVarDecl(VarDecl *D, CheckedScopeSpecifier CSS,
-                             EquivExprSets EQ, CheckingState &State) {
+                             const EquivExprSets EQ, CheckingState &State) {
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
       // If there is an initializer, check it.
@@ -2723,7 +2727,7 @@ namespace {
 
     // CheckReturnStmt returns empty bounds.
     BoundsExpr *CheckReturnStmt(ReturnStmt *RS, CheckedScopeSpecifier CSS,
-                                EquivExprSets EQ, CheckingState &State) {
+                                const EquivExprSets EQ, CheckingState &State) {
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
       Expr *RetValue = RS->getRetValue();
@@ -2750,7 +2754,8 @@ namespace {
     // If e is an lvalue, CheckTempBindingLValue should be called instead.
     BoundsExpr *CheckTemporaryBinding(CHKCBindTemporaryExpr *E,
                                       CheckedScopeSpecifier CSS,
-                                      EquivExprSets EQ, CheckingState &State) {
+                                      const EquivExprSets EQ,
+                                      CheckingState &State) {
       Expr *Child = E->getSubExpr();
 
       if (CallExpr *CE = dyn_cast<CallExpr>(Child))
@@ -2763,7 +2768,8 @@ namespace {
     // e is an rvalue.
     BoundsExpr *CheckBoundsValueExpr(BoundsValueExpr *E,
                                      CheckedScopeSpecifier CSS,
-                                     EquivExprSets EQ, CheckingState &State) {
+                                     const EquivExprSets EQ,
+                                     CheckingState &State) {
       Expr *Binding = E->getTemporaryBinding();
       return Check(Binding, CSS, EQ, State);
     }
@@ -2772,7 +2778,7 @@ namespace {
     // e is an rvalue.
     BoundsExpr *CheckConditionalOperator(AbstractConditionalOperator *E,
                                          CheckedScopeSpecifier CSS,
-                                         EquivExprSets EQ,
+                                         const EquivExprSets EQ,
                                          CheckingState &State) {
       CheckChildren(E, CSS, EQ, State);
       // TODO: infer correct bounds for conditional operators
@@ -2788,7 +2794,8 @@ namespace {
     // CheckDeclRefExpr returns the lvalue and target bounds of e.
     // e is an lvalue.
     BoundsExpr *CheckDeclRefExpr(DeclRefExpr *E, CheckedScopeSpecifier CSS,
-                                 EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                 const EquivExprSets EQ,
+                                 BoundsExpr *&OutTargetBounds,
                                  CheckingState &State) {
       CheckChildren(E, CSS, EQ, State);
       State.UEQ = EQ;
@@ -2868,7 +2875,8 @@ namespace {
     // lvalue and target bounds of e.
     // If e is an rvalue, CheckUnaryOperator should be called instead.
     BoundsExpr *CheckUnaryLValue(UnaryOperator *E, CheckedScopeSpecifier CSS,
-                                 EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                 const EquivExprSets EQ,
+                                 BoundsExpr *&OutTargetBounds,
                                  CheckingState &State) {
       BoundsExpr *SubExprBounds = Check(E->getSubExpr(), CSS, EQ, State);
 
@@ -2894,7 +2902,7 @@ namespace {
     // e is an lvalue.
     BoundsExpr *CheckArraySubscriptExpr(ArraySubscriptExpr *E,
                                         CheckedScopeSpecifier CSS,
-                                        EquivExprSets EQ,
+                                        const EquivExprSets EQ,
                                         BoundsExpr *&OutTargetBounds,
                                         CheckingState &State) {
       // Currently, we don't know the target bounds of a pointer returned by a
@@ -2924,7 +2932,8 @@ namespace {
     // (lvalue, lvalue + 1).   The lvalue is interpreted as a pointer to T,
     // where T is the type of the member.
     BoundsExpr *CheckMemberExpr(MemberExpr *E, CheckedScopeSpecifier CSS,
-                                EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                const EquivExprSets EQ,
+                                BoundsExpr *&OutTargetBounds,
                                 CheckingState &State) {
       // The lvalue and target bounds must be inferred before
       // performing any side effects on the base, since
@@ -2950,7 +2959,8 @@ namespace {
     // lvalue and target bounds of e.
     // If e is an rvalue, CheckCastExpr should be called instead.
     BoundsExpr *CheckCastLValue(CastExpr *E, CheckedScopeSpecifier CSS,
-                                EquivExprSets EQ, BoundsExpr *&OutTargetBounds,
+                                const EquivExprSets EQ,
+                                BoundsExpr *&OutTargetBounds,
                                 CheckingState &State) {
       // An LValueBitCast adjusts the type of the lvalue.  The bounds are not
       // changed, except that their relative alignment may change (the bounds 
@@ -2972,7 +2982,7 @@ namespace {
     // If e is an rvalue, CheckTemporaryBinding should be called instead.
     BoundsExpr *CheckTempBindingLValue(CHKCBindTemporaryExpr *E,
                                        CheckedScopeSpecifier CSS,
-                                       EquivExprSets EQ,
+                                       const EquivExprSets EQ,
                                        BoundsExpr *&OutTargetBounds,
                                        CheckingState &State) {
       OutTargetBounds = CreateBoundsAlwaysUnknown();
@@ -3148,7 +3158,7 @@ namespace {
   private:
     // Sets the bounds expressions based on
     // whether e is an lvalue or an rvalue.
-    void InferBounds(Expr *E, CheckedScopeSpecifier CSS, EquivExprSets EQ,
+    void InferBounds(Expr *E, CheckedScopeSpecifier CSS, const EquivExprSets EQ,
                      BoundsExpr *&TargetBounds, BoundsExpr *&LValueBounds,
                      BoundsExpr *&RValueBounds, CheckingState &State) {
       TargetBounds = CreateBoundsUnknown();

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -501,7 +501,7 @@ namespace {
   private:
     Sema &S;
     bool DumpBounds;
-    bool DumpEquivExprs;
+    bool DumpState;
     uint64_t PointerWidth;
     Stmt *Body;
     CFG *Cfg;
@@ -596,8 +596,7 @@ namespace {
       }
     }
 
-    void DumpEquivalentExpressions(raw_ostream &OS, Stmt *S,
-                                   CheckingState &State) {
+    void DumpCheckingState(raw_ostream &OS, Stmt *S, CheckingState &State) {
       OS << "\nStatement S:\n";
       S->dump(OS);
 
@@ -1778,7 +1777,7 @@ namespace {
   public:
     CheckBoundsDeclarations(Sema &SemaRef, Stmt *Body, CFG *Cfg, BoundsExpr *ReturnBounds, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
       DumpBounds(SemaRef.getLangOpts().DumpInferredBounds),
-      DumpEquivExprs(SemaRef.getLangOpts().DumpEquivExprs),
+      DumpState(SemaRef.getLangOpts().DumpCheckingState),
       PointerWidth(SemaRef.Context.getTargetInfo().getPointerWidth(0)),
       Body(Body),
       Cfg(Cfg),
@@ -1790,7 +1789,7 @@ namespace {
 
     CheckBoundsDeclarations(Sema &SemaRef, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
       DumpBounds(SemaRef.getLangOpts().DumpInferredBounds),
-      DumpEquivExprs(SemaRef.getLangOpts().DumpEquivExprs),
+      DumpState(SemaRef.getLangOpts().DumpCheckingState),
       PointerWidth(SemaRef.Context.getTargetInfo().getPointerWidth(0)),
       Body(nullptr),
       Cfg(nullptr),
@@ -2079,8 +2078,8 @@ namespace {
           break;
       }
 
-      if (DumpEquivExprs)
-        DumpEquivalentExpressions(llvm::outs(), S, State);
+      if (DumpState)
+        DumpCheckingState(llvm::outs(), S, State);
 
       if (Expr *E = dyn_cast<Expr>(S)) {
         // Bounds expressions are not null ptrs.
@@ -2158,8 +2157,8 @@ namespace {
           break;
       }
 
-      if (DumpEquivExprs)
-        DumpEquivalentExpressions(llvm::outs(), E, State);
+      if (DumpState)
+        DumpCheckingState(llvm::outs(), E, State);
 
       // The type for inferring the target bounds cannot ever be an array
       // type, as these are dealt with by an array conversion, not an lvalue

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -607,7 +607,7 @@ namespace {
         OS << "{\n";
         for (auto OuterList = State.UEQ->begin(); OuterList != State.UEQ->end(); ++OuterList) {
           auto ExprList = *OuterList;
-          DumpEqualExpr(OS, ExprList);
+          DumpEqualExpr(OS, &ExprList);
         }
         OS << "}\n";
       }
@@ -1562,7 +1562,7 @@ namespace {
                                      BoundsExpr *SrcBounds,
                                      CheckedScopeSpecifier CSS) {
       // Record expression equality implied by assignment.
-      SmallVector<SmallVector <Expr *, 4> *, 4> EquivExprs;
+      SmallVector<SmallVector <Expr *, 4>, 4> EquivExprs;
       SmallVector<Expr *, 4> EqualExpr;
 
       if (S.CheckIsNonModifying(Target, Sema::NonModifyingContext::NMC_Unknown,
@@ -1580,7 +1580,7 @@ namespace {
              EqualExpr.push_back(CreateTemporaryUse(Temp));
            else
              EqualExpr.push_back(Src);
-           EquivExprs.push_back(&EqualExpr);
+           EquivExprs.push_back(EqualExpr);
          }
       }
 
@@ -1613,7 +1613,7 @@ namespace {
                                   BoundsExpr *ExpectedArgBounds, Expr *Arg,
                                   BoundsExpr *ArgBounds,
                                   CheckedScopeSpecifier CSS,
-                                  SmallVector<SmallVector <Expr *, 4> *, 4> *EquivExprs) {
+                                  SmallVector<SmallVector <Expr *, 4>, 4> *EquivExprs) {
       SourceLocation ArgLoc = Arg->getBeginLoc();
       ProofFailure Cause;
       ProofResult Result = ProveBoundsDeclValidity(ExpectedArgBounds,
@@ -1641,7 +1641,7 @@ namespace {
                                       BoundsExpr *SrcBounds,
                                       CheckedScopeSpecifier CSS) {
       // Record expression equality implied by initialization.
-      SmallVector<SmallVector <Expr *, 4> *, 4> EquivExprs;
+      SmallVector<SmallVector <Expr *, 4>, 4> EquivExprs;
       SmallVector<Expr *, 4> EqualExpr;
       // Record equivalence between expressions implied by initializion.
       // If D declares a variable V, and
@@ -1672,7 +1672,7 @@ namespace {
           EqualExpr.push_back(CreateTemporaryUse(Temp));
         else
           EqualExpr.push_back(Src);
-        EquivExprs.push_back(&EqualExpr);
+        EquivExprs.push_back(EqualExpr);
         /*
         llvm::outs() << "Dumping target/src equality relation\n";
         for (Expr *E : EqualExpr)

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2860,7 +2860,7 @@ namespace {
       }
 
       Expr *AddrOf = CreateAddressOfOperator(E);
-      // G is { &v } for variables v with array type.
+      // G is { &v } for variables v that do not have array type.
       State.G->push_back(AddrOf);
       return CreateSingleElementBounds(AddrOf);
     }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2877,6 +2877,9 @@ namespace {
         else
           OutTargetBounds = CreateBoundsUnknown();
 
+        // G is empty for pointer dereferences.
+        State.G.clear();
+
         // The lvalue bounds of *e are the rvalue bounds of e.
         return SubExprBounds;
       }
@@ -2905,6 +2908,10 @@ namespace {
       // getBase returns the pointer-typed expression.
       BoundsExpr *Bounds = Check(E->getBase(), CSS, State);
       Check(E->getIdx(), CSS, State);
+
+      // G is empty for array subscript expressions.
+      State.G.clear();
+
       return Bounds;
     }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1997,6 +1997,8 @@ namespace {
     // Check recursively checks the children of e and performs any
     // necessary side effects on e.  Check and CheckLValue work together
     // to traverse each expression in a CFG exactly once.
+    //
+    // State is an out parameter that holds the result of Check.
     BoundsExpr *Check(Stmt *S, CheckedScopeSpecifier CSS, CheckingState &State) {
       if (!S)
         return CreateBoundsEmpty();
@@ -2112,6 +2114,8 @@ namespace {
     // CheckLValue recursively checks the children of e and performs any
     // necessary side effects on e.  Check and CheckLValue work together
     // to traverse each expression in a CFG exactly once.
+    //
+    // State is an out parameter that holds the result of Check.
     BoundsExpr *CheckLValue(Expr *E, CheckedScopeSpecifier CSS,
                             BoundsExpr *&OutTargetBounds,
                             CheckingState &State) {

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -4,18 +4,18 @@
 // This file does not test assignments that update the set of sets of equivalent expressions
 // (assignments will be tested in a separate test file).
 //
-// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s --dump-input=always
+// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
 
 #include <stdchecked.h>
 
 extern int a1 [12];
 extern void g1(void);
 
-// Note: the expressions tested below also include implicit casts.
-// Bounds checking methods currently do not update equivalent
-// expression sets for cast expressions, so these sets after
-// checking a cast expression will be the same as the sets after
-// checking the cast's subexpression.
+// Note: the expressions tested below include some kinds of
+// expressions which bounds checking currently does update
+// equivalent expression sets for (such as casts and integer literals).
+// The equivalent expression sets after checking an unsupported expression
+// kind will be the same as the sets after checking the expression's children.
 
 // DeclRefExpr
 void f1(int i, int a checked[5]) {
@@ -30,6 +30,7 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'i'
   // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'i'
@@ -49,6 +50,7 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'g1'
@@ -68,6 +70,7 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: {
   // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'arr'
@@ -88,6 +91,7 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: {
   // CHECK-NEXT: DeclRefExpr {{.*}} 'a1'
   // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a1'
@@ -109,6 +113,7 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
@@ -119,4 +124,102 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: }
+}
+
+// UnaryOperator: pointer dereferences
+void f2(int *p) {
+  *p;
+  // CHECK: Statement S:
+  // CHECK: DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: }
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} '*'
+  // CHECK-NEXT: `-ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   `-DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: `-UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:  `-ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:  `-DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+}
+
+// ArraySubscriptExpr
+void f3(int a [1]) {
+  a[0];
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // TODO: update equivalent expression sets for an IntegerLiteral
+  // CHECK: Statement S:
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK: Statement S:
+  // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int'
+  // CHECK-NEXT: |-ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: | `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: `-IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+  // TODO: update equivalent expression sets for an ImplicitCastExpr
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: `-ArraySubscriptExpr {{.*}} lvalue
+  // CHECK-NEXT:   |-ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   | `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   `-IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
 }

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -2,7 +2,7 @@
 // This file tests updating the set of expressions that produces the same value as an expression
 // after checking the expression during bounds analysis.
 // This file does not test assignments that update the set of sets of equivalent expressions
-// (assignments are testing in dump-equiv-expr-sets.c).
+// (assignments will be tested in a separate test file).
 //
 // RUN: %clang_cc1 -Wno-unused-value -fdump-equiv-exprs %s | FileCheck %s --dump-input=always
 

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -1,0 +1,74 @@
+// Tests for updating equivalent expression information during bounds inference and checking.
+// This file tests updating the set of expressions that produces the same value as an expression
+// after checking the expression during bounds analysis.
+// This file does not test assignments that update the set of sets of equivalent expressions
+// (assignments are testing in dump-equiv-expr-sets.c).
+//
+// RUN: %clang_cc1 -Wno-unused-value -fdump-equiv-exprs %s | FileCheck %s --dump-input=always
+
+#include <stdchecked.h>
+
+extern int a1 [12];
+extern void g1(void);
+
+// DeclRefExpr
+// Note: these expressions also include implicit LValueToRValue and
+// ArrayToPointerDecay casts.  These casts are not currently handled by
+// bounds checking methods.
+void f1(int i, int a checked[5]) {
+  // Non-array, non-function type
+  i;
+  // CHECK: Statement S:
+  // CHECK: DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+
+  // Function type
+  g1;
+  // CHECK: Statement S:
+  // CHECK: DeclRefExpr {{.*}} 'g1'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+
+  // Local checked array with known size
+  int arr checked[10];
+  arr;
+  // CHECK: Statement S:
+  // CHECK: DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+
+  // Extern unchecked array with known size
+  a1;
+  // CHECK: Statement S:
+  // CHECK: DeclRefExpr {{.*}} 'a1'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a1'
+  // CHECK-NEXT: }
+
+  // Array parameter with _Array_ptr<int> type
+  a;
+  // CHECK: Statement S:
+  // CHECK: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -4,7 +4,7 @@
 // This file does not test assignments that update the set of sets of equivalent expressions
 // (assignments will be tested in a separate test file).
 //
-// RUN: %clang_cc1 -Wno-unused-value -fdump-equiv-exprs %s | FileCheck %s --dump-input=always
+// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s --dump-input=always
 
 #include <stdchecked.h>
 

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -11,10 +11,13 @@
 extern int a1 [12];
 extern void g1(void);
 
+// Note: the expressions tested below also include implicit casts.
+// Bounds checking methods currently do not update equivalent
+// expression sets for cast expressions, so these sets after
+// checking a cast expression will be the same as the sets after
+// checking the cast's subexpression.
+
 // DeclRefExpr
-// Note: these expressions also include implicit LValueToRValue and
-// ArrayToPointerDecay casts.  These casts are not currently handled by
-// bounds checking methods.
 void f1(int i, int a checked[5]) {
   // Non-array, non-function type
   i;
@@ -25,7 +28,17 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'i'
   // CHECK-NEXT: }
 
   // Function type
@@ -36,12 +49,28 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'g1'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
 
   // Local checked array with known size
   int arr checked[10];
   arr;
   // CHECK: Statement S:
   // CHECK: DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
@@ -59,6 +88,15 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: {
   // CHECK-NEXT: DeclRefExpr {{.*}} 'a1'
   // CHECK-NEXT: }
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a1'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a1'
+  // CHECK-NEXT: }
 
   // Array parameter with _Array_ptr<int> type
   a;
@@ -69,6 +107,16 @@ void f1(int i, int a checked[5]) {
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '&'
+  // CHECK-NEXT: `-DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: }
 }


### PR DESCRIPTION
This PR starts the process of tracking equivalent expression sets while checking expressions in SemaBounds. CheckDeclRefExpr, CheckUnaryLValue, and CheckArraySubscriptExpr are currently the only methods that updates the equivalent expression sets in the state parameter. Future PRs will update these sets in other checking methods.

This PR also introduces a flag -fdump-checking-state to enable testing for equivalent expression sets, since these sets are not currently used to affect any compiler behavior. Once the bounds context is introduced as part of the CheckingState class, this flag can be used to test updating the bounds context as well.

Testing:
* Added equiv-exprs.c file to test equivalent expression sets
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux