### PR TITLE
Allow assume bounds casts for function pointers

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5195,6 +5195,10 @@ namespace {
       case CK_FunctionToPointerDecay:
       case CK_BitCast:
       case CK_LValueBitCast:
+      // An _Assume_bounds_cast can be used to cast an unchecked function
+      // pointer to a checked pointer, and should therefore be considered
+      // value-preserving for a function-pointer cast.
+      case CK_AssumePtrBounds:
         return true;
       default:
         S.Diag(E->getExprLoc(), diag::err_cast_to_checked_fn_ptr_not_value_preserving)

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5167,6 +5167,11 @@ namespace {
                                            ToPtrType->getPointeeType(),
                                            /*CompareUnqualifed=*/false,
                                            /*IgnoreBounds=*/false)) {
+            // An _Assume_bounds_cast can be used to cast an unchecked function
+            // pointer to a checked function pointer, if the only difference
+            // is that the source is an unchecked pointer type.
+            if (E->getCastKind() == CastKind::CK_AssumePtrBounds)
+              return;
             S.Diag(Needle->getExprLoc(), 
                    diag::err_cast_to_checked_fn_ptr_from_unchecked_fn_ptr) <<
               ToType << E->getSourceRange();

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2461,14 +2461,6 @@ namespace {
       }
 
       if (Expr *E = dyn_cast<Expr>(S)) {
-        // Bounds expressions are not null ptrs.
-        if (isa<BoundsExpr>(E))
-          return ResultBounds;
-
-        // Temporary bindings are not null ptrs.
-        if (isa<CHKCBindTemporaryExpr>(E))
-          return ResultBounds;
-
         // Null ptrs always have bounds(any).
         // This is the correct way to detect all the different ways that
         // C can make a null ptr.


### PR DESCRIPTION
Fixes #855 

This PR allows _Assume_bounds_casts to be used to convert an unchecked function pointer (including `NULL`) to a checked function pointer. The unchecked function pointer pointee type must be compatible with the checked function pointer pointee type.

For example, this will be allowed:
```
void test(int(*f)(int)) {
    ptr<int(int)> safe = _Assume_bounds_cast<ptr<int(int)>>(f);
}
```

This will not be allowed:
```
void test(int(*f)(int)) {
    ptr<void(double)> bad = _Assume_bounds_cast<ptr<void(double)>>(f);
}
```

#### Testing:
* Added tests in [checkedc/407](https://github.com/microsoft/checkedc/pull/407)
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux