### PR TITLE
Map top-level statements to variables with killed widened bounds

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -97,7 +97,7 @@ namespace clang {
   using StmtDeclSetTy = llvm::DenseMap<const Stmt *, DeclSetTy>;
 
   // StmtSet denotes a set of Stmts.
-  typedef llvm::SmallPtrSet<const Stmt *, 16> StmtSet;
+  using StmtSet = llvm::SmallPtrSet<const Stmt *, 16>;
 
   class BoundsAnalysis {
   private:

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -96,6 +96,9 @@ namespace clang {
   // 2. any variable used in the bounds expr of V is assigned to in S.
   using StmtDeclSetTy = llvm::DenseMap<const Stmt *, DeclSetTy>;
 
+  // StmtSet denotes a set of Stmts.
+  typedef llvm::SmallPtrSet<const Stmt *, 16> StmtSet;
+
   class BoundsAnalysis {
   private:
     Sema &S;
@@ -184,7 +187,9 @@ namespace clang {
 
     // Run the dataflow analysis to widen bounds for ntptr's.
     // @param[in] FD is the current function.
-    void WidenBounds(FunctionDecl *FD);
+    // @param[in] NestedStmts is a set of top-level statements that are
+    // nested in another top-level statement.
+    void WidenBounds(FunctionDecl *FD, StmtSet NestedStmts);
 
     // Get the widened bounds for block B.
     // @param[in] B is the block for which the widened bounds are needed.
@@ -214,7 +219,9 @@ namespace clang {
     // Compute Kill set for each block in BlockMap. For a block B, if a
     // variable V is assigned to in B by Stmt S, then the pair S:V is added to
     // the Kill set for the block.
-    void ComputeKillSets();
+    // @param[in] NestedStmts is a set of top-level statements that are
+    // nested in another top-level statement.
+    void ComputeKillSets(StmtSet NestedStmts);
 
     // Compute In set for each block in BlockMap. In[B1] = n Out[B*->B1], where
     // B* are all preds of B1.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -314,10 +314,12 @@ namespace clang {
     // @param[in] FD is the current function.
     void CollectNtPtrsInScope(FunctionDecl *FD);
 
-    // If variable V is killed by Stmt S in Block B, add S:V pair to EB->Kill.
+    // If variable V is killed by Stmt S in Block B, add TopLevelStmt:V pair
+    // to EB->Kill, where TopLevelStmt is the top-level Stmt that contains S.
     // @param[in] EB is the ElevatedCFGBlock for the current block.
+    // @param[in] TopLevelStmt is the top-level Stmt in the block.
     // @param[in] S is the current Stmt in the block.
-    void FillKillSet(ElevatedCFGBlock *EB, const Stmt *S);
+    void FillKillSet(ElevatedCFGBlock *EB, const Stmt *TopLevelStmt, const Stmt *S);
 
     // Initialize the In and Out sets for all blocks, except the Entry block,
     // as Top.

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -835,13 +835,10 @@ T BoundsAnalysis::Difference(T &A, U &B) const {
     return A;
 
   auto Ret = A;
-  for (auto I = Ret.begin(), E = Ret.end(); I != E; ) {
-    const auto *V = I->first;
-    if (B.count(V)) {
-      auto Next = std::next(I);
-      Ret.erase(I);
-      I = Next;
-    } else ++I;
+  for (auto I : A) {
+    const auto *V = I.first;
+    if (B.count(V))
+      Ret.erase(V);
   }
   return Ret;
 }

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -607,13 +607,15 @@ void BoundsAnalysis::ComputeKillSets() {
         const Stmt *S = Elem.castAs<CFGStmt>().getStmt();
         if (!S)
           continue;
-        FillKillSet(EB, S);
+        FillKillSet(EB, S, S);
       }
     }
   }
 }
 
-void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB, const Stmt *S) {
+void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB,
+                                 const Stmt *TopLevelStmt,
+                                 const Stmt *S) {
   if (!S)
     return;
 
@@ -635,7 +637,7 @@ void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB, const Stmt *S) {
         // If the variable being assigned to is an ntptr, add the Stmt:V pair
         // to the Kill set for the block.
         if (IsNtArrayType(V))
-          EB->Kill[S].insert(V);
+          EB->Kill[TopLevelStmt].insert(V);
 
         else {
           // Else look for the variable in BoundsVars.
@@ -655,7 +657,7 @@ void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB, const Stmt *S) {
             // If the variable exists in the bounds declaration for the ntptr,
             // then add the Stmt:ntptr pair to the Kill set for the block.
             if (Vars.count(V))
-              EB->Kill[S].insert(NtPtr);
+              EB->Kill[TopLevelStmt].insert(NtPtr);
           }
         }
       }
@@ -663,7 +665,7 @@ void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB, const Stmt *S) {
   }
 
   for (const Stmt *St : S->children())
-    FillKillSet(EB, St);
+    FillKillSet(EB, TopLevelStmt, St);
 }
 
 void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2064,8 +2064,6 @@ namespace {
       BoundsAnalyzer(BoundsAnalysis(SemaRef, nullptr)),
       IncludeNullTerminator(false) {}
 
-    typedef llvm::SmallPtrSet<const Stmt *, 16> StmtSet;
-
     void IdentifyChecked(Stmt *S, StmtSet &MemoryCheckedStmts, StmtSet &BoundsCheckedStmts, CheckedScopeSpecifier CSS) {
       if (!S)
         return;
@@ -2261,7 +2259,7 @@ namespace {
 
      // Run the bounds widening analysis on this function.
      BoundsAnalysis BA = getBoundsAnalyzer();
-     BA.WidenBounds(FD);
+     BA.WidenBounds(FD, NestedElements);
      if (S.getLangOpts().DumpWidenedBounds)
        BA.DumpWidenedBounds(FD);
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -1,10 +1,12 @@
-// Tests for updating equivalent expression information during bounds inference and checking.
+// Tests for updating the observed bounds context during bounds inference and checking.
 // This file tests updating the context mapping variables to their bounds
 // after checking expressions during bounds analysis.
 //
 // RUN: %clang_cc1 -Wno-unused-value -fdump-checking-state %s | FileCheck %s
 
 #include <stdchecked.h>
+
+extern void testNtArray(nt_array_ptr<char> p : count(0), int i);
 
 // Parameter and local variables with declared count bounds
 void f1(array_ptr<int> arr : count(len), int len, int size) {
@@ -273,4 +275,182 @@ void f2(int flag, int x, int y) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
   // CHECK-NEXT: }
+}
+
+void f3(nt_array_ptr<int> p : count(i), int i, int other) {
+  if (*(p + i)) {
+    // Observed bounds context: { p => bounds(p, p + i) }
+    // CHECK: Statement S:
+    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:   UnaryOperator {{.*}} '*'
+    // CHECK:          ParenExpr
+    // CHECK-NEXT:       BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: }
+
+    // Bounds of p are currently widened by 1
+    // Observed bounds context: { p => bounds(p, (p + i) + 1) }
+    p;
+    // CHECK: Statement S:
+    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+    // CHECK-NEXT: }
+
+    // This statement kills the widened bounds of p since it modifies i
+    // Observed bounds context: { p => bounds(p, p + 1) }
+    i++, --other;
+    // CHECK: Statement S:
+    // CHECK-NEXT: BinaryOperator {{.*}} ','
+    // CHECK-NEXT:   UnaryOperator {{.*}} postfix '++'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT:   UnaryOperator {{.*}} prefix '--'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'other'
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: }
+  }
+}
+
+void f4(nt_array_ptr<char> p : count(0), int other) {
+  if (*p) {
+    // Observed bounds context: { p => bounds(p, p + 0) }
+    // CHECK: Statement S:
+    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:   UnaryOperator {{.*}} '*'
+    // CHECK:          ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+    // CHECK:      Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: }
+
+    // Bounds of p are currently widened by 1
+    // Observed bounds context: { p => bounds(p, (p + 0) + 1) }
+    p[1];
+    // CHECK: Statement S:
+    // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:   ArraySubscriptExpr
+    // CHECK-NEXT:     Bounds Null-terminated read
+    // CHECK-NEXT:       RangeBoundsExpr
+    // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:         BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:           BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:             ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:               DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:             IntegerLiteral {{.*}} 0
+    // CHECK-NEXT:           IntegerLiteral {{.*}} 1
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+    // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+    // CHECK-NEXT: }
+
+    // This statement kills the widened bounds of p since it modifies p
+    // Observed bounds context: { p = bounds(p, p) }
+    testNtArray(p = 0, other = 0);
+    // CHECK: Statement S:
+    // CHECK-NEXT: CallExpr {{.*}} 'void'
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'testNtArray'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '='
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <NullToPointer>
+    // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+    // CHECK-NEXT:   BinaryOperator {{.*}} '='
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'other'
+    // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
+    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: }
+  }
 }


### PR DESCRIPTION
This PR adjusts bounds widening to map top-level CFG statements to the set of nt_array_ptr variables whose widened bounds are killed by the statement.

This is applicable to statements with multiple assignments. For example:
```
void f(nt_array_ptr<char> p : count(i), int i, int unrelated) {
  if (p[i])) {
    // p has widened bounds (p, p + i + 1).

    // This statement kills the widened bounds of p.
    // After this statement, p should have observed bounds (p, p + i).
    i = 0, unrelated = 0;
  }
}
```

Bounds declaration checking (CheckBoundsDeclarations::TraverseCFG) only checks top-level statements that are not nested within other top-level statements. The statement `i = 0, unrelated = 0;` will be checked, but `i = 0` and `unrelated = 0` will not be checked. In order for bounds checking to detect that the widened bounds of `p` have been killed, and that the observed bounds of `p` should be reset to the expanded declared bounds `(p, p + i)`, the killed bounds should map `i = 0, unrelated = 0` to `p`.

#### Context:
This work is related to validating the updated observed bounds context against the declared bounds after each top-level statement. In order to correctly detect errors in bounds checking, the bounds checker needs to know when a variable no longer has widened bounds.

#### Testing:
* Added tests to bounds-context.c to test killing widened bounds after statements with multiple assignments.
* Passed manual testing on Windows.
* Passed automated testing on Linux.