### PR TITLE
[WIP] Bounds context: update after assignments [2/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -642,9 +642,9 @@ namespace {
 }
 
 namespace {
-  // BoundsContextTy denotes a map of a variable or parameter declaration
-  // to the variable or parameter's current known bounds.
-  using BoundsContextTy = llvm::DenseMap<DeclaratorDecl *, BoundsExpr *>;
+  // BoundsContextTy denotes a map of a variable declaration to a bounds
+  // expression for the variable.
+  using BoundsContextTy = llvm::DenseMap<VarDecl *, BoundsExpr *>;
 
   // EqualExprTy denotes a set of expressions that produce the same value
   // as an expression e.
@@ -683,7 +683,7 @@ namespace {
         SemaRef(SemaRef),
         BoundsContextRef(Context) {}
 
-      bool VisitDeclaratorDecl(DeclaratorDecl *D) {
+      bool VisitVarDecl(VarDecl *D) {
         if (!D)
           return true;
         BoundsExpr *Bounds = D->getBoundsExpr();
@@ -833,11 +833,11 @@ namespace {
         // variable declarations in the context ordered first by name,
         // then by location in order to guarantee a deterministic output
         // so that printing the bounds context can be tested.
-        std::vector<DeclaratorDecl *> OrderedDecls;
+        std::vector<VarDecl *> OrderedDecls;
         for (auto Pair : UC)
           OrderedDecls.push_back(Pair.first);
         llvm::sort(OrderedDecls.begin(), OrderedDecls.end(),
-             [] (DeclaratorDecl *A, DeclaratorDecl *B) {
+             [] (VarDecl *A, VarDecl *B) {
                if (A->getNameAsString() == B->getNameAsString())
                  return A->getLocation() < B->getLocation();
                else

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3258,10 +3258,7 @@ namespace {
       BoundsExpr *B = nullptr;
       InteropTypeExpr *IT = nullptr;
       if (VD) {
-        if (State.UC.count(VD))
-          B = State.UC[VD];
-        else
-          B = VD->getBoundsExpr();
+        B = VD->getBoundsExpr();
         IT = VD->getInteropTypeExpr();
       }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -598,7 +598,7 @@ namespace {
       // does not preserve implicit casts.
       ExprResult TransformImplicitCastExpr(ImplicitCastExpr *E) {
         // Replace V with OV (if applicable) in the subexpression of E.
-        ExprResult ChildResult = BaseTransform::TransformImplicitCastExpr(E);
+        ExprResult ChildResult = TransformExpr(E->getSubExpr());
         if (ChildResult.isInvalid())
           return ChildResult;
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3679,6 +3679,9 @@ namespace {
         for (auto I = State.UEQ.begin(); I != State.UEQ.end(); ++I) {
           if (IsEqualExprsSubset(State.G, *I)) {
             I->push_back(Target);
+            // Add the target to G if G does not already contain the target.
+            if (!EqualExprsContainsExpr(State.G, Target))
+              State.G.push_back(Target);
             return;
           }
         }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4077,6 +4077,7 @@ namespace {
       Lexicographic Lex(S.Context, nullptr);
       for (auto I = G2.begin(); I != G2.end(); ++I) {
         Expr *E = Lex.IgnoreValuePreservingOperations(S.Context, *I);
+        DeclRefExpr *V = GetRValueVariable(E);
         if (!EqualExprsContainsExpr(G1, E))
           return false;
       }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -643,8 +643,9 @@ namespace {
 
 namespace {
   // BoundsContextTy denotes a map of a variable declaration to a bounds
-  // expression for the variable.
-  using BoundsContextTy = llvm::DenseMap<VarDecl *, BoundsExpr *>;
+  // expression for the variable (e.g. the variable's declared bounds or the
+  // observed bounds for the variable that are updated during bounds checking).
+  using BoundsContextTy = llvm::DenseMap<const VarDecl *, BoundsExpr *>;
 
   // EqualExprTy denotes a set of expressions that produce the same value
   // as an expression e.
@@ -840,11 +841,11 @@ namespace {
         // variable declarations in the context ordered first by name,
         // then by location in order to guarantee a deterministic output
         // so that printing the bounds context can be tested.
-        std::vector<VarDecl *> OrderedDecls;
+        std::vector<const VarDecl *> OrderedDecls;
         for (auto Pair : Context)
           OrderedDecls.push_back(Pair.first);
         llvm::sort(OrderedDecls.begin(), OrderedDecls.end(),
-             [] (VarDecl *A, VarDecl *B) {
+             [] (const VarDecl *A, const VarDecl *B) {
                if (A->getNameAsString() == B->getNameAsString())
                  return A->getLocation() < B->getLocation();
                else
@@ -853,7 +854,7 @@ namespace {
 
         OS << "{\n";
         for (auto I = OrderedDecls.begin(); I != OrderedDecls.end(); ++I) {
-          VarDecl *Variable = *I;
+          const VarDecl *Variable = *I;
           if (!Context[Variable])
             continue;
           OS << "Variable:\n";
@@ -3680,7 +3681,7 @@ namespace {
       // Adjust ObservedBounds to account for any uses of v in
       // PrevState.ObservedBounds.
       for (auto Pair : State.ObservedBounds) {
-        VarDecl *Decl = Pair.first;
+        const VarDecl *Decl = Pair.first;
         BoundsExpr *Bounds = Pair.second;
         BoundsExpr *AdjustedBounds = ReplaceVariableInBounds(Bounds, V, OV, CSS);
         State.ObservedBounds[Decl] = AdjustedBounds;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2195,6 +2195,7 @@ namespace {
             // context before checking S.  TODO: save this context in a
             // declared context DC.
             GetDeclaredBounds(this->S, BlockState.UC, S);
+            BlockState.G.clear();
             Check(S, CSS, BlockState);
             // TODO: validate the updated context BlockState.UC against
             // the declared context DC.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2902,9 +2902,9 @@ namespace {
         if (E->getType()->isCheckedPointerPtrType())
           ResultBounds = CreateTypeBasedBounds(E, E->getType(), false, false);
         else
-          ResultBounds = RValueCastBounds(CK, SubExprTargetBounds,
+          ResultBounds = RValueCastBounds(E, SubExprTargetBounds,
                                           SubExprLValueBounds,
-                                          SubExprBounds);
+                                          SubExprBounds, State);
       }
 
       CheckDisallowedFunctionPtrCasts(E);
@@ -4616,10 +4616,12 @@ namespace {
     }
 
     // Compute the bounds of a cast operation that produces an rvalue.
-    BoundsExpr *RValueCastBounds(CastKind CK, BoundsExpr *TargetBounds,
+    BoundsExpr *RValueCastBounds(CastExpr *E,
+                                 BoundsExpr *TargetBounds,
                                  BoundsExpr *LValueBounds,
-                                 BoundsExpr *RValueBounds) {
-      switch (CK) {
+                                 BoundsExpr *RValueBounds,
+                                 CheckingState State) {
+      switch (E->getCastKind()) {
         case CastKind::CK_BitCast:
         case CastKind::CK_NoOp:
         case CastKind::CK_NullToPointer:
@@ -4630,8 +4632,21 @@ namespace {
         case CastKind::CK_IntegralToBoolean:
         case CastKind::CK_BooleanToSignedIntegral:
           return RValueBounds;
-        case CastKind::CK_LValueToRValue:
+        case CastKind::CK_LValueToRValue: {
+          // For an rvalue cast of a variable v, if v has observed bounds,
+          // the rvalue bounds of the value of v should be the observed bounds.
+          // This also accounts for any variables that have widened bounds.
+          if (DeclRefExpr *V = GetRValueVariable(E)) {
+            if (const VarDecl *D = dyn_cast_or_null<VarDecl>(V->getDecl())) {
+              if (BoundsExpr *B = State.ObservedBounds[D])
+                return B;
+            }
+          }
+          // If an lvalue to rvalue cast e is not the value of a variable
+          // with observed bounds, the rvalue bounds of e default to the
+          // given target bounds.
           return TargetBounds;
+        }
         case CastKind::CK_ArrayToPointerDecay:
           return LValueBounds;
         case CastKind::CK_DynamicPtrBounds:

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2177,6 +2177,8 @@ namespace {
      for (const CFGBlock *Block : POView) {
        AFA.GetFacts(Facts);
        CheckingState BlockState = GetIncomingBlockState(Block, BlockStates);
+       // TODO: update BlockState.ObservedBounds to reflect the widened bounds
+       // for the block.
        for (CFGElement Elem : *Block) {
          if (Elem.getKind() == CFGElement::Statement) {
            CFGStmt CS = Elem.castAs<CFGStmt>();
@@ -2211,8 +2213,11 @@ namespace {
             // bounds for each variable v that is in scope are the widened
             // bounds for v (if any), or the declared bounds for v (if any).
             GetDeclaredBounds(this->S, BlockState.ObservedBounds, S);
-
+            // TODO: update BlockState.ObservedBounds to reset any widened
+            // bounds that are killed by S to the declared variable bounds.
+            BoundsContextTy InitialObservedBounds = BlockState.ObservedBounds;
             BlockState.G.clear();
+
             Check(S, CSS, BlockState);
 
             if (DumpState)
@@ -2221,6 +2226,12 @@ namespace {
             // TODO: for each variable v in ObservedBounds, check that the
             // observed bounds of v imply the declared bounds of v.
 
+            // The observed bounds that were updated after checking S should
+            // only be used to check that the updated observed bounds imply
+            // the declared variable bounds.  After checking the observed and
+            // declared bounds, the observed bounds for each variable should
+            // be reset to their observed bounds from before checking S.
+            BlockState.ObservedBounds = InitialObservedBounds;
          }
        }
        if (Block->getBlockID() != Cfg->getEntry().getBlockID())

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3140,6 +3140,11 @@ namespace {
           TargetTy = D->getType();
         }
         Expr *TargetExpr = CreateImplicitCast(TargetTy, Kind, TargetDeclRef);
+
+        // If v has declared bounds, update the observed bounds of v to the
+        // initializer bounds.
+        if (D->hasBoundsExpr())
+          State.ObservedBounds[D] = InitBounds;
         
         // Record equality between the target and initializer.
         RecordEqualityWithTarget(TargetExpr, State);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3682,6 +3682,21 @@ namespace {
       }
 
       RecordEqualityWithTarget(Target, State);
+
+    // ReplaceVariableInBounds returns a bounds expression where all uses
+    // of the variable v have been replaced with the original value (if any).
+    // If the original value is null and the bounds expression uses the value
+    // of v, the resulting bounds expression will be bounds(unknown).
+    BoundsExpr *ReplaceVariableInBounds(BoundsExpr *B, DeclRefExpr *V,
+                                        Expr *OV,
+                                        CheckedScopeSpecifier CSS) {
+      Expr *Replaced = ReplaceVariableReferences(S, B, V, OV, CSS);
+      if (!Replaced)
+        return CreateBoundsUnknown();
+      else if (BoundsExpr *Bounds = dyn_cast<BoundsExpr>(Replaced))
+        return Bounds;
+      else
+        return CreateBoundsUnknown();
     }
 
     // RecordEqualityWithTarget updates the checking state to record equality
@@ -4029,7 +4044,7 @@ namespace {
       return BlockState;
     }
 
-    // IntersectBoundsContexts returns a bounds context resulting from taking the
+    // IntersectBoundsContexts returns a bounds context resulting from taking
     // the intersection of the contexts Context1 and Context2.
     BoundsContextTy IntersectBoundsContexts(BoundsContextTy Context1,
                                             BoundsContextTy Context2) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -692,9 +692,11 @@ namespace {
       bool VisitVarDecl(VarDecl *D) {
         if (!D)
           return true;
+        if (D->isInvalidDecl())
+          return true;
         BoundsExpr *Bounds = D->getBoundsExpr();
         if (Bounds)
-          BoundsContextRef[D] = Bounds;
+          BoundsContextRef[D] = SemaRef.ExpandBoundsToRange(D, Bounds);
         return true;
       }
   };
@@ -2158,10 +2160,10 @@ namespace {
      // parameter bounds is the initial context for checking the function body.
      CheckingState ParamsState;
      for (auto I = FD->param_begin(); I != FD->param_end(); ++I) {
-       ParmVarDecl *Param = *I;
-       BoundsExpr *Bounds = Param->getBoundsExpr();
+       ParmVarDecl *D = *I;
+       BoundsExpr *Bounds = D->getBoundsExpr();
        if (Bounds)
-         ParamsState.UC[Param] = Bounds;
+         ParamsState.DeclaredBounds[D] = S.ExpandBoundsToRange(D, Bounds);
      }
 
      // Store a checking state for each CFG block in order to track

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4068,8 +4068,12 @@ namespace {
       return dyn_cast<DeclRefExpr>(E->IgnoreParens());
     }
 
-    // If E is an rvalue cast (ignoring value-preserving operations) of a
-    // variable V, GetRValueVariable returns V. Otherwise, it returns nullptr.
+    // If E is a possibly parenthesized rvalue cast of a variable V,
+    // GetRValueVariable returns V. Otherwise, it returns nullptr.
+    //
+    // V may have value-preserving operations applied to it.  For example,
+    // if E is (LValueToRValue(LValueBitCast(V))), where V is a variable,
+    // GetRValueVariable will return V.
     DeclRefExpr *GetRValueVariable(Expr *E) {
       if (CastExpr *CE = dyn_cast<CastExpr>(E->IgnoreParens())) {
         CastKind CK = CE->getCastKind();

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -17,7 +17,7 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 5
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Declared bounds context before checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
@@ -42,7 +42,7 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'size'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Declared bounds context before checking S:
   // CHECK-NEXT: {
   // CHECK: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
@@ -76,7 +76,7 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Declared bounds context before checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
@@ -97,7 +97,7 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
     // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
     // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-    // CHECK-NEXT: Bounds context after checking S:
+    // CHECK-NEXT: Declared bounds context before checking S:
     // CHECK-NEXT: {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
@@ -123,7 +123,7 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
     // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
     // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-    // CHECK-NEXT: Bounds context after checking S:
+    // CHECK-NEXT: Declared bounds context before checking S:
     // CHECK-NEXT: {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
@@ -156,7 +156,7 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Declared bounds context before checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -8,7 +8,8 @@
 
 // Parameter with bounds
 void f1(array_ptr<int> arr : count(len), int len, int size) {
-  // Updated bounds context: { a => count(5), arr => count(len) }
+  // Declared bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len) }
+  // Observed bounds context: { a => bounds(any), arr => bounds(arr, arr + len) }
   array_ptr<int> a : count(5) = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -22,17 +23,46 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT:   VarDecl {{.*}} arr
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT:   VarDecl {{.*}} arr
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 
-  // Updated bounds context: { a => count(5), arr => count(len), b => count(size) }
+  // Declared bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(b, b + size) }
+  // Observed bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(any) }
   array_ptr<int> b : count(size) = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -44,29 +74,73 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Declared bounds context before checking S:
   // CHECK-NEXT: {
-  // CHECK: Variable:
+  // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 5
-  // CHECK: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
-  // CHECK: Variable:
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT:   VarDecl {{.*}} arr
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} b
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT:   VarDecl {{.*}} arr
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} b
+  // CHECK: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 }
 
 // If statement, redeclared variable
 void f2(int flag, int x, int y) {
-  // Updated bounds context: { a => count(x) }
+  // Declared bounds context: { a => bounds(a, a + x) }
+  // Observed bounds context: { a => bounds(any) }
   array_ptr<int> a : count(x) = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -81,13 +155,26 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 
   if (flag) {
-    // Updated bounds context: { a => count(x), a => count(y) }
+    // Declared bounds context: { a => bounds(a, a + x), a => bounds(a, a + y) }
+    // Observed bounds context: { a => bounds(a, a + x), a => bounds(any) }
     array_ptr<int> a : count(y) = 0;
     // CHECK: Statement S:
     // CHECK:      DeclStmt
@@ -102,18 +189,47 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT: }
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+    // CHECK: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
 
-    // Updated bounds context: { a => count(x), a => count(y), b => count(y) }
+    // Declared bounds context: { a => bounds(a, a + x), a => bounds(a, a + y), b => bounds(b, b + 4) }
+    // Observed bounds context: { a => bounds(a, a + x), a => bounds(a, a + y), b => bounds(any) }
     array_ptr<int> b : count(y) = 0;
     // CHECK: Statement S:
     // CHECK:      DeclStmt
@@ -128,25 +244,70 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} b
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT: }
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+    // CHECK: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: Variable:
+    // CHECK-NEXT: VarDecl {{.*}} b
+    // CHECK: Bounds:
+    // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
   }
 
-  // Updated bounds context: { a => count(x), c => count(x) }
+  // Declared bounds context: { a => bounds(a, a + x), c => bounds(c, c + x) }
+  // Observed bounds context: { a => bounds(a, a + x), c => bounds(a, a + x) }
   array_ptr<int> c : count(x) = a;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -161,14 +322,49 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
-  // CHECK: Variable:
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} c
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} c
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: }
 }

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -8,7 +8,6 @@
 
 // Parameter with bounds
 void f1(array_ptr<int> arr : count(len), int len, int size) {
-  // Declared bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len) }
   // Observed bounds context: { a => bounds(any), arr => bounds(arr, arr + len) }
   array_ptr<int> a : count(5) = 0;
   // CHECK: Statement S:
@@ -18,38 +17,19 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 5
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Declared bounds context before checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT:   VarDecl {{.*}} arr
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: }
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
   // CHECK: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: Variable:
-  // CHECK-NEXT:   VarDecl {{.*}} arr
+  // CHECK-NEXT: VarDecl {{.*}} arr
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -61,7 +41,6 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 
-  // Declared bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(b, b + size) }
   // Observed bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(any) }
   array_ptr<int> b : count(size) = 0;
   // CHECK: Statement S:
@@ -72,45 +51,12 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'size'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Declared bounds context before checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT:   VarDecl {{.*}} arr
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} b
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
-  // CHECK-NEXT: }
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -120,7 +66,10 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 5
   // CHECK-NEXT: Variable:
-  // CHECK-NEXT:   VarDecl {{.*}} arr
+  // CHECK-NEXT: VarDecl {{.*}} arr
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -132,6 +81,9 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} b
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
   // CHECK: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
@@ -139,7 +91,6 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
 
 // If statement, redeclared variable
 void f2(int flag, int x, int y) {
-  // Declared bounds context: { a => bounds(a, a + x) }
   // Observed bounds context: { a => bounds(any) }
   array_ptr<int> a : count(x) = 0;
   // CHECK: Statement S:
@@ -150,30 +101,18 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Declared bounds context before checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 
   if (flag) {
-    // Declared bounds context: { a => bounds(a, a + x), a => bounds(a, a + y) }
     // Observed bounds context: { a => bounds(a, a + x), a => bounds(any) }
     array_ptr<int> a : count(y) = 0;
     // CHECK: Statement S:
@@ -184,35 +123,13 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
     // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
     // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-    // CHECK-NEXT: Declared bounds context before checking S:
-    // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK: Bounds:
-    // CHECK-NEXT: RangeBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK: Bounds:
-    // CHECK-NEXT: RangeBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
-    // CHECK-NEXT: }
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -224,11 +141,13 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Bounds:
     // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
 
-    // Declared bounds context: { a => bounds(a, a + x), a => bounds(a, a + y), b => bounds(b, b + 4) }
     // Observed bounds context: { a => bounds(a, a + x), a => bounds(a, a + y), b => bounds(any) }
     array_ptr<int> b : count(y) = 0;
     // CHECK: Statement S:
@@ -239,46 +158,13 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
     // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
     // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-    // CHECK-NEXT: Declared bounds context before checking S:
-    // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK: Bounds:
-    // CHECK-NEXT: RangeBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK: Bounds:
-    // CHECK-NEXT: RangeBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} b
-    // CHECK: Bounds:
-    // CHECK-NEXT: RangeBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
-    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
-    // CHECK-NEXT: }
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -290,6 +176,9 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -301,12 +190,14 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} b
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Bounds:
     // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
   }
 
-  // Declared bounds context: { a => bounds(a, a + x), c => bounds(c, c + x) }
   // Observed bounds context: { a => bounds(a, a + x), c => bounds(a, a + x) }
   array_ptr<int> c : count(x) = a;
   // CHECK: Statement S:
@@ -317,35 +208,13 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Declared bounds context before checking S:
-  // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} c
-  // CHECK: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: }
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -357,6 +226,9 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} c
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -905,8 +905,152 @@ void original_value11(int x, int y) {
   // CHECK-NEXT: }
 }
 
+// Original value from equivalence with another variable,
+// accounting for value-preserving casts when searching for a set
+// in UEQ that contains a variable w != v in an assignment v = src
+void original_value12(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
+  // Updated UEQ: { { arr_int + 1, arr } }
+  arr = arr_int + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { arr_int + 1, arr } { (array_ptr<const int>)arr_int, arr_const } }
+  arr_const = arr_int;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of arr_int: arr_const
+  // Updated UEQ: { { arr_const + 1, arr } }
+  arr_int = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Original value is a value-preserving cast of another variable
+void original_value13(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
+  // Updated UEQ: { { (array_ptr<int>)arr_const, arr_int } }
+  arr_int = arr_const;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Updated UEQ: { { (array_ptr<int>)arr_const, arr_int }, { arr_int + 1, arr } }
+  arr = arr_int + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of arr_int: (array_ptr<int>)arr_const
+  // Updated UEQ: { { (array_ptr<int>)arr_const + 1, arr } }
+  arr_int = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr_int'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr_const'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
 // The left-hand side variable is the original value
-void original_value12(int x) {
+void original_value14(int x) {
   // Original value of x in x: x
   // Updated UEQ: { }
   x = x;
@@ -932,7 +1076,7 @@ void original_value12(int x) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void original_value13(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value15(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:


### PR DESCRIPTION
This PR updates the bounds context mapping variables to their observed bounds after assignments to variables. It is currently a work in progress meant to show the proposed updates to the bounds context handling, which is relevant to the bounds widening work in #821. This PR also includes the changes in #820, which makes changes to UEQ handling that are necessary in order for this bounds context updating work.

#### Updates to bounds context handling
The UC bounds context has been replaced with DeclaredBounds and ObservedBounds contexts in CheckingState. DeclaredBounds maps variable declarations to the bounds the programmer has declared for the variable. These bounds should never be affected by assignments or bounds widening. ObservedBounds maps variable declarations to the bounds that are inferred during bounds checking. These bounds are affected by assignments, and may be affected by bounds widening.

Previously, CheckDeclRefExpr used the CheckingState.UC bounds context to get the target bounds of a variable. This allowed the widened bounds to be used as the observed rvalue bounds of the value of a variable, since CheckCastExpr returns the target bounds of the subexpression of an LValueToRValue cast as the rvalue bounds. This is no longer the case in CheckDeclRefExpr. The reason for this is that lvalue target bounds should never be affected by assignments or bounds widening. As a result, the observed rvalue bounds for the value of a variable that has widened bounds need to be inferred by another method rather than modifying CheckDeclRefExpr.