### PR TITLE
Compare Expressions: Preoder AST to semantically compare expressions for equality [1/n]

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -119,7 +119,8 @@ namespace clang {
     /// bounds expressions.
     Result CompareExpr(const Expr *E1, const Expr *E2);
     /// \brief Semantic comparison of expressions that can occur in
-    /// bounds expressions.
+    /// bounds expressions. A return value of true indicates that the two
+    /// expressions are equivalent semantically.
     bool CompareExprSemantically(const Expr *E1, const Expr *E2);
 
     /// \brief Compare declarations that may be used by expressions or

--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -120,7 +120,7 @@ namespace clang {
     Result CompareExpr(const Expr *E1, const Expr *E2);
     /// \brief Semantic comparison of expressions that can occur in
     /// bounds expressions.
-    Result CompareExprSemantically(const Expr *E1, const Expr *E2);
+    bool CompareExprSemantically(const Expr *E1, const Expr *E2);
 
     /// \brief Compare declarations that may be used by expressions or
     /// or types.

--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -50,8 +50,7 @@ namespace clang {
     enum class Result {
       LessThan,
       Equal,
-      GreaterThan,
-      NotEqual,
+      GreaterThan
     };
 
   private:

--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -52,7 +52,6 @@ namespace clang {
       Equal,
       GreaterThan,
       NotEqual,
-      Unknown,
     };
 
   private:

--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -50,7 +50,9 @@ namespace clang {
     enum class Result {
       LessThan,
       Equal,
-      GreaterThan
+      GreaterThan,
+      NotEqual,
+      Unknown,
     };
 
   private:
@@ -118,6 +120,9 @@ namespace clang {
     /// \brief Lexicographic comparison of expressions that can occur in
     /// bounds expressions.
     Result CompareExpr(const Expr *E1, const Expr *E2);
+    /// \brief Semantic comparison of expressions that can occur in
+    /// bounds expressions.
+    Result CompareExprSemantically(const Expr *E1, const Expr *E2);
 
     /// \brief Compare declarations that may be used by expressions or
     /// or types.

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -708,9 +708,10 @@ protected:
                  DeclarationName N, QualType T, TypeSourceInfo *TInfo,
                  SourceLocation StartL)
       : ValueDecl(DK, DC, L, N, T), DeclInfo(TInfo), InnerLocStart(StartL),
-        Annotations(nullptr) {}
+        Annotations(nullptr), NormalizedBounds(nullptr) {}
 
   BoundsAnnotations *Annotations;
+  BoundsExpr *NormalizedBounds;
 public:
   friend class ASTDeclReader;
   friend class ASTDeclWriter;
@@ -817,6 +818,30 @@ public:
     if (!Annotations)
       Annotations = new (Context) BoundsAnnotations();
     Annotations->setBoundsExpr(E);
+  }
+
+  // \brief The bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  BoundsExpr *getNormalizedBounds() const {
+    return const_cast<DeclaratorDecl *>(this)->getNormalizedBounds();
+  }
+
+  // \brief The bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  BoundsExpr *getNormalizedBounds() {
+    return NormalizedBounds;
+  }
+
+  // \brief Set the bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  void setNormalizedBounds(BoundsExpr *E) const {
+    const_cast<DeclaratorDecl *>(this)->setNormalizedBounds(E);
+  }
+
+  // \brief Set the bounds expression for this declaration, expanded to a
+  // range bounds expression.
+  void setNormalizedBounds(BoundsExpr *E) {
+    NormalizedBounds = E;
   }
 
   /// \brief The Checked C interop type declared or inferred for this

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -22,6 +22,8 @@
 
 namespace clang {
 
+  using Result = Lexicographic::Result;
+
   // Each binary operator of an expression results in a new node of the
   // PreorderAST. Each node contains 3 fields:
   // Opc: The opcode of the operator.
@@ -110,7 +112,9 @@ namespace clang {
     // @return Returns a bool indicating whether the two ASTs are equal.
     bool IsEqual(PreorderAST &P) { return IsEqual(Root, P.Root); }
 
-    // Check if an error has occurred during transformation of the AST.
+    // Check if an error has occurred during transformation of the AST. This
+    // is intended to be called from outside this class to check if an error
+    // has occurred during comparison of expressions.
     // @return Whether an error has occurred or not.
     bool GetError() { return Error; }
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -115,6 +115,12 @@ namespace clang {
     // @param[in] N is the root node of the AST.
     void Cleanup(ASTNode *N);
 
+    // Set Error in case an error occurs during transformation of the AST.
+    // @param[in] Err is the value to be set for the Error field.
+    void SetError(bool Err) {
+      Error = Err;
+    }
+
     // Print the preorder AST.
     // @param[in] N is the root node of the AST.
     void PrettyPrint(ASTNode *N);
@@ -143,12 +149,6 @@ namespace clang {
     // @return Whether an error has occurred or not.
     bool GetError() {
       return Error;
-    }
-
-    // Set Error in case an error occurs during transformation of the AST.
-    // @param[in] Err is the value to be set for the Error field.
-    void SetError(bool Err) {
-      Error = Err;
     }
 
     // Compare the current AST with the given AST. This in turn, invokes

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -1,4 +1,4 @@
-//===------- PreorderAST.h: An n-ary preorder abstract syntax tree -------===//
+//===------r PreorderAST.h: An n-ary preorder abstract syntax tree -------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -95,17 +95,15 @@ namespace clang {
     void Create(ASTNode *N, Expr *E, ASTNode *Parent = nullptr);
 
     // Normalize the input expression through a series of transforms on the
-    // preorder AST.
-    // @param[in] N is the root of the AST.
-    // @param[out] Error is populated if an error is encountered during
+    // preorder AST. The Error field is set if an error is encountered during
     // normalization.
-    void Normalize(ASTNode *N, bool &Error);
-
-    // Sort the variables in a node of the AST.
     // @param[in] N is the root of the AST.
-    // @param[out] Error is populated if an error is encountered during
-    // sorting.
-    void Sort(ASTNode *N, bool &Error);
+    void Normalize(ASTNode *N);
+
+    // Sort the variables in a node of the AST. The Error field is set if an
+    // error is encountered during normalization.
+    // @param[in] N is the root of the AST.
+    void Sort(ASTNode *N);
 
     // Check if the two ASTs N1 and N2 are equal.
     // @param[in] N1 is the first AST.
@@ -138,13 +136,19 @@ namespace clang {
 
       AST = new ASTNode(Ctx);
       Create(AST, E);
-      Normalize(AST, Error);
+      Normalize(AST);
     }
 
-    // Check if an error has occurred during normalization of the expression.
+    // Check if an error has occurred during transformation of the AST.
     // @return Whether an error has occurred or not.
-    bool HasError() {
+    bool GetError() {
       return Error;
+    }
+
+    // Set Error in case an error occurs during transformation of the AST.
+    // @param[in] Err is the value to be set for the Error field.
+    void SetError(bool Err) {
+      Error = Err;
     }
 
     // Compare the current AST with the given AST. This in turn, invokes

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -1,0 +1,174 @@
+//===------- PreorderAST.h: An n-ary preorder abstract syntax tree -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the interface for an n-ary preorder abstract syntax tree
+//  which is used to semantically compare two expressions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_PREORDER_AST_H
+#define LLVM_CLANG_PREORDER_AST_H
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/CanonBounds.h"
+#include "clang/AST/Expr.h"
+
+namespace clang {
+  // Each node of the PreorderAST has a variable-count list which stores the
+  // name of each variable along with a count of the number of times the
+  // variable appears in the node.
+  struct VarTy {
+    std::string name;
+    llvm::APSInt count;
+  };
+
+  // Each node of the PreorderAST contains 3 fields:
+  // - opcode: The opcode for the node.
+  // - variable-count list: A list of variables and their counts.
+  // - constant value: All constants occurring in the node are constant folded.
+
+  // For example, consider an expression E = a + 3 + b + 4 + a
+  // A node of the PreorderAST for E would contain the following:
+  // - opcode: +
+  // - variable-count list: [a:2, b:1]
+  // - constant value: 3 + 4 = 7
+
+  using VarListTy = std::vector<VarTy>;
+  using OpcodeTy = BinaryOperator::Opcode;
+  using ConstTy = llvm::APSInt;
+  using Result = Lexicographic::Result;
+
+  class PreorderAST {
+    class ASTNode {
+    public:
+      ASTContext &Ctx;
+      OpcodeTy opcode;
+      VarListTy variables;
+      ConstTy constant;
+      ASTNode *left, *right, *parent;
+      bool HasConstant;
+      
+      ASTNode(ASTContext &Ctx, ASTNode *Parent = nullptr) :
+        Ctx(Ctx), opcode(BO_Add),
+        left(nullptr), right(nullptr), parent(Parent),
+        HasConstant(false) {
+          // We initialize the constant value for each node to 0. So we need a
+          // way to indicate the absence of a constant. So we have a boolean
+          // HasConstant to indicate whether a node has a constant or not.
+          constant = getConstVal(0);
+        }
+
+      llvm::APSInt getConstVal(unsigned Val) {
+      return llvm::APSInt(llvm::APInt(Ctx.getTypeSize(Ctx.IntTy), Val));
+      }
+
+      void addVar(std::string name) {
+        // We initialize the count of each variable in a node to 1.
+        variables.push_back(VarTy {name, getConstVal(1)});
+      }
+
+      // Is the operator commutative and associative?
+      bool isOpCommutativeAndAssociative() {
+        return opcode == BO_Add ||
+               opcode == BO_Mul;
+      }
+    };
+
+  private:
+    ASTContext &Ctx;
+    Lexicographic Lex;
+    llvm::raw_ostream &OS;
+    bool HasError;
+    ASTNode *AST;
+
+  public:
+    PreorderAST(ASTContext &Ctx, Expr *E) :
+      Ctx(Ctx), Lex(Lexicographic(Ctx, nullptr)),
+      OS(llvm::outs()), HasError(false) {
+
+      HasError = false;
+      AST = new ASTNode(Ctx);
+      insert(AST, E);
+      normalize(AST, HasError);
+    }
+
+    // Create an preorder AST from the expression E.
+    // @param[in] N is the current node of the AST.
+    // @param[in] E is the sub expression which needs to be added to N.
+    // @param[in] Parent is the parent node for N.
+    void insert(ASTNode *N, Expr *E, ASTNode *Parent = nullptr);
+
+    // Normalize the input expression through a series of transforms on the
+    // preorder AST.
+    // @param[in] N is the root of the AST.
+    // @param[out] HasError is populated if an error is encountered during
+    // normalization.
+    void normalize(ASTNode *N, bool &HasError);
+
+    // Sort the variables in a node of the AST.
+    // @param[in] N is the root of the AST.
+    // @param[out] HasError is populated if an error is encountered during
+    // sorting.
+    void sort(ASTNode *N, bool &HasError);
+
+    // Check if the two ASTs N1 and N2 are equal.
+    // @param[in] N1 is the first AST.
+    // @param[in] N2 is the second AST.
+    // @return Returns a boolean indicating whether N1 and N2 are equal.
+    bool isEqual(ASTNode *N1, ASTNode *N2);
+
+    // Compare the current AST with the given AST. This in turn, invokes
+    // isEqual(N1, N2);
+    // @param[in] this is the first AST.
+    // @param[in] PT is the second AST.
+    // @return Returns a value of type Lexicographic::Result indicating whether
+    // the two ASTs are equal or not. 
+    Result compare(PreorderAST &PT);
+
+    // Cleanup the memory consumed by the AST.
+    // @param[in] N is the root node of the AST.
+    void cleanup(ASTNode *N);
+
+    // Cleanup the memory consumed by the AST. This is intended to be called
+    // from outside the PreorderAST class.
+    void cleanup();
+
+    // Check if an error has occurred during normalization of the expression.
+    // @return Whether an error has occurred or not.
+    bool hasError() {
+      return HasError;
+    }
+
+    // Print the preorder AST.
+    // @param[in] N is the root node of the AST.
+    void print(ASTNode *N);
+
+    // Invoke IgnoreValuePreservingOperations to strip off casts.
+    // @param[in] E is the expression whose casts must be stripped.
+    // @return E with casts stripped off.
+    Expr *IgnoreCasts(const Expr *E);
+
+    // A DeclRefExpr can be a reference either to an array subscript (in which
+    // case it is wrapped around a ArrayToPointerDecay cast) or to a pointer
+    // dereference (in which case it is wrapped around an LValueToRValue cast).
+    // @param[in] An expression E.
+    // @return Whether E is an expression containing a reference to an array
+    // subscript or a pointer dereference.
+    bool IsDeclOperand(Expr *E);
+
+    // Get the DeclRefExpr from an expression E.
+    // @param[in] An expression E which is known to be either an LValueToRValue
+    // cast or an ArrayToPointerDecay cast.
+    // @return The DeclRefExpr from the expression E.
+    DeclRefExpr *GetDeclOperand(Expr *E);
+  };
+}
+
+#endif

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -129,11 +129,8 @@ namespace clang {
     // case it is wrapped around a ArrayToPointerDecay cast) or to a pointer
     // dereference (in which case it is wrapped around an LValueToRValue cast).
     // @param[in] An expression E.
-    // @param[out] D is populated with the DeclRefExpr if E contains a
-    // DeclRefExpr.
-    // @return A bool indicating whether E is an expression containing a
-    // reference to an array subscript or a pointer dereference.
-    bool IsDeclOperand(Expr *E, DeclRefExpr *&D);
+    // @return Returns a DeclRefExpr if E is a DeclRefExpr, otherwise nullptr.
+    DeclRefExpr *GetDeclOperand(Expr *E);
 
   public:
     PreorderAST(ASTContext &Ctx, Expr *E) :

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -1,4 +1,4 @@
-//===------r PreorderAST.h: An n-ary preorder abstract syntax tree -------===//
+//===------- PreorderAST.h: An n-ary preorder abstract syntax tree -------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -96,12 +96,12 @@ namespace clang {
 
     // Normalize the input expression through a series of transforms on the
     // preorder AST. The Error field is set if an error is encountered during
-    // normalization.
+    // transformation of the AST.
     // @param[in] N is the root of the AST.
     void Normalize(ASTNode *N);
 
     // Sort the variables in a node of the AST. The Error field is set if an
-    // error is encountered during normalization.
+    // error is encountered during transformation of the AST.
     // @param[in] N is the root of the AST.
     void Sort(ASTNode *N);
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -99,7 +99,7 @@ namespace clang {
       normalize(AST, HasError);
     }
 
-    // Create an preorder AST from the expression E.
+    // Create a preorder AST from the expression E.
     // @param[in] N is the current node of the AST.
     // @param[in] E is the sub expression which needs to be added to N.
     // @param[in] Parent is the parent node for N.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -22,23 +22,23 @@
 
 namespace clang {
   // Each node of the PreorderAST has a variable-count list which stores the
-  // name of each variable along with a count of the number of times the
+  // Name of each variable along with a count of the number of times the
   // variable appears in the node.
   struct VarTy {
-    std::string name;
-    llvm::APSInt count;
+    std::string Name;
+    llvm::APSInt Count;
   };
 
   // Each node of the PreorderAST contains 3 fields:
-  // - opcode: The opcode for the node.
+  // - Opcode: The Opcode for the node.
   // - variable-count list: A list of variables and their counts.
-  // - constant value: All constants occurring in the node are constant folded.
+  // - Constant value: All Constants occurring in the node are Constant folded.
 
   // For example, consider an expression E = a + 3 + b + 4 + a
   // A node of the PreorderAST for E would contain the following:
-  // - opcode: +
+  // - Opcode: +
   // - variable-count list: [a:2, b:1]
-  // - constant value: 3 + 4 = 7
+  // - Constant value: 3 + 4 = 7
 
   using VarListTy = std::vector<VarTy>;
   using OpcodeTy = BinaryOperator::Opcode;
@@ -49,35 +49,35 @@ namespace clang {
     class ASTNode {
     public:
       ASTContext &Ctx;
-      OpcodeTy opcode;
-      VarListTy variables;
-      ConstTy constant;
-      ASTNode *left, *right, *parent;
+      OpcodeTy Opcode;
+      VarListTy Variables;
+      ConstTy Constant;
+      ASTNode *Left, *Right, *Parent;
       bool HasConstant;
       
       ASTNode(ASTContext &Ctx, ASTNode *Parent = nullptr) :
-        Ctx(Ctx), opcode(BO_Add),
-        left(nullptr), right(nullptr), parent(Parent),
+        Ctx(Ctx), Opcode(BO_Add),
+        Left(nullptr), Right(nullptr), Parent(Parent),
         HasConstant(false) {
-          // We initialize the constant value for each node to 0. So we need a
-          // way to indicate the absence of a constant. So we have a boolean
-          // HasConstant to indicate whether a node has a constant or not.
-          constant = getConstVal(0);
+          // We initialize the Constant value for each node to 0. So we need a
+          // way to indicate the absence of a Constant. So we have a boolean
+          // HasConstant to indicate whether a node has a Constant or not.
+          Constant = GetConstVal(0);
         }
 
-      llvm::APSInt getConstVal(unsigned Val) {
-      return llvm::APSInt(llvm::APInt(Ctx.getTypeSize(Ctx.IntTy), Val));
+      llvm::APSInt GetConstVal(unsigned Val) {
+        return llvm::APSInt(llvm::APInt(Ctx.getTypeSize(Ctx.IntTy), Val));
       }
 
-      void addVar(std::string name) {
+      void AddVar(std::string Name) {
         // We initialize the count of each variable in a node to 1.
-        variables.push_back(VarTy {name, getConstVal(1)});
+        Variables.push_back(VarTy {Name, GetConstVal(1)});
       }
 
       // Is the operator commutative and associative?
-      bool isOpCommutativeAndAssociative() {
-        return opcode == BO_Add ||
-               opcode == BO_Mul;
+      bool IsOpCommutativeAndAssociative() {
+        return Opcode == BO_Add ||
+               Opcode == BO_Mul;
       }
     };
 
@@ -85,44 +85,43 @@ namespace clang {
     ASTContext &Ctx;
     Lexicographic Lex;
     llvm::raw_ostream &OS;
-    bool HasError;
+    bool Error;
     ASTNode *AST;
 
   public:
     PreorderAST(ASTContext &Ctx, Expr *E) :
       Ctx(Ctx), Lex(Lexicographic(Ctx, nullptr)),
-      OS(llvm::outs()), HasError(false) {
+      OS(llvm::outs()), Error(false) {
 
-      HasError = false;
       AST = new ASTNode(Ctx);
-      insert(AST, E);
-      normalize(AST, HasError);
+      Create(AST, E);
+      Normalize(AST, Error);
     }
 
     // Create a preorder AST from the expression E.
     // @param[in] N is the current node of the AST.
     // @param[in] E is the sub expression which needs to be added to N.
-    // @param[in] Parent is the parent node for N.
-    void insert(ASTNode *N, Expr *E, ASTNode *Parent = nullptr);
+    // @param[in] Parent is the Parent node for N.
+    void Create(ASTNode *N, Expr *E, ASTNode *Parent = nullptr);
 
     // Normalize the input expression through a series of transforms on the
     // preorder AST.
     // @param[in] N is the root of the AST.
-    // @param[out] HasError is populated if an error is encountered during
+    // @param[out] Error is populated if an error is encountered during
     // normalization.
-    void normalize(ASTNode *N, bool &HasError);
+    void Normalize(ASTNode *N, bool &Error);
 
     // Sort the variables in a node of the AST.
     // @param[in] N is the root of the AST.
-    // @param[out] HasError is populated if an error is encountered during
+    // @param[out] Error is populated if an error is encountered during
     // sorting.
-    void sort(ASTNode *N, bool &HasError);
+    void Sort(ASTNode *N, bool &Error);
 
     // Check if the two ASTs N1 and N2 are equal.
     // @param[in] N1 is the first AST.
     // @param[in] N2 is the second AST.
     // @return Returns a boolean indicating whether N1 and N2 are equal.
-    bool isEqual(ASTNode *N1, ASTNode *N2);
+    bool IsEqual(ASTNode *N1, ASTNode *N2);
 
     // Compare the current AST with the given AST. This in turn, invokes
     // isEqual(N1, N2);
@@ -130,44 +129,35 @@ namespace clang {
     // @param[in] PT is the second AST.
     // @return Returns a value of type Lexicographic::Result indicating whether
     // the two ASTs are equal or not. 
-    Result compare(PreorderAST &PT);
+    Result Compare(PreorderAST &PT);
 
     // Cleanup the memory consumed by the AST.
     // @param[in] N is the root node of the AST.
-    void cleanup(ASTNode *N);
+    void Cleanup(ASTNode *N);
 
     // Cleanup the memory consumed by the AST. This is intended to be called
     // from outside the PreorderAST class.
-    void cleanup();
+    void Cleanup();
 
     // Check if an error has occurred during normalization of the expression.
     // @return Whether an error has occurred or not.
-    bool hasError() {
-      return HasError;
+    bool HasError() {
+      return Error;
     }
 
     // Print the preorder AST.
     // @param[in] N is the root node of the AST.
-    void print(ASTNode *N);
-
-    // Invoke IgnoreValuePreservingOperations to strip off casts.
-    // @param[in] E is the expression whose casts must be stripped.
-    // @return E with casts stripped off.
-    Expr *IgnoreCasts(const Expr *E);
+    void PrettyPrint(ASTNode *N);
 
     // A DeclRefExpr can be a reference either to an array subscript (in which
     // case it is wrapped around a ArrayToPointerDecay cast) or to a pointer
     // dereference (in which case it is wrapped around an LValueToRValue cast).
     // @param[in] An expression E.
-    // @return Whether E is an expression containing a reference to an array
-    // subscript or a pointer dereference.
-    bool IsDeclOperand(Expr *E);
-
-    // Get the DeclRefExpr from an expression E.
-    // @param[in] An expression E which is known to be either an LValueToRValue
-    // cast or an ArrayToPointerDecay cast.
-    // @return The DeclRefExpr from the expression E.
-    DeclRefExpr *GetDeclOperand(Expr *E);
+    // @param[out] D is populated with the DeclRefExpr if E contains a
+    // DeclRefExpr.
+    // @return A bool indicating whether E is an expression containing a
+    // reference to an array subscript or a pointer dereference.
+    bool IsDeclOperand(Expr *E, DeclRefExpr *&D);
   };
 }
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -88,16 +88,6 @@ namespace clang {
     bool Error;
     ASTNode *AST;
 
-  public:
-    PreorderAST(ASTContext &Ctx, Expr *E) :
-      Ctx(Ctx), Lex(Lexicographic(Ctx, nullptr)),
-      OS(llvm::outs()), Error(false) {
-
-      AST = new ASTNode(Ctx);
-      Create(AST, E);
-      Normalize(AST, Error);
-    }
-
     // Create a preorder AST from the expression E.
     // @param[in] N is the current node of the AST.
     // @param[in] E is the sub expression which needs to be added to N.
@@ -123,27 +113,9 @@ namespace clang {
     // @return Returns a boolean indicating whether N1 and N2 are equal.
     bool IsEqual(ASTNode *N1, ASTNode *N2);
 
-    // Compare the current AST with the given AST. This in turn, invokes
-    // isEqual(N1, N2);
-    // @param[in] this is the first AST.
-    // @param[in] PT is the second AST.
-    // @return Returns a value of type Lexicographic::Result indicating whether
-    // the two ASTs are equal or not. 
-    Result Compare(PreorderAST &PT);
-
     // Cleanup the memory consumed by the AST.
     // @param[in] N is the root node of the AST.
     void Cleanup(ASTNode *N);
-
-    // Cleanup the memory consumed by the AST. This is intended to be called
-    // from outside the PreorderAST class.
-    void Cleanup();
-
-    // Check if an error has occurred during normalization of the expression.
-    // @return Whether an error has occurred or not.
-    bool HasError() {
-      return Error;
-    }
 
     // Print the preorder AST.
     // @param[in] N is the root node of the AST.
@@ -158,6 +130,34 @@ namespace clang {
     // @return A bool indicating whether E is an expression containing a
     // reference to an array subscript or a pointer dereference.
     bool IsDeclOperand(Expr *E, DeclRefExpr *&D);
+
+  public:
+    PreorderAST(ASTContext &Ctx, Expr *E) :
+      Ctx(Ctx), Lex(Lexicographic(Ctx, nullptr)),
+      OS(llvm::outs()), Error(false) {
+
+      AST = new ASTNode(Ctx);
+      Create(AST, E);
+      Normalize(AST, Error);
+    }
+
+    // Check if an error has occurred during normalization of the expression.
+    // @return Whether an error has occurred or not.
+    bool HasError() {
+      return Error;
+    }
+
+    // Compare the current AST with the given AST. This in turn, invokes
+    // isEqual(N1, N2);
+    // @param[in] this is the first AST.
+    // @param[in] PT is the second AST.
+    // @return Returns a value of type Lexicographic::Result indicating whether
+    // the two ASTs are equal or not.
+    Result Compare(PreorderAST &PT);
+
+    // Cleanup the memory consumed by the AST. This is intended to be called
+    // from outside the PreorderAST class.
+    void Cleanup();
   };
 }
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5213,6 +5213,12 @@ public:
   // will always fail.
   void WarnDynamicCheckAlwaysFails(const Expr *Condition);
 
+  // If the VarDecl D has a byte_count or count bounds expression,
+  // NormalizeBounds expands it to a range bounds expression.  The expanded
+  // range bounds are attached to the VarDecl D to avoid recomputing the
+  // normalized bounds for D.
+  BoundsExpr *NormalizeBounds(const VarDecl *D);
+
   // This is wrapper around CheckBoundsDeclaration::ExpandToRange. This
   // provides an easy way to invoke this function from outside the class. Given
   // a byte_count or count bounds expression for the VarDecl D, ExpandToRange

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -56,6 +56,7 @@ add_clang_library(clangAST
   OSLog.cpp
   OpenMPClause.cpp
   ParentMap.cpp
+  PreorderAST.cpp
   PrintfFormatString.cpp
   QualTypeNames.cpp
   RawCommentList.cpp

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -225,18 +225,18 @@ Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
    Expr *E2 = const_cast<Expr *>(Arg2);
 
    PreorderAST PT1(Context, E1);
-   if (PT1.hasError()) {
-     PT1.cleanup();
+   if (PT1.HasError()) {
+     PT1.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
    PreorderAST PT2(Context, E2);
-   if (PT2.hasError()) {
-     PT2.cleanup();
+   if (PT2.HasError()) {
+     PT2.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
-   return PT1.compare(PT2);
+   return PT1.Compare(PT2);
 }
 
 Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -248,6 +248,7 @@ Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
 
   if (Res)
     return Result::Equal;
+  // We use Result::LessThan to indicate that Arg1 and Arg2 are not equal.
   return Result::LessThan;
 }
 

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -229,13 +229,13 @@ Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
    Expr *E2 = const_cast<Expr *>(Arg2);
 
    PreorderAST P1(Context, E1);
-   if (P1.HasError()) {
+   if (P1.GetError()) {
      P1.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
    PreorderAST P2(Context, E2);
-   if (P2.HasError()) {
+   if (P2.GetError()) {
      P2.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -236,7 +236,10 @@ Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
      return CompareExpr(Arg1, Arg2);
    }
 
-   return PT1.Compare(PT2);
+   Result ComparisonResult = PT1.Compare(PT2);
+   PT1.Cleanup();
+   PT2.Cleanup();
+   return ComparisonResult;
 }
 
 Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -221,24 +221,28 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) const
 
 Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
                                               const Expr *Arg2) {
+   // Compare Arg1 and Arg2 semantically. If we hit an error during comparison
+   // simply fallback to CompareExpr which compares two expressions
+   // structurally.
+
    Expr *E1 = const_cast<Expr *>(Arg1);
    Expr *E2 = const_cast<Expr *>(Arg2);
 
-   PreorderAST PT1(Context, E1);
-   if (PT1.HasError()) {
-     PT1.Cleanup();
+   PreorderAST P1(Context, E1);
+   if (P1.HasError()) {
+     P1.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
-   PreorderAST PT2(Context, E2);
-   if (PT2.HasError()) {
-     PT2.Cleanup();
+   PreorderAST P2(Context, E2);
+   if (P2.HasError()) {
+     P2.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
-   Result ComparisonResult = PT1.Compare(PT2);
-   PT1.Cleanup();
-   PT2.Cleanup();
+   Result ComparisonResult = P1.Compare(P2);
+   P1.Cleanup();
+   P2.Cleanup();
    return ComparisonResult;
 }
 

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -229,21 +229,26 @@ Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
    Expr *E2 = const_cast<Expr *>(Arg2);
 
    PreorderAST P1(Context, E1);
+   P1.Normalize();
    if (P1.GetError()) {
      P1.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
    PreorderAST P2(Context, E2);
+   P2.Normalize();
    if (P2.GetError()) {
      P2.Cleanup();
      return CompareExpr(Arg1, Arg2);
    }
 
-   Result ComparisonResult = P1.Compare(P2);
-   P1.Cleanup();
-   P2.Cleanup();
-   return ComparisonResult;
+  bool Res = P1.IsEqual(P2);
+  P1.Cleanup();
+  P2.Cleanup();
+
+  if (Res)
+    return Result::Equal;
+  return Result::LessThan;
 }
 
 Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -219,8 +219,8 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) const
   return Result::LessThan;
 }
 
-Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
-                                              const Expr *Arg2) {
+bool Lexicographic::CompareExprSemantically(const Expr *Arg1,
+                                            const Expr *Arg2) {
    // Compare Arg1 and Arg2 semantically. If we hit an error during comparison
    // simply fallback to CompareExpr which compares two expressions
    // structurally.
@@ -232,24 +232,20 @@ Result Lexicographic::CompareExprSemantically(const Expr *Arg1,
    P1.Normalize();
    if (P1.GetError()) {
      P1.Cleanup();
-     return CompareExpr(Arg1, Arg2);
+     return CompareExpr(Arg1, Arg2) == Result::Equal;
    }
 
    PreorderAST P2(Context, E2);
    P2.Normalize();
    if (P2.GetError()) {
      P2.Cleanup();
-     return CompareExpr(Arg1, Arg2);
+     return CompareExpr(Arg1, Arg2) == Result::Equal;
    }
 
   bool Res = P1.IsEqual(P2);
   P1.Cleanup();
   P2.Cleanup();
-
-  if (Res)
-    return Result::Equal;
-  // We use Result::LessThan to indicate that Arg1 and Arg2 are not equal.
-  return Result::LessThan;
+  return Res;
 }
 
 Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -101,9 +101,8 @@ void PreorderAST::Sort(Node *N) {
 
   // Sort the variables in the node lexicographically.
   llvm::sort(N->Vars.begin(), N->Vars.end(),
-             [](const VarDecl *V1, const VarDecl *V2) {
-               return V1->getQualifiedNameAsString().compare(
-                      V2->getQualifiedNameAsString()) < 0;
+             [&](const VarDecl *V1, const VarDecl *V2) {
+               return Lex.CompareDecl(V1, V2) == Result::LessThan;
              });
 
   Sort(N->Left);
@@ -137,8 +136,7 @@ bool PreorderAST::IsEqual(Node *N1, Node *N2) {
     auto &V2 = N2->Vars[I];
 
     // If any variable differs between the two nodes.
-    if (V1->getQualifiedNameAsString().compare(
-        V2->getQualifiedNameAsString()) != 0)
+    if (Lex.CompareDecl(V1, V2) != Result::Equal)
       return false;
   }
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -163,12 +163,7 @@ bool PreorderAST::IsEqual(ASTNode *N1, ASTNode *N2) {
 }
 
 Result PreorderAST::Compare(PreorderAST &PT) {
-  bool ExprsEqual = IsEqual(AST, PT.AST);
-  // Cleanup memory consumed by the ASTs.
-  Cleanup();
-  PT.Cleanup();
-
-  if (ExprsEqual)
+  if (IsEqual(AST, PT.AST))
     return Result::Equal;
   return Result::NotEqual;
 }

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -39,8 +39,7 @@ void PreorderAST::Create(Expr *E, Node *N, Node *Parent) {
 
   E = Lex.IgnoreValuePreservingOperations(Ctx, E);
 
-  // If E is a variable, store its name in the variable list for the current
-  // node.
+  // If E is a variable, store it in the variable list for the current node.
   if (DeclRefExpr *D = GetDeclOperand(E)) {
     if (const auto *V = dyn_cast_or_null<VarDecl>(D->getDecl())) {
       N->Vars.push_back(V);
@@ -176,13 +175,15 @@ void PreorderAST::PrettyPrint(Node *N) {
 
   OS << BinaryOperator::getOpcodeStr(N->Opc);
 
-  for (auto &V : N->Vars)
-    OS << " [" << V->getQualifiedNameAsString() << "]";
+  if (N->Vars.size()) {
+    OS << "[ ";
+    for (auto &V : N->Vars)
+      OS << V->getQualifiedNameAsString() << " ";
+    OS << "]\n";
+  }
 
   if (N->HasConst)
-    OS << " [const:" << N->Const << "]";
-
-  OS << "\n";
+    OS << " [const:" << N->Const << "]\n";
 
   PrettyPrint(N->Left);
   PrettyPrint(N->Right);

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -50,7 +50,7 @@ void PreorderAST::insert(ASTNode *N, Expr *E, ASTNode *Parent) {
   if (!N)
     N = new ASTNode(Ctx, Parent);
 
-  // If the parent is non null, make sure that the current node is marked as a
+  // If the parent is non-null, make sure that the current node is marked as a
   // child of the parent. As a convention, we create left children first.
   if (Parent) {
     if (!Parent->left)

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -1,0 +1,214 @@
+//===------ PreorderAST.cpp: An n-ary preorder abstract syntax tree -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements methods to create and manipulate an n-ary preorder
+//  abstract syntax tree which is used to semantically compare two expressions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/PreorderAST.h"
+
+using namespace clang;
+
+Expr *PreorderAST::IgnoreCasts(const Expr *E) {
+  return Lex.IgnoreValuePreservingOperations(Ctx, const_cast<Expr *>(E));
+}
+
+bool PreorderAST::IsDeclOperand(Expr *E) {
+  if (auto *CE = dyn_cast<CastExpr>(E)) {
+    assert(CE->getSubExpr() && "invalid CastExpr expression");
+
+    if (CE->getCastKind() == CastKind::CK_LValueToRValue ||
+        CE->getCastKind() == CastKind::CK_ArrayToPointerDecay)
+      return isa<DeclRefExpr>(IgnoreCasts(CE->getSubExpr()));
+  }
+  return false;
+}
+
+DeclRefExpr *PreorderAST::GetDeclOperand(Expr *E) {
+  if (!E || !isa<CastExpr>(E))
+    return nullptr;
+  auto *CE = dyn_cast<CastExpr>(E);
+  assert(CE->getSubExpr() && "invalid CastExpr expression");
+
+  return dyn_cast<DeclRefExpr>(IgnoreCasts(CE->getSubExpr()));
+}
+
+void PreorderAST::insert(ASTNode *N, Expr *E, ASTNode *Parent) {
+  if (!E)
+    return;
+
+  // When we invoke insert(N->left, ...) or insert(N->right, ...) we need to
+  // create the left or the right nodes with N as the parent node.
+  if (!N)
+    N = new ASTNode(Ctx, Parent);
+
+  // If the parent is non null, make sure that the current node is marked as a
+  // child of the parent. As a convention, we create left children first.
+  if (Parent) {
+    if (!Parent->left)
+      Parent->left = N;
+    else
+      Parent->right = N;
+  }
+
+  E = IgnoreCasts(E);
+
+  // If E is a variable, store its name in the variable list for the current
+  // node. Initialize the count of the variable to 1.
+  if (IsDeclOperand(E)) {
+    const DeclRefExpr *D = GetDeclOperand(E);
+    if (const auto *V = dyn_cast_or_null<VarDecl>(D->getDecl())) {
+      N->addVar(V->getQualifiedNameAsString());
+      return;
+    }
+  }
+
+  // If E is a constant, store it in the constant field of the current node and
+  // mark that this node has a constant.
+  llvm::APSInt IntVal;
+  if (E->isIntegerConstantExpr(IntVal, Ctx)) {
+    N->constant = IntVal;
+    N->HasConstant = true;
+    return;
+  }
+
+  if (const auto *BO = dyn_cast<BinaryOperator>(E)) {
+    OpcodeTy Opc = BO->getOpcode();
+    Expr *LHS = BO->getLHS()->IgnoreParens();
+    Expr *RHS = BO->getRHS()->IgnoreParens();
+
+    // Set the opcode for the current node.
+    N->opcode = Opc;
+
+    if (isa<BinaryOperator>(LHS))
+      // Insert the LHS as the left child of the current node.
+      insert(N->left, LHS, /* parent node */ N);
+    else
+      // Insert the LHS in the current node.
+      insert(N, LHS);
+
+    if (isa<BinaryOperator>(RHS))
+      // Insert the RHS as the right child of the current node.
+      insert(N->right, RHS, /* parent node */ N);
+    else
+      // Insert the RHS in the current node.
+      insert(N, RHS);
+  }
+}
+
+void PreorderAST::sort(ASTNode *N, bool &HasError) {
+  if (HasError)
+    return;
+
+  if (!N || !N->variables.size())
+    return;
+
+  if (!N->isOpCommutativeAndAssociative()) {
+    HasError = true;
+    return;
+  }
+
+  // Sort the variables in the node lexicographically.
+  llvm::sort(N->variables.begin(), N->variables.end(),
+             [](VarTy a, VarTy b) {
+               return a.name.compare(b.name) < 0;
+             });
+
+  sort(N->left, HasError);
+  sort(N->right, HasError);
+}
+
+void PreorderAST::normalize(ASTNode *N, bool &HasError) {
+  sort(N, HasError);
+}
+
+bool PreorderAST::isEqual(ASTNode *N1, ASTNode *N2) {
+  // If both the nodes are null.
+  if (!N1 && !N2)
+    return true;
+
+  // If only one of the nodes is null.
+  if ((N1 && !N2) || (!N1 && N2))
+    return false;
+
+  // If the opcodes mismatch.
+  if (N1->opcode != N2->opcode)
+    return false;
+
+  // If the number of variables in the two nodes mismatch.
+  if (N1->variables.size() != N2->variables.size())
+    return false;
+
+  // If the values of the constants in the two nodes differ.
+  if (llvm::APSInt::compareValues(N1->constant, N2->constant) != 0)
+    return false;
+
+  // Match each variable occurring in the two nodes.
+  for (size_t i = 0; i != N1->variables.size(); ++i) {
+    auto &V1 = N1->variables[i];
+    auto &V2 = N2->variables[i];
+
+    // If any variable differs between the two nodes.
+    if (V1.name.compare(V2.name) != 0)
+      return false;
+
+    // If the count of any variable differs.
+    if (V1.count != V2.count)
+      return false;
+  }
+
+  // Recursively match the left and the right subtrees of the AST.
+  return isEqual(N1->left, N2->left) &&
+         isEqual(N1->right, N2->right);
+}
+
+Result PreorderAST::compare(PreorderAST &PT) {
+  bool areExprsEqual = isEqual(AST, PT.AST);
+  // Cleanup memory consumed by the ASTs.
+  cleanup();
+  PT.cleanup();
+
+  if (areExprsEqual)
+    return Result::Equal;
+  return Result::NotEqual;
+}
+
+void PreorderAST::print(ASTNode *N) {
+  if (!N)
+    return;
+
+  OS << BinaryOperator::getOpcodeStr(N->opcode);
+  if (N->variables.size()) {
+    for (auto &V : N->variables)
+      OS << " [" << V.name << ":" << V.count << "]";
+  }
+
+  if (N->HasConstant)
+    OS << " [const:" << N->constant << "]";
+  OS << "\n";
+
+  print(N->left);
+  print(N->right);
+}
+
+void PreorderAST::cleanup(ASTNode *N) {
+  if (!N)
+    return;
+
+  cleanup(N->left);
+  cleanup(N->right);
+
+  delete N;
+}
+
+void PreorderAST::cleanup() {
+  cleanup(AST);
+}

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -38,12 +38,12 @@ void PreorderAST::Create(ASTNode *N, Expr *E, ASTNode *Parent) {
     return;
 
   // When we invoke Create(N->Left, ...) or Create(N->Right, ...) we need to
-  // create the Left or the Right nodes with N as the Parent node.
+  // create the left or the right nodes with N as the parent node.
   if (!N)
     N = new ASTNode(Ctx, Parent);
 
-  // If the Parent is non-null, make sure that the current node is marked as a
-  // child of the Parent. As a convention, we create Left children first.
+  // If the parent is non-null, make sure that the current node is marked as a
+  // child of the parent. As a convention, we create left children first.
   if (Parent) {
     if (!Parent->Left)
       Parent->Left = N;
@@ -53,7 +53,7 @@ void PreorderAST::Create(ASTNode *N, Expr *E, ASTNode *Parent) {
 
   E = Lex.IgnoreValuePreservingOperations(Ctx, E);
 
-  // If E is a variable, store its Name in the variable list for the current
+  // If E is a variable, store its name in the variable list for the current
   // node. Initialize the count of the variable to 1.
   DeclRefExpr *D;
   if (IsDeclOperand(E, D)) {
@@ -63,8 +63,8 @@ void PreorderAST::Create(ASTNode *N, Expr *E, ASTNode *Parent) {
     }
   }
 
-  // If E is a Constant, store it in the Constant field of the current node and
-  // mark that this node has a Constant.
+  // If E is a constant, store it in the constant field of the current node and
+  // mark that this node has a constant.
   llvm::APSInt IntVal;
   if (E->isIntegerConstantExpr(IntVal, Ctx)) {
     N->Constant = IntVal;
@@ -81,15 +81,15 @@ void PreorderAST::Create(ASTNode *N, Expr *E, ASTNode *Parent) {
     N->Opcode = Opc;
 
     if (isa<BinaryOperator>(LHS))
-      // Create the LHS as the Left child of the current node.
-      Create(N->Left, LHS, /* Parent node */ N);
+      // Create the LHS as the left child of the current node.
+      Create(N->Left, LHS, /* parent node */ N);
     else
       // Create the LHS in the current node.
       Create(N, LHS);
 
     if (isa<BinaryOperator>(RHS))
-      // Create the RHS as the Right child of the current node.
-      Create(N->Right, RHS, /* Parent node */ N);
+      // Create the RHS as the right child of the current node.
+      Create(N->Right, RHS, /* parent node */ N);
     else
       // Create the RHS in the current node.
       Create(N, RHS);
@@ -120,6 +120,7 @@ void PreorderAST::Sort(ASTNode *N, bool &Error) {
 
 void PreorderAST::Normalize(ASTNode *N, bool &Error) {
   Sort(N, Error);
+  // TODO: Coalesce nodes having the same commutative and associative operator.
 }
 
 bool PreorderAST::IsEqual(ASTNode *N1, ASTNode *N2) {
@@ -139,7 +140,7 @@ bool PreorderAST::IsEqual(ASTNode *N1, ASTNode *N2) {
   if (N1->Variables.size() != N2->Variables.size())
     return false;
 
-  // If the values of the Constants in the two nodes differ.
+  // If the values of the constants in the two nodes differ.
   if (llvm::APSInt::compareValues(N1->Constant, N2->Constant) != 0)
     return false;
 
@@ -157,7 +158,7 @@ bool PreorderAST::IsEqual(ASTNode *N1, ASTNode *N2) {
       return false;
   }
 
-  // Recursively match the Left and the Right subtrees of the AST.
+  // Recursively match the left and the right subtrees of the AST.
   return IsEqual(N1->Left, N2->Left) &&
          IsEqual(N1->Right, N2->Right);
 }

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -120,7 +120,11 @@ void PreorderAST::Sort(ASTNode *N) {
 
 void PreorderAST::Normalize(ASTNode *N) {
   Sort(N);
+
   // TODO: Coalesce nodes having the same commutative and associative operator.
+  // TODO: Constant fold the constants in the nodes.
+  // TODO: Perform simple arithmetic optimizations/transformations on the
+  // constants in the nodes.
 }
 
 bool PreorderAST::IsEqual(ASTNode *N1, ASTNode *N2) {

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -96,15 +96,15 @@ void PreorderAST::Create(ASTNode *N, Expr *E, ASTNode *Parent) {
   }
 }
 
-void PreorderAST::Sort(ASTNode *N, bool &Error) {
-  if (Error)
+void PreorderAST::Sort(ASTNode *N) {
+  if (GetError())
     return;
 
   if (!N || !N->Variables.size())
     return;
 
   if (!N->IsOpCommutativeAndAssociative()) {
-    Error = true;
+    SetError(true);
     return;
   }
 
@@ -114,12 +114,12 @@ void PreorderAST::Sort(ASTNode *N, bool &Error) {
                return a.Name.compare(b.Name) < 0;
              });
 
-  Sort(N->Left, Error);
-  Sort(N->Right, Error);
+  Sort(N->Left);
+  Sort(N->Right);
 }
 
-void PreorderAST::Normalize(ASTNode *N, bool &Error) {
-  Sort(N, Error);
+void PreorderAST::Normalize(ASTNode *N) {
+  Sort(N);
   // TODO: Coalesce nodes having the same commutative and associative operator.
 }
 

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -327,10 +327,6 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
   //   if (*(p + 1)) // no widening
   //     if (*(p + i)) // widen p and q by 1
 
-  // TODO: Currently, Lexicographic::CompareExpr does not understand
-  // commutativity of operations. Exprs like "p + e" and "e + p" are considered
-  // unequal.
-
   // TODO: Currently, we iterate and re-compute info for all ntptrs in scope
   // for each ntptr dereference. We can optimize this at the cost of space by
   // storing the VarDecls, variables used in bounds exprs and base/offset for
@@ -371,8 +367,7 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
       continue;
     llvm::APSInt UpperOffset = UpperExprIntPair.second;
 
-    if (Lex.CompareExprSemantically(DerefBase, UpperBase) !=
-        Lexicographic::Result::Equal)
+    if (!Lex.CompareExprSemantically(DerefBase, UpperBase))
       continue;
 
     // We cannot widen the bounds if the offset in the deref expr is less than

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -371,7 +371,7 @@ void BoundsAnalysis::FillGenSetAndGetBoundsVars(const Expr *E,
       continue;
     llvm::APSInt UpperOffset = UpperExprIntPair.second;
 
-    if (Lex.CompareExpr(DerefBase, UpperBase) !=
+    if (Lex.CompareExprSemantically(DerefBase, UpperBase) !=
         Lexicographic::Result::Equal)
       continue;
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -712,10 +712,12 @@ namespace {
           return true;
         if (D->isInvalidDecl())
           return true;
+        if (!D->hasBoundsExpr())
+          return true;
         // The bounds expressions in the bounds context should be normalized
         // to range bounds.
-        if (const BoundsExpr *Bounds = D->getBoundsExpr())
-          BoundsContextRef[D] = SemaRef.ExpandBoundsToRange(D, Bounds);
+        if (BoundsExpr *Bounds = SemaRef.NormalizeBounds(D))
+          BoundsContextRef[D] = Bounds;
         return true;
       }
   };
@@ -2157,21 +2159,10 @@ namespace {
 
      // KilledBounds stores a mapping of statements to all variables whose
      // bounds are killed by each statement. Here we reset the bounds of all
-     // variables killed by the statement S to the declared bounds.
+     // variables killed by the statement S to the normalized declared bounds.
      for (const VarDecl *V : I->second) {
-       if (const BoundsExpr *Bounds = V->getBoundsExpr())
-
-         // TODO: Throughout clang in general (and inside dataflow analysis in
-         // particular) we repeatedly invoke ExpandBoundsToRange in order to
-         // canonicalize the bounds of a variable to RangeBoundsExpr. Sometimes
-         // we do this multiple times for the same variable. This is very
-         // inefficient because ExpandBoundsToRange can allocate AST data
-         // structures that are permanently allocated and increase the memory
-         // usage of the compiler. The solution is to canonicalize the bounds
-         // once and attach it to the VarDecl. See issue
-         // https://github.com/microsoft/checkedc-clang/issues/830.
-
-         ObservedBounds[V] = S.ExpandBoundsToRange(V, Bounds);
+       if (BoundsExpr *Bounds = S.NormalizeBounds(V))
+         ObservedBounds[V] = Bounds;
      }
    }
 
@@ -2186,20 +2177,9 @@ namespace {
        const VarDecl *V = item.first;
        unsigned Offset = item.second;
 
-       // We normalize the declared bounds to RangBoundsExpr here so that we
+       // We normalize the declared bounds to RangeBoundsExpr here so that we
        // can easily apply the offset to the upper bound.
-
-       // TODO: Throughout clang in general (and inside dataflow analysis in
-       // particular) we repeatedly invoke ExpandBoundsToRange in order to
-       // canonicalize the bounds of a variable to RangeBoundsExpr. Sometimes
-       // we do this multiple times for the same variable. This is very
-       // inefficient because ExpandBoundsToRange can allocate AST data
-       // structures that are permanently allocated and increase the memory
-       // usage of the compiler. The solution is to canonicalize the bounds
-       // once and attach it to the VarDecl. See issue
-       // https://github.com/microsoft/checkedc-clang/issues/830.
-
-       BoundsExpr *Bounds = S.ExpandBoundsToRange(V, V->getBoundsExpr());
+       BoundsExpr *Bounds = S.NormalizeBounds(V);
        if (RangeBoundsExpr *RBE = dyn_cast<RangeBoundsExpr>(Bounds)) {
          const llvm::APInt
            APIntOff(Context.getTargetInfo().getPointerWidth(0), Offset);
@@ -2241,9 +2221,10 @@ namespace {
      CheckingState ParamsState;
      for (auto I = FD->param_begin(); I != FD->param_end(); ++I) {
        ParmVarDecl *Param = *I;
-       BoundsExpr *Bounds = Param->getBoundsExpr();
-       if (Bounds)
-         ParamsState.ObservedBounds[Param] = ExpandToRange(Param, Bounds);
+       if (!Param->hasBoundsExpr())
+         continue;
+       if (BoundsExpr *Bounds = S.NormalizeBounds(Param))
+         ParamsState.ObservedBounds[Param] = Bounds;
      }
 
      // Store a checking state for each CFG block in order to track
@@ -4340,8 +4321,8 @@ namespace {
         const VarDecl *D = Pair.first;
         if (!Pair.second || !Context2.count(D))
           continue;
-        if (const BoundsExpr *B = D->getBoundsExpr())
-          IntersectedContext[D] = S.ExpandBoundsToRange(D, B);
+        if (BoundsExpr *B = S.NormalizeBounds(D))
+          IntersectedContext[D] = B;
       }
       return IntersectedContext;
     }
@@ -5539,6 +5520,22 @@ void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
         << Condition->getSourceRange();
     }
   }
+}
+
+// If the VarDecl D has a byte_count or count bounds expression,
+// NormalizeBounds expands it to a range bounds expression.  The expanded
+// range bounds are attached to the VarDecl D to avoid recomputing the
+// normalized bounds for D.
+BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
+  // If D already has a normalized bounds expression, do not recompute it.
+  if (BoundsExpr *NormalizedBounds = D->getNormalizedBounds())
+    return NormalizedBounds;
+
+  // Normalize the bounds of D to a RangeBoundsExpr and attach the normalized
+  // bounds to D to avoid recomputing them.
+  BoundsExpr *Bounds = ExpandBoundsToRange(D, D->getBoundsExpr());
+  D->setNormalizedBounds(Bounds);
+  return Bounds;
 }
 
 // This is wrapper around CheckBoundsDeclaration::ExpandToRange. This provides

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -1,0 +1,36 @@
+// Tests for bounds widening of _Nt_array_ptr's using function to semantically
+// compare two expressions.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s 2>&1 | FileCheck %s
+
+// expected-no-diagnostics
+
+void f1(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
+
+  if (*(i + p)) {}
+
+// CHECK: In function: f1
+// CHECK:   2: *(i + p)
+// CHECK: upper_bound(p) = 1
+}
+
+void f2(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a";
+
+  if (*(p + (j + i))) {}
+
+// CHECK: In function: f2
+// CHECK:   2: *(p + (j + i))
+// CHECK: upper_bound(p) = 1
+}
+
+void f3(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a";
+
+  if (*(p + (j * i))) {}
+
+// CHECK: In function: f3
+// CHECK:   2: *(p + (j * i))
+// CHECK: upper_bound(p) = 1
+}


### PR DESCRIPTION
We implement a preoder AST data structure to compare two expressions.
This AST is a mirror of the clang AST with the following properties:
-	It is an n-ary tree
-	It represents an expression in the preorder form
-	Each node of the clang AST is a node in the preorder AST
-	Its internal nodes represent the operator nodes of the clang AST
-	Its leaf nodes represent the operands of the clang AST

We traverse the ASTs for the expressions E1 and E2 and create the respective
preorder AST’s. Then we perform tree transforms to "normalize" the expressions
and finally match the tree node-by-node to determine if E1 and E2 are equal.