### PR TITLE
Bounds context: observed bounds [2/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -846,12 +846,13 @@ namespace {
         OS << "{\n";
         for (auto I = OrderedDecls.begin(); I != OrderedDecls.end(); ++I) {
           const VarDecl *Variable = *I;
-          if (!Context[Variable])
+          auto It = Context.find(Variable);
+          if (It == Context.end())
             continue;
           OS << "Variable:\n";
           Variable->dump(OS);
           OS << "Bounds:\n";
-          Context[Variable]->dump(OS);
+          It->second->dump(OS);
         }
         OS << "}\n";
       }
@@ -4030,13 +4031,13 @@ namespace {
       return BlockState;
     }
 
-    // IntersectUC returns a bounds context resulting from taking the
-    // intersection of the contexts Context1 and Context2.
+    // IntersectBoundsContexts returns a bounds context resulting from taking
+    // the intersection of the contexts Context1 and Context2.
     BoundsContextTy IntersectBoundsContexts(BoundsContextTy Context1,
                                             BoundsContextTy Context2) {
       BoundsContextTy IntersectedContext;
       for (auto Pair : Context1) {
-        if (!Pair.second || !Context2[Pair.first])
+        if (!Pair.second || !Context2.count(Pair.first))
           continue;
         IntersectedContext[Pair.first] = Pair.second;
       }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3266,10 +3266,7 @@ namespace {
       BoundsExpr *B = nullptr;
       InteropTypeExpr *IT = nullptr;
       if (VD) {
-        if (State.ObservedBounds.count(VD))
-          B = State.ObservedBounds[VD];
-        else
-          B = VD->getBoundsExpr();
+        B = VD->getBoundsExpr();
         IT = VD->getInteropTypeExpr();
       }
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -8,7 +8,7 @@
 
 // Parameter with bounds
 void f1(array_ptr<int> arr : count(len), int len, int size) {
-  // Updated bounds context: { a => count(5), arr => count(len) }
+  // Observed bounds context: { a => bounds(any), arr => bounds(arr, arr + len) }
   array_ptr<int> a : count(5) = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -17,22 +17,26 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 5
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
+  // CHECK-NEXT: VarDecl {{.*}} arr
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK: Bounds:
   // CHECK-NEXT: CountBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 
-  // Updated bounds context: { a => count(5), arr => count(len), b => count(size) }
+  // Observed bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(any) }
   array_ptr<int> b : count(size) = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -42,31 +46,47 @@ void f1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'size'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
-  // CHECK-NEXT:   IntegerLiteral {{.*}} 5
-  // CHECK: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
-  // CHECK: Variable:
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: VarDecl {{.*}} arr
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} b
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 }
 
 // If statement, redeclared variable
 void f2(int flag, int x, int y) {
-  // Updated bounds context: { a => count(x) }
+  // Observed bounds context: { a => bounds(any) }
   array_ptr<int> a : count(x) = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -76,18 +96,19 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
   // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 
   if (flag) {
-    // Updated bounds context: { a => count(x), a => count(y) }
+    // Observed bounds context: { a => bounds(a, a + x), a => bounds(any) }
     array_ptr<int> a : count(y) = 0;
     // CHECK: Statement S:
     // CHECK:      DeclStmt
@@ -97,23 +118,32 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
     // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
     // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-    // CHECK-NEXT: Bounds context after checking S:
+    // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
 
-    // Updated bounds context: { a => count(x), a => count(y), b => count(y) }
+    // Observed bounds context: { a => bounds(a, a + x), a => bounds(a, a + y), b => bounds(any) }
     array_ptr<int> b : count(y) = 0;
     // CHECK: Statement S:
     // CHECK:      DeclStmt
@@ -123,30 +153,47 @@ void f2(int flag, int x, int y) {
     // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
     // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
     // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-    // CHECK-NEXT: Bounds context after checking S:
+    // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
     // CHECK-NEXT: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} a
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
+    // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Variable:
     // CHECK-NEXT: VarDecl {{.*}} b
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
     // CHECK: Bounds:
-    // CHECK-NEXT: CountBoundsExpr
-    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+    // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
   }
 
-  // Updated bounds context: { a => count(x), c => count(x) }
+  // Observed bounds context: { a => bounds(a, a + x), c => bounds(a, a + x) }
   array_ptr<int> c : count(x) = a;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -156,19 +203,35 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT: Bounds context after checking S:
+  // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
-  // CHECK: Variable:
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} c
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK: Bounds:
-  // CHECK-NEXT: CountBoundsExpr
+  // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: }
 }


### PR DESCRIPTION
This PR replaces the UC bounds context member of CheckingState with ObservedBounds, and uses the observed bounds as the rvalue bounds for the value of a variable, rather than as the lvalue target bounds for a variable.

#### Context:
This is part of the ongoing work to improve the soundness of bounds checking involving assignments to variables. This work is also related to the bounds widening analysis (e.g. #821). After this PR is merged, and the ObservedBounds context is updated to reflect the widened bounds of nt_array_ptrs, the bounds checking can use the widened bounds as the rvalue bounds of the value of an nt_array_ptr variable.

#### Notable changes:
* Rename the UC bounds context to ObservedBounds. This makes the meaning of the bounds expressions in the bounds context more clear: the observed bounds are the bounds that are currently known to be valid for a variable. These bounds are updated during bounds checking and will later be used to verify that the observed bounds imply the declared bounds for all variables after an assignment.
* Do not use the observed bounds of a variable as the lvalue target bounds. The target bounds of a variable should always be the programmer-declared bounds.
* Use the observed bounds of a variable as the rvalue bounds by modifying RValueCastBounds for LValueToRValue casts.

#### Tests:
* Modified the bounds-context.c tests to reflect changes in how the bounds context is printed.
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux.