### PR TITLE
Equivalent expressions: bounds cast inverse [7/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4091,7 +4091,7 @@ namespace {
         case CastKind::CK_BooleanToSignedIntegral:
         case CastKind::CK_IntegralToFloating:
           return IsInvertible(X, E->getSubExpr());
-        // Bounds casts may be invertible
+        // Bounds casts may be invertible.
         case CastKind::CK_DynamicPtrBounds:
         case CastKind::CK_AssumePtrBounds: {
           CHKCBindTemporaryExpr *Temp =
@@ -4104,7 +4104,7 @@ namespace {
         case CastKind::CK_PointerToIntegral:
         case CastKind::CK_IntegralCast:
           return Size1 >= Size2 && IsInvertible(X, E->getSubExpr());
-        // All other casts are considered narrowing
+        // All other casts are considered narrowing.
         default:
           return false;
       }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3829,6 +3829,8 @@ namespace {
 
       // If Val introduces a temporary to hold the value produced by e,
       // add the value of the temporary to G.
+      // TODO: checkedc-clang issue #832: adding uses of temporaries here
+      // can result in false equivalence being recorded between expressions.
       if (CHKCBindTemporaryExpr *Temp = GetTempBinding(Val))
         G.push_back(CreateTemporaryUse(Temp));
     }

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1846,6 +1846,7 @@ void original_value26(array_ptr<int> a : count(1), array_ptr<int> val) {
 
   // Original value of a: (array_ptr<int>)(array_ptr<const int>)a - 1
   // Updated UEQ: { { (array_ptr<int>)(array_ptr<const int>)a - 1 + 1, val }, { value(temp(a + 1)), a } }
+  // TODO: checkedc-clang issue #832: equality between value(temp(a + 1)) and a should not be recorded
   a = _Dynamic_bounds_cast<array_ptr<const int>>(a + 1, count(1));
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1721,8 +1721,168 @@ void original_value23(double d, double val) {
   // CHECK-NEXT: { }
 }
 
+// Bounds cast expression inverse where the type is the same as the LHS variable type
+void original_value24(array_ptr<int> a : count(1), array_ptr<int> val) {
+  // Updated UEQ: { { a + 1, val } }
+  val = a + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of a: (array_ptr<int>)a
+  // Updated UEQ: { { (array_ptr<int>)a + 1, val } }
+  a = _Dynamic_bounds_cast<array_ptr<int>>(a, count(1));
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BoundsCastExpr {{.*}} '_Array_ptr<int>' <DynamicPtrBounds>
+  // CHECK:          CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   CStyleCastExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }  
+}
+
+// Bounds cast expression inverse including a type cast
+void original_value25(array_ptr<int> a : count(1), array_ptr<int> val) {
+  // Updated UEQ: { { a + 1, val } }
+  val = a + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of a: (array_ptr<int>)(array_ptr<const int>)a
+  // Updated UEQ: { { (array_ptr<int>)(array_ptr<const int>)a + 1, val } }
+  a = _Assume_bounds_cast<array_ptr<const int>>(a, count(1));
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     BoundsCastExpr {{.*}} '_Array_ptr<const int>' <AssumePtrBounds>
+  // CHECK:            CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:       CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   CStyleCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }  
+}
+
+// Combined bounds cast and binary inverse
+void original_value26(array_ptr<int> a : count(1), array_ptr<int> val) {
+  // Updated UEQ: { { a + 1, val } }
+  val = a + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of a: (array_ptr<int>)(array_ptr<const int>)a - 1
+  // Updated UEQ: { { (array_ptr<int>)(array_ptr<const int>)a - 1 + 1, val }, { value(temp(a + 1)), a } }
+  a = _Dynamic_bounds_cast<array_ptr<const int>>(a + 1, count(1));
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <NoOp>
+  // CHECK-NEXT:     BoundsCastExpr {{.*}} '_Array_ptr<const int>' <DynamicPtrBounds>
+  // CHECK:            CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:         BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:       CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     CStyleCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} '_Array_ptr<const int>' <NoOp>
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'val'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BoundsValueExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }  
+}
+
 // CallExpr: using the left-hand side of an assignment as a call argument
-void original_value24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value27(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:
@@ -1766,7 +1926,7 @@ void original_value24(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) 
 // The original value is type-compatible with the variable,
 // even when expressions in the same set are not type compatible
 // (resulting from assignments to NullToPointer casts)
-void original_value25(int *p,
+void original_value28(int *p,
                       array_ptr<int> val, array_ptr<int> arr,
                       array_ptr<int> a, array_ptr<int> b,
                       array_ptr<char> c, nt_array_ptr<int> n) {


### PR DESCRIPTION
This PR extends the IsInvertible and Inverse methods to return the inverse of a bounds cast expression.

#### Context:
This work is part of the ongoing work for soundness of bounds declaration checking. In order to update the bounds context after assignments that involve bounds cast expressions, IsInvertible and Inverse need to be able to handle bounds casts.

Consider:
```
void bounds_casts_correct(array_ptr<int> a : count(1), array_ptr<char> b : count(4)) {
  // Source bounds for dynamic cast: (temp(a), temp(a) + 1)
  // Original value of a: a
  // Updated observed bounds for a: (temp(a), temp(a) + 1)
  a = _Dynamic_bounds_cast<array_ptr<int>>(a, count(1));

  // Source bounds of dynamic bounds cast are (a, a + 1)
  // Original value of a: a
  // Updated observed bounds for a: bounds(a, a + 1)
  a = _Dynamic_bounds_cast<array_ptr<int>>(a, bounds(a, a + 1));
}

void bounds_casts_incorrect(array_ptr<int> a : count(1), array_ptr<char> b : count(4)) {
  // Source bounds for dynamic cast: (temp(a), temp(a) + 1)
  // Original value of a: null
  // Updated observed bounds for a: (temp(a), temp(a) + 1)
  a = _Dynamic_bounds_cast<array_ptr<int>>(a, count(1));

  // Source bounds of dynamic bounds cast are (a, a + 1)
  // Original value of a: null
  // Updated observed bounds for a: bounds(unknown)
  a = _Dynamic_bounds_cast<array_ptr<int>>(a, bounds(a, a + 1));
}
```
In the incorrect case, where the original value of `a` is `null`, the observed bounds for `a` will become `bounds(unknown)` after the second assignment. In the correct case (as implemented by this PR), where the original value of `a` is `a`, the observed bounds for `a` will become `bounds(a, a + 1)` after the second assignment. This matches the behavior of the first assignment.

#### Major changes:
* Update IsInvertible to determine that a bounds cast expression `BoundsCast<T1>(temp(e1))` is invertible with respect to a variable `x` if and only if `e1` is invertible with respect to `x`
* Update Inverse to return `(T2)e1` as the inverse of a bounds cast expression `BoundsCast<T1>(temp(e1))`, where `e1` has type `T2`.

#### Testing;
* Add tests for bounds cast inverses in equiv-expr-sets.c
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux