### PR TITLE
Use the widened bounds to update bounds in context

### DIFF
--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -622,11 +622,15 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
 }
 
 StmtDeclSetTy BoundsAnalysis::GetKillSet(const CFGBlock *B) {
+  if (!BlockMap.count(B))
+    return StmtDeclSetTy();
   ElevatedCFGBlock *EB = BlockMap[B];
   return EB->Kill;
 }
 
 BoundsMapTy BoundsAnalysis::GetWidenedBounds(const CFGBlock *B) {
+  if (!BlockMap.count(B))
+    return BoundsMapTy();
   ElevatedCFGBlock *EB = BlockMap[B];
   return EB->In;
 }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2027,6 +2027,8 @@ namespace {
             Check(S, CSS, BlockState);
             // TODO: validate the updated context BlockState.UC against
             // the declared context DC.
+            if (DumpState)
+              DumpCheckingState(llvm::outs(), S, BlockState);
          }
        }
        AFA.Next();
@@ -2169,9 +2171,6 @@ namespace {
           break;
       }
 
-      if (DumpState)
-        DumpCheckingState(llvm::outs(), S, State);
-
       if (Expr *E = dyn_cast<Expr>(S)) {
         // Bounds expressions are not null ptrs.
         if (isa<BoundsExpr>(E))
@@ -2249,9 +2248,6 @@ namespace {
           CheckChildren(E, CSS, State);
           break;
       }
-
-      if (DumpState)
-        DumpCheckingState(llvm::outs(), E, State);
 
       // The type for inferring the target bounds cannot ever be an array
       // type, as these are dealt with by an array conversion, not an lvalue

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2021,7 +2021,6 @@ namespace {
             // context before checking S.  TODO: save this context in a
             // declared context DC.
             GetDeclaredBounds(this->S, BlockState.UC, S);
-            BoundsContextTy DeclaredBounds = BlockState.UC;
             Check(S, CSS, BlockState);
             // TODO: validate the updated context BlockState.UC against
             // the declared context DC.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3413,8 +3413,10 @@ namespace {
       CheckingState BlockState;
       bool IntersectionEmpty = true;
       for (const CFGBlock *PredBlock : Block->preds()) {
-        // Prevent non-traversed (e.g. unreachable) blocks from causing
-        // the incoming UC for a block to be empty.
+        // Prevent null or non-traversed (e.g. unreachable) blocks from
+        // causing the incoming UC for a block to be empty.
+        if (!PredBlock)
+          continue;
         if (BlockStates.find(PredBlock->getBlockID()) == BlockStates.end())
           continue;
         CheckingState PredState = BlockStates[PredBlock->getBlockID()];

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -673,6 +673,8 @@ namespace {
         OS << "{\n";
         for (auto I = OrderedDecls.begin(); I != OrderedDecls.end(); ++I) {
           DeclaratorDecl *Variable = *I;
+          if (!UC[Variable])
+            continue;
           OS << "Variable:\n";
           Variable->dump(OS);
           OS << "Bounds:\n";
@@ -2954,7 +2956,10 @@ namespace {
       BoundsExpr *B = nullptr;
       InteropTypeExpr *IT = nullptr;
       if (VD) {
-        B = VD->getBoundsExpr();
+        if (State.UC[VD])
+          B = State.UC[VD];
+        else
+          B = VD->getBoundsExpr();
         IT = VD->getInteropTypeExpr();
       }
 
@@ -3432,7 +3437,7 @@ namespace {
     BoundsContextTy IntersectUC(BoundsContextTy UC1, BoundsContextTy UC2) {
       BoundsContextTy IntersectedUC;
       for (auto Pair : UC1) {
-        if (UC2.find(Pair.first) == UC2.end())
+        if (!Pair.second || !UC2[Pair.first])
           continue;
         if (Pair.second->isUnknown() || UC2[Pair.first]->isUnknown())
           IntersectedUC[Pair.first] = CreateBoundsUnknown();

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -475,6 +475,10 @@ namespace {
 }
 
 namespace {
+  // BoundsContextTy denotes a map of a variable or parameter declaration
+  // to the variable or parameter's current known bounds.
+  using BoundsContextTy = llvm::DenseMap<DeclaratorDecl *, BoundsExpr *>;
+
   // EqualExprTy denotes a set of expressions that produce the same value
   // as an expression e.
   using EqualExprTy = SmallVector<Expr *, 4>;
@@ -488,6 +492,9 @@ namespace {
   // and are updated while checking individual expressions.
   class CheckingState {
     public:
+      // UC is a map of variables or parameters to their current known bounds.
+      BoundsContextTy UC;
+
       // UEQ stores sets of expressions that are equivalent to each other
       // after checking an expression e.
       EquivExprSets UEQ;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -666,8 +666,10 @@ namespace {
           OrderedDecls.push_back(Pair.first);
         llvm::sort(OrderedDecls.begin(), OrderedDecls.end(),
              [] (DeclaratorDecl *A, DeclaratorDecl *B) {
-               return std::tie(A->getNameAsString(), A->getLocation()) <
-                                std::tie(B->getNameAsString(), B->getLocation());
+               if (A->getNameAsString() == B->getNameAsString())
+                 return A->getLocation() < B->getLocation();
+               else
+                 return A->getNameAsString() < B->getNameAsString();
              });
 
         OS << "{\n";

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -666,10 +666,8 @@ namespace {
           OrderedDecls.push_back(Pair.first);
         llvm::sort(OrderedDecls.begin(), OrderedDecls.end(),
              [] (DeclaratorDecl *A, DeclaratorDecl *B) {
-               if (A->getNameAsString() == B->getNameAsString())
-                 return A->getLocation() < B->getLocation();
-               else
-                 return A->getNameAsString() < B->getNameAsString();
+               return std::tie(A->getNameAsString(), A->getLocation()) <
+                                std::tie(B->getNameAsString(), B->getLocation());
              });
 
         OS << "{\n";

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -1,0 +1,174 @@
+// Tests for updating equivalent expression information during bounds inference and checking.
+// This file tests updating the context mapping variables to their bounds
+// after checking expressions during bounds analysis.
+//
+// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
+
+#include <stdchecked.h>
+
+// Parameter with bounds
+void f1(array_ptr<int> arr : count(len), int len, int size) {
+  // Updated bounds context: { a => count(5), arr => count(len) }
+  array_ptr<int> a : count(5) = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} a
+  // CHECK-NEXT:     CountBoundsExpr
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 5
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} arr
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: }
+
+  // Updated bounds context: { a => count(5), arr => count(len), b => count(size) }
+  array_ptr<int> b : count(size) = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} b
+  // CHECK-NEXT:     CountBoundsExpr
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 5
+  // CHECK: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} arr
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
+  // CHECK: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} b
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: }
+}
+
+// If statement, redeclared variable
+void f2(int flag, int x, int y) {
+  // Updated bounds context: { a => count(x) }
+  array_ptr<int> a : count(x) = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} a
+  // CHECK-NEXT:     CountBoundsExpr
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+
+  if (flag) {
+    // Updated bounds context: { a => count(x), a => count(y) }
+    array_ptr<int> a : count(y) = 0;
+    // CHECK: Statement S:
+    // CHECK:      DeclStmt
+    // CHECK-NEXT:   VarDecl {{.*}} a
+    // CHECK-NEXT:     CountBoundsExpr
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
+    // CHECK-NEXT:         IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: Bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+    // CHECK: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT: }
+
+    // Updated bounds context: { a => count(x), a => count(y), b => count(y) }
+    array_ptr<int> b : count(y) = 0;
+    // CHECK: Statement S:
+    // CHECK:      DeclStmt
+    // CHECK-NEXT:   VarDecl {{.*}} b
+    // CHECK-NEXT:     CountBoundsExpr
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
+    // CHECK-NEXT:         IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: Bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+    // CHECK: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} b
+    // CHECK: Bounds:
+    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT: }
+  }
+
+  // Updated bounds context: { a => count(x), c => count(x) }
+  array_ptr<int> c : count(x) = a;
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} c
+  // CHECK-NEXT:     CountBoundsExpr
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} c
+  // CHECK: Bounds:
+  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -4,7 +4,7 @@
 // This file does not test assignments that update the set of sets of equivalent expressions
 // (assignments will be tested in a separate test file).
 //
-// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s --dump-input=always
+// RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
 
 #include <stdchecked.h>
 
@@ -18,20 +18,9 @@ void f1(int i, int a checked[5]) {
   // Non-array type
   i;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
@@ -41,19 +30,9 @@ void f1(int i, int a checked[5]) {
   int arr checked[10];
   arr;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK:      ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
@@ -62,19 +41,9 @@ void f1(int i, int a checked[5]) {
   // Extern unchecked array with known size
   a1;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'a1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a1'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a1'
@@ -83,20 +52,9 @@ void f1(int i, int a checked[5]) {
   // Array parameter with _Array_ptr<int> type
   a;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
@@ -107,110 +65,42 @@ void f1(int i, int a checked[5]) {
 void f2(int *p, int x, int y) {
   *p;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: { }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   UnaryOperator {{.*}} '*'
   // CHECK-NEXT:    ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:      DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 
   &x;
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: }
 
   int a[3];
-  &a;
   // CHECK: Statement S:
-  // CHECK: DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} a
+  &a;
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} '&'
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: }
 
   !y;
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} '!'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: UnaryOperator {{.*}} '!'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -222,50 +112,12 @@ void f2(int *p, int x, int y) {
 void f3(int a [1]) {
   a[0];
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: { }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   ArraySubscriptExpr {{.*}} lvalue
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 }
 
@@ -274,40 +126,17 @@ void f4() {
   5;
   // CHECK: Statement S:
   // CHECK-NEXT: IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: IntegerLiteral {{.*}} 5
   // CHECK-NEXT: }
 
   "abc";
   // CHECK: Statement S:
-  // CHECK-NEXT: StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:   StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:   StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: BoundsValueExpr {{.*}} 'char [4]'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'char [4]'
   // CHECK-NEXT:     StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} 'char [4]'
@@ -319,28 +148,10 @@ void f4() {
 void f5() {
   1 + 2;
   // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT:   IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
@@ -349,28 +160,10 @@ void f5() {
 
   3 < 4;
   // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '<'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 3
   // CHECK-NEXT:   IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '<'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 3
@@ -379,28 +172,10 @@ void f5() {
 
   5 & 6;
   // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 6
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 6
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '&'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 6
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '&'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 5
@@ -409,28 +184,10 @@ void f5() {
 
   7, 8;
   // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 7
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 7
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 8
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 8
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
   // CHECK-NEXT:   IntegerLiteral {{.*}} 7
   // CHECK-NEXT:   IntegerLiteral {{.*}} 8
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: IntegerLiteral {{.*}} 8
   // CHECK-NEXT: }
@@ -440,31 +197,10 @@ void f5() {
 void f6(int i, array_ptr<int> arr : count(1)) {
   (double)i;
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: CStyleCastExpr {{.*}} <IntegralToFloating>
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: CStyleCastExpr {{.*}} <IntegralToFloating>
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -473,47 +209,13 @@ void f6(int i, array_ptr<int> arr : count(1)) {
 
   _Assume_bounds_cast<array_ptr<char>>(arr, count(4));
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: UnaryOperator {{.*}} '&'
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: BoundsValueExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: BoundsCastExpr {{.*}} <AssumePtrBounds>
   // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:      DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:   CountBoundsExpr
   // CHECK-NEXT:     IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: {
   // CHECK-NEXT: BoundsCastExpr {{.*}} <AssumePtrBounds>
   // CHECK-NEXT:   CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
@@ -530,116 +232,30 @@ void f7(void) {
   // Function with no parameters
   g1();
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: CallExpr {{.*}} 'void'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'g1'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 
   // Function with no parameter annotations
   g2(0);
   // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g2'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
   // CHECK-NEXT: CallExpr {{.*}} 'void'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'g2'
   // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 
   // Function with parameter annotations
   g3(0);
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'g3'
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
-  // CHECK: Statement S:
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: }
   // CHECK: Statement S:
   // CHECK-NEXT: CallExpr {{.*}} 'void'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'g3'
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: { }
-  // CHECK-NEXT: Expressions that produce the same value as S:
+  // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 }


### PR DESCRIPTION
Use the widened bounds calculated by the analysis in BoundsAnalysis.cpp to
    widen the bounds of nt_array_ptr.