### PR TITLE
Add .gitattributes file to fix line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
When we run validations on multiple platforms, we can sometimes encounter
problems with different line endings. Historically, Linux and macOS used
linefeed (LF) characters while Windows used a carriage return plus a linefeed
(CRLF). Git tries to compensate for the difference by automatically making
lines end in LF in the repo but CRLF in the working directory on Windows.

Most Windows tools are fine with LF-only endings, and this automatic behavior
can cause more problems than it solves. This causes a lot of unit test failures
on ADO. A way to fix this is to specify core.autocrlf=false to git clone. But
checkedc-clang is cloned directly by ADO and we do not have an option to
specify this flag. So we are adding this .gitattributes file to configure Git
to prefer LF everywhere.

Refer:
1. https://docs.microsoft.com/en-us/azure/devops/pipelines/troubleshooting?view=azure-devops
2. https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings