### PR TITLE
Update checkedc-convert license after community switched to Apache-2.0 license

### DIFF
--- a/clang/tools/checked-c-convert/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/tools/checked-c-convert/ArrayBoundsInferenceConsumer.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementation of all the methods of the class ArrayBoundsInferenceConsumer.

--- a/clang/tools/checked-c-convert/ArrayBoundsInferenceConsumer.h
+++ b/clang/tools/checked-c-convert/ArrayBoundsInferenceConsumer.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // This is an ASTConsumer that tries to infer the CheckedC style bounds

--- a/clang/tools/checked-c-convert/CheckedCConvert.cpp
+++ b/clang/tools/checked-c-convert/CheckedCConvert.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/tools/checked-c-convert/ConstraintBuilder.cpp
+++ b/clang/tools/checked-c-convert/ConstraintBuilder.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementation of visitor methods for the FunctionVisitor class. These 

--- a/clang/tools/checked-c-convert/ConstraintBuilder.h
+++ b/clang/tools/checked-c-convert/ConstraintBuilder.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/tools/checked-c-convert/ConstraintVariables.cpp
+++ b/clang/tools/checked-c-convert/ConstraintVariables.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementation of ConstraintVariables methods.

--- a/clang/tools/checked-c-convert/ConstraintVariables.h
+++ b/clang/tools/checked-c-convert/ConstraintVariables.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // The class allocates constraint variables and maps program locations

--- a/clang/tools/checked-c-convert/Constraints.cpp
+++ b/clang/tools/checked-c-convert/Constraints.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/tools/checked-c-convert/Constraints.h
+++ b/clang/tools/checked-c-convert/Constraints.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/tools/checked-c-convert/MappingVisitor.cpp
+++ b/clang/tools/checked-c-convert/MappingVisitor.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementations of the MappingVisitor functions for VisitStmt and VisitDecl.

--- a/clang/tools/checked-c-convert/MappingVisitor.h
+++ b/clang/tools/checked-c-convert/MappingVisitor.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // The MappingVisitor is used to traverse an AST and re-define a mapping from

--- a/clang/tools/checked-c-convert/PersistentSourceLoc.cpp
+++ b/clang/tools/checked-c-convert/PersistentSourceLoc.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementation of the PersistentSourceLoc infrastructure.

--- a/clang/tools/checked-c-convert/PersistentSourceLoc.h
+++ b/clang/tools/checked-c-convert/PersistentSourceLoc.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // This class specifies a location in a source file that persists across

--- a/clang/tools/checked-c-convert/ProgramInfo.cpp
+++ b/clang/tools/checked-c-convert/ProgramInfo.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementation of ProgramInfo methods.

--- a/clang/tools/checked-c-convert/ProgramInfo.h
+++ b/clang/tools/checked-c-convert/ProgramInfo.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // This class represents all the information about a source file

--- a/clang/tools/checked-c-convert/RewriteUtils.cpp
+++ b/clang/tools/checked-c-convert/RewriteUtils.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // This class contains implementation of the functions and

--- a/clang/tools/checked-c-convert/RewriteUtils.h
+++ b/clang/tools/checked-c-convert/RewriteUtils.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // This class contains functions and classes that deal with

--- a/clang/tools/checked-c-convert/Utils.cpp
+++ b/clang/tools/checked-c-convert/Utils.cpp
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Implementation of Utils methods.

--- a/clang/tools/checked-c-convert/Utils.h
+++ b/clang/tools/checked-c-convert/Utils.h
@@ -1,7 +1,8 @@
 //                     The LLVM Compiler Infrastructure
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 // Type declarations for map data structures.


### PR DESCRIPTION
The LLVM community has switched to Apache-2.0 license. We are updating all
checkedc-convert files to Apache-2.0 license here.

Refer https://llvm.org/foundation/relicensing