### PR TITLE
Reset killed widened bounds after validating a statement

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2379,10 +2379,6 @@ namespace {
             // bounds for v (if any), or the declared bounds for v (if any).
             GetDeclaredBounds(this->S, BlockState.ObservedBounds, S);
 
-            // If any bounds are killed by statement S, reset their bounds
-            // to their declared bounds.
-            ResetKilledBounds(KilledBounds, S, BlockState);
-
             BoundsContextTy InitialObservedBounds = BlockState.ObservedBounds;
             BlockState.Reset();
 
@@ -2402,6 +2398,13 @@ namespace {
             // declared bounds, the observed bounds for each variable should
             // be reset to their observed bounds from before checking S.
             BlockState.ObservedBounds = InitialObservedBounds;
+
+            // If the widened bounds of any variables are killed by statement
+            // S, reset their observed bounds to their declared bounds.
+            // Resetting the widened bounds killed by S should be the last
+            // thing done as part of traversing S.  The widened bounds of each
+            // variable should be in effect until the very end of traversing S.
+            ResetKilledBounds(KilledBounds, S, BlockState);
          }
        }
        if (Block->getBlockID() != Cfg->getEntry().getBlockID())

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3241,8 +3241,8 @@ namespace {
         BoundsExpr *IncDecResultBounds = SubExprTargetBounds;
 
         // Create the target of the implied assignment `e1 = e1 +/- 1`.
-        Expr *Target = CreateImplicitCast(SubExpr->getType(),
-                                            CK_LValueToRValue, SubExpr);
+        CastExpr *Target = CreateImplicitCast(SubExpr->getType(),
+                                              CK_LValueToRValue, SubExpr);
 
         // Only use the RHS `e1 +/1 ` of the implied assignment to update
         // the checking state if the integer constant 1 can be created, which
@@ -3262,8 +3262,12 @@ namespace {
           // Update SameValue to be the set of expressions that produce the
           // same value as the RHS `e1 +/- 1` (if the RHS could be created).
           UpdateSameValue(E, State.SameValue, State.SameValue, RHS);
-          IncDecResultBounds = UpdateAfterAssignment(V, Target, RHS,
-                                                     IncDecResultBounds,
+          // The bounds of the RHS `e1 +/- 1` are the rvalue bounds of the
+          // rvalue cast `e1`.
+          BoundsExpr *RHSBounds = RValueCastBounds(Target, SubExprTargetBounds,
+                                                   SubExprLValueBounds,
+                                                   SubExprBounds, State);
+          IncDecResultBounds = UpdateAfterAssignment(V, Target, RHS, RHSBounds,
                                                      CSS, State, State);
         }
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -2170,7 +2170,7 @@ void killed_widened_bounds1(
     // This statement kills the widened bounds of p since it modifies i
     // Observed bounds context: { p => bounds(unknown) }
     i++, --other; // expected-error {{inferred bounds for 'p' are unknown after statement}} \
-                  // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i)' of 'p'}}
+                  // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}}
     // CHECK: Statement S:
     // CHECK-NEXT: BinaryOperator {{.*}} ','
     // CHECK-NEXT:   UnaryOperator {{.*}} postfix '++'
@@ -2404,11 +2404,11 @@ void killed_widened_bounds3(
       // CHECK-NEXT: }
 
       // This statement kills the widened bounds of p and q
-      // Observed bounds context: { p => bounds(unknown), q => bounds(q - 1, q - 1 + 1) }
+      // Observed bounds context: { p => bounds(unknown), q => bounds(q - 1, q - 1 + 1 + 1) }
       i = 0, q++; // expected-error {{inferred bounds for 'p' are unknown after statement}} \
-                  // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i)' of 'p'}} \
+                  // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}} \
                   // expected-warning {{cannot prove declared bounds for 'q' are valid after statement}} \
-                  // expected-note {{(expanded) inferred bounds are 'bounds(q - 1, q - 1 + 1)'}}
+                  // expected-note {{(expanded) inferred bounds are 'bounds(q - 1, q - 1 + 1 + 1)'}}
       // CHECK: Statement S:
       // CHECK-NEXT: BinaryOperator {{.*}} ','
       // CHECK-NEXT:   BinaryOperator {{.*}} '='
@@ -2436,9 +2436,11 @@ void killed_widened_bounds3(
       // CHECK-NEXT:       DeclRefExpr {{.*}} 'q'
       // CHECK-NEXT:     IntegerLiteral {{.*}} 1
       // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-      // CHECK-NEXT:     BinaryOperator {{.*}} '-'
-      // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:         DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+      // CHECK-NEXT:       BinaryOperator {{.*}} '-'
+      // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:           DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT:         IntegerLiteral {{.*}} 1
       // CHECK-NEXT:       IntegerLiteral {{.*}} 1
       // CHECK-NEXT:     IntegerLiteral {{.*}} 1
       // CHECK-NEXT: }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-check.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-check.c
@@ -13,8 +13,7 @@ void f1() {
   {}
 
   if (*p) {
-    // TODO: checkedc-clang issue #872: declared bounds for p should not be invalid
-    p++; // expected-error {{declared bounds for 'p' are invalid after statement}}
+    p++; // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}}
     if (*(p + 1)) // expected-error {{out-of-bounds memory access}}
     {}
   }


### PR DESCRIPTION
Fixes #872 

This PR reorders statement traversal so that if the widened bounds of a variable 'v' are killed by statement 'S', 'v' still has widened bounds while checking 'S'. For example:

```
void f(_Array_ptr<int> p : bounds(p, p)) {
  if (*p) {
    // Declared bounds of p: (p, p)
    // p currently has widened bounds (p, p + 1)
    // Original value of p: p - 1
    // Updated observed bounds of p before validating the bounds context: (p - 1, p - 1 + 1)
    // Warning: cannot prove (p - 1, p - 1 + 1) implies (p, p) (this is a separate issue)
    // Updated observed bounds of p after resetting the killed widened bounds: (p, p)
    p++;
  }
}
```

#### Testing:
* Updated widened-bounds-check and bounds-context check to reflect the fact that a variable's widened bounds are not killed until the end of checking a statement
* Passed manual testing on Windows
* Passed automated testing on Windows/Linux