### PR TITLE
Allow bounds widening for the default case of a switch-case

### DIFF
--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -150,8 +150,8 @@ void BoundsAnalysis::ComputeGenSets() {
       if (pred->succ_size() == 0)
         continue;
 
-      const CFGBlock *FalseDefaultBlock = *(pred->succs().end() - 1);
-      if (EB->Block == FalseDefaultBlock)
+      const CFGBlock *FalseOrDefaultBlock = *(pred->succs().end() - 1);
+      if (EB->Block == FalseOrDefaultBlock)
         continue;
 
       // Get the edge condition and fill the Gen set.
@@ -175,9 +175,9 @@ void BoundsAnalysis::ComputeGenSets() {
           // If we establish that another label in a switch statement tests for
           // 0, then the default case will handle non-zero case, and the bounds
           // can be widened there.
-          if (FalseDefaultBlock && FalseDefaultBlock->getLabel() &&
-              isa<DefaultStmt>(FalseDefaultBlock->getLabel()))
-            FillGenSet(E, BlockMap[pred], BlockMap[FalseDefaultBlock]);
+          if (FalseOrDefaultBlock && FalseOrDefaultBlock->getLabel() &&
+              isa<DefaultStmt>(FalseOrDefaultBlock->getLabel()))
+            FillGenSet(E, BlockMap[pred], BlockMap[FalseOrDefaultBlock]);
 
           continue;
         }

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -168,9 +168,9 @@ void BoundsAnalysis::ComputeGenSets() {
 
         // According to C11 standard section 6.8.4.2, the controlling
         // expression of a switch shall have integer type.
-        // If we have switch(*p) where p is _Nt_array_ptr<char> then it casted
-        // to integer type and an IntegralCast is generated. Here we strip off
-        // the IntegralCast.
+        // If we have switch(*p) where p is _Nt_array_ptr<char> then it is
+        // casted to integer type and an IntegralCast is generated. Here we
+        // strip off the IntegralCast.
         if (auto *CE = dyn_cast<CastExpr>(E)) {
           if (CE->getCastKind() == CastKind::CK_IntegralCast)
             E = CE->getSubExpr();

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -124,7 +124,7 @@ void BoundsAnalysis::ComputeGenSets() {
   for (const auto item : BlockMap) {
     ElevatedCFGBlock *EB = item.second;
 
-    // Check if this is a switch case and whether the case label is non-null.
+    // Check if this is a switch case and whether the case label is null.
     // In a switch, we can only widen the bounds in the following cases:
     // 1. Inside a case with a non-null case label.
     // 2. Inside the default case, only if there is another case with a null
@@ -176,12 +176,12 @@ void BoundsAnalysis::ComputeGenSets() {
             E = CE->getSubExpr();
         }
 
-        // If the current block has a non-null case label, we cannot widen the
+        // If the current block has a null case label, we cannot widen the
         // bounds inside that case.
         if (IsSwitchCaseNull) {
-          // If we are here it means there is a case label that tests for null.
-          // This means that the default case is the non-null case. Hence, we
-          // can widen the bounds inside the default case.
+          // If we are here it means that the current case label is null.
+          // This means that the default case would represent the non-null
+          // case. Hence, we can widen the bounds inside the default case.
           if (FalseOrDefaultBlock && FalseOrDefaultBlock->getLabel() &&
               isa<DefaultStmt>(FalseOrDefaultBlock->getLabel()))
             FillGenSet(E, BlockMap[pred], BlockMap[FalseOrDefaultBlock]);

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -796,6 +796,9 @@ void f26() {
   }
 
   switch (*p) {
+  default: break;
+// CHECK:   default:
+// CHECK: upper_bound(p) = 1
   case '\0': break;
 // CHECK:   case '\x00':
 // CHECK-NOT: upper_bound(p)
@@ -811,6 +814,9 @@ void f26() {
   case 'a': break;
 // CHECK:   case '\x00':
 // CHECK-NOT: upper_bound(p)
+  default: break;
+// CHECK:   default:
+// CHECK: upper_bound(p) = 1
   }
 }
 
@@ -824,6 +830,10 @@ void f27() {
 // CHECK: In function: f27
 
   switch (*p) {
+  default: break;
+// CHECK:   default:
+// CHECK: upper_bound(p) = 1
+
   case a: break;
 // CHECK:   case a:
 // CHECK-NOT: upper_bound(p)
@@ -850,6 +860,10 @@ void f27() {
   case e2: break;
 // CHECK:   case e2:
 // CHECK: upper_bound(p) = 1
+
+  default: break;
+// CHECK:   default:
+// CHECK: upper_bound(p) = 1
   }
 }
 
@@ -860,8 +874,16 @@ void f28() {
 // CHECK: In function: f28
 
   switch (*p) {
+  default: break;
+// CHECK:   default:
+// CHECK: upper_bound(p) = 1
+
   case 0:
     switch (*p) {
+      default: break;
+// CHECK:   default:
+// CHECK-NOT: upper_bound(p)
+
       case 1: break;
     }
 // CHECK:  [B11]
@@ -1092,4 +1114,119 @@ void f31() {
 // CHECK: case x:
 // CHECK: upper_bound(p) = 1
   }
+}
+
+void f32() {
+// CHECK: In function: f32
+
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch(*p) {
+    default: f1(); break;
+    case 0: {
+      switch(*p) {
+        default: f2(); break;
+        case 'a': break;
+      }
+      break;
+    }
+  }
+
+// CHECK:   default:
+// CHECK:    1: f1()
+// CHECK: upper_bound(p) = 1
+// CHECK:   default:
+// CHECK:    1: f2()
+// CHECK-NOT: upper_bound(p)
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 1
+// CHECK:   case 0:
+// CHECK-NOT: upper_bound(p)
+
+  switch(*p) {
+    default: f1(); break;
+    case 0: {
+      switch(*p) {
+        default: f2(); break;
+        case '\0': break;
+      }
+      break;
+    }
+  }
+
+// CHECK:   default:
+// CHECK:    1: f1()
+// CHECK: upper_bound(p) = 1
+// CHECK:   default:
+// CHECK:    1: f2()
+// CHECK: upper_bound(p) = 1
+// CHECK:   case '\x00':
+// CHECK-NOT: upper_bound(p)
+// CHECK:   case 0:
+// CHECK-NOT: upper_bound(p)
+
+  switch(*p) {
+    default: f1(); break;
+    case 'b': {
+      switch(*(p+1)) {
+        default: f2(); break;
+        case 'a': break;
+      }
+      break;
+    }
+  }
+
+// CHECK:   default:
+// CHECK:    1: f1()
+// CHECK-NOT: upper_bound(p)
+// CHECK:   default:
+// CHECK:    1: f2()
+// CHECK: upper_bound(p) = 1
+// CHECK:   case 'a':
+// CHECK: upper_bound(p) = 2
+// CHECK:   case 'b':
+// CHECK: upper_bound(p) = 1
+
+  switch(*p) {
+    default: f1(); break;
+    case 'b': {
+      switch(*(p+1)) {
+        default: f2(); break;
+        case '\0': break;
+      }
+      break;
+    }
+  }
+
+// CHECK:   default:
+// CHECK:    1: f1()
+// CHECK-NOT: upper_bound(p)
+// CHECK:   default:
+// CHECK:    1: f2()
+// CHECK: upper_bound(p) = 2
+// CHECK:   case '\x00':
+// CHECK: upper_bound(p) = 1
+// CHECK:   case 'b':
+// CHECK: upper_bound(p) = 1
+
+  switch(*p) {
+    default: {
+      switch(*(p+1)) {
+        default: f2(); break;
+        case '\0': break;
+      }
+      break;
+    }
+    case 0: break;
+  }
+
+// CHECK:   default:
+// CHECK:    1: f2()
+// CHECK: upper_bound(p) = 2
+// CHECK:   case '\x00':
+// CHECK: upper_bound(p) = 1
+// CHECK:   default:
+// CHECK: upper_bound(p) = 1
+// CHECK:   case 0:
+// CHECK-NOT: upper_bound(p)
 }


### PR DESCRIPTION
If we establish that another label in a switch statement tests for 0, then the
default case will handle non-zero case, and the bounds can be widened there.
Programmers will use all the different forms of case statements and may depend
on that behavior.

See https://github.com/microsoft/checkedc-clang/issues/818