### PR TITLE
Fixes for Visual Studio 16.6.5 update

### DIFF
--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
@@ -16,6 +16,7 @@
 #include "llvm/Demangle/DemangleConfig.h"
 #include "llvm/Demangle/StringView.h"
 #include <array>
+#include <string>
 
 namespace llvm {
 namespace itanium_demangle {

--- a/llvm/include/llvm/Support/ManagedStatic.h
+++ b/llvm/include/llvm/Support/ManagedStatic.h
@@ -40,8 +40,8 @@ template <typename T, size_t N> struct object_deleter<T[N]> {
 // constexpr, a dynamic initializer may be emitted depending on optimization
 // settings. For the affected versions of MSVC, use the old linker
 // initialization pattern of not providing a constructor and leaving the fields
-// uninitialized.
-#if !defined(_MSC_VER) || defined(__clang__)
+// uninitialized. See http://llvm.org/PR41367 for details.
+#if !defined(_MSC_VER) || (_MSC_VER >= 1925) || defined(__clang__)
 #define LLVM_USE_CONSTEXPR_CTOR
 #endif
 


### PR DESCRIPTION
After updating VS to version 16.6.5, the compiler build on Windows with VS seems to fail. This is because our compiler sources are now a bit outdated and do not have the fixes which the community has for supporting newer versions of VS. This PR brings in two such fixes from the community.

Refer:
1. https://bugs.llvm.org/show_bug.cgi?id=41367
2. https://reviews.llvm.org/D80433
3. https://reviews.llvm.org/D64937