### PR TITLE
Support bounds widening for conditionals with while loops

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -17,6 +17,7 @@
 #define LLVM_CLANG_BOUNDS_ANALYSIS_H
 
 #include "clang/AST/CanonBounds.h"
+#include "clang/Analysis/Analyses/Dominators.h"
 #include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Sema/Sema.h"
 #include <queue>
@@ -174,7 +175,8 @@ namespace clang {
     // Compute In set for each block in BlockMap. In[B1] = n Out[B*->B1], where
     // B* are all preds of B1.
     // @param[in] EB is the block to compute the In set for.
-    void ComputeInSets(ElevatedCFGBlock *EB);
+    // @param[in] Dom is the dominator tree for the CFG.
+    void ComputeInSets(ElevatedCFGBlock *EB, CFGDomTree &Dom);
 
     // Compute Out set for each outgoing edge of EB. If the Out set on any edge
     // of EB changes then the successor of EB on that edge is added to

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -534,3 +534,49 @@ void f20() {
 // CHECK:  [B1]
 // CHECK-NOT: upper_bound(u)
 }
+
+void f21() {
+  char p _Nt_checked[] : count(0) = "abc";
+
+  while (p[0])
+    while (p[1])   // expected-error {{out-of-bounds memory access}}
+      while (p[2]) // expected-error {{out-of-bounds memory access}}
+  {}
+
+// CHECK:  [B6]
+// CHECK:    1: p[0]
+// CHECK:  [B5]
+// CHECK:    1: p[1]
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B4]
+// CHECK:    1: p[2]
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B3]
+// CHECK: upper_bound(p) = 3
+// CHECK:  [B2]
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B1]
+// CHECK: upper_bound(p) = 1
+}
+
+void f22() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p)
+    while (*(p + 1))   // expected-error {{out-of-bounds memory access}}
+      if (*(p + 2)) // expected-error {{out-of-bounds memory access}}
+  {}
+
+// CHECK:  [B5]
+// CHECK:    2: *p
+// CHECK:  [B4]
+// CHECK:    1: *(p + 1)
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B3]
+// CHECK:    1: *(p + 2)
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B2]
+// CHECK: upper_bound(p) = 3
+// CHECK:  [B1]
+// CHECK: upper_bound(p) = 2
+}


### PR DESCRIPTION
Added support for nt_array_ptr dereferences with while loops. For example, in
"while (*p) {}" we would widen the bounds of p upon entry to the loop.