### PR TITLE
Support bounds widening for conditionals within switch statements

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -116,6 +116,26 @@ namespace clang {
       // block.
       BoundsVarTy BoundsVars;
 
+      // To compute In[B] we compute the intersection of Out[B*->B], where B*
+      // are all preds of B. When there is a back edge from block B' to B (for
+      // example in loops), the Out set for block B' will be empty when we
+      // first enter B. As a result, the intersection operation would always
+      // result in an empty In set for B.
+
+      // So to handle this, we initialize the In and Out sets for all blocks as
+      // Top so that the intersection does not result in an empty In set.
+
+      // But we also need to handle the case where there is an unconditional
+      // jump into a block (as a result of a goto). In this case, we cannot
+      // widen the bounds because we would not have checked for the ptr
+      // dereference. So we want the intersection to result in an empty set.
+
+      // So we want to initialize the In and Out sets of the entry block as
+      // empty. IsInSetEmpty and IsOutSetEmpty indicate whether the In and Out
+      // sets for a block have been initialized to empty.
+      bool IsInSetEmpty;
+      llvm::DenseMap<const CFGBlock *, bool> IsOutSetEmpty;
+
       ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
     };
 

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -122,17 +122,21 @@ namespace clang {
       // first enter B. As a result, the intersection operation would always
       // result in an empty In set for B.
 
-      // So to handle this, we initialize the In and Out sets for all blocks as
-      // Top so that the intersection does not result in an empty In set.
+      // So to handle this, we consider the In and Out sets for all blocks to
+      // have a default value of "Top" which indicates a set of all members of
+      // the Gen set. In this way we ensure that the intersection does not
+      // result in an empty set even if the Out set for a block is actually
+      // empty.
 
       // But we also need to handle the case where there is an unconditional
-      // jump into a block (as a result of a goto). In this case, we cannot
-      // widen the bounds because we would not have checked for the ptr
-      // dereference. So we want the intersection to result in an empty set.
+      // jump into a block (for example, as a result of a goto). In this case,
+      // we cannot widen the bounds because we would not have checked for the
+      // ptr dereference. So in this case we want the intersection to result in
+      // an empty set.
 
-      // So we want to initialize the In and Out sets of the entry block as
-      // empty. IsInSetEmpty and IsOutSetEmpty indicate whether the In and Out
-      // sets for a block have been initialized to empty.
+      // So we mark the In and Out sets of the Entry block as "empty".
+      // IsInSetEmpty and IsOutSetEmpty indicate whether the In and Out sets
+      // for a block have been marked as "empty".
       bool IsInSetEmpty;
       llvm::DenseMap<const CFGBlock *, bool> IsOutSetEmpty;
 

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -327,10 +327,6 @@ namespace clang {
     // @param[in] EB is the ElevatedCFGBlock for the current block.
     bool CheckIsSwitchCaseNull(ElevatedCFGBlock *EB);
 
-    // Get the value of the switch case label.
-    // @param[in] CaseExpr is the expr for the case label.
-    llvm::APSInt GetSwitchCaseVal(const Expr *CaseExpr);
-
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.
     // @param[in] B is a set.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -327,6 +327,10 @@ namespace clang {
     // @param[in] EB is the ElevatedCFGBlock for the current block.
     bool CheckIsSwitchCaseNull(ElevatedCFGBlock *EB);
 
+    // Get the value of the switch case label.
+    // @param[in] CaseExpr is the expr for the case label.
+    llvm::APSInt GetSwitchCaseVal(const Expr *CaseExpr);
+
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.
     // @param[in] B is a set.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -323,6 +323,10 @@ namespace clang {
     // as Top.
     void InitInOutSets();
 
+    // Check if the switch case label is null.
+    // @param[in] EB is the ElevatedCFGBlock for the current block.
+    bool CheckIsSwitchCaseNull(ElevatedCFGBlock *EB);
+
     // Compute the intersection of sets A and B.
     // @param[in] A is a set.
     // @param[in] B is a set.

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -38,8 +38,8 @@ void BoundsAnalysis::WidenBounds(FunctionDecl *FD) {
     WorkList.append(EB);
     BlockMap[B] = EB;
 
-    // Mark the In set for the entry block as empty. The Out set for the entry
-    // block would be marked as empty in ComputeOutSets.
+    // Mark the In set for the Entry block as "empty". The Out set for the
+    // Entry block would be marked as "empty" in ComputeOutSets.
     EB->IsInSetEmpty = B == &Cfg->getEntry();
   }
 
@@ -571,9 +571,9 @@ void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
 
     ElevatedCFGBlock *PredEB = BlockMap[pred];
 
-    // If the Out set on any incoming edge to a block is marked as empty, then
-    // the intersection of Out's would result in an empty In set. So we mark
-    // the In set as empty and return early.
+    // If the Out set on any incoming edge to a block is marked as "empty",
+    // then the intersection of Out's would result in an empty In set. So we
+    // mark the In set as "empty" and return early.
     if (PredEB->IsOutSetEmpty[EB->Block]) {
       EB->IsInSetEmpty = true;
       return;
@@ -630,8 +630,8 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
 
     EB->Out[succ] = Union(Diff, EB->Gen[succ]);
 
-    // The Out set on an edge is marked empty if the In set is marked empty and
-    // the Gen set on that edge is empty.
+    // The Out set on an edge is marked "empty" if the In set is marked "empty"
+    // and the Gen set on that edge is empty.
     EB->IsOutSetEmpty[succ] = EB->IsInSetEmpty && !EB->Gen[succ].size();
 
     if (Differ(OldOut, EB->Out[succ]))

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -579,9 +579,10 @@ void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
       return;
     }
 
-    // If the Out set of the pred on the incoming edge is not marked as empty,
-    // it means we should treat the Out set as Top. So we should perform the
-    // intersection only if the Out set has at least one element.
+    // If the Out set of the pred on the incoming edge is not marked as
+    // "empty", it means we should treat the Out set as "Top". So we simulate
+    // "Top" by performing the intersection only if the size of the Out set is
+    // non-zero.
     if (!Intersections.size())
       Intersections = PredEB->Out[EB->Block];
     else if (PredEB->Out[EB->Block].size())

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -656,6 +656,8 @@ Expr *BoundsAnalysis::GetTerminatorCondition(const CFGBlock *B) const {
       return const_cast<Expr *>(IfS->getCond());
     if (const auto *WhileS = dyn_cast<WhileStmt>(S))
       return const_cast<Expr *>(WhileS->getCond());
+    if (const auto *ForS = dyn_cast<ForStmt>(S))
+      return const_cast<Expr *>(ForS->getCond());
   }
   return nullptr;
 }

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -119,10 +119,10 @@ void BoundsAnalysis::ComputeGenSets() {
 	    if (IsSwitchCaseNullTerm)
               continue;
 
-            // The switch expression should result in an integral constant.
-            if (auto *CE = dyn_cast<CastExpr>(E)) {
-              assert(CE->getCastKind() == CastKind::CK_IntegralCast &&
-                     "invalid switch expression");
+	    // If the switch expression is integral, strip off the
+	    // IntegralCast.
+	    if (auto *CE = dyn_cast<CastExpr>(E)) {
+              if (CE->getCastKind() == CastKind::CK_IntegralCast)
                 E = CE->getSubExpr();
             }
           }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -664,3 +664,91 @@ void f24() {
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
 }
+
+void f25() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  int i;
+
+// CHECK: In function: f25
+
+  for (; *p; ) {
+    i = 0;
+    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+      i = 1;
+      for (; *(p + 2); ) { // expected-error {{out-of-bounds memory access}}
+        i = 2;
+      }
+    }
+  }
+
+// CHECK:  [B22]
+// CHECK:    1: *p
+// CHECK:    T: for
+// CHECK:  [B21]
+// CHECK:    1: i = 0
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B20]
+// CHECK:    1: *(p + 1)
+// CHECK:    T: for
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B19]
+// CHECK:    1: i = 1
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B18]
+// CHECK:    1: *(p + 2)
+// CHECK:    T: for
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B17]
+// CHECK:    1: i = 2
+// CHECK: upper_bound(p) = 3
+// CHECK:  [B16]
+// CHECK: upper_bound(p) = 3
+// CHECK:  [B15]
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B14]
+// CHECK: upper_bound(p) = 1
+
+  for (; *p; ) {
+D:  p;
+    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+      p;
+    }
+  }
+  goto D;
+
+// CHECK:  [B13]
+// CHECK:    1: *p
+// CHECK:    T: for
+// CHECK:  [B12]
+// CHECK:   D:
+// CHECK:    1: p
+// CHECK-NOT: upper_bound(p)
+// CHECK:  [B11]
+// CHECK:    1: *(p + 1)
+// CHECK:    T: for
+// CHECK:  [B10]
+// CHECK:    1: p
+// CHECK-NOT: upper_bound(p)
+// CHECK:  [B7]
+// CHECK:    T: goto D;
+
+  for (; *p; ) {
+    p++;
+    for (; *(p + 1); ) {
+      p;
+    }
+  }
+
+// CHECK:  [B6]
+// CHECK:    1: *p
+// CHECK:    T: for
+// CHECK:  [B5]
+// CHECK:    1: p++
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B4]
+// CHECK:    1: *(p + 1)
+// CHECK:    T: for
+// CHECK:  [B3]
+// CHECK:    1: p
+// CHECK-NOT: upper_bound(p)
+}

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -752,3 +752,108 @@ D:  p;
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
 }
+
+void f26() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+// CHECK: In function: f26
+
+  switch (*p) {
+  default: break;
+// CHECK:   default:
+// CHECK-NOT: upper_bound(p)
+  case 'a': break;
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+  case 'b': break;
+// CHECK:   case 'b':
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+  case 'a':
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+  default:
+// CHECK:   default:
+// CHECK-NOT: upper_bound(p)
+  case 'b': break;
+// CHECK:   case 'b':
+// CHECK-NOT: upper_bound(p)
+  }
+
+  switch (*p) {
+  case 'a': break;
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+  default:
+// CHECK:   default:
+// CHECK-NOT: upper_bound(p)
+  case 'b': break;
+// CHECK:   case 'b':
+// CHECK-NOT: upper_bound(p)
+  }
+
+  switch (*p) {
+  case '\0': break;
+// CHECK:   case '\x00':
+// CHECK-NOT: upper_bound(p)
+  case 'a': break;
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+  case '\0':
+// CHECK:   case 'a':
+// CHECK-NOT: upper_bound(p)
+  case 'a': break;
+// CHECK:   case '\x00':
+// CHECK-NOT: upper_bound(p)
+  }
+}
+
+void f27() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  int i;
+
+// CHECK: In function: f27
+
+  switch (*p) {
+  case 'a':
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+
+    if (*(p + 1)) {           // expected-error {{out-of-bounds memory access}}
+      i = 0;
+// CHECK:    1: i = 0
+// CHECK: upper_bound(p) = 2
+
+      for (;*(p + 2);) {      // expected-error {{out-of-bounds memory access}}
+        i = 1;
+// CHECK:    1: i = 1
+// CHECK: upper_bound(p) = 3
+
+        while (*(p + 3)) {    // expected-error {{out-of-bounds memory access}}
+          i = 2;
+// CHECK:    1: i = 2
+// CHECK: upper_bound(p) = 4
+        }
+
+        i = 3;
+// CHECK:    1: i = 3
+// CHECK: upper_bound(p) = 3
+      }
+
+      i = 4;
+// CHECK:    1: i = 4
+// CHECK: upper_bound(p) = 2
+    }
+
+    i = 5;
+// CHECK:    1: i = 5
+// CHECK: upper_bound(p) = 1
+
+    break;
+  }
+}

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -3,6 +3,7 @@
 // RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s 2>&1 | FileCheck %s
 
 #include <limits.h>
+#include <stdint.h>
 
 void f1() {
   _Nt_array_ptr<char> p : count(0) = "a";
@@ -1076,6 +1077,19 @@ void f31() {
 
   case UINT_MAX: break;
 // CHECK: case (2147483647 * 2U + 1U):
+// CHECK: upper_bound(p) = 1
+  }
+
+  _Nt_array_ptr<uint64_t> q : count(0) = 0;
+  const uint64_t x = 0x0000444400004444LL;
+
+  switch (*p) {
+    case ULLONG_MAX: break;
+// CHECK: case (9223372036854775807LL * 2ULL + 1ULL):
+// CHECK: upper_bound(p) = 1
+
+    case x: break;
+// CHECK: case x:
 // CHECK: upper_bound(p) = 1
   }
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -852,51 +852,6 @@ void f27() {
   }
 }
 
-void f29() {
-  _Nt_array_ptr<char> p : count(0) = "";
-  int i;
-
-// CHECK: In function: f29
-
-  switch (*p) {
-  case 'a':
-// CHECK:   case 'a':
-// CHECK: upper_bound(p) = 1
-
-    if (*(p + 1)) {           // expected-error {{out-of-bounds memory access}}
-      i = 0;
-// CHECK:    1: i = 0
-// CHECK: upper_bound(p) = 2
-
-      for (;*(p + 2);) {      // expected-error {{out-of-bounds memory access}}
-        i = 1;
-// CHECK:    1: i = 1
-// CHECK: upper_bound(p) = 3
-
-        while (*(p + 3)) {    // expected-error {{out-of-bounds memory access}}
-          i = 2;
-// CHECK:    1: i = 2
-// CHECK: upper_bound(p) = 4
-        }
-
-        i = 3;
-// CHECK:    1: i = 3
-// CHECK: upper_bound(p) = 3
-      }
-
-      i = 4;
-// CHECK:    1: i = 4
-// CHECK: upper_bound(p) = 2
-    }
-
-    i = 5;
-// CHECK:    1: i = 5
-// CHECK: upper_bound(p) = 1
-
-    break;
-  }
-}
-
 void f28() {
   _Nt_array_ptr<char> p : count(0) = "";
   int a;
@@ -948,4 +903,95 @@ void f28() {
 // CHECK:    1: a
 // CHECK:    T: do ... while
 // CHECK: upper_bound(p) = 1
+}
+
+void f29() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  int i;
+
+// CHECK: In function: f29
+
+  switch (*p) {
+  case 'a':
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+
+    if (*(p + 1)) {           // expected-error {{out-of-bounds memory access}}
+      i = 0;
+// CHECK:    1: i = 0
+// CHECK: upper_bound(p) = 2
+
+      for (;*(p + 2);) {      // expected-error {{out-of-bounds memory access}}
+        i = 1;
+// CHECK:    1: i = 1
+// CHECK: upper_bound(p) = 3
+
+        while (*(p + 3)) {    // expected-error {{out-of-bounds memory access}}
+          i = 2;
+// CHECK:    1: i = 2
+// CHECK: upper_bound(p) = 4
+        }
+
+        i = 3;
+// CHECK:    1: i = 3
+// CHECK: upper_bound(p) = 3
+      }
+
+      i = 4;
+// CHECK:    1: i = 4
+// CHECK: upper_bound(p) = 2
+    }
+
+    i = 5;
+// CHECK:    1: i = 5
+// CHECK: upper_bound(p) = 1
+
+    break;
+  }
+}
+
+void f30() {
+// CHECK: In function: f30
+
+  _Nt_array_ptr<char> p : count(0) = "";
+  const int i = -1;
+  const int j = 1;
+
+  switch (*p) {
+    case i ... j: break;
+// CHECK:   case i ... j:
+// CHECK-NOT: upper_bound(p)
+  }
+
+  switch (*p) {
+    case 1 ... -1: break;
+// CHECK:   case 1 ... -1:
+// CHECK-NOT: upper_bound(p)
+
+    case 1 ... 0: break;
+// CHECK:   case 1 ... 0:
+// CHECK-NOT: upper_bound(p)
+
+    case -2 ... -1: break;
+// CHECK:   case -2 ... -1:
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+    case -1 ... 1: break;
+// CHECK:   case -1 ... 1:
+// CHECK-NOT: upper_bound(p)
+  }
+
+  switch (*p) {
+    case 0 ... 1: break;
+// CHECK:   case 0 ... 1:
+// CHECK-NOT: upper_bound(p)
+  }
+
+  switch (*p) {
+    case 1 ... 2: break;
+// CHECK:   case 1 ... 2:
+// CHECK: upper_bound(p) = 1
+  }
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -1007,7 +1007,7 @@ void f31() {
 
   switch (*p) {
   case 999999999999999999999999999: break; // expected-error {{integer literal is too large to be represented in any integer type}}
-// CHECK: case 11515845246265065471ULL:
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
 
   case 00000000000000000000000000000000000: break;
@@ -1019,7 +1019,7 @@ void f31() {
 // CHECK: upper_bound(p) = 1
 
   case '00000000000000000000000000000000000': break;
-// CHECK: case '\U30303030':
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
 
   case i: break;
@@ -1037,33 +1037,33 @@ void f31() {
 
   switch (*p) {
   case INT_MAX: break;
-// CHECK: case 2147483647:
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
 
   case INT_MIN: break;
-// CHECK: case (-2147483647 - 1):
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
 
   case INT_MAX + INT_MAX: break;
-// CHECK: case 2147483647 + 2147483647:
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
 
   case INT_MAX - INT_MAX: break;
-// CHECK: case 2147483647 - 2147483647:
+// CHECK: case {{.*}}
 // CHECK-NOT: upper_bound(p)
 
   case INT_MAX + INT_MIN: break;
-// CHECK: case 2147483647 + (-2147483647 - 1):
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
   }
 
   switch (*p) {
   case INT_MIN - INT_MIN: break;
-// CHECK: case (-2147483647 - 1) - (-2147483647 - 1):
+// CHECK: case {{.*}}
 // CHECK-NOT: upper_bound(p)
 
   case INT_MAX - INT_MIN: break;
-// CHECK: case 2147483647 - (-2147483647 - 1):
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
   }
 
@@ -1072,11 +1072,11 @@ void f31() {
   // computed to 0 and we have the warning: overflow in expression; result is 0
   // with type 'int'.
   case INT_MIN + INT_MIN: break;
-// CHECK: case (-2147483647 - 1) + (-2147483647 - 1):
+// CHECK: case {{.*}}
 // CHECK-NOT: upper_bound(p)
 
   case UINT_MAX: break;
-// CHECK: case (2147483647 * 2U + 1U):
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
   }
 
@@ -1085,7 +1085,7 @@ void f31() {
 
   switch (*p) {
     case ULLONG_MAX: break;
-// CHECK: case (9223372036854775807LL * 2ULL + 1ULL):
+// CHECK: case {{.*}}
 // CHECK: upper_bound(p) = 1
 
     case x: break;

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -995,3 +995,87 @@ void f30() {
 // CHECK: upper_bound(p) = 1
   }
 }
+
+void f31() {
+// CHECK: In function: f31
+
+  _Nt_array_ptr<char> p : count(0) = "";
+  const int i = 'abc';
+  const char c = 'xyz';
+  const unsigned u = UINT_MAX;
+
+  switch (*p) {
+  case 999999999999999999999999999: break; // expected-error {{integer literal is too large to be represented in any integer type}}
+// CHECK: case 11515845246265065471ULL:
+// CHECK: upper_bound(p) = 1
+
+  case 00000000000000000000000000000000000: break;
+// CHECK: case 0:
+// CHECK-NOT: upper_bound(p)
+
+  case 00000000000000000000000000000000001: break;
+// CHECK: case 1:
+// CHECK: upper_bound(p) = 1
+
+  case '00000000000000000000000000000000000': break;
+// CHECK: case '\U30303030':
+// CHECK: upper_bound(p) = 1
+
+  case i: break;
+// CHECK: case i:
+// CHECK: upper_bound(p) = 1
+
+  case c: break;
+// CHECK: case c:
+// CHECK: upper_bound(p) = 1
+
+  case u: break;
+// CHECK: case u:
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+  case INT_MAX: break;
+// CHECK: case 2147483647:
+// CHECK: upper_bound(p) = 1
+
+  case INT_MIN: break;
+// CHECK: case (-2147483647 - 1):
+// CHECK: upper_bound(p) = 1
+
+  case INT_MAX + INT_MAX: break;
+// CHECK: case 2147483647 + 2147483647:
+// CHECK: upper_bound(p) = 1
+
+  case INT_MAX - INT_MAX: break;
+// CHECK: case 2147483647 - 2147483647:
+// CHECK-NOT: upper_bound(p)
+
+  case INT_MAX + INT_MIN: break;
+// CHECK: case 2147483647 + (-2147483647 - 1):
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+  case INT_MIN - INT_MIN: break;
+// CHECK: case (-2147483647 - 1) - (-2147483647 - 1):
+// CHECK-NOT: upper_bound(p)
+
+  case INT_MAX - INT_MIN: break;
+// CHECK: case 2147483647 - (-2147483647 - 1):
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+  // Note: This does not widen the bounds as the value of the expression is
+  // computed to 0 and we have the warning: overflow in expression; result is 0
+  // with type 'int'.
+  case INT_MIN + INT_MIN: break;
+// CHECK: case (-2147483647 - 1) + (-2147483647 - 1):
+// CHECK-NOT: upper_bound(p)
+
+  case UINT_MAX: break;
+// CHECK: case (2147483647 * 2U + 1U):
+// CHECK: upper_bound(p) = 1
+  }
+}

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -815,9 +815,48 @@ void f26() {
 
 void f27() {
   _Nt_array_ptr<char> p : count(0) = "";
-  int i;
+  const char a = '\0';
+  const int b = '0';
+  const char c = '1';
+  const int d = '2';
 
 // CHECK: In function: f27
+
+  switch (*p) {
+  case a: break;
+// CHECK:   case a:
+// CHECK-NOT: upper_bound(p)
+
+  case b: break;
+// CHECK:   case b:
+// CHECK: upper_bound(p) = 1
+
+  case c: break;
+// CHECK:   case c:
+// CHECK: upper_bound(p) = 1
+
+  case d: break;
+// CHECK:   case d:
+// CHECK: upper_bound(p) = 1
+  }
+
+  enum {e1, e2};
+  switch (*p) {
+  case e1: break;
+// CHECK:   case e1:
+// CHECK-NOT: upper_bound(p)
+
+  case e2: break;
+// CHECK:   case e2:
+// CHECK: upper_bound(p) = 1
+  }
+}
+
+void f29() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  int i;
+
+// CHECK: In function: f29
 
   switch (*p) {
   case 'a':
@@ -856,4 +895,57 @@ void f27() {
 
     break;
   }
+}
+
+void f28() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  int a;
+
+// CHECK: In function: f28
+
+  switch (*p) {
+    case 0:
+      switch (*p) {
+        case 1: break;
+      }
+// CHECK:  [B11]
+// CHECK:   case 1:
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B10]
+// CHECK:   case 0:
+// CHECK-NOT: upper_bound(p)
+  }
+
+  switch (*p) {
+    case 1:
+      switch (*(p + 1)) {  // expected-error {{out-of-bounds memory access}}
+        case 2: break;
+      }
+// CHECK:  [B8]
+// CHECK:   case 2:
+// CHECK:    T: break;
+// CHECK: upper_bound(p) = 2
+// CHECK:  [B7]
+// CHECK:   case 1:
+// CHECK:    1: *(p + 1)
+// CHECK:    T: switch
+// CHECK: upper_bound(p) = 1
+  }
+
+  switch (*p) {
+  case 1: do { a;
+          } while (a);
+  }
+// CHECK:  [B5]
+// CHECK:   case 1:
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B4]
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B3]
+// CHECK:    1: a
+// CHECK: upper_bound(p) = 1
+// CHECK:  [B2]
+// CHECK:    1: a
+// CHECK:    T: do ... while
+// CHECK: upper_bound(p) = 1
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -859,10 +859,10 @@ void f28() {
 // CHECK: In function: f28
 
   switch (*p) {
-    case 0:
-      switch (*p) {
-        case 1: break;
-      }
+  case 0:
+    switch (*p) {
+      case 1: break;
+    }
 // CHECK:  [B11]
 // CHECK:   case 1:
 // CHECK: upper_bound(p) = 1
@@ -872,10 +872,10 @@ void f28() {
   }
 
   switch (*p) {
-    case 1:
-      switch (*(p + 1)) {  // expected-error {{out-of-bounds memory access}}
-        case 2: break;
-      }
+  case 1:
+    switch (*(p + 1)) {  // expected-error {{out-of-bounds memory access}}
+      case 2: break;
+    }
 // CHECK:  [B8]
 // CHECK:   case 2:
 // CHECK:    T: break;
@@ -958,39 +958,39 @@ void f30() {
   const int j = 1;
 
   switch (*p) {
-    case i ... j: break;
+  case i ... j: break;
 // CHECK:   case i ... j:
 // CHECK-NOT: upper_bound(p)
   }
 
   switch (*p) {
-    case 1 ... -1: break;
+  case 1 ... -1: break;
 // CHECK:   case 1 ... -1:
 // CHECK-NOT: upper_bound(p)
 
-    case 1 ... 0: break;
+  case 1 ... 0: break;
 // CHECK:   case 1 ... 0:
 // CHECK-NOT: upper_bound(p)
 
-    case -2 ... -1: break;
+  case -2 ... -1: break;
 // CHECK:   case -2 ... -1:
 // CHECK: upper_bound(p) = 1
   }
 
   switch (*p) {
-    case -1 ... 1: break;
+  case -1 ... 1: break;
 // CHECK:   case -1 ... 1:
 // CHECK-NOT: upper_bound(p)
   }
 
   switch (*p) {
-    case 0 ... 1: break;
+  case 0 ... 1: break;
 // CHECK:   case 0 ... 1:
 // CHECK-NOT: upper_bound(p)
   }
 
   switch (*p) {
-    case 1 ... 2: break;
+  case 1 ... 2: break;
 // CHECK:   case 1 ... 2:
 // CHECK: upper_bound(p) = 1
   }


### PR DESCRIPTION
Added support for widening bounds for nt_array_ptr dereferences in switch
statements. For example, "switch (*p) {case 'a': break;}" would widen the
bounds of p inside the "case 'a'" block.