### PR TITLE
Add bigobj compile flag to RewriteUtils.cpp

### DIFF
--- a/clang/lib/CConv/CMakeLists.txt
+++ b/clang/lib/CConv/CMakeLists.txt
@@ -4,6 +4,10 @@ set( LLVM_LINK_COMPONENTS
         Support
         )
 
+if (MSVC)
+  set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)	
+endif()
+
 add_clang_library(CConv
   ArrayBoundsInferenceConsumer.cpp
   ArrayBoundsInformation.cpp


### PR DESCRIPTION
This PR fixes a build failure for the checkedc-convert file RewriteUtils.cpp by adding the compile flag /bigobj to cmake.

Build failure message:
clang\lib\CConv\RewriteUtils.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

#### Testing:
* Passed manual testing on Windows X64
* Automated testing on Windows X64 and Linux in progress