### PR TITLE
Save normalized VarDecl bounds

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -822,7 +822,7 @@ public:
 
   // \brief The bounds expression for this declaration, expanded to a
   // range bounds expression.
-  const BoundsExpr *getNormalizedBounds() const {
+  BoundsExpr *getNormalizedBounds() const {
     return const_cast<DeclaratorDecl *>(this)->getNormalizedBounds();
   }
 

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -708,9 +708,10 @@ protected:
                  DeclarationName N, QualType T, TypeSourceInfo *TInfo,
                  SourceLocation StartL)
       : ValueDecl(DK, DC, L, N, T), DeclInfo(TInfo), InnerLocStart(StartL),
-        Annotations(nullptr) {}
+        Annotations(nullptr), NormalizedBounds(nullptr) {}
 
   BoundsAnnotations *Annotations;
+  BoundsExpr *NormalizedBounds;
 public:
   friend class ASTDeclReader;
   friend class ASTDeclWriter;
@@ -817,6 +818,30 @@ public:
     if (!Annotations)
       Annotations = new (Context) BoundsAnnotations();
     Annotations->setBoundsExpr(E);
+  }
+
+  // \brief The bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  const BoundsExpr *getNormalizedBounds() const {
+    return const_cast<DeclaratorDecl *>(this)->getNormalizedBounds();
+  }
+
+  // \brief The bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  BoundsExpr *getNormalizedBounds() {
+    return NormalizedBounds;
+  }
+
+  // \brief Set the bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  void setNormalizedBounds(BoundsExpr *E) const {
+    const_cast<DeclaratorDecl *>(this)->setNormalizedBounds(E);
+  }
+
+  // \brief Set the bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  void setNormalizedBounds(BoundsExpr *E) {
+    NormalizedBounds = E;
   }
 
   /// \brief The Checked C interop type declared or inferred for this

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5213,6 +5213,12 @@ public:
   // will always fail.
   void WarnDynamicCheckAlwaysFails(const Expr *Condition);
 
+  // If the VarDecl D has a byte_count or count bounds expression,
+  // NormalizeBounds expands it to a range bounds expression.  The expanded
+  // range bounds are attached to the VarDecl D to avoid recomputing the
+  // normalized bounds for D.
+  BoundsExpr *NormalizeBounds(const VarDecl *D);
+
   // This is wrapper around CheckBoundsDeclaration::ExpandToRange. This
   // provides an easy way to invoke this function from outside the class. Given
   // a byte_count or count bounds expression for the VarDecl D, ExpandToRange

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5543,6 +5543,22 @@ void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
   }
 }
 
+// If the VarDecl D has a byte_count or count bounds expression,
+// NormalizeBounds expands it to a range bounds expression.  The expanded
+// range bounds are attached to the VarDecl D to avoid recomputing the
+// normalized bounds for D.
+BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
+  // If D already has a normalized bounds expression, do not recompute it.
+  if (const BoundsExpr *NormalizedBounds = D->getNormalizedBounds()) 
+    return const_cast<BoundsExpr *>(NormalizedBounds);
+
+  // Normalize the bounds of D to a RangeBoundsExpr and attach the normalized
+  // bounds to D to avoid recomputing them.
+  BoundsExpr *Bounds = ExpandBoundsToRange(D, D->getBoundsExpr());
+  D->setNormalizedBounds(Bounds);
+  return Bounds;
+}
+
 // This is wrapper around CheckBoundsDeclaration::ExpandToRange. This provides
 // an easy way to invoke this function from outside the class. Given a
 // byte_count or count bounds expression for the VarDecl D, ExpandToRange will

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5530,8 +5530,8 @@ void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
 // normalized bounds for D.
 BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
   // If D already has a normalized bounds expression, do not recompute it.
-  if (const BoundsExpr *NormalizedBounds = D->getNormalizedBounds())
-    return const_cast<BoundsExpr *>(NormalizedBounds);
+  if (BoundsExpr *NormalizedBounds = D->getNormalizedBounds())
+    return NormalizedBounds;
 
   // Normalize the bounds of D to a RangeBoundsExpr and attach the normalized
   // bounds to D to avoid recomputing them.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2179,7 +2179,7 @@ namespace {
        const VarDecl *V = item.first;
        unsigned Offset = item.second;
 
-       // We normalize the declared bounds to RangBoundsExpr here so that we
+       // We normalize the declared bounds to RangeBoundsExpr here so that we
        // can easily apply the offset to the upper bound.
        BoundsExpr *Bounds = S.NormalizeBounds(V);
        if (RangeBoundsExpr *RBE = dyn_cast<RangeBoundsExpr>(Bounds)) {
@@ -2223,9 +2223,10 @@ namespace {
      CheckingState ParamsState;
      for (auto I = FD->param_begin(); I != FD->param_end(); ++I) {
        ParmVarDecl *Param = *I;
-       BoundsExpr *Bounds = Param->getBoundsExpr();
-       if (Bounds)
-         ParamsState.ObservedBounds[Param] = ExpandToRange(Param, Bounds);
+       if (!Param->hasBoundsExpr())
+         continue;
+       if (BoundsExpr *Bounds = S.NormalizeBounds(Param))
+         ParamsState.ObservedBounds[Param] = Bounds;
      }
 
      // Store a checking state for each CFG block in order to track
@@ -5529,7 +5530,7 @@ void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
 // normalized bounds for D.
 BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
   // If D already has a normalized bounds expression, do not recompute it.
-  if (const BoundsExpr *NormalizedBounds = D->getNormalizedBounds()) 
+  if (const BoundsExpr *NormalizedBounds = D->getNormalizedBounds())
     return const_cast<BoundsExpr *>(NormalizedBounds);
 
   // Normalize the bounds of D to a RangeBoundsExpr and attach the normalized


### PR DESCRIPTION
Fixes #830 

This PR attaches a normalized bounds expression to a VarDecl to avoid repeated calls to ExpandBoundsToRange, which can allocate AST structures and increase the memory usage of the compiler. This is relevant for updating and validating the observed context and using widened bounds, which is currently recomputing the normalized bounds of a VarDecl.

#### Testing:
* Passed manual testing on Windows
* Passed automated testing on Linux