### PR TITLE
Add bigobj compile flag to checked-c-convert RewriteUtils.cpp

### DIFF
--- a/clang/tools/checked-c-convert/CMakeLists.txt
+++ b/clang/tools/checked-c-convert/CMakeLists.txt
@@ -4,6 +4,10 @@ set( LLVM_LINK_COMPONENTS
   Support
   )
 
+if (MSVC)
+  set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
 add_clang_executable(checked-c-convert
   ArrayBoundsInferenceConsumer.cpp
   ArrayBoundsInformation.cpp


### PR DESCRIPTION
This PR fixes a build failure with checked-c-convert by adding the bigobj compile flag to the CMake file for RewriteUtils.cpp.

Build failure message:
clang\tools\checked-c-convert\RewriteUtils.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

Testing:
* Passed manual testing on Windows X64
* Passed automated testing on Windows X64 and Linux
* Automated testing in progress on Windows X86