### PR TITLE
Fix dereference of null pointer

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4377,7 +4377,7 @@ namespace {
             assert(ME->getBase()->isRValue());
             // This can happen if the base expression is an rvalue expression.
             // It could be a function call that returns a struct, for example.
-            CreateBoundsNotAllowedYet();
+            return CreateBoundsNotAllowedYet();
           }
           if (B->isElementCount() || B->isByteCount()) {
             Expr *Base = CreateImplicitCast(Context.getDecayedType(ME->getType()),


### PR DESCRIPTION
We ran the PREfast static analysis tool on clang and it reported several null
pointer dereference issues. Here were are fixing one such warning in Checked C
specific code.