### PR TITLE
Move bounds expression assertions from TreeTransform to setBoundsExpr

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2205,7 +2205,11 @@ public:
   BoundsExpr *getBoundsExpr() { return Bounds; }
 
   /// \brief Set the bounds to use during the bounds check of this expression.
-  void setBoundsExpr(BoundsExpr *E) { Bounds = E; }
+  void setBoundsExpr(BoundsExpr *E) {
+    assert(!hasBoundsExpr() &&
+           "inferred bounds checks should not be present");
+    Bounds = E;
+  }
 
   static_assert(BCK_MaxKind < (1 << NumBoundsCheckKindBits), "kind field too small");
 
@@ -2619,7 +2623,11 @@ public:
   BoundsExpr *getBoundsExpr() { return Bounds; }
 
   /// \brief Set the bounds to use during the bounds check of this expression.
-  void setBoundsExpr(BoundsExpr *E) { Bounds = E; }
+  void setBoundsExpr(BoundsExpr *E) {
+    assert(!hasBoundsExpr() &&
+           "inferred bounds checks should not be present");
+    Bounds = E;
+  }
 
   /// \brief Return the kind of bounds check to do.
   BoundsCheckKind getBoundsCheckKind() const {
@@ -3187,7 +3195,11 @@ public:
 
   /// \brief Set the bounds to use for bounds checking the base expression
   /// lvalue.
-  void setBoundsExpr(BoundsExpr *E) { Bounds = E; }
+  void setBoundsExpr(BoundsExpr *E) {
+    assert(!hasBoundsExpr() &&
+           "inferred bounds checks should not be present");
+    Bounds = E;
+  }
 };
 
 /// CompoundLiteralExpr - [C99 6.5.2.5]
@@ -3587,6 +3599,8 @@ public:
   }
 
   void setBoundsExpr(BoundsExpr *E) {
+    assert(!hasBoundsExpr() &&
+           "inferred bounds checks should not be present");
     SubExprs[BOUNDS] = E;
   }
 

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2979,7 +2979,7 @@ class MemberExpr final
              QualType T, ExprValueKind VK, ExprObjectKind OK,
              NonOdrUseReason NOUR);
   MemberExpr(EmptyShell Empty)
-      : Expr(MemberExprClass, Empty), Base(), MemberDecl() {}
+      : Expr(MemberExprClass, Empty), Base(), MemberDecl(), Bounds(nullptr) {}
 
 public:
   static MemberExpr *Create(const ASTContext &C, Expr *Base, bool IsArrow,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -9634,9 +9634,6 @@ ExprResult
 TreeTransform<Derived>::TransformUnaryOperator(UnaryOperator *E) {
   ExprResult SubExpr;
 
-  assert(E->getBoundsExpr() == nullptr &&
-         "inferred bounds checks should not be present");
-
   if (E->getOpcode() == UO_AddrOf)
     SubExpr = TransformAddressOfOperand(E->getSubExpr());
   else
@@ -9808,8 +9805,6 @@ TreeTransform<Derived>::TransformUnaryExprOrTypeTraitExpr(
 template<typename Derived>
 ExprResult
 TreeTransform<Derived>::TransformArraySubscriptExpr(ArraySubscriptExpr *E) {
-  assert(E->getBoundsExpr() == nullptr &&
-         "inferred bounds checks should not be present");
   ExprResult LHS = getDerived().TransformExpr(E->getLHS());
   if (LHS.isInvalid())
     return ExprError();
@@ -9890,8 +9885,6 @@ TreeTransform<Derived>::TransformCallExpr(CallExpr *E) {
 template<typename Derived>
 ExprResult
 TreeTransform<Derived>::TransformMemberExpr(MemberExpr *E) {
-  assert(E->getBoundsExpr() == nullptr &&
-         "inferred bounds checks should not be present");
   ExprResult Base = getDerived().TransformExpr(E->getBase());
   if (Base.isInvalid())
     return ExprError();
@@ -10069,8 +10062,6 @@ TreeTransform<Derived>::TransformImplicitCastExpr(ImplicitCastExpr *E) {
 template<typename Derived>
 ExprResult
 TreeTransform<Derived>::TransformCStyleCastExpr(CStyleCastExpr *E) {
-  assert(E->getBoundsExpr() == nullptr &&
-         "inferred bounds checks should not be present");
   TypeSourceInfo *Type = getDerived().TransformType(E->getTypeInfoAsWritten());
   if (!Type)
     return ExprError();


### PR DESCRIPTION
TreeTransform previously asserted that expressions did not have a bounds expression set to prevent setting a bounds expression twice for an expression. However, in some cases it is expected behavior to transform an expression that has already had a bounds expression set, in particular during the bottom-up analysis in SemaBounds.

This PR removes the asserts from TreeTransform and instead asserts that the bounds expressions are null during setBoundsExpr, since setting the bounds expression twice on any given expression is still unwanted behavior.

Testing:
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux.