### PR TITLE
Fixing intermittent test failures

### DIFF
--- a/clang/lib/CConv/CConvInteractiveData.cpp
+++ b/clang/lib/CConv/CConvInteractiveData.cpp
@@ -36,11 +36,10 @@ void DisjointSet::AddElements(ConstraintKey A, ConstraintKey B) {
         LeaderB = Leaders[A];
       }
       GrpA.insert(GrpB.begin(), GrpB.end());
-      Groups.erase(LeaderB);
       for (auto k : GrpB) {
         Leaders[k] = LeaderA;
       }
-
+      Groups.erase(LeaderB);
     } else {
       Groups[Leaders[A]].insert(B);
       Leaders[B] = Leaders[A];

--- a/clang/test/CheckedCRewriter/basic_checks.c
+++ b/clang/test/CheckedCRewriter/basic_checks.c
@@ -1,5 +1,3 @@
-// UNSUPPORTED: system-windows
-
 // Tests for Checked C rewriter tool.
 //
 // Tests properties about type re-writing and replacement, and simple function

--- a/clang/test/CheckedCRewriter/global.c
+++ b/clang/test/CheckedCRewriter/global.c
@@ -1,5 +1,3 @@
-// UNSUPPORTED: system-windows
-
 // Tests for Checked C rewriter tool.
 //
 // Tests for rewriting global declarations.

--- a/clang/test/CheckedCRewriter/simple_locals.c
+++ b/clang/test/CheckedCRewriter/simple_locals.c
@@ -1,5 +1,3 @@
-// UNSUPPORTED: system-windows
-
 // Tests for Checked C rewriter tool.
 //
 // Checks very simple inference properties for local variables.


### PR DESCRIPTION
Reference: https://github.com/microsoft/checkedc-clang/pull/854

We fixed root cause memory corruption and enabled all the tests.