### PR TITLE
Support bounds widening for conditionals with for loops

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -116,6 +116,26 @@ namespace clang {
       // block.
       BoundsVarTy BoundsVars;
 
+      // To compute In[B] we compute the intersection of Out[B*->B], where B*
+      // are all preds of B. When there is a back edge from block B' to B (for
+      // example in loops), the Out set for block B' will be empty when we
+      // first enter B. As a result, the intersection operation would always
+      // result in an empty In set for B.
+
+      // So to handle this, we initialize the In and Out sets for all blocks as
+      // Top so that the intersection does not result in an empty In set.
+
+      // But we also need to handle the case where there is an unconditional
+      // jump into a block (as a result of a goto). In this case, we cannot
+      // widen the bounds because we would not have checked for the ptr
+      // dereference. So we want the intersection to result in an empty set.
+
+      // So we want to initialize the In and Out sets of the entry block as
+      // empty. IsInSetEmpty and IsOutSetEmpty indicate whether the In and Out
+      // sets for a block have been initialized to empty.
+      bool IsInSetEmpty;
+      llvm::DenseMap<const CFGBlock *, bool> IsOutSetEmpty;
+
       ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
     };
 

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -122,17 +122,21 @@ namespace clang {
       // first enter B. As a result, the intersection operation would always
       // result in an empty In set for B.
 
-      // So to handle this, we initialize the In and Out sets for all blocks as
-      // Top so that the intersection does not result in an empty In set.
+      // So to handle this, we consider the In and Out sets for all blocks to
+      // have a default value of "Top" which indicates a set of all members of
+      // the Gen set. In this way we ensure that the intersection does not
+      // result in an empty set even if the Out set for a block is actually
+      // empty.
 
       // But we also need to handle the case where there is an unconditional
-      // jump into a block (as a result of a goto). In this case, we cannot
-      // widen the bounds because we would not have checked for the ptr
-      // dereference. So we want the intersection to result in an empty set.
+      // jump into a block (for example, as a result of a goto). In this case,
+      // we cannot widen the bounds because we would not have checked for the
+      // ptr dereference. So in this case we want the intersection to result in
+      // an empty set.
 
-      // So we want to initialize the In and Out sets of the entry block as
-      // empty. IsInSetEmpty and IsOutSetEmpty indicate whether the In and Out
-      // sets for a block have been initialized to empty.
+      // So we mark the In and Out sets of the Entry block as "empty".
+      // IsInSetEmpty and IsOutSetEmpty indicate whether the In and Out sets
+      // for a block have been marked as "empty".
       bool IsInSetEmpty;
       llvm::DenseMap<const CFGBlock *, bool> IsOutSetEmpty;
 

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -38,8 +38,8 @@ void BoundsAnalysis::WidenBounds(FunctionDecl *FD) {
     WorkList.append(EB);
     BlockMap[B] = EB;
 
-    // Mark the In set for the entry block as empty. The Out set for the entry
-    // block would be marked as empty in ComputeOutSets.
+    // Mark the In set for the Entry block as "empty". The Out set for the
+    // Entry block would be marked as "empty" in ComputeOutSets.
     EB->IsInSetEmpty = B == &Cfg->getEntry();
   }
 
@@ -571,9 +571,9 @@ void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
 
     ElevatedCFGBlock *PredEB = BlockMap[pred];
 
-    // If the Out set on any incoming edge to a block is marked as empty, then
-    // the intersection of Out's would result in an empty In set. So we mark
-    // the In set as empty and return early.
+    // If the Out set on any incoming edge to a block is marked as "empty",
+    // then the intersection of Out's would result in an empty In set. So we
+    // mark the In set as "empty" and return early.
     if (PredEB->IsOutSetEmpty[EB->Block]) {
       EB->IsInSetEmpty = true;
       return;
@@ -630,8 +630,8 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
 
     EB->Out[succ] = Union(Diff, EB->Gen[succ]);
 
-    // The Out set on an edge is marked empty if the In set is marked empty and
-    // the Gen set on that edge is empty.
+    // The Out set on an edge is marked "empty" if the In set is marked "empty"
+    // and the Gen set on that edge is empty.
     EB->IsOutSetEmpty[succ] = EB->IsInSetEmpty && !EB->Gen[succ].size();
 
     if (Differ(OldOut, EB->Out[succ]))

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -579,9 +579,10 @@ void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
       return;
     }
 
-    // If the Out set of the pred on the incoming edge is not marked as empty,
-    // it means we should treat the Out set as Top. So we should perform the
-    // intersection only if the Out set has at least one element.
+    // If the Out set of the pred on the incoming edge is not marked as
+    // "empty", it means we should treat the Out set as "Top". So we simulate
+    // "Top" by performing the intersection only if the size of the Out set is
+    // non-zero.
     if (!Intersections.size())
       Intersections = PredEB->Out[EB->Block];
     else if (PredEB->Out[EB->Block].size())

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -656,6 +656,8 @@ Expr *BoundsAnalysis::GetTerminatorCondition(const CFGBlock *B) const {
       return const_cast<Expr *>(IfS->getCond());
     if (const auto *WhileS = dyn_cast<WhileStmt>(S))
       return const_cast<Expr *>(WhileS->getCond());
+    if (const auto *ForS = dyn_cast<ForStmt>(S))
+      return const_cast<Expr *>(ForS->getCond());
   }
   return nullptr;
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -664,3 +664,91 @@ void f24() {
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
 }
+
+void f25() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  int i;
+
+// CHECK: In function: f25
+
+  for (; *p; ) {
+    i = 0;
+    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+      i = 1;
+      for (; *(p + 2); ) { // expected-error {{out-of-bounds memory access}}
+        i = 2;
+      }
+    }
+  }
+
+// CHECK:  [B22]
+// CHECK:    1: *p
+// CHECK:    T: for
+// CHECK:  [B21]
+// CHECK:    1: i = 0
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B20]
+// CHECK:    1: *(p + 1)
+// CHECK:    T: for
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B19]
+// CHECK:    1: i = 1
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B18]
+// CHECK:    1: *(p + 2)
+// CHECK:    T: for
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B17]
+// CHECK:    1: i = 2
+// CHECK: upper_bound(p) = 3
+// CHECK:  [B16]
+// CHECK: upper_bound(p) = 3
+// CHECK:  [B15]
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B14]
+// CHECK: upper_bound(p) = 1
+
+  for (; *p; ) {
+D:  p;
+    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+      p;
+    }
+  }
+  goto D;
+
+// CHECK:  [B13]
+// CHECK:    1: *p
+// CHECK:    T: for
+// CHECK:  [B12]
+// CHECK:   D:
+// CHECK:    1: p
+// CHECK-NOT: upper_bound(p)
+// CHECK:  [B11]
+// CHECK:    1: *(p + 1)
+// CHECK:    T: for
+// CHECK:  [B10]
+// CHECK:    1: p
+// CHECK-NOT: upper_bound(p)
+// CHECK:  [B7]
+// CHECK:    T: goto D;
+
+  for (; *p; ) {
+    p++;
+    for (; *(p + 1); ) {
+      p;
+    }
+  }
+
+// CHECK:  [B6]
+// CHECK:    1: *p
+// CHECK:    T: for
+// CHECK:  [B5]
+// CHECK:    1: p++
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B4]
+// CHECK:    1: *(p + 1)
+// CHECK:    T: for
+// CHECK:  [B3]
+// CHECK:    1: p
+// CHECK-NOT: upper_bound(p)
+}


### PR DESCRIPTION
Added support for widenening bounds for nt_array_ptr dereferences in for
loops. For example, "for (; *p; ) {}" would widen the bounds of p upon
entry to the loop.