### PR TITLE
Fix CodeGen assert failure for bounds-safe interfaces

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -2372,6 +2372,25 @@ public:
            getCanonicalType(T2).getTypePtr();
   }
 
+  /// Determine whether the given types are equivalent after
+  /// cvr-qualifiers have been removed, ignoring any difference
+  /// in pointer checkedness.
+  bool hasSameUnqualifiedUncheckedType(QualType T1, QualType T2) const {
+    if (hasSameUnqualifiedType(T1, T2))
+      return true;
+
+    // See if the only difference between T1 and T2 is that one is a
+    // checked pointer type and one is an unchecked pointer type.
+    if (T1->isPointerType() && T2->isPointerType()) {
+      const PointerType *PtrType1 = T1->getAs<PointerType>();
+      const PointerType *PtrType2 = T2->getAs<PointerType>();
+      return hasSameUnqualifiedUncheckedType(PtrType1->getPointeeType(),
+                                             PtrType2->getPointeeType());
+    }
+
+    return false;
+  }
+
   bool hasSameNullabilityTypeQualifier(QualType SubT, QualType SuperT,
                                        bool IsParam) const {
     auto SubTnullability = SubT->getNullability(*this);

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2168,7 +2168,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     llvm_unreachable("scalar cast to non-scalar value");
 
   case CK_LValueToRValue:
-    assert(CGF.getContext().hasSameUnqualifiedType(E->getType(), DestTy));
+    assert(CGF.getContext().hasSameUnqualifiedUncheckedType(E->getType(), DestTy));
     assert(E->isGLValue() && "lvalue-to-rvalue applied to r-value!");
     return Visit(const_cast<Expr*>(E));
 


### PR DESCRIPTION
Fixes #861 

This PR fixes a type-related assert that failed during code generation. The assertion was that the subexpression of an LValueToRValue cast had the same unqualified type as the destination type. However, this failed for cases involving bounds-safe interfaces. For example:

```
_Checked unsigned f(const unsigned char *cp : count(1))
{
    return cp[0];
}
```

Since `cp` has a bounds-safe interface type of `_Array_ptr<unsigned char>`, there is an implicit cast `(_Array_ptr<const unsigned char>)cp` in the subexpression of the cast `LValueToRValue((_Array_ptr<const unsigned char>)cp)`. The destination type of the LValueToRValue cast is `unsigned char *`. This caused the CodeGen assert `hasSameUnqualifiedType(_Array_ptr<const unsigned char>, unsigned char *)` to fail.

This PR introduces a new method `hasSameUnqualifiedUncheckedType` which returns true if two types are the same, ignoring qualifiers and the checkedness of any pointer types. `hasSameUnqualifiedUncheckedType(_Array_ptr<const unsigned char>, unsigned char *)` returns true.

#### Testing:
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux.