### PR TITLE
Compare Expressions: Add a field for non-variable, non-constant expressions [3/n]

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -30,6 +30,7 @@ namespace clang {
   // Opc: The opcode of the operator.
   // Vars: A list of variables in the sub expression.
   // Const: Constants of the sub expression are folded.
+  // Others: A list of all other non-variable, non-constant expressions.
   // HasConst: Indicates whether there is a constant in the node. It is used to
   // differentiate between the absence of a constant and a constant value of 0.
   // Parent: A link to the parent node of the current node.
@@ -40,6 +41,7 @@ namespace clang {
     BinaryOperator::Opcode Opc;
     std::vector<const VarDecl *> Vars;
     llvm::APSInt Const;
+    std::vector<const Expr *> Others;
     bool HasConst;
     Node *Parent;
     std::vector<Node *> Children;

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -25,24 +25,27 @@ namespace clang {
   using Result = Lexicographic::Result;
 
   // Each binary operator of an expression results in a new node of the
-  // PreorderAST. Each node contains 3 fields:
+  // PreorderAST. Each node contains the following fields:
+
   // Opc: The opcode of the operator.
   // Vars: A list of variables in the sub expression.
   // Const: Constants of the sub expression are folded.
+  // HasConst: Indicates whether there is a constant in the node. It is used to
+  // differentiate between the absence of a constant and a constant value of 0.
+  // Parent: A link to the parent node of the current node.
+  // Children: The preorder AST is an n-ary tree. Children is a list of all the
+  // child nodes of the current node.
 
   struct Node {
     BinaryOperator::Opcode Opc;
     std::vector<const VarDecl *> Vars;
     llvm::APSInt Const;
-    // HasConst indicates whether there is a constant in the node. This is used
-    // to differentiate between an absence of a constant and a constant of value
-    // 0.
     bool HasConst;
-    Node *Parent, *Left, *Right;
+    Node *Parent;
+    std::vector<Node *> Children;
 
     Node(Node *Parent) :
-      Opc(BO_Add), HasConst(false),
-      Parent(Parent), Left(nullptr), Right(nullptr) {}
+      Opc(BO_Add), HasConst(false), Parent(Parent) {}
 
     // Is the operator commutative and associative?
     bool IsOpCommutativeAndAssociative() {

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -28,10 +28,12 @@ void PreorderAST::Create(Expr *E, Node *N, Node *Parent) {
   if (!Root)
     Root = N;
 
-  // If the parent is non-null, make sure that the current node is added to the
-  // children of the parent.
-  if (Parent)
-    Parent->Children.push_back(N);
+  // If the parent is non-null and the current node has not already been added
+  // to the list of children of the parent, add it.
+  if (Parent) {
+    if (!Parent->Children.size() || Parent->Children.back() != N)
+      Parent->Children.push_back(N);
+  }
 
   E = Lex.IgnoreValuePreservingOperations(Ctx, E);
 
@@ -159,7 +161,6 @@ void PreorderAST::Normalize() {
   // constants in the nodes.
 
   Sort(Root);
-  PrettyPrint(Root);
 }
 
 DeclRefExpr *PreorderAST::GetDeclOperand(Expr *E) {

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -28,14 +28,10 @@ void PreorderAST::Create(Expr *E, Node *N, Node *Parent) {
   if (!Root)
     Root = N;
 
-  // If the parent is non-null, make sure that the current node is marked as a
-  // child of the parent. As a convention, we create left children first.
-  if (Parent) {
-    if (!Parent->Left)
-      Parent->Left = N;
-    else
-      Parent->Right = N;
-  }
+  // If the parent is non-null, make sure that the current node is added to the
+  // children of the parent.
+  if (Parent)
+    Parent->Children.push_back(N);
 
   E = Lex.IgnoreValuePreservingOperations(Ctx, E);
 
@@ -64,15 +60,15 @@ void PreorderAST::Create(Expr *E, Node *N, Node *Parent) {
     Expr *RHS = BO->getRHS()->IgnoreParens();
   
     if (isa<BinaryOperator>(LHS))
-      // Create the LHS as the left child of the current node.
-      Create(LHS, N->Left, N);
+      // Create the LHS as a child of the current node.
+      Create(LHS, nullptr, N);
     else
       // Create the LHS in the current node.
       Create(LHS, N);
   
     if (isa<BinaryOperator>(RHS))
-      // Create the RHS as the right child of the current node.
-      Create(RHS, N->Right, N);
+      // Create the RHS as a child of the current node.
+      Create(RHS, nullptr, N);
     else
       // Create the RHS in the current node.
       Create(RHS, N);
@@ -105,8 +101,8 @@ void PreorderAST::Sort(Node *N) {
                return Lex.CompareDecl(V1, V2) == Result::LessThan;
              });
 
-  Sort(N->Left);
-  Sort(N->Right);
+  for (auto *Child : N->Children)
+    Sort(Child);
 }
 
 bool PreorderAST::IsEqual(Node *N1, Node *N2) {
@@ -130,6 +126,10 @@ bool PreorderAST::IsEqual(Node *N1, Node *N2) {
   if (llvm::APSInt::compareValues(N1->Const, N2->Const) != 0)
     return false;
 
+  // If the number of children of the two nodes mismatch.
+  if (N1->Children.size() != N2->Children.size())
+    return false;
+
   // Match each variable occurring in the two nodes.
   for (size_t I = 0; I != N1->Vars.size(); ++I) {
     auto &V1 = N1->Vars[I];
@@ -140,9 +140,16 @@ bool PreorderAST::IsEqual(Node *N1, Node *N2) {
       return false;
   }
 
-  // Recursively match the left and the right subtrees of the AST.
-  return IsEqual(N1->Left, N2->Left) &&
-         IsEqual(N1->Right, N2->Right);
+  // Match each child of the two nodes.
+  for (size_t I = 0; I != N1->Children.size(); ++I) {
+    auto *Child1 = N1->Children[I];
+    auto *Child2 = N2->Children[I];
+
+    // If any child differs between the two nodes.
+    if (!IsEqual(Child1, Child2))
+      return false;
+  }
+  return true;
 }
 
 void PreorderAST::Normalize() {
@@ -152,6 +159,7 @@ void PreorderAST::Normalize() {
   // constants in the nodes.
 
   Sort(Root);
+  PrettyPrint(Root);
 }
 
 DeclRefExpr *PreorderAST::GetDeclOperand(Expr *E) {
@@ -183,16 +191,16 @@ void PreorderAST::PrettyPrint(Node *N) {
   if (N->HasConst)
     OS << " [const:" << N->Const << "]\n";
 
-  PrettyPrint(N->Left);
-  PrettyPrint(N->Right);
+  for (auto *Child : N->Children)
+    PrettyPrint(Child);
 }
 
 void PreorderAST::Cleanup(Node *N) {
   if (!N)
     return;
 
-  Cleanup(N->Left);
-  Cleanup(N->Right);
+  for (auto *Child : N->Children)
+    Cleanup(Child);
 
   delete N;
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -34,3 +34,13 @@ void f3(int i, int j) {
 // CHECK:   2: *(p + (j * i))
 // CHECK: upper_bound(p) = 1
 }
+
+void f4(int i, int *r) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + *r) = "a";
+
+  if (*(i + p + *r)) {}
+
+// CHECK: In function: f4
+// CHECK:   2: *(i + p + *r)
+// CHECK: upper_bound(p) = 1
+}


### PR DESCRIPTION
Currently, a node of the preorder AST has fields for variables and constants. However, an input expression may contain sub-expressions which are neither variables nor constants. We add a field "Others" of type Expr to store all such expressions.