### PR TITLE
Equivalent expressions: address-of and dereference inverses [8/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4044,13 +4044,35 @@ namespace {
 
     // Returns true if a unary operator is invertible with respect to x.
     bool IsUnaryOperatorInvertible(DeclRefExpr *X, UnaryOperator *E) {
+      Expr *SubExpr = E->getSubExpr()->IgnoreParens();
       UnaryOperatorKind Op = E->getOpcode();
-      if (Op != UnaryOperatorKind::UO_Not &&
-          Op != UnaryOperatorKind::UO_Minus &&
-          Op != UnaryOperatorKind::UO_Plus)
-        return false;
 
-      return IsInvertible(X, E->getSubExpr());
+      // &*e1 is invertible with respect to x if e1 is invertible with
+      // respect to x.
+      if (Op == UnaryOperatorKind::UO_AddrOf) {
+        if (UnaryOperator *UnarySubExpr = dyn_cast<UnaryOperator>(SubExpr)) {
+          if (UnarySubExpr->getOpcode() == UnaryOperatorKind::UO_Deref)
+            return IsInvertible(X, UnarySubExpr->getSubExpr());
+        }
+      }
+
+      // *&e1 is invertible with respect to x if e1 is invertible with
+      // respect to x.
+      if (Op == UnaryOperatorKind::UO_Deref) {
+        if (UnaryOperator *UnarySubExpr = dyn_cast<UnaryOperator>(SubExpr)) {
+          if (UnarySubExpr->getOpcode() == UnaryOperatorKind::UO_AddrOf)
+            return IsInvertible(X, UnarySubExpr->getSubExpr());
+        }
+      }
+
+      // ~e1, -e1, and +e1 are invertible with respect to x if e1 is
+      // invertible with respect to x.
+      if (Op == UnaryOperatorKind::UO_Not ||
+          Op == UnaryOperatorKind::UO_Minus ||
+          Op == UnaryOperatorKind::UO_Plus)
+        return IsInvertible(X, SubExpr);
+
+      return false;
     }
 
     // Returns true if a binary operator is invertible with respect to x.
@@ -4170,11 +4192,30 @@ namespace {
       return nullptr;
     }
 
-    // Returns the inverse of a unary operator using the following rule:
-    // Inverse(f, @e1) = Inverse(@f, e1) where @ can be ~, -, or +.
+    // Returns the inverse of a unary operator.
     Expr *UnaryOperatorInverse(DeclRefExpr *X, Expr *F, UnaryOperator *E) {
-      Expr *SubExpr = E->getSubExpr();
+      Expr *SubExpr = E->getSubExpr()->IgnoreParens();
       UnaryOperatorKind Op = E->getOpcode();
+      
+      // Inverse(f, &*e1) = Inverse(f, e1)
+      if (Op == UnaryOperatorKind::UO_AddrOf) {
+        if (UnaryOperator *UnarySubExpr = dyn_cast<UnaryOperator>(SubExpr)) {
+          if (UnarySubExpr->getOpcode() == UnaryOperatorKind::UO_Deref)
+            return Inverse(X, F, UnarySubExpr->getSubExpr());
+        }
+      }
+
+      // Inverse(f, *&e1) = Inverse(f, e1)
+      if (Op == UnaryOperatorKind::UO_Deref) {
+        if (UnaryOperator *UnarySubExpr = dyn_cast<UnaryOperator>(SubExpr)) {
+          if (UnarySubExpr->getOpcode() == UnaryOperatorKind::UO_AddrOf)
+            return Inverse(X, F, UnarySubExpr->getSubExpr());
+        }
+      }
+
+      // Inverse(f, ~e1) = Inverse(~f, e1)
+      // Inverse(f, -e1) = Inverse(-f, e1)
+      // Inverse(f, +e1) = Inverse(+f, e1)
       Expr *Child = ExprCreatorUtil::EnsureRValue(S, F);
       Expr *F1 = new (S.Context) UnaryOperator(Child, Op, E->getType(),
                                                E->getValueKind(),

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3843,12 +3843,14 @@ namespace {
       // value as the source, add the target to F.  This prevents EquivExprs
       // from growing too large and containing redundant equality information.
       // For example, for the assignments x = 1; y = x; where the target is y,
-      // SameValue = { 1, x }, and EquivExprs contains F = { 1, x }, EquivExprs
+      // SameValue = { x }, and EquivExprs contains F = { 1, x }, EquivExprs
       // should contain { 1, x, y } rather than { 1, x } and { 1, x, y }.
       if (State.SameValue.size() > 0) {
-        for (auto I = State.EquivExprs.begin(); I != State.EquivExprs.end(); ++I) {
-          if (IsEqualExprsSubset(State.SameValue, *I)) {
-            I->push_back(Target);
+        for (auto F = State.EquivExprs.begin(); F != State.EquivExprs.end(); ++F) {
+          if (IsEqualExprsSubset(State.SameValue, *F)) {
+            if (!EqualExprsContainsExpr(*F, Target))
+              F->push_back(Target);
+
             // Add the target to SameValue if SameValue does not already
             // contain the target.
             if (!EqualExprsContainsExpr(State.SameValue, Target))

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -818,8 +818,194 @@ void original_value7(unsigned x, unsigned i) {
   // CHECK-NEXT: }
 }
 
+// UnaryOperator: &* inverse
+void original_value8(array_ptr<int> p) {
+  // Updated EquivExprs: { { p, q } }
+  array_ptr<int> q = p;
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} q
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'q'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of p in &*p: p
+  // Updated EquivExprs: { { p, q } }
+  p = &*p;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '&'
+  // CHECK-NEXT:     UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'q'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of p in &(*(p + 1)): p - 1
+  // Updated EquivExprs: { { p - 1, q } }
+  p = &(*(p + 1));
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '&'
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:         ParenExpr
+  // CHECK-NEXT:           BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:             ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:               DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:             IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'q'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: *& inverse
+void original_value9(int x, int y) {
+  // Updated EquivExprs: { { x, y } }
+  y = x;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of x in (*((&(x)))): x
+  // Updated EquivExprs: { { x, y } }
+  x = (*((&(x))));
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:         ParenExpr
+  // CHECK-NEXT:           ParenExpr
+  // CHECK-NEXT:             UnaryOperator {{.*}} '&'
+  // CHECK-NEXT:               ParenExpr
+  // CHECK-NEXT:                 DeclRefExpr {{.*}} 'x'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// UnaryOperator: & and * with no inverse
+void original_value10(int *p, int *q, int *r, int *s) {
+  // Updated EquivExprs: { { p + 1, q }, { r + 1, s } }
+  q = p + 1, s = r + 1;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK-NEXT:   BinaryOperator {{.*}} '='
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   BinaryOperator {{.*}} '='
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'r'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'q'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'r'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of p in &*&p: null
+  // Updated EquivExprs: { { r + 1, s } }
+  p = &*&p;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} 'int *' <BitCast>
+  // CHECK-NEXT:     UnaryOperator {{.*}} '&'
+  // CHECK-NEXT:       UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:         UnaryOperator {{.*}} '&'
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'r'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Original value of r in *r: null
+  // Updated EquivExprs: { }
+  r = *r;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'r'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} 'int *' <IntegralToPointer>
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+  // CHECK-NEXT:       UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'r'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+}
+
 // UnaryOperator: pre-increment and post-increment inverses
-void original_value8(unsigned x, unsigned i) {
+void original_value11(unsigned x, unsigned i) {
   // Updated EquivExprs: { { i, x } }
   x = i;
   // CHECK: Statement S:
@@ -889,7 +1075,7 @@ void original_value8(unsigned x, unsigned i) {
 }
 
 // UnaryOperator: pre-decrement and post-decrement inverses
-void original_value9(unsigned x, unsigned i) {
+void original_value12(unsigned x, unsigned i) {
   // Updated EquivExprs: { { i, x } }
   x = i;
   // CHECK: Statement S:
@@ -959,7 +1145,7 @@ void original_value9(unsigned x, unsigned i) {
 }
 
 // UnaryOperator: pre-increment with no inverse
-void original_value10(int x, int i) {
+void original_value13(int x, int i) {
   // Updated EquivExprs: { { i, x } }
   x = i;
   // CHECK: Statement S:
@@ -1002,7 +1188,7 @@ void original_value10(int x, int i) {
 }
 
 // UnaryOperator: post-increment with no inverse
-void original_value11(int x, int i) {
+void original_value14(int x, int i) {
   // Updated EquivExprs: { { i, x } }
   x = i;
   // CHECK: Statement S:
@@ -1047,7 +1233,7 @@ void original_value11(int x, int i) {
 }
 
 // UnaryOperator: pre-decrement with no inverse
-void original_value12(int x, int i) {
+void original_value15(int x, int i) {
   // Updated EquivExprs: { { i, x } }
   x = i;
   // CHECK: Statement S:
@@ -1090,7 +1276,7 @@ void original_value12(int x, int i) {
 }
 
 // UnaryOperator: post-decrement with no inverse
-void original_value13(int x, int i) {
+void original_value16(int x, int i) {
   // Updated EquivExprs: { { i, x } }
   x = i;
   // CHECK: Statement S:
@@ -1135,7 +1321,7 @@ void original_value13(int x, int i) {
 }
 
 // No inverse
-void original_value14(unsigned x, unsigned i, unsigned *p, unsigned arr[1]) {
+void original_value17(unsigned x, unsigned i, unsigned *p, unsigned arr[1]) {
   // Updated EquivExprs: { { i * 1, x } }, Updated SameValue: { i * 1, x }
   x = i * 1;
   // CHECK: Statement S:
@@ -1242,7 +1428,7 @@ void original_value14(unsigned x, unsigned i, unsigned *p, unsigned arr[1]) {
 }
 
 // Original value from equivalence with another variable
-void original_value15(int x, int y) {
+void original_value18(int x, int y) {
   // Updated EquivExprs: { { y, x } }
   x = y;
   // CHECK: Statement S:
@@ -1292,7 +1478,7 @@ void original_value15(int x, int y) {
 // Original value from equivalence with another variable,
 // accounting for value-preserving casts when searching for a set
 // in EquivExprs that contains a variable w != v in an assignment v = src
-void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
+void original_value19(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
   // Updated EquivExprs: { { arr_int + 1, arr } }
   arr = arr_int + 1;
   // CHECK: Statement S:
@@ -1368,7 +1554,7 @@ void original_value16(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
 }
 
 // Original value is a value-preserving cast of another variable
-void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
+void original_value20(array_ptr<int> arr_int, array_ptr<const int> arr_const, array_ptr<int> arr) {
   // Updated EquivExprs: { { (array_ptr<int>)arr_const, arr_int } }
   arr_int = arr_const;
   // CHECK: Statement S:
@@ -1444,7 +1630,7 @@ void original_value17(array_ptr<int> arr_int, array_ptr<const int> arr_const, ar
 }
 
 // The left-hand side variable is the original value
-void original_value18(int x, int val) {
+void original_value21(int x, int val) {
   // Updated EquivExprs: { { x + 1, val } }
   val = x + 1;
   // CHECK: Statement S:
@@ -1488,7 +1674,7 @@ void original_value18(int x, int val) {
 }
 
 // Original value is a no-op cast
-void original_value19(int i) {
+void original_value22(int i) {
   // Updated EquivExprs: { { i + 1, val } }
   int val = i + 1;
   // CHECK: Statement S:
@@ -1534,7 +1720,7 @@ void original_value19(int i) {
 }
 
 // Original value involves explicit and implicit casts
-void original_value20(int i, int val) {
+void original_value23(int i, int val) {
   // Updated EquivExprs: { { i + 1, val } }
   val = i + 1;
   // CHECK: Statement S:
@@ -1591,7 +1777,7 @@ void original_value20(int i, int val) {
 }
 
 // Combined CastExpr and BinaryOperator inverse
-void original_value21(int i, unsigned j, int val) {
+void original_value24(int i, unsigned j, int val) {
   // Updated EquivExprs: { { i + 1, val } }
   val = i + 1;
   // CHECK: Statement S:
@@ -1645,7 +1831,7 @@ void original_value21(int i, unsigned j, int val) {
 }
 
 // No original value for an implicit narrowing cast
-void original_value22(int i, float f, int val) {
+void original_value25(int i, float f, int val) {
   // Updated EquivExprs: { { i + 1, val } }
   val = i + 1;
   // CHECK: Statement S:
@@ -1685,7 +1871,7 @@ void original_value22(int i, float f, int val) {
 }
 
 // No original value for an explicit narrowing cast
-void original_value23(double d, double val) {
+void original_value26(double d, double val) {
   // Updated EquivExprs: { { d + 1.0, val } }
   val = d + 1.0;
   // CHECK: Statement S:
@@ -1722,7 +1908,7 @@ void original_value23(double d, double val) {
 }
 
 // Bounds cast expression inverse where the type is the same as the LHS variable type
-void original_value24(array_ptr<int> a : count(1), array_ptr<int> val) {
+void original_value27(array_ptr<int> a : count(1), array_ptr<int> val) {
   // Updated UEQ: { { a + 1, val } }
   val = a + 1;
   // CHECK: Statement S:
@@ -1771,7 +1957,7 @@ void original_value24(array_ptr<int> a : count(1), array_ptr<int> val) {
 }
 
 // Bounds cast expression inverse including a type cast
-void original_value25(array_ptr<int> a : count(1), array_ptr<int> val) {
+void original_value28(array_ptr<int> a : count(1), array_ptr<int> val) {
   // Updated UEQ: { { a + 1, val } }
   val = a + 1;
   // CHECK: Statement S:
@@ -1822,7 +2008,7 @@ void original_value25(array_ptr<int> a : count(1), array_ptr<int> val) {
 }
 
 // Combined bounds cast and binary inverse
-void original_value26(array_ptr<int> a : count(1), array_ptr<int> val) {
+void original_value29(array_ptr<int> a : count(1), array_ptr<int> val) {
   // Updated UEQ: { { a + 1, val } }
   val = a + 1;
   // CHECK: Statement S:
@@ -1883,7 +2069,7 @@ void original_value26(array_ptr<int> a : count(1), array_ptr<int> val) {
 }
 
 // CallExpr: using the left-hand side of an assignment as a call argument
-void original_value27(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
+void original_value30(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) {
   // Updated UEQ: { { b, a } }
   a = b;
   // CHECK: Statement S:
@@ -1927,7 +2113,7 @@ void original_value27(array_ptr<int> a : count(1), array_ptr<int> b : count(1)) 
 // The original value is type-compatible with the variable,
 // even when expressions in the same set are not type compatible
 // (resulting from assignments to NullToPointer casts)
-void original_value28(int *p,
+void original_value31(int *p,
                       array_ptr<int> val, array_ptr<int> arr,
                       array_ptr<int> a, array_ptr<int> b,
                       array_ptr<char> c, nt_array_ptr<int> n) {


### PR DESCRIPTION
This PR modifies the IsInvertible and Inverse methods to handle address-of dereferences and dereferences of address-of operators.

For example, this allows the inverse of the following expressions to be `p` with respect to the variable `p`:
* `&*p`
* `*&p`
* `&(*(p))`
* `*&*&p`

Address-of and dereference operators that do not cancel do not have an inverse. For example, the following expressions have no inverse:
* `&p`
* `*p`
* `&*&p`
* `*&*p`

Checked C issue [403](https://github.com/microsoft/checkedc/issues/403) tracks the spec updates to cover this invertibility case.

#### Context:
This work is part of the ongoing soundness work for checking bounds declarations after assignments to variables. In particular, making the inverse methods more robust will prevent false positive error messages after the changes in #836 are merged. Without this change, the assignment `p = &*p` would update the observed bounds of `p` to unknown if `&*p` has no inverse. With this change, the assignment behaves in the same way as `p = p`.

#### Testing:
* Added tests for the inverse of address-of/dereference expressions to equiv-expr-sets.c
* Passed manual testing on Windows
* Passed automated testing on Linux
* Automated testing on Windows is currently blocked by other queued jobs