### PR TITLE
Equivalent expressions: various fixes [5/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -598,7 +598,7 @@ namespace {
       // does not preserve implicit casts.
       ExprResult TransformImplicitCastExpr(ImplicitCastExpr *E) {
         // Replace V with OV (if applicable) in the subexpression of E.
-        ExprResult ChildResult = BaseTransform::TransformImplicitCastExpr(E);
+        ExprResult ChildResult = TransformExpr(E->getSubExpr());
         if (ChildResult.isInvalid())
           return ChildResult;
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3679,6 +3679,9 @@ namespace {
         for (auto I = State.UEQ.begin(); I != State.UEQ.end(); ++I) {
           if (IsEqualExprsSubset(State.G, *I)) {
             I->push_back(Target);
+            // Add the target to G if G does not already contain the target.
+            if (!EqualExprsContainsExpr(State.G, Target))
+              State.G.push_back(Target);
             return;
           }
         }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3687,20 +3687,6 @@ namespace {
     // State.G is assumed to contain expressions that produce the same value
     // as the source of the assignment.
     void RecordEqualityWithTarget(Expr *Target, CheckingState &State) {
-      // Do not record equality between the target and source if the source
-      // produces the same value as a NullToPointer cast.  This avoids
-      // recording equality between non-assignment-compatible variables
-      // with pointer types.  For example, for the assignments int *p = 0;
-      // array_ptr<int> a = 0; UEQ should not contain { 0, p, a }.  UEQ
-      // also should not contain { 0, p } and { 0, a } so that UEQ does not
-      // grow too large.
-      for (auto I = State.G.begin(); I != State.G.end(); ++I) {
-        if (CastExpr *CE = dyn_cast<CastExpr>(*I)) {
-          if (CE->getCastKind() == CastKind::CK_NullToPointer)
-            return;
-        }
-      }
-
       // If UEQ contains a set F of expressions that produce the same value
       // as the source, add the target to F.  This prevents UEQ from growing
       // too large and containing redundant equality information.  For example,

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4077,6 +4077,7 @@ namespace {
       Lexicographic Lex(S.Context, nullptr);
       for (auto I = G2.begin(); I != G2.end(); ++I) {
         Expr *E = Lex.IgnoreValuePreservingOperations(S.Context, *I);
+        DeclRefExpr *V = GetRValueVariable(E);
         if (!EqualExprsContainsExpr(G1, E))
           return false;
       }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3855,8 +3855,10 @@ namespace {
         Lexicographic Lex(S.Context, nullptr);
         Expr *E = Lex.IgnoreValuePreservingOperations(S.Context, *I);
         DeclRefExpr *W = GetRValueVariable(E);
-        if (W != nullptr && !EqualValue(S.Context, V, W, nullptr))
-          return *I;
+        if (W != nullptr && !EqualValue(S.Context, V, W, nullptr)) {
+          if (S.Context.typesAreCompatible(V->getType(), (*I)->getType()))
+            return *I;
+        }
       }
 
       return nullptr;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2195,6 +2195,7 @@ namespace {
             // context before checking S.  TODO: save this context in a
             // declared context DC.
             GetDeclaredBounds(this->S, BlockState.UC, S);
+            BlockState.G.clear();
             Check(S, CSS, BlockState);
             // TODO: validate the updated context BlockState.UC against
             // the declared context DC.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3672,6 +3672,20 @@ namespace {
     // State.G is assumed to contain expressions that produce the same value
     // as the source of the assignment.
     void RecordEqualityWithTarget(Expr *Target, CheckingState &State) {
+      // Do not record equality between the target and source if the source
+      // produces the same value as a NullToPointer cast.  This avoids
+      // recording equality between non-assignment-compatible variables
+      // with pointer types.  For example, for the assignments int *p = 0;
+      // array_ptr<int> a = 0; UEQ should not contain { 0, p, a }.  UEQ
+      // also should not contain { 0, p } and { 0, a } so that UEQ does not
+      // grow too large.
+      for (auto I = State.G.begin(); I != State.G.end(); ++I) {
+        if (CastExpr *CE = dyn_cast<CastExpr>(*I)) {
+          if (CE->getCastKind() == CastKind::CK_NullToPointer)
+            return;
+        }
+      }
+
       // If UEQ contains a set F of expressions that produce the same value
       // as the source, add the target to F.  This prevents UEQ from growing
       // too large and containing redundant equality information.  For example,
@@ -3807,17 +3821,8 @@ namespace {
         Lexicographic Lex(S.Context, nullptr);
         Expr *E = Lex.IgnoreValuePreservingOperations(S.Context, *I);
         DeclRefExpr *W = GetRValueVariable(E);
-        if (W != nullptr && !EqualValue(S.Context, V, W, nullptr)) {
-          // Any variable used as the orginal value of v must have a type that
-          // is compatible with the type of v.  Expression equality recorded in
-          // UEQ does not take types into account, so expressions in the same
-          // set in UEQ may have incompatible types.
-          Sema::AssignConvertType Conv =
-            S.CheckAssignmentConstraints(SourceLocation(), V->getType(), W->getType());
-          if (Conv == Sema::AssignConvertType::Compatible ||
-              Conv == Sema::AssignConvertType::CompatiblePointerDiscardsQualifiers)
-            return *I;
-        }
+        if (W != nullptr && !EqualValue(S.Context, V, W, nullptr))
+          return *I;
       }
 
       return nullptr;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4068,8 +4068,12 @@ namespace {
       return dyn_cast<DeclRefExpr>(E->IgnoreParens());
     }
 
-    // If E is an rvalue cast (ignoring value-preserving operations) of a
-    // variable V, GetRValueVariable returns V. Otherwise, it returns nullptr.
+    // If E is a possibly parenthesized rvalue cast of a variable V,
+    // GetRValueVariable returns V. Otherwise, it returns nullptr.
+    //
+    // V may have value-preserving operations applied to it.  For example,
+    // if E is (LValueToRValue(LValueBitCast(V))), where V is a variable,
+    // GetRValueVariable will return V.
     DeclRefExpr *GetRValueVariable(Expr *E) {
       if (CastExpr *CE = dyn_cast<CastExpr>(E->IgnoreParens())) {
         CastKind CK = CE->getCastKind();

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -379,6 +379,78 @@ void multiple_assign2(int x, int y) {
   // CHECK-NEXT: }
 }
 
+// Equivalence with NullToPointer casts is not recorded
+void multiple_assign3(int i, int *p, ptr<int> pt, array_ptr<int> a, array_ptr<int> b) {
+  // Updated UEQ: { { 0, i } }
+  i = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { 0, i } }
+  p = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { 0, i } }
+  a = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { 0, i }, { a, b } }
+  b = a;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
 ///////////////////////////////////////////
 // Assignments involving original values // 
 ///////////////////////////////////////////
@@ -886,7 +958,7 @@ void original_value12(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT: }
 
   // Original value of arr_int: arr_const
-  // Updated UEQ: { { arr_const + 1, arr }, { NullToPointer(0), arr_int } }
+  // Updated UEQ: { { arr_const + 1, arr } }
   arr_int = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -902,12 +974,6 @@ void original_value12(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
@@ -962,7 +1028,7 @@ void original_value13(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT: }
 
   // Original value of arr_int: (array_ptr<int>)arr_const
-  // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr }, { NullToPointer(0), arr_int } }
+  // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr } }
   arr_int = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -980,239 +1046,11 @@ void original_value13(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
 
-// The original value of a variable must have a type compatible with the type of the variable
-void original_value14(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<char> arr_char, array_ptr<int> arr) {
-  // Updated UEQ: { { NullToPointer(0), arr_int } }
-  arr_int = 0;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} '='
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-
-  // Updated UEQ: { { NullToPointer(0), arr_int }, { arr_int + 1, arr } }
-  arr = arr_int + 1;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} '='
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-
-  // Updated UEQ: { { NullToPointer(0), arr_int, arr_char, arr_const }, { arr_int + 1, arr } }
-  arr_char = 0, arr_const = 0;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} ','
-  // CHECK-NEXT:   BinaryOperator {{.*}} '='
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_char'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT:   BinaryOperator {{.*}} '='
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_char'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-
-  // Original value of arr_int: arr_const
-  // Note that, although arr_char appears before arr_const in the set { NullToPointer(0), arr_int, arr_char, arr_const },
-  // arr_char's type (nt_array_ptr<char>) is not compatible with arr_int's type (nt_array_ptr<int>), so arr_char is not
-  // chosen as the original value of arr_int.
-  // Updated UEQ: { { NullToPointer(0), arr_const, arr_char, arr_int }, { arr_const + 1, arr } }
-  arr_int = 0;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} '='
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_char'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-}
-
-// The original value of a variable must have a type compatible with the type of the variable
-void original_value15(int x, int y, int *p, int val) {
-  // Updated UEQ: { { x, 0 } }
-  x = 0;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} '='
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-
-  // Updated UEQ: { { 0, x }, { x + 1, val } }
-  val = x + 1;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} '='
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-
-  // Updated UEQ: { { 0, x, p, y }, { x + 1, val } }
-  p = 0, y = 0;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} ','
-  // CHECK-NEXT:   BinaryOperator {{.*}} '='
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT:   BinaryOperator {{.*}} '='
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-
-  // Original value of x: y
-  // Note that, although p appears before y in the set { 0, x, p, y },
-  // p's type (int *) is not compatible with x's type (int), so p is not
-  // chosen as the original value of x.
-  // Updated UEQ: { { 0, y, p, x }, { y + 1, val } }
-  x = 0;
-  // CHECK: Statement S:
-  // CHECK-NEXT: BinaryOperator {{.*}} '='
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
-  // CHECK: Sets of equivalent expressions after checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
-}
-
-// The left-hand side variable (or a value-preserving cast of the variable)
-// is the original value of the variable
-void original_value16(int x) {
+// The left-hand side variable is the original value
+void original_value14(int x) {
   // Original value of x in x: x
   // Updated UEQ: { }
   x = x;
@@ -1238,7 +1076,7 @@ void original_value16(int x) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void original_value17(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value15(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -392,7 +392,7 @@ void multiple_assign2(int x, int y) {
   // CHECK-NEXT: }
 }
 
-// Equivalence with NullToPointer casts is not recorded
+// Equivalence resulting from assignments to 0 (including NullToPointer casts)
 void multiple_assign3(int i, int *p, ptr<int> pt, array_ptr<int> a, array_ptr<int> b) {
   // Updated UEQ: { { 0, i } }
   i = 0;
@@ -409,7 +409,7 @@ void multiple_assign3(int i, int *p, ptr<int> pt, array_ptr<int> a, array_ptr<in
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Updated UEQ: { { 0, i } }
+  // Updated UEQ: { { 0, i, p } }
   p = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -422,10 +422,12 @@ void multiple_assign3(int i, int *p, ptr<int> pt, array_ptr<int> a, array_ptr<in
   // CHECK-NEXT: IntegerLiteral {{.*}} 0
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Updated UEQ: { { 0, i } }
+  // Updated UEQ: { { 0, i, p, a } }
   a = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -438,10 +440,14 @@ void multiple_assign3(int i, int *p, ptr<int> pt, array_ptr<int> a, array_ptr<in
   // CHECK-NEXT: IntegerLiteral {{.*}} 0
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Updated UEQ: { { 0, i }, { a, b } }
+  // Updated UEQ: { { 0, i, p, a, b } }
   b = a;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -454,8 +460,8 @@ void multiple_assign3(int i, int *p, ptr<int> pt, array_ptr<int> a, array_ptr<in
   // CHECK-NEXT: IntegerLiteral {{.*}} 0
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1336,7 +1342,7 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT: }
 
   // Original value of arr_int: arr_const
-  // Updated UEQ: { { arr_const + 1, arr } }
+  // Updated UEQ: { { arr_const + 1, arr }, { NullToPointer(0), arr_int } }
   arr_int = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1353,6 +1359,11 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
   // CHECK-NEXT: }
 }
 
@@ -1368,14 +1379,14 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // C HECK-NEXT: {
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
 
   // Updated UEQ: { { (array_ptr<int>)arr_const, arr_int }, { arr_int + 1, arr } }
   arr = arr_int + 1;
@@ -1388,25 +1399,25 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // C HECK-NEXT: {
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: {
-  // C HECK-NEXT: BinaryOperator {{.*}} '+'
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // C HECK-NEXT:   IntegerLiteral {{.*}} 1
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
 
   // Original value of arr_int: (array_ptr<int>)arr_const
-  // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr } }
+  // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr }, { NullToPointer(0), arr_int } }
   arr_int = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1415,16 +1426,21 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // C HECK-NEXT: {
-  // C HECK-NEXT: BinaryOperator {{.*}} '+'
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
-  // C HECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
-  // C HECK-NEXT:   IntegerLiteral {{.*}} 1
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
 }
 
 // The left-hand side variable is the original value

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1298,15 +1298,15 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: BinaryOperator {{.*}} '+'
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // C HECK-NEXT:     IntegerLiteral {{.*}} 1
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: }
 
   // Updated UEQ: { { arr_int + 1, arr } { (array_ptr<const int>)arr_int, arr_const } }
   arr_const = arr_int;
@@ -1318,22 +1318,22 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: BinaryOperator {{.*}} '+'
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // C HECK-NEXT:     IntegerLiteral {{.*}} 1
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: }
 
   // Original value of arr_int: arr_const
   // Updated UEQ: { { arr_const + 1, arr } }
@@ -1345,15 +1345,15 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: BinaryOperator {{.*}} '+'
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // C HECK-NEXT:   IntegerLiteral {{.*}} 1
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: }
 }
 
 // Original value is a value-preserving cast of another variable
@@ -1368,14 +1368,14 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: }
 
   // Updated UEQ: { { (array_ptr<int>)arr_const, arr_int }, { arr_int + 1, arr } }
   arr = arr_int + 1;
@@ -1388,22 +1388,22 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: BinaryOperator {{.*}} '+'
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // C HECK-NEXT:   IntegerLiteral {{.*}} 1
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: }
 
   // Original value of arr_int: (array_ptr<int>)arr_const
   // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr } }
@@ -1415,16 +1415,16 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: {
-  // CHECK-NEXT: BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT: }
-  // CHECK-NEXT: }
+  // C HECK-NEXT: {
+  // C HECK-NEXT: BinaryOperator {{.*}} '+'
+  // C HECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // C HECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
+  // C HECK-NEXT:   IntegerLiteral {{.*}} 1
+  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // C HECK-NEXT: }
+  // C HECK-NEXT: }
 }
 
 // The left-hand side variable is the original value

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -905,8 +905,152 @@ void original_value11(int x, int y) {
   // CHECK-NEXT: }
 }
 
+// Original value from equivalence with another variable,
+// accounting for value-preserving casts when searching for a set
+// in UEQ that contains a variable w != v in an assignment v = src
+void original_value12(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
+  // Updated UEQ: { { arr_int + 1, arr } }
+  arr = arr_int + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { arr_int + 1, arr } { (array_ptr<const int>)arr_int, arr_const } }
+  arr_const = arr_int;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of arr_int: arr_const
+  // Updated UEQ: { { arr_const + 1, arr } }
+  arr_int = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Original value is a value-preserving cast of another variable
+void original_value13(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
+  // Updated UEQ: { { (array_ptr<int>)arr_const, arr_int } }
+  arr_int = arr_const;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { (array_ptr<int>)arr_const, arr_int }, { arr_int + 1, arr } }
+  arr = arr_int + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of arr_int: (array_ptr<int>)arr_const
+  // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr } }
+  arr_int = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
 // The left-hand side variable is the original value
-void original_value12(int x) {
+void original_value14(int x) {
   // Original value of x in x: x
   // Updated UEQ: { }
   x = x;
@@ -932,7 +1076,7 @@ void original_value12(int x) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void original_value13(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value15(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1298,15 +1298,15 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // C HECK-NEXT: {
-  // C HECK-NEXT: BinaryOperator {{.*}} '+'
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // C HECK-NEXT:     IntegerLiteral {{.*}} 1
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
 
   // Updated UEQ: { { arr_int + 1, arr } { (array_ptr<const int>)arr_int, arr_const } }
   arr_const = arr_int;
@@ -1318,22 +1318,22 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // C HECK-NEXT: {
-  // C HECK-NEXT: BinaryOperator {{.*}} '+'
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // C HECK-NEXT:     IntegerLiteral {{.*}} 1
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: {
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
 
   // Original value of arr_int: arr_const
   // Updated UEQ: { { arr_const + 1, arr } }
@@ -1345,15 +1345,15 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
-  // C HECK-NEXT: {
-  // C HECK-NEXT: BinaryOperator {{.*}} '+'
-  // C HECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
-  // C HECK-NEXT:   IntegerLiteral {{.*}} 1
-  // C HECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
-  // C HECK-NEXT:   DeclRefExpr {{.*}} 'arr'
-  // C HECK-NEXT: }
-  // C HECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
 }
 
 // Original value is a value-preserving cast of another variable

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1511,6 +1511,176 @@ void original_value19(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) 
   // CHECK-NEXT: }
 }
 
+// The original value is type-compatible with the variable,
+// even when expressions in the same set are not type compatible
+// (resulting from assignments to NullToPointer casts)
+void original_value20(int *p,
+                      array_ptr<int> val, array_ptr<int> arr,
+                      array_ptr<int> a, array_ptr<int> b,
+                      array_ptr<char> c, nt_array_ptr<int> n) {
+  // Updated UEQ: { { NullToPointer(0), p } }
+  p = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { NullToPointer(0), p, c }
+  c = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { NullToPointer(0), p, c, n }
+  n = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'n'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'n'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { NullToPointer(0), p, c, n, b, a }
+  b = 0, a = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK-NEXT:   BinaryOperator {{.*}} '='
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:   BinaryOperator {{.*}} '='
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'n'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { NullToPointer(0), p, c, n, b, a }, { a + 1, val } }
+  val = a + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'n'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of a: b
+  // Note: p, c, and n are not the original value of a since their types are
+  // not compatible with the type of a
+  // Updated UEQ: { { NullToPointer(0), p, c, n, b }, { b + 1, val }, { arr, a } }
+  a = arr;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'n'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
 /////////////////////////////////
 // Functions with control flow //
 /////////////////////////////////


### PR DESCRIPTION
This PR makes several changes to equivalent expression set handling that will be necessary to update the bounds context during assignments.

#### Context:
This is part of the ongoing work to improve the soundness of bounds checking involving assignments to variables. The next step in this process will be to update the bounds context mapping variables to their observed bounds after assignments to variables. That process depends on fixing some issues with the current approach to tracking equivalent expression sets. The process of getting the original value of a variable after an assignment partially depends on the contents of the equivalent expression sets. This PR fixes some issues with these sets that would affect the original value for updating the bounds context.

#### Notable changes:
#### Account for value-preserving casts in GetOriginalValue:
##### When searching for a set F in UEQ containing the target variable v:
Consider the assignments:
```
array_ptr<int> arr_int;
array_ptr<const int> arr_const = arr_int;
arr_int = 0;
```
At the assignment `arr_int  =0`, UEQ contains the set F = `{ (array_ptr<const int>)arr_int, arr_const }`. When getting the original value of `arr_int`, GetOriginalValue should find the set F containing the value-preserving cast `(array_ptr<const int>)arr_int`, and return `arr_const` as the original value of `arr_int`.

##### When searching for a variable w != v:
Consider the assigments:
```
array_ptr<const int> arr_const;
array_ptr<int> arr_int = arr_const;
arr_int = 0;
```
At the assignment `arr_int = 0;` UEQ contains the set F = `{ (array_ptr<int>)arr_const, arr_int }`. When getting the original value of `arr_int`, GetOriginalValue should find the value-preserving cast `(array_ptr<int>)arr_const` in F and return `(array_ptr<int>)arr_const` as the original value of `arr_int`.

#### Add a type compatibility check to GetOriginalValue when searching for a variable w != v:
Consider the following assignments:
```
int val = 0;
array_ptr<int> arr = NullToPointer(0);
array_ptr<int> uses_arr = arr + 1;
arr = some_other_value;
```
Since `0` and `NullToPointer(0)` are considered equivalent, UEQ contains the set `{ 0, val, arr }` after these assignments. When getting the original value for `arr` in the fourth assignment, the variable `val` appears in the same set as `arr` and would be the original value of `arr` without this change. Then equality between `uses_arr` and `val + 1` would be recorded. This is incorrect since `val` is an integer and should not be used as the original value of the array_ptr `arr`. These errors can happen since UEQ does not consider type information when recording equality between expressions, so expressions that do not have the same type can be included in the same set in UEQ. With the change in this PR to add the type compatibility check, the original value of the array_ptr `arr` would no longer be the integer `val`.
One subtlety here is assignments involving value-preserving casts. Consider the following assignments:
```
array_ptr<int> arr, array_ptr<const int> arr_const;
arr_const = (array_ptr<const int>)arr;
```
After these assignments, UEQ contains the set `{ (array_ptr<const int>)arr, arr_const }`. When getting the original value of `arr`, GetOriginalValue finds the set F = `{ (array_ptr<const int>)arr, arr_const }` that contains the variable `arr` (since `(array_ptr<const int>)` is a value-preserving cast. The original value of `arr` should be `arr_const`. Since the type compatibility check does not consider `array_ptr<int>` (the type of `arr`) and `array_ptr<const int>` (the type of arr_const) to be compatible, GetOriginalValue would ordinarily not return `arr_const` as the original value of `arr`. To mitigate this, the type compatibility check uses the type of the value-preserving cast `(array_ptr<const int>)arr` expression that appears as `arr` in the set in UEQ, and checks for type compatibility between `array_ptr<const int>` (the type of the value-preserving cast of `arr`) and `array_ptr<const int>` (the type of `arr_const`). 

#### Testing;
* Added tests to equiv-expr-sets.c to value-preserving casts and type compatibility of original values
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux