### PR TITLE
Disable failing unit tests

### DIFF
--- a/clang/test/CheckedCRewriter/basic_checks.c
+++ b/clang/test/CheckedCRewriter/basic_checks.c
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // Tests for Checked C rewriter tool.
 //
 // Tests properties about type re-writing and replacement, and simple function

--- a/clang/test/CheckedCRewriter/global.c
+++ b/clang/test/CheckedCRewriter/global.c
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // Tests for Checked C rewriter tool.
 //
 // Tests for rewriting global declarations.

--- a/clang/test/CheckedCRewriter/simple_locals.c
+++ b/clang/test/CheckedCRewriter/simple_locals.c
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // Tests for Checked C rewriter tool.
 //
 // Checks very simple inference properties for local variables.


### PR DESCRIPTION
After #837 merged we see the following three unit tests failing intermittently
only on Windows:

test/CheckedCRewriter/global.c
test/CheckedCRewriter/simple_locals.c
test/CheckedCRewriter/basic_checks.c

In order to unblock our failing ADO builds we are disabling these three tests.
We can enable them when we have these fixed.

See issue https://github.com/microsoft/checkedc-clang/issues/851