### PR TITLE
Add llvm/out to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 
 # Nested build directory
 /build
+# Visual Studio nested build directory
+/llvm/out
 
 #==============================================================================#
 # Explicit files to ignore (only matches one).


### PR DESCRIPTION
This is in preparation to moving the Windows checkedc-clang builds to switch
over to cmake/ninja with Visual Studio. The default cmake configuration creates
the build dir under src/llvm/out. This default setting can easily be changed by
the user. But for those who don't change it, all build files under llvm/out
would start getting tracked by git and show up as "modified". So we are adding
llvm/out to .gitignore.