### PR TITLE
Equivalent expressions: assignments [3/n]

### DIFF
--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -283,6 +283,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::DeclRefExprClass: return Compare<DeclRefExpr>(E1, E2);
      case Expr::IntegerLiteralClass: return Compare<IntegerLiteral>(E1, E2);
      case Expr::FloatingLiteralClass: return Compare<FloatingLiteral>(E1, E2);
+     case Expr::FixedPointLiteralClass: break;
      case Expr::ImaginaryLiteralClass: break;
      case Expr::StringLiteralClass: return Compare<StringLiteral>(E1, E2);
      case Expr::CharacterLiteralClass: return Compare<CharacterLiteral>(E1, E2);
@@ -298,9 +299,12 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::CompoundAssignOperatorClass:
        Cmp = Compare<CompoundAssignOperator>(E1, E2); break;
      case Expr::BinaryConditionalOperatorClass: break;
+     case Expr::ConditionalOperatorClass: break;
      case Expr::ImplicitCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CStyleCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CompoundLiteralExprClass: Cmp = Compare<CompoundLiteralExpr>(E1, E2); break;
+     case Expr::InitListExprClass: break;
+     case Expr::ImplicitValueInitExprClass: break;
      // TODO:
      // case: ExtVectorElementExpr
      case Expr::VAArgExprClass: break;
@@ -323,9 +327,12 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::PositionalParameterExprClass: Cmp = Compare<PositionalParameterExpr>(E1, E2); break;
      case Expr::BoundsCastExprClass: Cmp = Compare<BoundsCastExpr>(E1, E2); break;
      case Expr::BoundsValueExprClass: Cmp = Compare<BoundsValueExpr>(E1, E2); break;
-     // Binding of a tempoary to the result of an expression.  These are
+     // Binding of a temporary to the result of an expression.  These are
      // equal if their child expressions are equal.
      case Expr::CHKCBindTemporaryExprClass: break;
+
+     // Checked C extensions
+     case Expr::PackExprClass: break;
 
      // Clang extensions
      case Expr::ShuffleVectorExprClass: break;
@@ -337,8 +344,12 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      // case Expr::MSPropertyRefExprClass:
      // case Expr::MSPropertySubscriptExprClass:
 
+     case Expr::ExtVectorElementExprClass: break;
+     case Expr::ExprWithCleanupsClass: break;
+     case Expr::SourceLocExprClass: break;
+
      default:
-       return Result::LessThan;         
+       llvm_unreachable("unexpected expression kind");
    }
 
    if (Cmp != Result::Equal)

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -298,6 +298,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::CompoundAssignOperatorClass:
        Cmp = Compare<CompoundAssignOperator>(E1, E2); break;
      case Expr::BinaryConditionalOperatorClass: break;
+     case Expr::ConditionalOperatorClass: break;
      case Expr::ImplicitCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CStyleCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CompoundLiteralExprClass: Cmp = Compare<CompoundLiteralExpr>(E1, E2); break;

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -283,7 +283,6 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::DeclRefExprClass: return Compare<DeclRefExpr>(E1, E2);
      case Expr::IntegerLiteralClass: return Compare<IntegerLiteral>(E1, E2);
      case Expr::FloatingLiteralClass: return Compare<FloatingLiteral>(E1, E2);
-     case Expr::FixedPointLiteralClass: break;
      case Expr::ImaginaryLiteralClass: break;
      case Expr::StringLiteralClass: return Compare<StringLiteral>(E1, E2);
      case Expr::CharacterLiteralClass: return Compare<CharacterLiteral>(E1, E2);
@@ -299,12 +298,9 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      case Expr::CompoundAssignOperatorClass:
        Cmp = Compare<CompoundAssignOperator>(E1, E2); break;
      case Expr::BinaryConditionalOperatorClass: break;
-     case Expr::ConditionalOperatorClass: break;
      case Expr::ImplicitCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CStyleCastExprClass: Cmp = Compare<CastExpr>(E1, E2); break;
      case Expr::CompoundLiteralExprClass: Cmp = Compare<CompoundLiteralExpr>(E1, E2); break;
-     case Expr::InitListExprClass: break;
-     case Expr::ImplicitValueInitExprClass: break;
      // TODO:
      // case: ExtVectorElementExpr
      case Expr::VAArgExprClass: break;
@@ -331,9 +327,6 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      // equal if their child expressions are equal.
      case Expr::CHKCBindTemporaryExprClass: break;
 
-     // Checked C extensions
-     case Expr::PackExprClass: break;
-
      // Clang extensions
      case Expr::ShuffleVectorExprClass: break;
      case Expr::ConvertVectorExprClass: break;
@@ -343,10 +336,6 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      // TODO:
      // case Expr::MSPropertyRefExprClass:
      // case Expr::MSPropertySubscriptExprClass:
-
-     case Expr::ExtVectorElementExprClass: break;
-     case Expr::ExprWithCleanupsClass: break;
-     case Expr::SourceLocExprClass: break;
 
      default:
        llvm_unreachable("unexpected expression kind");

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -338,7 +338,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
      // case Expr::MSPropertySubscriptExprClass:
 
      default:
-       llvm_unreachable("unexpected expression kind");         
+       return Result::LessThan;         
    }
 
    if (Cmp != Result::Equal)

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -7118,15 +7118,7 @@ public:
 
 static bool EvaluatePointer(const Expr* E, LValue& Result, EvalInfo &Info,
                             bool InvalidBaseOK) {
-  assert(E->isRValue(),
-        "expression of type " + E->getType().getAsString() +
-        " with statement class " + E->getStmtClassName() +
-        " must be an rvalue");
-  assert(E->getType()->hasPointerRepresentation(),
-        "expression of type " + E->getType().getAsString() +
-        " with statement class " + E->getStmtClassName() +
-        " must have pointer representation");
-  //assert(E->isRValue() && E->getType()->hasPointerRepresentation());
+  assert(E->isRValue() && E->getType()->hasPointerRepresentation());
   return PointerExprEvaluator(Info, Result, InvalidBaseOK).Visit(E);
 }
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -7118,10 +7118,15 @@ public:
 
 static bool EvaluatePointer(const Expr* E, LValue& Result, EvalInfo &Info,
                             bool InvalidBaseOK) {
-  llvm::outs() << "*** ExprConstant::EvaluatePointer ***\n";
-  llvm::outs() << "*** E->isRValue? " << (E->isRValue() ? "true" : "false") << " ***\n";
-  llvm::outs() << "E->getType()->hasPointerRepresentation: " << (E->getType()->hasPointerRepresentation() ? "true" : "false") << " ***\n";
-  assert(E->isRValue() && E->getType()->hasPointerRepresentation());
+  assert(E->isRValue(),
+        "expression of type " + E->getType().getAsString() +
+        " with statement class " + E->getStmtClassName() +
+        " must be an rvalue");
+  assert(E->getType()->hasPointerRepresentation(),
+        "expression of type " + E->getType().getAsString() +
+        " with statement class " + E->getStmtClassName() +
+        " must have pointer representation");
+  //assert(E->isRValue() && E->getType()->hasPointerRepresentation());
   return PointerExprEvaluator(Info, Result, InvalidBaseOK).Visit(E);
 }
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -7118,6 +7118,9 @@ public:
 
 static bool EvaluatePointer(const Expr* E, LValue& Result, EvalInfo &Info,
                             bool InvalidBaseOK) {
+  llvm::outs() << "*** ExprConstant::EvaluatePointer ***\n";
+  llvm::outs() << "*** E->isRValue? " << (E->isRValue() ? "true" : "false") << " ***\n";
+  llvm::outs() << "E->getType()->hasPointerRepresentation: " << (E->getType()->hasPointerRepresentation() ? "true" : "false") << " ***\n";
   assert(E->isRValue() && E->getType()->hasPointerRepresentation());
   return PointerExprEvaluator(Info, Result, InvalidBaseOK).Visit(E);
 }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2507,15 +2507,9 @@ namespace {
           // Create the RHS of the implied assignment `e1 = e1 @ e2`.
           Src = ExprCreatorUtil::CreateBinaryOperator(S, Target, RHS, Op);
 
-          // Update the set of expressions that produce the same value as `e1`
-          // to be the set of expressions equal to `e1` before the assignment,
-          // since the compound assignment modifies `e1`.
-          SubExprGs[LHS] = GetEqualExprSetContainingExpr(LHS, State.UEQ);
-
           // Update State.G to be the set of expressions that produce the same
           // value as the source `e1 @ e2` of the assignment `e1 = e1 @ e2`.
           UpdateG(Src, SubExprGs, State.G);
-          SubExprGs[Src] = State.G;
         }
 
         // Update UEQ and G for assignments to `e1` where `e1` is a variable.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4172,7 +4172,12 @@ namespace {
         AdjustedType = Ty->getPointeeType();
       if (!AdjustedType->isIntegerType())
         return nullptr;
+
       unsigned BitSize = Context.getTypeSize(AdjustedType);
+      unsigned IntWidth = Context.getIntWidth(AdjustedType);
+      if (BitSize != IntWidth)
+        return nullptr;
+
       llvm::APInt ResultVal(BitSize, Value);
       return IntegerLiteral::Create(Context, ResultVal, AdjustedType,
                                     SourceLocation());

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3681,6 +3681,9 @@ namespace {
     // IsInvertible returns true if the expression e can be inverted
     // with respect to the variable x.
     bool IsInvertible(DeclRefExpr *X, Expr *E) {
+      if (!E)
+        return false;
+
       E = E->IgnoreParens();
       if (IsRValueCastOfVariable(E, X))
         return true;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2507,7 +2507,9 @@ namespace {
           // Create the RHS of the implied assignment `e1 = e1 @ e2`.
           Src = ExprCreatorUtil::CreateBinaryOperator(S, Target, RHS, Op);
 
-          // Update the set of expressions that produce the same value as `e1`.
+          // Update the set of expressions that produce the same value as `e1`
+          // to be the set of expressions equal to `e1` before the assignment,
+          // since the compound assignment modifies `e1`.
           SubExprGs[LHS] = GetEqualExprSetContainingExpr(LHS, State.UEQ);
 
           // Update State.G to be the set of expressions that produce the same
@@ -2516,12 +2518,12 @@ namespace {
           SubExprGs[Src] = State.G;
         }
 
-        // Update UEQ and G for assignments to a variable `e1`.
+        // Update UEQ and G for assignments to `e1` where `e1` is a variable.
         if (DeclRefExpr *V = GetLValueVariable(LHS)) {
           Expr *OV = GetOriginalValue(V, Src, State.UEQ);
           UpdateAfterAssignment(V, Target, OV, CSS, State, State);
         }
-        // Update UEQ and G for assignments to a non-variable `e1`.
+        // Update UEQ and G for assignments where `e1` is not a variable.
         else {
           if (!E->isCompoundAssignmentOp()) {
             // TODO: update State for non-compound assignments `e1 = e2`
@@ -2940,12 +2942,12 @@ namespace {
           Expr *Val = IsPostIncDec ? SubExpr : RHS;
           UpdateG(RHS, State.G, State.G, Val);
 
-          // Update UEQ and G for inc/dec operators on a variable `e1`.
+          // Update UEQ and G for inc/dec operators where `e1` is a variable.
           if (DeclRefExpr *V = GetLValueVariable(SubExpr)) {
             Expr *OV = GetOriginalValue(V, RHS, State.UEQ);
             UpdateAfterAssignment(V, Target, OV, CSS, State, State);
           }
-          // Do nothing for inc/dec operators on a non-variable `e1`.
+          // Do nothing for inc/dec operators where `e1` is not a variable.
           // Since the RHS `e1 +/- 1` of the implied assignment
           // `e1 = e1 +/- 1` uses the value of `e1` and `e1` has no
           // original value in `e1 +/- 1`, State.UEQ remains unchanged.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2120,6 +2120,8 @@ namespace {
             llvm::outs().flush();
 #endif
             Check(S, CSS, BlockState);
+            if (DumpState)
+              DumpCheckingState(llvm::outs(), S, BlockState);
          }
        }
        BlockStates[Block] = BlockState;
@@ -2166,7 +2168,10 @@ namespace {
   public:
     BoundsExpr *Check(Stmt *S, CheckedScopeSpecifier CSS) {
       CheckingState State;
-      return Check(S, CSS, State);
+      BoundsExpr *Bounds = Check(S, CSS, State);
+      if (DumpState)
+        DumpCheckingState(llvm::outs(), S, State);
+      return Bounds;
     }
 
     // If e is an rvalue, Check checks e and its children, performing any
@@ -2261,9 +2266,6 @@ namespace {
           break;
       }
 
-      if (DumpState)
-        DumpCheckingState(llvm::outs(), S, State);
-
       if (Expr *E = dyn_cast<Expr>(S)) {
         // Bounds expressions are not null ptrs.
         if (isa<BoundsExpr>(E))
@@ -2341,9 +2343,6 @@ namespace {
           CheckChildren(E, CSS, State);
           break;
       }
-
-      if (DumpState)
-        DumpCheckingState(llvm::outs(), E, State);
 
       // The type for inferring the target bounds cannot ever be an array
       // type, as these are dealt with by an array conversion, not an lvalue

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4001,6 +4001,7 @@ namespace {
         case Expr::PackExprClass:
         case Expr::FixedPointLiteralClass:
         case Expr::ConditionalOperatorClass:
+        case Expr::StringLiteralClass:
           return false;
         default: {
           for (auto I = E->child_begin(); I != E->child_end(); ++I) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3622,6 +3622,25 @@ namespace {
       }
     }
 
+    // If the variable X appears exactly once in Ei and does not
+    // appear in Ej, SplitByVarCount returns the pair (Ei, Ej).
+    // Otherwise, SplitByVarCount returns an empty pair.
+    std::pair<Expr *, Expr *> SplitByVarCount(DeclRefExpr *X, Expr *E1, Expr *E2) {
+      std::pair<Expr *, Expr *> Pair;
+      int Count1 = VariableOccurrenceCount(S, X, E1);
+      int Count2 = VariableOccurrenceCount(S, X, E2);
+      if (Count1 == 1 && Count2 == 0) {
+        // X appears once in E1 and does not appear in E2.
+        Pair.first = E1;
+        Pair.second = E2;
+      } else if (Count2 == 1 && Count1 == 0) {
+        // X appears once in E2 and does not appear in E1.
+        Pair.first = E2;
+        Pair.second = E1;
+      }
+      return Pair;
+    }
+
     // CheckIsNonModifying suppresses diagnostics while checking
     // whether e is a non-modifying expression.
     bool CheckIsNonModifying(Expr *E) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2955,11 +2955,10 @@ namespace {
           // value as the RHS `e1 +/- 1` of the assignment `e1 = e1 +/- 1`,
           // so State.G also remains unchanged.
         } else {
-          // Update State.G using the the target of the inc/dec operator for
-          // expressions where the integer constant 1 could not be constructed
-          // (e.g. floating point expressions). State.UEQ remains unchanged.
-          if (CheckIsNonModifying(Target) && CanBeInEqualExprSet(Target))
-            State.G = { Target };
+          // State.G is empty for expressions where the integer constant 1
+          // could not be constructed (e.g. floating point expressions).
+          // State.UEQ remains unchanged.
+          State.G.clear();
         }
       }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3710,7 +3710,8 @@ namespace {
           return IsUnaryOperatorInvertible(X, cast<UnaryOperator>(E));
         case Expr::BinaryOperatorClass:
           return IsBinaryOperatorInvertible(X, cast<BinaryOperator>(E));
-        // TODO: determine whether a cast expression is invertible.
+        // TODO: determine whether a cast expression is invertible (is a
+        // bit-preserving or widening cast).
         default:
           return false;
       }
@@ -3724,16 +3725,7 @@ namespace {
           Op != UnaryOperatorKind::UO_Plus)
         return false;
 
-      // X must appear exactly once in the subexpression of e
-      // and the subexpression must be invertible with respect to x.
-      Expr *SubExpr = E->getSubExpr();
-      int SubExprVarCount = VariableOccurrenceCount(S, X, SubExpr);
-      if (SubExprVarCount != 1)
-        return false;
-      if (!IsInvertible(X, SubExpr))
-        return false;
-
-      return true;
+      return IsInvertible(X, E->getSubExpr());
     }
 
     // Returns true if a binary operator is invertible with respect to x.
@@ -3847,7 +3839,7 @@ namespace {
           F1 = ExprCreatorUtil::CreateBinaryOperator(S, F, E_NotX, BinaryOperatorKind::BO_Xor);
           break;
         default:
-          break;
+          llvm_unreachable("unexpected binary operator kind");
       }
 
       return Inverse(X, F1, E_X);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3513,7 +3513,11 @@ namespace {
     }
 
     // Returns true if the expression e reads memory via a pointer.
-    bool ReadsMemoryViaPointer(Expr *E) {
+    // IncludeAllMemberExprs is used to modify the behavior to return true
+    // if e is or contains a pointer dereference, member reference, or
+    // indirect member reference (including e1.f which may not read memory
+    // via a pointer).
+    bool ReadsMemoryViaPointer(Expr *E, bool IncludeAllMemberExprs = false) {
       E = E->IgnoreParens();
 
       switch (E->getStmtClass()) {
@@ -3526,6 +3530,9 @@ namespace {
         case Expr::ArraySubscriptExprClass:
           return true;
         case Expr::MemberExprClass: {
+          if (IncludeAllMemberExprs)
+            return true;
+
           MemberExpr *ME = cast<MemberExpr>(E);
           // e1->f reads memory via a pointer.
           if (ME->isArrow())

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -113,6 +113,35 @@ public:
 }
 
 namespace {
+  class VariableUtil {
+    public:
+      // If E is a (possibly parenthesized or no-op cast) variable V,
+      // GetVariable returns V.  Otherwise, GetVariable returns nullptr.
+      static DeclRefExpr *GetVariable(Sema &SemaRef, Expr *E) {
+        if (!E)
+          return nullptr;
+
+        return dyn_cast<DeclRefExpr>(E->IgnoreParenNoopCasts(SemaRef.Context));
+      }
+
+      // SameVariable returns true if the expressions E1 and E2
+      // are the same (possibly parenthesized or no-op cast) variable.
+      static bool SameVariable(Sema &SemaRef, Expr *E1, Expr *E2) {
+        DeclRefExpr *V1 = GetVariable(SemaRef, E1);
+        if (!V1)
+          return false;
+
+        DeclRefExpr *V2 = GetVariable(SemaRef, E2);
+        if (!V2)
+          return false;
+
+        Lexicographic Lex(SemaRef.Context, nullptr);
+        return Lex.CompareExpr(V1, V2) == Lexicographic::Result::Equal;
+      }
+  };
+}
+
+namespace {
   class AbstractBoundsExpr : public TreeTransform<AbstractBoundsExpr> {
     typedef TreeTransform<AbstractBoundsExpr> BaseTransform;
     typedef ArrayRef<DeclaratorChunk::ParamInfo> ParamsInfo;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3498,6 +3498,29 @@ namespace {
         G.push_back(CreateTemporaryUse(Temp));
     }
 
+  // Methods to get the original value of an expression.
+
+    // GetOriginalValue returns the original value (if it exists) of the
+    // source expression with respect to the variable v.
+    Expr *GetOriginalValue(DeclRefExpr *V, Expr *Src, const EquivExprSets EQ) {
+      // Check if Src has an inverse expression with respect to v.
+      Expr *IV = nullptr;
+      if (IsInvertible(V, Src))
+        IV = Inverse(V, V, Src);
+      if (IV)
+        return IV;
+      
+      // Check EQ for a variable w != v that produces the same value as v.
+      EqualExprTy F = GetEqualExprSetContainingVariable(V, EQ);
+      for (auto I = F.begin(); I != F.end(); ++I) {
+        DeclRefExpr *W = VariableUtil::GetVariable(S, *I);
+        if (W != nullptr && !VariableUtil::SameVariable(S, V, W))
+          return W;
+      }
+
+      return nullptr;
+    }
+
     // IsInvertible returns true if the expression e can be inverted
     // with respect to the variable x.
     bool IsInvertible(DeclRefExpr *X, Expr *E) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3498,6 +3498,40 @@ namespace {
         G.push_back(CreateTemporaryUse(Temp));
     }
 
+    // IntersectUEQ returns the intersection of two sets of sets of equivalent
+    // expressions, where each set in UEQ1 is intersected with each set in
+    // UEQ2 to produce an element of the result.
+    EquivExprSets IntersectUEQ(const EquivExprSets UEQ1, const EquivExprSets UEQ2) {
+      EquivExprSets IntersectedUEQ;
+      for (auto I1 = UEQ1.begin(); I1 != UEQ1.end(); ++I1) {
+        EqualExprTy G1 = *I1;
+        for (auto I2 = UEQ2.begin(); I2 != UEQ2.end(); ++I2) {
+          EqualExprTy G2 = *I2;
+          EqualExprTy IntersectedG = IntersectG(G1, G2);
+          if (IntersectedG.size() > 1)
+            IntersectedUEQ.push_back(IntersectedG);
+        }
+      }
+      return IntersectedUEQ;
+    }
+
+    // IntersectG returns the intersection of two sets of equivalent expressions.
+    EqualExprTy IntersectG(const EqualExprTy G1, const EqualExprTy G2) {
+      EqualExprTy IntersectedG;
+      for (auto I = G1.begin(); I != G1.end(); ++I) {
+        Expr *E1 = *I;
+        for (auto J = G2.begin(); J != G2.end(); ++J) {
+          Expr *E2 = *J;
+          // Don't add duplicate expressions to the intersection.
+          if (EqualExprsContainsExpr(IntersectedG, E2, nullptr))
+            continue;
+          if (EqualValue(S.Context, E1, E2, nullptr))
+            IntersectedG.push_back(E1);
+        }
+      }
+      return IntersectedG;
+    }
+
     // If E appears in a set F in EQ, GetEqualExprSetContainingExpr
     // returns F.  Otherwise, it returns an empty set.
     EqualExprTy GetEqualExprSetContainingExpr(Expr *E, EquivExprSets EQ) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3005,10 +3005,14 @@ namespace {
       Expr *Init = D->getInit();
       BoundsExpr *InitBounds = nullptr;
       // If there is an initializer, check it, and update the state to record
-      // expression equality implied by initialization.
+      // expression equality implied by initialization. After checking Init,
+      // State.G will contain non-modifying expressions that produce values
+      // equivalent to the value produced by Init.
       if (Init) {
         InitBounds = Check(Init, CSS, State);
 
+        // Create an rvalue expression for v. v could be an array or
+        // non-array variable.
         DeclRefExpr *TargetDeclRef =
           DeclRefExpr::Create(S.getASTContext(), NestedNameSpecifierLoc(),
                               SourceLocation(), D, false, SourceLocation(),

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3640,21 +3640,23 @@ namespace {
       else if (CheckIsNonModifying(Val))
         G.push_back(Val);
 
-      // If Val is a modifying expression, use the Gi for the subexpressions
-      // to try to construct a non-modifying expression Val' that
-      // produces the same value as Val.
+      // If Val is a modifying expression, use the G_i sets of expressions
+      // that produce the same value as the subexpressions of e to try to
+      // construct a non-modifying expression ValPrime that produces the same
+      // value as Val.
       else {
         Expr *ValPrime = nullptr;
         for (llvm::detail::DenseMapPair<Expr *, EqualExprTy> Pair : SubExprGs) {
-          Expr *Si = Pair.first;
-          // For any modifying subexpression Si of e,
-          // try to set Val' to a nonmodifying expression from Gi.
-          if (!CheckIsNonModifying(Si)) {
-            EqualExprTy Gi = Pair.second;
-            for (auto I = Gi.begin(); I != Gi.end(); ++I) {
-              Expr *Ei = *I;
-              if (CheckIsNonModifying(Ei)) {
-                ValPrime = Ei;
+          Expr *SubExpr_i = Pair.first;
+          // For any modifying subexpression SubExpr_i of e, try to set
+          // ValPrime to a nonmodifying expression from the set G_i of
+          // expressions that produce the same value as SubExpr_i.
+          if (!CheckIsNonModifying(SubExpr_i)) {
+            EqualExprTy G_i = Pair.second;
+            for (auto I = G_i.begin(); I != G_i.end(); ++I) {
+              Expr *E_i = *I;
+              if (CheckIsNonModifying(E_i)) {
+                ValPrime = E_i;
                 break;
               }
             }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3521,7 +3521,7 @@ namespace {
         RValueBounds = Check(E, CSS, State);
     }
 
-  // Methods to update sets of equivalent expressions.
+    // Methods to update sets of equivalent expressions.
 
     // UpdateAfterAssignment updates the checking state after a variable V
     // is assigned to, based on the state before the assignment.
@@ -3666,7 +3666,7 @@ namespace {
         G.push_back(CreateTemporaryUse(Temp));
     }
 
-  // Methods to get the original value of an expression.
+    // Methods to get the original value of an expression.
 
     // GetOriginalValue returns the original value (if it exists) of the
     // expression Src with respect to the variable V in an assignment V = Src.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -143,11 +143,15 @@ namespace {
 namespace {
   class ExprCreatorUtil {
     public:
-      // Create a non-compound binary operator, casting each child to an
-      // rvalue expression if necessary.
+      // If Op is not a compound operator, CreateBinaryOperator returns a
+      // binary operator LHS Op RHS.  If Op is a compound operator @=,
+      // CreateBinaryOperator returns a binary operator LHS @ RHS.
+      // LHS and RHS are cast to rvalues if necessary.
       static BinaryOperator *CreateBinaryOperator(Sema &SemaRef,
                                                   Expr *LHS, Expr *RHS,
                                                   BinaryOperatorKind Op) {
+        assert(LHS && "expected LHS to exist");
+        assert(RHS && "expected RHS to exist");
         LHS = EnsureRValue(SemaRef, LHS);
         RHS = EnsureRValue(SemaRef, RHS);
         if (BinaryOperator::isCompoundAssignmentOp(Op))

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2755,12 +2755,12 @@ namespace {
       // same value as e.
       if (CK == CastKind::CK_ArrayToPointerDecay) {
         // State.G = { e } for lvalues with array type.
-        if (!CreatesNewObject(E))
+        if (!CreatesNewObject(E) && CheckIsNonModifying(E))
           State.G = { E };
       } else if (CK == CastKind::CK_LValueToRValue) {
         if (E->getType()->isArrayType()) {
           // State.G = { e } for lvalues with array type.
-          if (!CreatesNewObject(E))
+          if (!CreatesNewObject(E) && CheckIsNonModifying(E))
             State.G = { E };
         }
         else {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -647,6 +647,10 @@ namespace {
   // returns nullptr.
   Expr *PruneVariableReferences(Sema &SemaRef, Expr *E, DeclRefExpr *V,
                                 Expr *OV, CheckedScopeSpecifier CSS) {
+    // Don't transform e if it does not use the value of v.
+    if (VariableOccurrenceCount(SemaRef, V, E) < 1)
+      return E;
+
     // Account for checked scope information when transforming the expression.
     Sema::CheckedScopeRAII CheckedScope(SemaRef, CSS);
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2524,13 +2524,15 @@ namespace {
         // Update UEQ and G for assignments to a non-variable `e1`.
         else {
           if (!E->isCompoundAssignmentOp()) {
-            // Record equality implied by the assignment `e1 = e2` to a
-            // non-variable `e1`. At this point, State.G contains expressions
-            // that produce the same value as `e2`.
-            // TODO: this doesn't properly handle cases where the RHS
-            // uses the value of the LHS, e.g. *p = 2 - *p.
-            State.G.push_back(Target);
-            State.UEQ.push_back(State.G);
+            if (CheckIsNonModifying(Target)) {
+              // Record equality implied by the assignment `e1 = e2` to a
+              // non-variable, non-modifying expression `e1`. At this point,
+              // State.G contains expressions that produce the same value as
+              // `e2`. TODO: this doesn't properly handle cases where `e2`
+              // uses the value of `e1`, e.g. *p = 2 - *p.
+              State.G.push_back(Target);
+              State.UEQ.push_back(State.G);
+            }
           }
           // Do nothing for compound assignments `e1 @= e2` to a
           // non-variable `e1`. Since the RHS `e1 @ e2` of the implied

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -143,13 +143,15 @@ namespace {
 namespace {
   class ExprCreatorUtil {
     public:
-      // Create a binary operator, casting each child to an rvalue
-      // expression if necessary.
+      // Create a non-compound binary operator, casting each child to an
+      // rvalue expression if necessary.
       static BinaryOperator *CreateBinaryOperator(Sema &SemaRef,
                                                   Expr *LHS, Expr *RHS,
                                                   BinaryOperatorKind Op) {
         LHS = EnsureRValue(SemaRef, LHS);
         RHS = EnsureRValue(SemaRef, RHS);
+        if (BinaryOperator::isCompoundAssignmentOp(Op))
+          Op = BinaryOperator::getOpForCompoundAssignment(Op);
         return new (SemaRef.Context) BinaryOperator(LHS, RHS, Op,
                                                     LHS->getType(),
                                                     LHS->getValueKind(),

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -628,6 +628,36 @@ namespace {
 }
 
 namespace {
+  class VariableCountHelper : public RecursiveASTVisitor<VariableCountHelper> {
+    private:
+      Sema &SemaRef;
+      DeclRefExpr *V;
+      int Count;
+
+    public:
+      VariableCountHelper(Sema &SemaRef, DeclRefExpr *V) :
+        SemaRef(SemaRef),
+        V(V),
+        Count(0) {}
+
+      int GetCount() { return Count; }
+
+      bool VisitDeclRefExpr(DeclRefExpr *E) {
+        if (VariableUtil::SameVariable(SemaRef, E, V))
+          ++Count;
+        return true;
+      }
+  };
+
+  // VariableOccurrenceCount returns the number of occurrences of V in E.
+  int VariableOccurrenceCount(Sema &SemaRef, DeclRefExpr *V, Expr *E) {
+    VariableCountHelper Counter(SemaRef, V);
+    Counter.TraverseStmt(E);
+    return Counter.GetCount();
+  }
+}
+
+namespace {
   // EqualExprTy denotes a set of expressions that produce the same value
   // as an expression e.
   using EqualExprTy = SmallVector<Expr *, 4>;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2519,18 +2519,10 @@ namespace {
         }
         // Update UEQ and G for assignments where `e1` is not a variable.
         else {
-          if (!E->isCompoundAssignmentOp()) {
-            // TODO: update State for non-compound assignments `e1 = e2`
-            // to a non-variable `e1`, i.e. generalize the current
-            // approach to updating the state from variables to lvalues.
-          }
-          // Do nothing for compound assignments `e1 @= e2` to a
-          // non-variable `e1`. Since the RHS `e1 @ e2` of the implied
-          // assignment `e1 = e1 @ e2` uses the value of `e1` and `e1` has no
-          // original value in `e1 @ e2`, State.UEQ remains unchanged.
-          // State.G already contains expressions that produce the same
-          // value as the RHS `e1 @ e2` of the assignment `e1 = e1 @ e2`,
-          // so State.G also remains unchanged.
+          // G is empty for assignments to a non-variable.  This conservative
+          // approach avoids recording false equality facts for assignments
+          // where the LHS appears on the RHS, e.g. *p = *p + 1.
+          State.G.clear();
         }
       } else if (BinaryOperator::isLogicalOp(Op)) {
         // TODO: update State for logical operators `e1 && e2` and `e1 || e2`.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3678,7 +3678,7 @@ namespace {
   // Methods to get the original value of an expression.
 
     // GetOriginalValue returns the original value (if it exists) of the
-    // source expression with respect to the variable v.
+    // expression Src with respect to the variable V in an assignment V = Src.
     Expr *GetOriginalValue(DeclRefExpr *V, Expr *Src, const EquivExprSets EQ) {
       // Check if Src has an inverse expression with respect to v.
       Expr *IV = nullptr;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3967,7 +3967,10 @@ namespace {
 
     // CanBeInEqualExprSet returns true if the expression e can be added to
     // the UEQ or G sets of equivalent expressions in the checking state.
-    // Only scalar expressions should be added to the UEQ and G sets.
+    // Expressions that create new objects should not be added to these sets.
+    // CanBeInEqualExprSet may return true if e is a modifying expression.
+    // It is the caller's responsibility to ensure that only non-modifying
+    // expressions are added to the UEQ and G sets.
     bool CanBeInEqualExprSet(Expr *E) {
       switch (E->getStmtClass()) {
         case Expr::InitListExprClass:

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3622,9 +3622,9 @@ namespace {
       }
     }
 
-    // If the variable X appears exactly once in Ei and does not
-    // appear in Ej, SplitByVarCount returns the pair (Ei, Ej).
-    // Otherwise, SplitByVarCount returns an empty pair.
+    // If the variable X appears exactly once in Ei and does not appear in
+    // Ej, SplitByVarCount returns the pair (Ei, Ej).  Otherwise, it returns
+    // an empty pair.
     std::pair<Expr *, Expr *> SplitByVarCount(DeclRefExpr *X, Expr *E1, Expr *E2) {
       std::pair<Expr *, Expr *> Pair;
       int Count1 = VariableOccurrenceCount(S, X, E1);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2926,7 +2926,6 @@ namespace {
           // and these expressions should not be added to UEQ.
           State.G.clear();
           Expr *OV = GetOriginalValue(V, RHS, State.UEQ);
-          Dragon.Message("+++ Original value: ").Stmt(OV).Message(" +++\n");
           UpdateAfterAssignment(V, Target, OV, CSS, State, State);
         }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3908,6 +3908,11 @@ namespace {
     // If a set F in EQ contains an expression that is an rvalue cast of
     // the variable V, GetEqualExprSetContainingVariable returns F.
     // Otherwise, it returns an empty set.
+    //
+    // This is a specialized version of GetEqualExprSetContainingExpr
+    // for variables.  It prevents the need to allocate a cast expression
+    // containing the variable v (which would be needed to call
+    // GetEqualExprSetContainingExpr).
     EqualExprTy GetEqualExprSetContainingVariable(DeclRefExpr *V,
                                                   EquivExprSets EQ) {
       for (auto OuterList = EQ.begin(); OuterList != EQ.end(); ++OuterList) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -13917,9 +13917,11 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
   auto *UO = new (Context)
       UnaryOperator(Input.get(), Opc, resultType, VK, OK, OpLoc, CanOverflow);
 
-  if (Opc == UO_Deref && UO->getType()->hasAttr(attr::NoDeref) &&
-      !isa<ArrayType>(UO->getType().getDesugaredType(Context)))
-    ExprEvalContexts.back().PossibleDerefs.insert(UO);
+  if (!DisableSubstitionDiagnostics) {
+    if (Opc == UO_Deref && UO->getType()->hasAttr(attr::NoDeref) &&
+        !isa<ArrayType>(UO->getType().getDesugaredType(Context)))
+      ExprEvalContexts.back().PossibleDerefs.insert(UO);
+  }
 
   // Convert the result back to a half vector.
   if (ConvertHalfVec)

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -12955,7 +12955,8 @@ TreeTransform<Derived>::TransformBlockExpr(BlockExpr *E) {
       VarDecl *newCapture =
         cast<VarDecl>(getDerived().TransformDecl(E->getCaretLocation(),
                                                  oldCapture));
-      assert(blockScope->CaptureMap.count(newCapture));
+      assert(blockScope->CaptureMap.count(newCapture) ==
+             blockScope->CaptureMap.count(oldCapture));
     }
     assert(oldBlock->capturesCXXThis() == blockScope->isCXXThisCaptured());
   }

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -33,7 +33,18 @@ void f1(void) {
 }
 
 // BinaryOperator: non-compound assignment to a variable
-void f2(int i) {
+void f2(int i, nt_array_ptr<char> c) {
+  // Updated UEQ: { }
+  c = "abc";
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT:     CHKCBindTemporaryExpr {{.*}} 'char [4]'
+  // CHECK-NEXT:       StringLiteral {{.*}} "abc"
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+
   // Updated UEQ: { { 1, i } }
   i = 1;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -179,8 +179,8 @@ void f8(array_ptr<int> arr) {
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 'unsigned int' 1
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 'int' 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: }
@@ -220,7 +220,7 @@ void f10(array_ptr<int> arr) {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: }
@@ -261,7 +261,7 @@ void f12(int *p) {
   // CHECK-NEXT:     UnaryOperator {{.*}} '*'
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: }
 }
 

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -29,3 +29,94 @@ void f1(void) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
+
+// BinaryOperator: non-compound assignment to a variable
+void f2(int i) {
+  // Updated UEQ: { { 1, i } }
+  i = 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// BinaryOperator: compound assignment to a variable
+void f3(unsigned i) {
+  // Updated UEQ: { { (i - 2) + 2, i } }
+  i += 2;
+  // CHECK: Statement S:
+  // CHECK-NEXT: CompoundAssignOperator {{.*}} '+='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// BinaryOperator: non-compound assignment to a non-variable
+void f4(ptr<int> p) {
+  // Updated UEQ: { { 3, *p } }
+  *p = 3;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// BinaryOperator: compound assignment to a non-variable
+void f5(int arr[1]) {
+  // Updated UEQ: { }, Updated G: { arr[0] * 4 }
+  arr[0] *= 4;
+  // CHECK: Statement S:
+  // CHECK-NEXT: CompoundAssignOperator {{.*}} '*='
+  // CHECK-NEXT:   ArraySubscriptExpr
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '*'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     ArraySubscriptExpr
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:  IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -16,7 +16,7 @@ extern array_ptr<int> g1(array_ptr<int> arr : count(1)) : count(1);
 //////////////////////////////////////////////
 
 // VarDecl: initializer
-void f1(void) {
+void vardecl_1(void) {
   int i = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -33,7 +33,7 @@ void f1(void) {
 }
 
 // BinaryOperator: non-compound assignment to a variable
-void f2(int i, nt_array_ptr<char> c) {
+void binary_1(int i, nt_array_ptr<char> c) {
   // Updated UEQ: { }
   c = "abc";
   // CHECK: Statement S:
@@ -62,7 +62,7 @@ void f2(int i, nt_array_ptr<char> c) {
 }
 
 // BinaryOperator: compound assignment to a variable
-void f3(unsigned i) {
+void binary_2(unsigned i) {
   // Updated UEQ: { { (i - 2) + 2, i } }
   i += 2;
   // CHECK: Statement S:
@@ -87,27 +87,23 @@ void f3(unsigned i) {
   // CHECK-NEXT: }
 }
 
-// BinaryOperator: non-compound assignment to a non-variable
-void f4(ptr<int> p) {
-  // Updated UEQ: { }, Updated G: { 3 }
-  *p = 3;
+// BinaryOperator: non-compound assignments to non-variables
+// (non-modifying and modifying expressions)
+void binary_3(int arr[1], int i) {
+  // Updated UEQ: { }, Updated G: { }
+  *arr = 3;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   UnaryOperator {{.*}} '*'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: }
-}
+  // CHECK-NEXT: { }
 
-// BinaryOperator: non-compound assignment to a modifying expression
-void f5(int arr[1], int i) {
-  // Updated UEQ: { }, Updated G: { 3 }
+  // Updated UEQ: { }, Updated G: { }
   arr[i++] = 3;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -120,14 +116,13 @@ void f5(int arr[1], int i) {
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: }
+  // CHECK-NEXT: { }
 }
 
-// BinaryOperator: compound assignment to a non-variable
-void f6(int arr[1]) {
-  // Updated UEQ: { }, Updated G: { arr[0] * 4 }
+// BinaryOperator: compound assignments to non-variables
+// (non-modifying and modifying expressions)
+void binary_4(int arr[1], int i) {
+  // Updated UEQ: { }, Updated G: { }
   arr[0] *= 4;
   // CHECK: Statement S:
   // CHECK-NEXT: CompoundAssignOperator {{.*}} '*='
@@ -139,19 +134,26 @@ void f6(int arr[1]) {
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '*'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     ArraySubscriptExpr
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT:  IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: }
+  // CHECK-NEXT: { }
+
+  // Updated UEQ: { }, Updated G: { }
+  arr[--i] += 4;
+  // CHECK: Statement S:
+  // CHECK-NEXT: CompoundAssignOperator {{.*}} '+='
+  // CHECK-NEXT:   ArraySubscriptExpr
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     UnaryOperator {{.*}} prefix '--'
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
 }
 
 // UnaryOperator: pre-increment operator on a variable (unsigned integer arithmetic)
-void f7(unsigned x) {
+void binary_5(unsigned x) {
   // Updated UEQ: { { (x - 1) + 1, x } }
   ++x;
   // CHECK: Statement S:
@@ -173,7 +175,7 @@ void f7(unsigned x) {
 }
 
 // UnaryOperator: pre-decrement operator on a variable (checked pointer arithmetic)
-void f8(array_ptr<int> arr) {
+void binary_6(array_ptr<int> arr) {
   // Updated UEQ: { { (arr + 1) - 1, arr } }
   --arr;
   // CHECK: Statement S:
@@ -195,7 +197,7 @@ void f8(array_ptr<int> arr) {
 }
 
 // UnaryOperator: post-increment operator on a variable (unsigned integer arithmetic)
-void f9(unsigned x) {
+void unary_1(unsigned x) {
   // Updated UEQ: { { x - 1, x } }
   x++;
   // CHECK: Statement S:
@@ -215,7 +217,7 @@ void f9(unsigned x) {
 }
 
 // UnaryOperator: post-decrement operator on a variable (checked pointer arithmetic)
-void f10(array_ptr<int> arr) {
+void unary_2(array_ptr<int> arr) {
   // Updated UEQ: { { arr + 1, arr } }
   arr--;
   // CHECK: Statement S:
@@ -235,7 +237,7 @@ void f10(array_ptr<int> arr) {
 }
 
 // UnaryOperator: pre-increment operator on a variable (float arithmetic)
-void f11 (float f) {
+void unary_3(float f) {
   // Updated UEQ: { }, Updated G: { }
   ++f;
   // CHECK: Statement S:
@@ -248,7 +250,7 @@ void f11 (float f) {
 }
 
 // UnaryOperator: pre-decrement operator on a non-variable
-void f12(int *p) {
+void unary_4(int *p) {
   // Updated UEQ: { }, Updated G: { *p - 1 }
   --*p;
   // CHECK: Statement S:
@@ -274,7 +276,7 @@ void f12(int *p) {
 //////////////////////////////////////////////////////////////
 
 // Assign one value to each variable.
-void f13(int x, int y, int z, int w) {
+void multiple_assign1(int x, int y, int z, int w) {
   // Updated UEQ: { { 1, x }, { 2, y } }
   x = 1, y = 2;
   // CHECK: Statement S:
@@ -331,7 +333,7 @@ void f13(int x, int y, int z, int w) {
 }
 
 // Overwrite variable values.
-void f14(int x, int y) {
+void multiple_assign2(int x, int y) {
   // Updated UEQ: { { 1, x } }
   x = 1;
   // CHECK: Statement S:
@@ -391,7 +393,7 @@ void f14(int x, int y) {
 ///////////////////////////////////////////
 
 // UnaryOperator: '+' inverse
-void f15(int i) {
+void original_value1(int i) {
   // Original value of i in +i: +i
   // Updated UEQ: { { +(+i), i } }
   i = +i;
@@ -415,7 +417,7 @@ void f15(int i) {
 }
 
 // UnaryOperator: '-' inverse
-void f16(int i) {
+void original_value2(int i) {
   // Original value of i in -i: -i
   // Updated UEQ: { { -(-i), i } }
   i = -i;
@@ -439,7 +441,7 @@ void f16(int i) {
 }
 
 // UnaryOperator: '~' inverse
-void f17(int i) {
+void original_value3(int i) {
   // Original value of i in ~i: ~i
   // Updated UEQ: { { ~(~i), i } }
   i = ~i;
@@ -463,7 +465,7 @@ void f17(int i) {
 }
 
 // BinaryOperator: '^' inverse
-void f18(int i) {
+void original_value4(int i) {
   // Original value of i in 2 ^ i: i ^ 2
   // Updated UEQ: { { 2 ^ (i ^ 2), i } }
   i = 2 ^ i;
@@ -490,7 +492,7 @@ void f18(int i) {
 }
 
 // BinaryOperator: '+' inverse
-void f19(unsigned i, unsigned j) {
+void original_value5(unsigned i, unsigned j) {
   // Original value of i in i - j: i + j
   // Updated UEQ: { { (i + j) - j, i } }
   i = i - j;
@@ -520,7 +522,7 @@ void f19(unsigned i, unsigned j) {
 }
 
 // Combined UnaryOperator and BinaryOperator inverse
-void f20(unsigned i) {
+void original_value6(unsigned i) {
   // Original value of i in -(i + 2): -i - 2
   // Updated UEQ: { { -((-i - 2) + 2), i } }
   i = -(i + 2);
@@ -555,7 +557,7 @@ void f20(unsigned i) {
 }
 
 // Combined BinaryOperator and UnaryOperator inverse
-void f21(unsigned i) {
+void original_value7(unsigned i) {
   // Original value of i in ~i + 3: ~(i - 3)
   // Updated UEQ: { { ~(~(i - 3)) + 3, i } }
   i = ~i + 3;
@@ -588,7 +590,7 @@ void f21(unsigned i) {
 }
 
 // No inverse
-void f22(unsigned i, unsigned *p, unsigned arr[1]) {
+void original_value8(unsigned i, unsigned *p, unsigned arr[1]) {
   // Updated UEQ: { }, Updated G: { i }
   i = i + i;
   // CHECK: Statement S:
@@ -662,7 +664,7 @@ void f22(unsigned i, unsigned *p, unsigned arr[1]) {
 }
 
 // Original value from equivalence with another variable
-void f23(int x, int y) {
+void original_value9(int x, int y) {
   // Updated UEQ: { { y, x } }
   x = y;
   // CHECK: Statement S:
@@ -701,7 +703,7 @@ void f23(int x, int y) {
 }
 
 // The left-hand side variable is the original value
-void f24(int x) {
+void original_value10(int x) {
   // Original value of x in x: x
   // Updated UEQ: { }
   x = x;
@@ -727,7 +729,7 @@ void f24(int x) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void f25(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value11(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:
@@ -773,7 +775,7 @@ void f25(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
 /////////////////////////////////
 
 // If statement: assignment that affects equality sets
-void f26(int flag, int i, int j) {
+void control_flow1(int flag, int i, int j) {
   // Updated UEQ: { { i, len } }
   int len = i;
   // CHECK: Statement S:
@@ -825,7 +827,7 @@ void f26(int flag, int i, int j) {
 }
 
 // If statement: assignment that does not affect equality sets
-void f27(int flag, int i, int j) {
+void control_flow2(int flag, int i, int j) {
   // Updated UEQ: { { i, len } }
   int len = i;
   // CHECK: Statement S:
@@ -889,7 +891,7 @@ void f27(int flag, int i, int j) {
 }
 
 // If/else statements: different assignments
-void f28(int flag, int i, int j, int k) {
+void control_flow3(int flag, int i, int j, int k) {
   // Updated UEQ: { { i, len } }
   int len = i;
   // CHECK: Statement S:
@@ -966,7 +968,7 @@ void f28(int flag, int i, int j, int k) {
 }
 
 // If/else statements: more complicated intersection of equality sets
-void f29(int flag, int x, int y, int z, int w) {
+void control_flow4(int flag, int x, int y, int z, int w) {
   // Updated UEQ: { { 0, len } }
   int len = 0;
   // CHECK: Statement S:
@@ -1164,7 +1166,7 @@ void f29(int flag, int x, int y, int z, int w) {
 }
 
 // If/else statements: unreachable else
-void f30(int flag, int i, int j) {
+void control_flow5(int flag, int i, int j) {
   // Updated UEQ: { { 0, len } }
   int len = 0;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -236,7 +236,7 @@ void f10(array_ptr<int> arr) {
 
 // UnaryOperator: pre-increment operator on a variable (float arithmetic)
 void f11 (float f) {
-  // Updated UEQ: { }, Updated G: { f }
+  // Updated UEQ: { }, Updated G: { }
   ++f;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
@@ -244,10 +244,7 @@ void f11 (float f) {
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'f'
-  // CHECK-NEXT: }
+  // CHECK-NEXT: { }
 }
 
 // UnaryOperator: pre-decrement operator on a non-variable

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1,0 +1,31 @@
+// Tests for updating equivalent expression information during bounds inference and checking.
+// This file tests updating the set UEQ of sets of equivalent expressions after checking
+// initializations and assignments during bounds analysis.
+// Updating this set of sets also updates the set G of expressions that produce the same value
+// as a given expression. Since the set G is usually included in the set UEQ, this file typically
+// does not explicitly test the contents of G (G is tested in equiv-exprs.c).
+//
+// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
+
+#include <stdchecked.h>
+
+//////////////////////////////////////////////
+// Functions containing a single assignment //
+//////////////////////////////////////////////
+
+// VarDecl: initializer
+void f1(void) {
+  int i = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} i
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -120,3 +120,125 @@ void f5(int arr[1]) {
   // CHECK-NEXT:  IntegerLiteral {{.*}} 4
   // CHECK-NEXT: }
 }
+
+// UnaryOperator: pre-increment operator on a variable (unsigned integer arithmetic)
+void f6(unsigned x) {
+  // Updated UEQ: { { (x - 1) + 1, x } }
+  ++x;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: pre-decrement operator on a variable (checked pointer arithmetic)
+void f7(array_ptr<int> arr) {
+  // Updated UEQ: { { (arr + 1) - 1, arr } }
+  --arr;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: post-increment operator on a variable (unsigned integer arithmetic)
+void f8(unsigned x) {
+  // Updated UEQ: { { x - 1, x } }
+  x++;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: post-decrement operator on a variable (checked pointer arithmetic)
+void f9(array_ptr<int> arr) {
+  // Updated UEQ: { { arr + 1, arr } }
+  arr--;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '--'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: pre-increment operator on a variable (float arithmetic)
+void f10 (float f) {
+  // Updated UEQ: { }, Updated G: { f }
+  ++f;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'f'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'f'
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: pre-decrement operator on a non-variable
+void f11(int *p) {
+  // Updated UEQ: { }, Updated G: { *p - 1 }
+  --*p;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -361,3 +361,413 @@ void f13(int x, int y) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
+
+///////////////////////////////////////////
+// Assignments involving original values // 
+///////////////////////////////////////////
+
+// UnaryOperator: '+' inverse
+void f14(int i) {
+  // Original value of i in +i: +i
+  // Updated UEQ: { { +(+i), i } }
+  i = +i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '+'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: '-' inverse
+void f15(int i) {
+  // Original value of i in -i: -i
+  // Updated UEQ: { { -(-i), i } }
+  i = -i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '-'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: '~' inverse
+void f16(int i) {
+  // Original value of i in ~i: ~i
+  // Updated UEQ: { { ~(~i), i } }
+  i = ~i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '~'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '~'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '~'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// BinaryOperator: '^' inverse
+void f17(int i) {
+  // Original value of i in 2 ^ i: i ^ 2
+  // Updated UEQ: { { 2 ^ (i ^ 2), i } }
+  i = 2 ^ i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '^'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '^'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   BinaryOperator {{.*}} '^'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// BinaryOperator: '+' inverse
+void f18(unsigned i, unsigned j) {
+  // Original value of i in i - j: i + j
+  // Updated UEQ: { { (i + j) - j, i } }
+  i = i - j;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Combined UnaryOperator and BinaryOperator inverse
+void f19(unsigned i) {
+  // Original value of i in -(i + 2): -i - 2
+  // Updated UEQ: { { -((-i - 2) + 2), i } }
+  i = -(i + 2);
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: UnaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:       BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:         UnaryOperator {{.*}} '-'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Combined BinaryOperator and UnaryOperator inverse
+void f20(unsigned i) {
+  // Original value of i in ~i + 3: ~(i - 3)
+  // Updated UEQ: { { ~(~(i - 3)) + 3, i } }
+  i = ~i + 3;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     UnaryOperator {{.*}} '~'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '~'
+  // CHECK-NEXT:     UnaryOperator {{.*}} '~'
+  // CHECK-NEXT:       BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 3
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// No inverse
+void f21(unsigned i, unsigned *p, unsigned arr[1]) {
+  // Updated UEQ: { }, Updated G: { i }
+  i = i + i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { }, Updated G: { i }
+  i = 2 * i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '*'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { }, Update G: { i }
+  i += *p;
+  // CHECK: Statement S:
+  // CHECK-NEXT: CompoundAssignOperator {{.*}} '+='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { }, Updated G: { i }
+  i -= arr[0];
+  // CHECK: Statement S:
+  // CHECK-NEXT: CompoundAssignOperator {{.*}} '-='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     ArraySubscriptExpr
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+}
+
+// Original value from equivalence with another variable
+void f22(int x, int y) {
+  // Updated UEQ: { { y, x } }
+  x = y;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of x in x * 2: y
+  // Updated UEQ: { { y, y }, { y * 2, x } }
+  x *= 2;
+  // CHECK: Statement S:
+  // CHECK-NEXT: CompoundAssignOperator {{.*}} '*='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '*'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// The left-hand side variable is the original value
+void f23(int x) {
+  // Original value of x in x: x
+  // Updated UEQ: { { x, x } }
+  x = x;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of x in (int)x: x
+  // Updated UEQ: { { x, x, x } }
+  x = (int)x;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   CStyleCastExpr {{.*}} 'int' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// CallExpr: using the left-hand side of an assignment as a call argument
+void f24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+  // Updated UEQ: { { b, a } }
+  a = b;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of a in g1(a): b
+  // Updated UEQ: { { b, b }, { g1(a), a } }
+  // Note that a is not replaced with b in g1(a)
+  a = g1(a);
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:     CallExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'g1'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BoundsValueExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -89,7 +89,7 @@ void f3(unsigned i) {
 
 // BinaryOperator: non-compound assignment to a non-variable
 void f4(ptr<int> p) {
-  // Updated UEQ: { { 3, *p } }
+  // Updated UEQ: { }, Updated G: { 3 }
   *p = 3;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -98,14 +98,10 @@ void f4(ptr<int> p) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
 

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -98,8 +98,28 @@ void f4(ptr<int> p) {
   // CHECK-NEXT: }
 }
 
+// BinaryOperator: non-compound assignment to a modifying expression
+void f5(int arr[1], int i) {
+  // Updated UEQ: { }, Updated G: { 3 }
+  arr[i++] = 3;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   ArraySubscriptExpr
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     UnaryOperator {{.*}} postfix '++'
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:  IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: }
+}
+
 // BinaryOperator: compound assignment to a non-variable
-void f5(int arr[1]) {
+void f6(int arr[1]) {
   // Updated UEQ: { }, Updated G: { arr[0] * 4 }
   arr[0] *= 4;
   // CHECK: Statement S:
@@ -124,7 +144,7 @@ void f5(int arr[1]) {
 }
 
 // UnaryOperator: pre-increment operator on a variable (unsigned integer arithmetic)
-void f6(unsigned x) {
+void f7(unsigned x) {
   // Updated UEQ: { { (x - 1) + 1, x } }
   ++x;
   // CHECK: Statement S:
@@ -146,7 +166,7 @@ void f6(unsigned x) {
 }
 
 // UnaryOperator: pre-decrement operator on a variable (checked pointer arithmetic)
-void f7(array_ptr<int> arr) {
+void f8(array_ptr<int> arr) {
   // Updated UEQ: { { (arr + 1) - 1, arr } }
   --arr;
   // CHECK: Statement S:
@@ -168,7 +188,7 @@ void f7(array_ptr<int> arr) {
 }
 
 // UnaryOperator: post-increment operator on a variable (unsigned integer arithmetic)
-void f8(unsigned x) {
+void f9(unsigned x) {
   // Updated UEQ: { { x - 1, x } }
   x++;
   // CHECK: Statement S:
@@ -188,7 +208,7 @@ void f8(unsigned x) {
 }
 
 // UnaryOperator: post-decrement operator on a variable (checked pointer arithmetic)
-void f9(array_ptr<int> arr) {
+void f10(array_ptr<int> arr) {
   // Updated UEQ: { { arr + 1, arr } }
   arr--;
   // CHECK: Statement S:
@@ -208,7 +228,7 @@ void f9(array_ptr<int> arr) {
 }
 
 // UnaryOperator: pre-increment operator on a variable (float arithmetic)
-void f10 (float f) {
+void f11 (float f) {
   // Updated UEQ: { }, Updated G: { f }
   ++f;
   // CHECK: Statement S:
@@ -224,7 +244,7 @@ void f10 (float f) {
 }
 
 // UnaryOperator: pre-decrement operator on a non-variable
-void f11(int *p) {
+void f12(int *p) {
   // Updated UEQ: { }, Updated G: { *p - 1 }
   --*p;
   // CHECK: Statement S:
@@ -250,7 +270,7 @@ void f11(int *p) {
 //////////////////////////////////////////////////////////////
 
 // Assign one value to each variable.
-void f12(int x, int y, int z, int w) {
+void f13(int x, int y, int z, int w) {
   // Updated UEQ: { { 1, x }, { 2, y } }
   x = 1, y = 2;
   // CHECK: Statement S:
@@ -307,7 +327,7 @@ void f12(int x, int y, int z, int w) {
 }
 
 // Overwrite variable values.
-void f13(int x, int y) {
+void f14(int x, int y) {
   // Updated UEQ: { { 1, x } }
   x = 1;
   // CHECK: Statement S:
@@ -367,7 +387,7 @@ void f13(int x, int y) {
 ///////////////////////////////////////////
 
 // UnaryOperator: '+' inverse
-void f14(int i) {
+void f15(int i) {
   // Original value of i in +i: +i
   // Updated UEQ: { { +(+i), i } }
   i = +i;
@@ -391,7 +411,7 @@ void f14(int i) {
 }
 
 // UnaryOperator: '-' inverse
-void f15(int i) {
+void f16(int i) {
   // Original value of i in -i: -i
   // Updated UEQ: { { -(-i), i } }
   i = -i;
@@ -415,7 +435,7 @@ void f15(int i) {
 }
 
 // UnaryOperator: '~' inverse
-void f16(int i) {
+void f17(int i) {
   // Original value of i in ~i: ~i
   // Updated UEQ: { { ~(~i), i } }
   i = ~i;
@@ -439,7 +459,7 @@ void f16(int i) {
 }
 
 // BinaryOperator: '^' inverse
-void f17(int i) {
+void f18(int i) {
   // Original value of i in 2 ^ i: i ^ 2
   // Updated UEQ: { { 2 ^ (i ^ 2), i } }
   i = 2 ^ i;
@@ -466,7 +486,7 @@ void f17(int i) {
 }
 
 // BinaryOperator: '+' inverse
-void f18(unsigned i, unsigned j) {
+void f19(unsigned i, unsigned j) {
   // Original value of i in i - j: i + j
   // Updated UEQ: { { (i + j) - j, i } }
   i = i - j;
@@ -496,7 +516,7 @@ void f18(unsigned i, unsigned j) {
 }
 
 // Combined UnaryOperator and BinaryOperator inverse
-void f19(unsigned i) {
+void f20(unsigned i) {
   // Original value of i in -(i + 2): -i - 2
   // Updated UEQ: { { -((-i - 2) + 2), i } }
   i = -(i + 2);
@@ -531,7 +551,7 @@ void f19(unsigned i) {
 }
 
 // Combined BinaryOperator and UnaryOperator inverse
-void f20(unsigned i) {
+void f21(unsigned i) {
   // Original value of i in ~i + 3: ~(i - 3)
   // Updated UEQ: { { ~(~(i - 3)) + 3, i } }
   i = ~i + 3;
@@ -564,7 +584,7 @@ void f20(unsigned i) {
 }
 
 // No inverse
-void f21(unsigned i, unsigned *p, unsigned arr[1]) {
+void f22(unsigned i, unsigned *p, unsigned arr[1]) {
   // Updated UEQ: { }, Updated G: { i }
   i = i + i;
   // CHECK: Statement S:
@@ -638,7 +658,7 @@ void f21(unsigned i, unsigned *p, unsigned arr[1]) {
 }
 
 // Original value from equivalence with another variable
-void f22(int x, int y) {
+void f23(int x, int y) {
   // Updated UEQ: { { y, x } }
   x = y;
   // CHECK: Statement S:
@@ -677,7 +697,7 @@ void f22(int x, int y) {
 }
 
 // The left-hand side variable is the original value
-void f23(int x) {
+void f24(int x) {
   // Original value of x in x: x
   // Updated UEQ: { }
   x = x;
@@ -703,7 +723,7 @@ void f23(int x) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void f24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void f25(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:
@@ -749,7 +769,7 @@ void f24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
 /////////////////////////////////
 
 // If statement: assignment that affects equality sets
-void f25(int flag, int i, int j) {
+void f26(int flag, int i, int j) {
   // Updated UEQ: { { i, len } }
   int len = i;
   // CHECK: Statement S:
@@ -801,7 +821,7 @@ void f25(int flag, int i, int j) {
 }
 
 // If statement: assignment that does not affect equality sets
-void f26(int flag, int i, int j) {
+void f27(int flag, int i, int j) {
   // Updated UEQ: { { i, len } }
   int len = i;
   // CHECK: Statement S:
@@ -865,7 +885,7 @@ void f26(int flag, int i, int j) {
 }
 
 // If/else statements: different assignments
-void f27(int flag, int i, int j, int k) {
+void f28(int flag, int i, int j, int k) {
   // Updated UEQ: { { i, len } }
   int len = i;
   // CHECK: Statement S:
@@ -942,7 +962,7 @@ void f27(int flag, int i, int j, int k) {
 }
 
 // If/else statements: more complicated intersection of equality sets
-void f28(int flag, int x, int y, int z, int w) {
+void f29(int flag, int x, int y, int z, int w) {
   // Updated UEQ: { { 0, len } }
   int len = 0;
   // CHECK: Statement S:
@@ -1140,7 +1160,7 @@ void f28(int flag, int x, int y, int z, int w) {
 }
 
 // If/else statements: unreachable else
-void f29(int flag, int i, int j) {
+void f30(int flag, int i, int j) {
   // Updated UEQ: { { 0, len } }
   int len = 0;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -16,7 +16,7 @@ extern array_ptr<int> g1(array_ptr<int> arr : count(1)) : count(1);
 //////////////////////////////////////////////
 
 // VarDecl: initializer
-void vardecl_1(void) {
+void vardecl1(void) {
   int i = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -33,7 +33,7 @@ void vardecl_1(void) {
 }
 
 // BinaryOperator: non-compound assignment to a variable
-void binary_1(int i, nt_array_ptr<char> c) {
+void binary1(int i, nt_array_ptr<char> c) {
   // Updated UEQ: { }
   c = "abc";
   // CHECK: Statement S:
@@ -62,8 +62,8 @@ void binary_1(int i, nt_array_ptr<char> c) {
 }
 
 // BinaryOperator: compound assignment to a variable
-void binary_2(unsigned i) {
   // Updated UEQ: { { (i - 2) + 2, i } }
+void binary2(unsigned i) {
   i += 2;
   // CHECK: Statement S:
   // CHECK-NEXT: CompoundAssignOperator {{.*}} '+='
@@ -89,7 +89,7 @@ void binary_2(unsigned i) {
 
 // BinaryOperator: non-compound assignments to non-variables
 // (non-modifying and modifying expressions)
-void binary_3(int arr[1], int i) {
+void binary3(int arr[1], int i) {
   // Updated UEQ: { }, Updated G: { }
   *arr = 3;
   // CHECK: Statement S:
@@ -121,7 +121,7 @@ void binary_3(int arr[1], int i) {
 
 // BinaryOperator: compound assignments to non-variables
 // (non-modifying and modifying expressions)
-void binary_4(int arr[1], int i) {
+void binary4(int arr[1], int i) {
   // Updated UEQ: { }, Updated G: { }
   arr[0] *= 4;
   // CHECK: Statement S:
@@ -153,91 +153,75 @@ void binary_4(int arr[1], int i) {
 }
 
 // UnaryOperator: pre-increment operator on a variable (unsigned integer arithmetic)
-void binary_5(unsigned x) {
-  // Updated UEQ: { { (x - 1) + 1, x } }
+void unary1(unsigned x) {
+  // Updated UEQ: { }, Updated G: { x + 1 }
   ++x;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: pre-decrement operator on a variable (checked pointer arithmetic)
-void binary_6(array_ptr<int> arr) {
-  // Updated UEQ: { { (arr + 1) - 1, arr } }
+void unary2(array_ptr<int> arr) {
+  // Updated UEQ: { }, Updated G: { arr - 1 }
   --arr;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 'int' 1
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: post-increment operator on a variable (unsigned integer arithmetic)
-void unary_1(unsigned x) {
-  // Updated UEQ: { { x - 1, x } }
+void unary3(unsigned x) {
+  // Updated UEQ: { }, Updated G: { x }
   x++;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: post-decrement operator on a variable (checked pointer arithmetic)
-void unary_2(array_ptr<int> arr) {
-  // Updated UEQ: { { arr + 1, arr } }
+void unary4(array_ptr<int> arr) {
+  // Updated UEQ: { }, Updated G: { arr }
   arr--;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} postfix '--'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: pre-increment operator on a variable (float arithmetic)
-void unary_3(float f) {
+void unary5(float f) {
   // Updated UEQ: { }, Updated G: { }
   ++f;
   // CHECK: Statement S:
@@ -250,7 +234,7 @@ void unary_3(float f) {
 }
 
 // UnaryOperator: pre-decrement operator on a non-variable
-void unary_4(int *p) {
+void unary6(int *p) {
   // Updated UEQ: { }, Updated G: { *p - 1 }
   --*p;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -62,8 +62,8 @@ void binary1(int i, nt_array_ptr<char> c) {
 }
 
 // BinaryOperator: compound assignment to a variable
-  // Updated UEQ: { { (i - 2) + 2, i } }
 void binary2(unsigned i) {
+  // Updated UEQ: { { (i - 2) + 2, i } }
   i += 2;
   // CHECK: Statement S:
   // CHECK-NEXT: CompoundAssignOperator {{.*}} '+='
@@ -154,7 +154,7 @@ void binary4(int arr[1], int i) {
 
 // UnaryOperator: pre-increment operator on a variable (unsigned integer arithmetic)
 void unary1(unsigned x) {
-  // Updated UEQ: { }, Updated G: { x + 1 }
+  // Updated UEQ: { }, Updated G: { x }
   ++x;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
@@ -163,16 +163,14 @@ void unary1(unsigned x) {
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: pre-decrement operator on a variable (checked pointer arithmetic)
 void unary2(array_ptr<int> arr) {
-  // Updated UEQ: { }, Updated G: { arr - 1 }
+  // Updated UEQ: { }, Updated G: { arr }
   --arr;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
@@ -181,16 +179,14 @@ void unary2(array_ptr<int> arr) {
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '-'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: post-increment operator on a variable (unsigned integer arithmetic)
 void unary3(unsigned x) {
-  // Updated UEQ: { }, Updated G: { x }
+  // Updated UEQ: { }, Updated G: { x - 1 }
   x++;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
@@ -199,14 +195,16 @@ void unary3(unsigned x) {
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 }
 
 // UnaryOperator: post-decrement operator on a variable (checked pointer arithmetic)
 void unary4(array_ptr<int> arr) {
-  // Updated UEQ: { }, Updated G: { arr }
+  // Updated UEQ: { }, Updated G: { arr + 1 }
   arr--;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} postfix '--'
@@ -215,8 +213,10 @@ void unary4(array_ptr<int> arr) {
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 }
 
@@ -233,24 +233,26 @@ void unary5(float f) {
   // CHECK-NEXT: { }
 }
 
-// UnaryOperator: pre-decrement operator on a non-variable
+// UnaryOperator: post-decrement operator on a non-variable
 void unary6(int *p) {
-  // Updated UEQ: { }, Updated G: { *p - 1 }
-  --*p;
+  // Updated UEQ: { }, Updated G: { (*p) + 1 }
+  (*p)--;
   // CHECK: Statement S:
-  // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
-  // CHECK-NEXT:   UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '--'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 1
   // CHECK-NEXT: }
 }
@@ -475,7 +477,7 @@ void original_value4(int i) {
   // CHECK-NEXT: }
 }
 
-// BinaryOperator: '+' inverse
+// BinaryOperator: '-' inverse
 void original_value5(unsigned i, unsigned j) {
   // Original value of i in i - j: i + j
   // Updated UEQ: { { (i + j) - j, i } }
@@ -573,8 +575,148 @@ void original_value7(unsigned i) {
   // CHECK-NEXT: }
 }
 
+// UnaryOperator: pre-increment and post-increment inverses
+void original_value8(unsigned x, unsigned i) {
+  // Updated UEQ: { { i, x } }
+  x = i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of i in i + 1: i - 1
+  // Updated UEQ: { { i - 1, x } }, Updated G: { i }
+  ++i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+
+  // Original value of i in i + 1: i - 1
+  // Updated UEQ: { { i - 1 - 1, x } }, Updated G: { i - 1 }
+  i++;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: pre-decrement and post-decrement inverses
+void original_value9(unsigned x, unsigned i) {
+  // Updated UEQ: { { i, x } }
+  x = i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of i in i - 1: i + 1
+  // Updated UEQ: { { i + 1, x } }, Updated G: { i }
+  --i;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+
+  // Original value of i in i - 1: i + 1
+  // Updated UEQ: { { i + 1 + 1, x } }, Updated G: { i + 1 }
+  i--;
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '--'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: }
+}
+
 // No inverse
-void original_value8(unsigned i, unsigned *p, unsigned arr[1]) {
+void original_value10(unsigned i, unsigned *p, unsigned arr[1]) {
   // Updated UEQ: { }, Updated G: { i }
   i = i + i;
   // CHECK: Statement S:
@@ -648,7 +790,7 @@ void original_value8(unsigned i, unsigned *p, unsigned arr[1]) {
 }
 
 // Original value from equivalence with another variable
-void original_value9(int x, int y) {
+void original_value11(int x, int y) {
   // Updated UEQ: { { y, x } }
   x = y;
   // CHECK: Statement S:
@@ -687,7 +829,7 @@ void original_value9(int x, int y) {
 }
 
 // The left-hand side variable is the original value
-void original_value10(int x) {
+void original_value12(int x) {
   // Original value of x in x: x
   // Updated UEQ: { }
   x = x;
@@ -713,7 +855,7 @@ void original_value10(int x) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void original_value11(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value13(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -341,7 +341,7 @@ void f13(int x, int y) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Updated UEQ: { { 1, y, y }, { 2, x } }
+  // Updated UEQ: { { 1, y }, { 2, x } }
   x = 2;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -351,8 +351,6 @@ void f13(int x, int y) {
   // CHECK-NEXT: {
   // CHECK-NEXT: {
   // CHECK-NEXT: IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
   // CHECK-NEXT: }
@@ -659,7 +657,7 @@ void f22(int x, int y) {
   // CHECK-NEXT: }
 
   // Original value of x in x * 2: y
-  // Updated UEQ: { { y, y }, { y * 2, x } }
+  // Updated UEQ: { { y * 2, x } }
   x *= 2;
   // CHECK: Statement S:
   // CHECK-NEXT: CompoundAssignOperator {{.*}} '*='
@@ -667,12 +665,6 @@ void f22(int x, int y) {
   // CHECK-NEXT:   IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: }
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '*'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -687,7 +679,7 @@ void f22(int x, int y) {
 // The left-hand side variable is the original value
 void f23(int x) {
   // Original value of x in x: x
-  // Updated UEQ: { { x, x } }
+  // Updated UEQ: { }
   x = x;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -695,17 +687,10 @@ void f23(int x) {
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // CHECK-NEXT: { }
 
   // Original value of x in (int)x: x
-  // Updated UEQ: { { x, x, x } }
+  // Updated UEQ: { }
   x = (int)x;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -714,16 +699,7 @@ void f23(int x) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // CHECK-NEXT: { }
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
@@ -746,7 +722,7 @@ void f24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // CHECK-NEXT: }
 
   // Original value of a in g1(a): b
-  // Updated UEQ: { { b, b }, { g1(a), a } }
+  // Updated UEQ: { { g1(a), a } }
   // Note that a is not replaced with b in g1(a)
   a = g1(a);
   // CHECK: Statement S:
@@ -760,12 +736,6 @@ void f24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT: }
   // CHECK-NEXT: {
   // CHECK-NEXT: BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -800,7 +770,7 @@ void f25(int flag, int i, int j) {
   if (flag) {
     // Current UEQ: { { i, len } }
     // Original value of len in j: i
-    // Updated UEQ: { { i, i }, { j, len } }
+    // Updated UEQ: { { j, len } }
     len = j;
     // CHECK: Statement S:
     // CHECK:      BinaryOperator {{.*}} '='
@@ -809,12 +779,6 @@ void f25(int flag, int i, int j) {
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'j'
     // CHECK-NEXT: Sets of equivalent expressions after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: {
-    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: }
     // CHECK-NEXT: {
     // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:   DeclRefExpr {{.*}} 'j'
@@ -881,7 +845,7 @@ void f26(int flag, int i, int j) {
 
   // Current UEQ: { { i, len } }
   // Original value of len in len * 2: i
-  // Updated UEQ: { { i, i }, { i * 2, len } }
+  // Updated UEQ: { { i * 2, len } }
   len *= 2;
   // CHECK: Statement S:
   // CHECK-NEXT: CompoundAssignOperator {{.*}} '*='
@@ -889,12 +853,6 @@ void f26(int flag, int i, int j) {
   // CHECK-NEXT:   IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '*'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -932,7 +890,7 @@ void f27(int flag, int i, int j, int k) {
   if (flag) {
     // Current UEQ: { { i, len } }
     // Original value for len in j: i
-    // Updated UEQ: { { i, i }, { j, len } }
+    // Updated UEQ: { { j, len } }
     len = j;
     // Expected output of len = k from the "else" block
     // CHECK: Statement S:
@@ -944,12 +902,6 @@ void f27(int flag, int i, int j, int k) {
     // CHECK-NEXT: {
     // CHECK-NEXT: {
     // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: }
-    // CHECK-NEXT: {
-    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:   DeclRefExpr {{.*}} 'k'
     // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:   DeclRefExpr {{.*}} 'len'
@@ -958,7 +910,7 @@ void f27(int flag, int i, int j, int k) {
   } else {
     // Current UEQ: { { i, len } }
     // Original value for len in k: i
-    // Updated UEQ: { { i, i }, { k, len } }
+    // Updated UEQ: { { k, len } }
     len = k;
     // Expected output of len = j from the "if" block
     // CHECK: Statement S:
@@ -968,12 +920,6 @@ void f27(int flag, int i, int j, int k) {
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'j'
     // CHECK-NEXT: Sets of equivalent expressions after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: {
-    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: }
     // CHECK-NEXT: {
     // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:   DeclRefExpr {{.*}} 'j'
@@ -1235,7 +1181,7 @@ void f29(int flag, int i, int j) {
 
   // Current UEQ: { { i, len } }
   // Original value of len in len * 2: i
-  // Updated UEQ: { { i, i }, { i * 2, len } }
+  // Updated UEQ: { { i * 2, len } }
   len *= 2;
   // CHECK: Statement S:
   // CHECK-NEXT: CompoundAssignOperator {{.*}} '*='
@@ -1243,12 +1189,6 @@ void f29(int flag, int i, int j) {
   // CHECK-NEXT:   IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '*'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -242,3 +242,122 @@ void f11(int *p) {
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'unsigned int' 1
   // CHECK-NEXT: }
 }
+
+//////////////////////////////////////////////////////////////
+// Functions and statements containing multiple assignments //
+//////////////////////////////////////////////////////////////
+
+// Assign one value to each variable.
+void f12(int x, int y, int z, int w) {
+  // Updated UEQ: { { 1, x }, { 2, y } }
+  x = 1, y = 2;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK-NEXT:   BinaryOperator {{.*}} '='
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   BinaryOperator {{.*}} '='
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { 1, x }, { 2, y }, { 3, w, z } }
+  z = (w = 3);
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'w'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'w'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Overwrite variable values.
+void f13(int x, int y) {
+  // Updated UEQ: { { 1, x } }
+  x = 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { 1, x, y } }
+  y = x;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { 1, y, y }, { 2, x } }
+  x = 2;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -2,7 +2,7 @@
 // This file tests updating the set of expressions that produces the same value as an expression
 // after checking the expression during bounds analysis.
 // This file does not test assignments that update the set of sets of equivalent expressions
-// (assignments will be tested in a separate test file).
+// (assignments are tested in equiv-expr-sets.c).
 //
 // RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
 

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -142,8 +142,18 @@ void f3(int a [1]) {
   // CHECK-NEXT: { }
 }
 
-// IntegerLiteral, StringLiteral, CHKCBindTemporaryExpr
+// CharacterLiteral, IntegerLiteral, FloatingLiteral
 void f4() {
+  'a';
+  // CHECK: Statement S:
+  // CHECK-NEXT: CharacterLiteral {{.*}} 'int' 97
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: CharacterLiteral {{.*}} 'int' 97
+  // CHECK-NEXT: }
+
   5;
   // CHECK: Statement S:
   // CHECK-NEXT: IntegerLiteral {{.*}} 5
@@ -154,18 +164,14 @@ void f4() {
   // CHECK-NEXT: IntegerLiteral {{.*}} 5
   // CHECK-NEXT: }
 
-  "abc";
+  3.14f;
   // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:     StringLiteral {{.*}} "abc"
+  // CHECK-NEXT: FloatingLiteral {{.*}} 'float' 3.14
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:     StringLiteral {{.*}} "abc"
+  // CHECK-NEXT: FloatingLiteral {{.*}} 'float' 3.14
   // CHECK-NEXT: }
 }
 
@@ -297,6 +303,44 @@ void f7(void) {
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'g3'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+}
+
+// StringLiteral, InitListExpr, CompoundLiteral
+void f8(void) {
+  "abc";
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'char [4]'
+  // CHECK-NEXT:     StringLiteral {{.*}} "abc"
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+
+  (int []){ 0, 1, 2 };
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'int [3]'
+  // CHECK-NEXT:     CompoundLiteralExpr {{.*}} 'int [3]'
+  // CHECK-NEXT:       InitListExpr {{.*}} 'int [3]'
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+
+  &(double []){ 2.72 };
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '&'
+  // CHECK-NEXT:   CompoundLiteralExpr {{.*}} 'double [1]'
+  // CHECK-NEXT:     InitListExpr {{.*}} 'double [1]'
+  // CHECK-NEXT:       FloatingLiteral 0{{.*}} 'double' 2.72
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: { }
   // CHECK-NEXT: Expressions that produce the same value as S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -4,7 +4,7 @@
 // This file does not test assignments that update the set of sets of equivalent expressions
 // (assignments will be tested in a separate test file).
 //
-// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s --dump-input=always
+// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
 
 #include <stdchecked.h>
 
@@ -17,15 +17,6 @@ extern void g3(array_ptr<int> arr : count(1));
 void f1(int i, int a checked[5]) {
   // Non-array type
   i;
-  // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
@@ -41,13 +32,8 @@ void f1(int i, int a checked[5]) {
   int arr checked[10];
   arr;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} arr
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
@@ -62,14 +48,6 @@ void f1(int i, int a checked[5]) {
   // Extern unchecked array with known size
   a1;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'a1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a1'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a1'
   // CHECK-NEXT: Sets of equivalent expressions after checking S:
@@ -82,15 +60,6 @@ void f1(int i, int a checked[5]) {
 
   // Array parameter with _Array_ptr<int> type
   a;
-  // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
@@ -107,33 +76,6 @@ void f1(int i, int a checked[5]) {
 void f2(int *p, int x, int y) {
   *p;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: { }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   UnaryOperator {{.*}} '*'
   // CHECK-NEXT:    ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -144,15 +86,6 @@ void f2(int *p, int x, int y) {
   // CHECK-NEXT: { }
 
   &x;
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
@@ -167,13 +100,8 @@ void f2(int *p, int x, int y) {
   int a[3];
   &a;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} a
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
@@ -185,25 +113,6 @@ void f2(int *p, int x, int y) {
   // CHECK-NEXT: }
 
   !y;
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} '!'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -221,42 +130,6 @@ void f2(int *p, int x, int y) {
 // ArraySubscriptExpr
 void f3(int a [1]) {
   a[0];
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: { }
   // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   ArraySubscriptExpr {{.*}} lvalue
@@ -283,25 +156,6 @@ void f4() {
 
   "abc";
   // CHECK: Statement S:
-  // CHECK-NEXT: StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:   StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:   StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: BoundsValueExpr {{.*}} 'char [4]'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'char [4]'
   // CHECK-NEXT:     StringLiteral {{.*}} "abc"
@@ -319,22 +173,6 @@ void f4() {
 void f5() {
   1 + 2;
   // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT:   IntegerLiteral {{.*}} 2
@@ -348,22 +186,6 @@ void f5() {
   // CHECK-NEXT: }
 
   3 < 4;
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '<'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 3
@@ -379,22 +201,6 @@ void f5() {
 
   5 & 6;
   // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 6
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 6
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '&'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 6
@@ -408,22 +214,6 @@ void f5() {
   // CHECK-NEXT: }
 
   7, 8;
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 7
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 7
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 8
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 8
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
   // CHECK-NEXT:   IntegerLiteral {{.*}} 7
@@ -440,25 +230,6 @@ void f5() {
 void f6(int i, array_ptr<int> arr : count(1)) {
   (double)i;
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: CStyleCastExpr {{.*}} <IntegralToFloating>
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
@@ -472,38 +243,6 @@ void f6(int i, array_ptr<int> arr : count(1)) {
   // CHECK-NEXT: }
 
   _Assume_bounds_cast<array_ptr<char>>(arr, count(4));
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: BoundsValueExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: BoundsCastExpr {{.*}} <AssumePtrBounds>
   // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
@@ -530,24 +269,6 @@ void f7(void) {
   // Function with no parameters
   g1();
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: CallExpr {{.*}} 'void'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'g1'
@@ -558,32 +279,6 @@ void f7(void) {
 
   // Function with no parameter annotations
   g2(0);
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: CallExpr {{.*}} 'void'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
@@ -596,42 +291,6 @@ void f7(void) {
 
   // Function with parameter annotations
   g3(0);
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: CallExpr {{.*}} 'void'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -346,3 +346,19 @@ void f8(void) {
   // CHECK-NEXT: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 }
+
+// ArrayToPointerDecay cast of a modifying expression
+void f9(array_ptr<int [3]> arr : count(1), int i) {
+  arr[i++];
+  // CHECK: Statement S:
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT:   ArraySubscriptExpr
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     UnaryOperator {{.*}} postfix '++'
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK-NEXT: { }
+}


### PR DESCRIPTION
This PR updates the sets UEQ and G of equivalent expressions while checking expressions that involve assignments. This is done with the following changes:

* Update UEQ and G from CheckVarDecl (for declarations with initializers), CheckBinaryOperator (for assignments and compound assignments), and CheckUnaryOperator (for increment/decrement operators).
* Add a GetIncomingBlockState method that gets the state that is true at the beginning of a CFG block by getting the intersection of the UEQ sets of the block's predecessors.
* Add an UpdateAfterAssignment method that updates UEQ and G after an assignment to a variable V.
* Add a GetOriginalValue method that gets the original value of a variable in an expression. Helper methods IsInvertible and Inverse are used to get the original value.
* Add helpers PruneVariableReferences and VariableOccurrenceCount to help with getting the inverse of an expression.
* Add utility classes VariableUtil and ExprCreatorUtil to help with detecting and comparing variables and creating certain kinds of expressions.
* Modify asserts and diagnostic behavior in CanonBounds, TreeTransform, and SemaExpr to reflect the greater variety of expressions that can be lexicographically compared and transformed.

Testing:
* Changed the behavior of the -fdump-checking-state flag to only dump the checking state after checking a top-level CFG statement, rather than after every expression. The equiv-exprs.c test has been modified to reflect this change.
* Added a test equiv-expr-sets.c to test that the set UEQ of sets of equivalent expressions is properly updated while checking assignments. This file also tests that the incoming UEQ set is properly determined for CFG blocks in functions with `if` statements.
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux.