### PR TITLE
Fix the handling of killed bounds with loops

### DIFF
--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -655,7 +655,7 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
     // problematic for loops as we end up widening the bounds in the following
     // case:
     //
-    //   while (p[i])
+    //   while (*p)
     //     p++;
     //
     // So we handle this as:

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -656,7 +656,7 @@ void f24() {
 // CHECK:    T: while
 // CHECK:  [B5]
 // CHECK:    1: p++
-// CHECK: upper_bound(p) = 1
+// CHECK-NOT: upper_bound(p)
 // CHECK:  [B4]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: while


### PR DESCRIPTION
The dataflow equation for the Out set is:
`
  Out[B1->B2] = (In[B1] - Kill[B1]) ∪ Gen[B1->B2]
`

So if a variable is in the Gen set for an edge then it would be added to the
Out set for the edge even if it is killed inside the outgoing block. This
happens because of the union operation with Gen. This becomes problematic for
loops and we end up widening the bounds in the following case:

```
  while (*p)
    p++;
```

So we handle this as:
  1. Compute the Out set for a block `B` as usual.
  2. Then, if a variable `V` is in `Kill[B]`, remove `V` from the `Gen[B->B']`.

This would have no effect on liner code but in loops this would ensure we do
not widen bounds in the above case.