### PR TITLE
Target a single assignment in bounds checking error messages

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10177,7 +10177,8 @@ def err_bounds_type_annotation_lost_checking : Error<
     "%select{assignment|initialization|statement|increment|decrement}0">;
 
   def err_unknown_inferred_bounds : Error<
-    "inferred bounds for %0 are unknown after statement">;
+    "inferred bounds for %1 are unknown after "
+    "%select{assignment|initialization|statement|increment|decrement}0">;
 
   def note_declared_bounds : Note<
     "(expanded) declared bounds are '%0'">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10164,17 +10164,17 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def warn_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
-    "%select{assignment|initialization|statement}0">,
+    "%select{assignment|initialization|statement|increment|decrement}0">,
     InGroup<CheckBoundsDeclsUnchecked>;
 
   def warn_checked_scope_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
-    "%select{assignment|initialization|statement}0">,
+    "%select{assignment|initialization|statement|increment|decrement}0">,
     InGroup<CheckBoundsDeclsChecked>;
 
   def error_bounds_declaration_invalid : Error<
     "declared bounds for %1 are invalid after "
-    "%select{assignment|initialization|statement}0">;
+    "%select{assignment|initialization|statement|increment|decrement}0">;
 
   def err_unknown_inferred_bounds : Error<
     "inferred bounds for %0 are unknown after statement">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10164,21 +10164,21 @@ def err_bounds_type_annotation_lost_checking : Error<
 
   def warn_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
-    "%select{assignment|initialization|statement|increment|decrement}0">,
+    "%select{assignment|decrement|increment|initialization|statement}0">,
     InGroup<CheckBoundsDeclsUnchecked>;
 
   def warn_checked_scope_bounds_declaration_invalid : Warning<
     "cannot prove declared bounds for %1 are valid after "
-    "%select{assignment|initialization|statement|increment|decrement}0">,
+    "%select{assignment|decrement|increment|initialization|statement}0">,
     InGroup<CheckBoundsDeclsChecked>;
 
   def error_bounds_declaration_invalid : Error<
     "declared bounds for %1 are invalid after "
-    "%select{assignment|initialization|statement|increment|decrement}0">;
+    "%select{assignment|decrement|increment|initialization|statement}0">;
 
   def err_unknown_inferred_bounds : Error<
     "inferred bounds for %1 are unknown after "
-    "%select{assignment|initialization|statement|increment|decrement}0">;
+    "%select{assignment|decrement|increment|initialization|statement}0">;
 
   def note_declared_bounds : Note<
     "(expanded) declared bounds are '%0'">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5187,7 +5187,9 @@ public:
   enum BoundsDeclarationCheck {
       BDC_Assignment,
       BDC_Initialization,
-      BDC_Statement
+      BDC_Statement,
+      BDC_Increment,
+      BDC_Decrement
   };
 
   /// \brief Check that address=of operation is not taking the

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5186,10 +5186,10 @@ public:
 
   enum BoundsDeclarationCheck {
       BDC_Assignment,
+      BDC_Decrement,
+      BDC_Increment,
       BDC_Initialization,
       BDC_Statement,
-      BDC_Increment,
-      BDC_Decrement
   };
 
   /// \brief Check that address=of operation is not taking the

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4056,8 +4056,9 @@ namespace {
         SrcRange = BlameExpr->getSourceRange();
 
         // Choose the type of assignment E to show in the diagnostic messages
-        // from: assignment (=), decrement (--) or increment (++). These are all
-        // modifying operators that can update observed bounds.
+        // from: assignment (=), decrement (--) or increment (++). If none of
+        // these cases match, the diagnostic message reports that the error is
+        // for a statement.
         if (UnaryOperator *UO = dyn_cast<UnaryOperator>(BlameExpr)) {
           if (UO->isIncrementOp())
             BDCType = Sema::BoundsDeclarationCheck::BDC_Increment;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4031,6 +4031,7 @@ namespace {
     SourceLocation BlameAssignmentWithinStmt(Stmt *St, const VarDecl *V,
                                              CheckingState State,
                                              unsigned DiagId) const {
+      assert(St);
       SourceRange SrcRange = St->getSourceRange();
       auto BDCType = Sema::BoundsDeclarationCheck::BDC_Statement;
 
@@ -4053,9 +4054,10 @@ namespace {
         Expr *BlameExpr = It->second;
         Loc = BlameExpr->getBeginLoc();
         SrcRange = BlameExpr->getSourceRange();
-        
-        // Choose the type of assignment E to show in the diagnostic messages:
-        // assignment (=), decrement (--) or increment (++).
+
+        // Choose the type of assignment E to show in the diagnostic messages
+        // from: assignment (=), decrement (--) or increment (++). These are all
+        // modifying operators that can update observed bounds.
         if (UnaryOperator *UO = dyn_cast<UnaryOperator>(BlameExpr)) {
           if (UO->isIncrementOp())
             BDCType = Sema::BoundsDeclarationCheck::BDC_Increment;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -503,35 +503,35 @@ namespace {
 }
 #endif
 
-// Convert all temporary bindings in an expression to uses of the values
-// produced by a binding.   This should be done for bounds expressions that
-// are used in runtime checks.  That way we don't try to recompute a
-// temporary multiple times in an expression.
-namespace {
-  class PruneTemporaryHelper : public TreeTransform<PruneTemporaryHelper> {
-    typedef TreeTransform<PruneTemporaryHelper> BaseTransform;
+// Convert all temporary bindings in an expression to uses of the values	
+// produced by a binding.   This should be done for bounds expressions that	
+// are used in runtime checks.  That way we don't try to recompute a	
+// temporary multiple times in an expression.	
+namespace {	
+  class PruneTemporaryHelper : public TreeTransform<PruneTemporaryHelper> {	
+    typedef TreeTransform<PruneTemporaryHelper> BaseTransform;	
 
 
-  public:
-    PruneTemporaryHelper(Sema &SemaRef) :
-      BaseTransform(SemaRef) { }
+  public:	
+    PruneTemporaryHelper(Sema &SemaRef) :	
+      BaseTransform(SemaRef) { }	
 
-    ExprResult TransformCHKCBindTemporaryExpr(CHKCBindTemporaryExpr *E) {
-      return new (SemaRef.Context) BoundsValueExpr(SourceLocation(), E);
-    }
-  };
+    ExprResult TransformCHKCBindTemporaryExpr(CHKCBindTemporaryExpr *E) {	
+      return new (SemaRef.Context) BoundsValueExpr(SourceLocation(), E);	
+    }	
+  };	
 
-  Expr *PruneTemporaryBindings(Sema &SemaRef, Expr *E, CheckedScopeSpecifier CSS) {
+  Expr *PruneTemporaryBindings(Sema &SemaRef, Expr *E, CheckedScopeSpecifier CSS) {	
     // Account for checked scope information when transforming the expression.
     Sema::CheckedScopeRAII CheckedScope(SemaRef, CSS);
 
-    Sema::ExprSubstitutionScope Scope(SemaRef); // suppress diagnostics
-    ExprResult R = PruneTemporaryHelper(SemaRef).TransformExpr(E);
+    Sema::ExprSubstitutionScope Scope(SemaRef); // suppress diagnostics	
+    ExprResult R = PruneTemporaryHelper(SemaRef).TransformExpr(E);	
     if (R.isInvalid())
       return SemaRef.Context.getPrebuiltBoundsUnknown();
     else
       return R.get();
-  }
+  }	
 }
 
 namespace {
@@ -752,7 +752,7 @@ namespace {
 
       // If a variable declaration has declared bounds, modify BoundsContextRef
       // to map the variable declaration to the normalized declared bounds.
-      //
+      // 
       // Returns true if visiting the variable declaration did not terminate
       // early.  Visiting variable declarations in DeclaredBoundsHelper should
       // never terminate early.
@@ -1510,7 +1510,7 @@ namespace {
     // 5. If OP signs are not equivalent in both, return false.
     // 6. If ConstantParts are not equal, return false.
     // If the expressions pass all the above tests, then return true.
-    //
+    //      
     // Note that in all steps involving in checking the equality of the types or values of offsets, parentheses and
     // casts are ignored.
     static bool EqualExtended(ASTContext &Ctx, Expr *Base1, Expr *Base2, Expr *Offset1, Expr *Offset2, EquivExprSets *EquivExprs) {
@@ -2008,7 +2008,7 @@ namespace {
                                       CheckedScopeSpecifier CSS) {
       // Record expression equality implied by initialization (see
       // CheckBoundsDeclAtAssignment).
-
+      
       // Record equivalence between expressions implied by initializion.
       // If D declares a variable V, and
       // 1. Src binds a temporary variable T, record equivalence
@@ -2726,7 +2726,7 @@ namespace {
       SubExprSameValueSets[RHS] = State.SameValue;
 
       BinaryOperatorKind Op = E->getOpcode();
-
+      
       // Bounds of the binary operator.
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
@@ -3187,7 +3187,7 @@ namespace {
 
         if (DumpBounds)
           DumpBoundsCastBounds(llvm::outs(), E, DeclaredBounds, NormalizedBounds, SubExprBounds);
-
+        
         return ExpandToRange(SubExprAtNewType, E->getBoundsExpr());
       }
 
@@ -3444,7 +3444,7 @@ namespace {
       if (!ReturnBounds)
         return ResultBounds;
 
-      // TODO: Actually check that the return expression bounds imply the
+      // TODO: Actually check that the return expression bounds imply the 
       // return bounds.
       // TODO: Also check that any parameters used in the return bounds are
       // unmodified.
@@ -3672,7 +3672,7 @@ namespace {
                                 BoundsExpr *&OutTargetBounds,
                                 CheckingState &State) {
       // An LValueBitCast adjusts the type of the lvalue.  The bounds are not
-      // changed, except that their relative alignment may change (the bounds
+      // changed, except that their relative alignment may change (the bounds 
       // may only cover a partial object).  TODO: When we add relative
       // alignment support to the compiler, adjust the relative alignment.
       if (E->getCastKind() == CastKind::CK_LValueBitCast)
@@ -4378,7 +4378,7 @@ namespace {
       // value is either some variable w != v in EQ, or it is null.  In either
       // case, the original value cannot use the value of v.
       OriginalValueUsesV = false;
-
+      
       // Check EQ for a variable w != v that produces the same value as v.
       Expr *ValuePreservingV = nullptr;
       EqualExprTy F = GetEqualExprSetContainingExpr(Target, EQ, ValuePreservingV);
@@ -4488,7 +4488,7 @@ namespace {
 
       Expr *LHS = E->getLHS();
       Expr *RHS = E->getRHS();
-
+      
       // Addition and subtraction operations must be for checked pointer
       // arithmetic or unsigned integer arithmetic.
       if (Op == BinaryOperatorKind::BO_Add || Op == BinaryOperatorKind::BO_Sub) {
@@ -4599,7 +4599,7 @@ namespace {
     Expr *UnaryOperatorInverse(DeclRefExpr *X, Expr *F, UnaryOperator *E) {
       Expr *SubExpr = E->getSubExpr()->IgnoreParens();
       UnaryOperatorKind Op = E->getOpcode();
-
+      
       if (Op == UnaryOperatorKind::UO_AddrOf) {
         // Inverse(f, &*e1) = Inverse(f, e1)
         if (UnaryOperator *UnarySubExpr = dyn_cast<UnaryOperator>(SubExpr)) {
@@ -5231,7 +5231,7 @@ namespace {
                                       /*IsInteropTypeAnnotation=*/true);
         return cast<BoundsExpr>(PruneTemporaryBindings(S, B, CSS));
       }
-
+      
       if (!B)
         return CreateBoundsAlwaysUnknown();
 
@@ -5281,7 +5281,7 @@ namespace {
       } else if (Ty->isCheckedPointerNtArrayType()) {
         BE = Context.getPrebuiltCountZero();
       }
-
+      
       if (!BE)
         return CreateBoundsEmpty();
 
@@ -5335,7 +5335,7 @@ namespace {
           if (DeclRefExpr *V = GetRValueVariable(E)) {
             if (const VarDecl *D = dyn_cast_or_null<VarDecl>(V->getDecl())) {
               auto It = State.ObservedBounds.find(D);
-              if (It != State.ObservedBounds.end())
+              if (It != State.ObservedBounds.end()) 
                 return It->second;
             }
           }
@@ -5511,7 +5511,7 @@ namespace {
 
         // If we've found a cast expression...
         if (const CastExpr *NeedleCast = dyn_cast<CastExpr>(Needle)) {
-          if (const ImplicitCastExpr *ICE =
+          if (const ImplicitCastExpr *ICE = 
                 dyn_cast<ImplicitCastExpr>(NeedleCast))
             // Stop at lvalue-to-ravlue casts.
             if (ICE->getCastKind() == CK_LValueToRValue)
@@ -5590,14 +5590,14 @@ namespace {
             // is that the source is an unchecked pointer type.
             if (E->getCastKind() == CastKind::CK_AssumePtrBounds)
               return;
-            S.Diag(Needle->getExprLoc(),
+            S.Diag(Needle->getExprLoc(), 
                    diag::err_cast_to_checked_fn_ptr_from_unchecked_fn_ptr) <<
               ToType << E->getSourceRange();
             return;
           }
         }
 
-        S.Diag(Needle->getExprLoc(),
+        S.Diag(Needle->getExprLoc(), 
                diag::err_cast_to_checked_fn_ptr_from_incompatible_type)
           << ToType << NeedleTy << NeedleTy->isCheckedPointerPtrType()
           << E->getSourceRange();
@@ -5812,7 +5812,7 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   }
   else {
     // A CFG couldn't be constructed.  CFG construction doesn't support
-    // __finally or may encounter a malformed AST.  Fall back on to non-flow
+    // __finally or may encounter a malformed AST.  Fall back on to non-flow 
     // based analysis.  The CSS parameter is ignored because the checked
     // scope information is obtained from Body, which is a compound statement.
     Checker.Check(Body, CheckedScopeSpecifier::CSS_Unchecked);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -239,7 +239,7 @@ namespace {
 
 bool Sema::AbstractForFunctionType(
   BoundsAnnotations &Annots,
-  ArrayRef<DeclaratorChunk::ParamInfo> Params) {
+  ArrayRef<DeclaratorChunk::ParamInfo> Params) {  
 
   BoundsExpr *Expr = Annots.getBoundsExpr();
   // If there is no bounds expression, the itype does not change
@@ -1510,7 +1510,7 @@ namespace {
     // 5. If OP signs are not equivalent in both, return false.
     // 6. If ConstantParts are not equal, return false.
     // If the expressions pass all the above tests, then return true.
-    //      
+    //
     // Note that in all steps involving in checking the equality of the types or values of offsets, parentheses and
     // casts are ignored.
     static bool EqualExtended(ASTContext &Ctx, Expr *Base1, Expr *Base2, Expr *Offset1, Expr *Offset2, EquivExprSets *EquivExprs) {
@@ -1526,7 +1526,7 @@ namespace {
 
       bool CreatedStdForm1 = CreateStandardForm(Ctx, Base1, Offset1, ConstantPart1, IsOpSigned1, VariablePart1);
       bool CreatedStdForm2 = CreateStandardForm(Ctx, Base2, Offset2, ConstantPart2, IsOpSigned2, VariablePart2);
-
+      
       if (!CreatedStdForm1 || !CreatedStdForm2)
         return false;
       if (!EqualValue(Ctx, VariablePart1, VariablePart2, EquivExprs))
@@ -2726,7 +2726,7 @@ namespace {
       SubExprSameValueSets[RHS] = State.SameValue;
 
       BinaryOperatorKind Op = E->getOpcode();
-      
+
       // Bounds of the binary operator.
       BoundsExpr *ResultBounds = CreateBoundsEmpty();
 
@@ -2742,7 +2742,7 @@ namespace {
       // are RValues.
       else if (Op == BinaryOperatorKind::BO_Comma)
         ResultBounds = RHSBounds;
-
+      
       else {
         // Compound Assignments function like assignments mostly,
         // except the LHS is an L-Value, so we'll use its lvalue target bounds
@@ -5231,7 +5231,7 @@ namespace {
                                       /*IsInteropTypeAnnotation=*/true);
         return cast<BoundsExpr>(PruneTemporaryBindings(S, B, CSS));
       }
-      
+            
       if (!B)
         return CreateBoundsAlwaysUnknown();
 
@@ -5281,7 +5281,7 @@ namespace {
       } else if (Ty->isCheckedPointerNtArrayType()) {
         BE = Context.getPrebuiltCountZero();
       }
-      
+    
       if (!BE)
         return CreateBoundsEmpty();
 
@@ -5335,7 +5335,7 @@ namespace {
           if (DeclRefExpr *V = GetRValueVariable(E)) {
             if (const VarDecl *D = dyn_cast_or_null<VarDecl>(V->getDecl())) {
               auto It = State.ObservedBounds.find(D);
-              if (It != State.ObservedBounds.end()) 
+              if (It != State.ObservedBounds.end())
                 return It->second;
             }
           }
@@ -5385,7 +5385,7 @@ namespace {
       }
       else {
         // Get the function prototype, where the abstract function return
-        // bounds are kept.  The callee (if it exists)
+        // bounds are kept.  The callee (if it exists) 
         // is always a function pointer.
         const PointerType *PtrTy =
           CE->getCallee()->getType()->getAs<PointerType>();

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4074,7 +4074,7 @@ namespace {
         default:
           break;
         }
-      } else if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(E)) {
+      } else if (dyn_cast<BinaryOperator>(E)) {
         // Must be an assignment or a compounds assignment, because E is
         // modifying.
         return Sema::BoundsDeclarationCheck::BDC_Assignment;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5281,7 +5281,7 @@ namespace {
       } else if (Ty->isCheckedPointerNtArrayType()) {
         BE = Context.getPrebuiltCountZero();
       }
-     
+   
       if (!BE)
         return CreateBoundsEmpty();
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5281,7 +5281,7 @@ namespace {
       } else if (Ty->isCheckedPointerNtArrayType()) {
         BE = Context.getPrebuiltCountZero();
       }
-    
+     
       if (!BE)
         return CreateBoundsEmpty();
 

--- a/clang/test/CheckedC/inferred-bounds/basic.c
+++ b/clang/test/CheckedC/inferred-bounds/basic.c
@@ -150,7 +150,7 @@ void f6(_Array_ptr<int> a : bounds(a, a + 5)) {
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
 
 void f7(void) {
-  _Array_ptr<int> d : count(5) = (_Array_ptr<int>) 5; // expected-error {{inferred bounds for 'd' are unknown after statement}}
+  _Array_ptr<int> d : count(5) = (_Array_ptr<int>) 5; // expected-error {{inferred bounds for 'd' are unknown after initialization}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} d '_Array_ptr<int>' cinit
@@ -190,7 +190,7 @@ void f8(_Array_ptr<int> a, _Array_ptr<int> b : count(5)) {
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 
 void f9(int a) {
-  _Array_ptr<int> b : count(5) = (_Array_ptr<int>) !a; // expected-error {{inferred bounds for 'b' are unknown after statement}}
+  _Array_ptr<int> b : count(5) = (_Array_ptr<int>) !a; // expected-error {{inferred bounds for 'b' are unknown after initialization}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
@@ -207,7 +207,7 @@ void f9(int a) {
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Invalid
 
 void f10(float a) {
-  _Array_ptr<int> b : count(5) = (_Array_ptr<int>)((int)a); // expected-error {{inferred bounds for 'b' are unknown after statement}}
+  _Array_ptr<int> b : count(5) = (_Array_ptr<int>)((int)a); // expected-error {{inferred bounds for 'b' are unknown after initialization}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} b '_Array_ptr<int>' cinit
@@ -280,7 +280,7 @@ void f21(_Array_ptr<int> a : count(5),
 
 // Only test declarations for the negative case (where an error is expected}
 void f22(_Array_ptr<int> b) {
-  _Array_ptr<int> a : count(5) = b;  // expected-error {{inferred bounds for 'a' are unknown after statement}}
+  _Array_ptr<int> a : count(5) = b;  // expected-error {{inferred bounds for 'a' are unknown after initialization}}
 }
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} a '_Array_ptr<int>' cinit

--- a/clang/test/CheckedC/inferred-bounds/basic.c
+++ b/clang/test/CheckedC/inferred-bounds/basic.c
@@ -131,7 +131,7 @@ void f5(void) {
 // CHECK: NullaryBoundsExpr {{0x[0-9a-f]+}} 'NULL TYPE' Any
 
 void f6(_Array_ptr<int> a : bounds(a, a + 5)) {
-  a = (_Array_ptr<int>) 5; // expected-error {{inferred bounds for 'a' are unknown after statement}}
+  a = (_Array_ptr<int>) 5; // expected-error {{inferred bounds for 'a' are unknown after assignment}}
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
@@ -260,7 +260,7 @@ void f20(_Array_ptr<int> a : count(len),
 
 void f21(_Array_ptr<int> a : count(5),
          _Array_ptr<int> b) {
-  a = b;  // expected-error {{inferred bounds for 'a' are unknown after statement}}
+  a = b;  // expected-error {{inferred bounds for 'a' are unknown after assignment}}
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -345,9 +345,9 @@ void assign2(
   // Observed bounds context before assignment: { a => bounds(a, a + len - 1), b => bounds(b, b + len) }
   // Original value of len: len + 3
   // Observed bounds context after assignment : { a => bounds(a, a + ((len + 3) - 1)), b => bounds(b, b + (len + 3)) }
-  len = len - 3; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  len = len - 3; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
                  // expected-note {{(expanded) inferred bounds are 'bounds(a, a + len + 3 - 1)'}} \
-                 // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
+                 // expected-warning {{cannot prove declared bounds for 'b' are valid after assignment}} \
                  // expected-note {{(expanded) inferred bounds are 'bounds(b, b + len + 3)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -438,7 +438,7 @@ void assign4(array_ptr<int> a : count(len), unsigned len) { // expected-note {{(
   // Observed bounds context before assignment: { a => bounds(a, a + len) }
   // Original value of a: a - 1, original value of len: len + 1
   // Observed bounds context after assignment:  { a => bounds(a - 1, (a - 1) + (len + 1)) }
-  ++a, len--; // expected-warning {{cannot prove declared bounds for 'a' are valid after increment}} \
+  ++a, len--; // expected-warning {{cannot prove declared bounds for 'a' are valid after decrement}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(a - 1, a - 1 + len + 1U)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -501,7 +501,7 @@ void assign5(array_ptr<int> a : count(len), int len, int size) { // expected-not
   // Observed bounds context before assignment: { a => bounds(a, a + len) }
   // Original value of len: size
   // Observed bounds context after assignment:  { a => bounds(a, a + size) }
-  len = len * 2; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  len = len * 2; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
                  // expected-note {{(expanded) inferred bounds are 'bounds(a, a + size)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -617,8 +617,8 @@ void assign7(
   // Original value of a: b
   // Observed bounds context after assignment:  { a => bounds(b, b + 1), b => bounds(b, b + 1), c => bounds(b, b + 1) }
   a = c; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
-         // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
-         // expected-warning {{cannot prove declared bounds for 'c' are valid after statement}} \
+         // expected-warning {{cannot prove declared bounds for 'b' are valid after assignment}} \
+         // expected-warning {{cannot prove declared bounds for 'c' are valid after assignment}} \
          // expected-note 3 {{(expanded) inferred bounds are 'bounds(b, b + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1275,8 +1275,8 @@ void multiple_assign2(
 ) {
   // Observed bounds of a at memory access a[len]: bounds(a, a + (len - 1))
   // Observed bounds context after statement: { a => bounds(a, a + (len - 1)), b => bounds(a, a + (len - 1)) }
-  len++, a[len]; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
-                 // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
+  len++, a[len]; // expected-warning {{cannot prove declared bounds for 'a' are valid after increment}} \
+                 // expected-warning {{cannot prove declared bounds for 'b' are valid after increment}} \
                  // expected-note 2 {{(expanded) inferred bounds are 'bounds(a, a + len - 1U)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -306,7 +306,7 @@ void assign1(array_ptr<int> arr : count(1)) { // expected-note {{(expanded) decl
   // Observed bounds context before assignment: { arr => bounds(arr, arr + 1) }
   // Original value of arr: arr - 2
   // Observed bounds context after assignment:  { arr => bounds(arr - 2, (arr - 2) + 1) }
-  arr = arr + 2; // expected-warning {{cannot prove declared bounds for 'arr' are valid after statement}} \
+  arr = arr + 2; // expected-warning {{cannot prove declared bounds for 'arr' are valid after assignment}} \
                  // expected-note {{(expanded) inferred bounds are 'bounds(arr - 2, arr - 2 + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -438,7 +438,7 @@ void assign4(array_ptr<int> a : count(len), unsigned len) { // expected-note {{(
   // Observed bounds context before assignment: { a => bounds(a, a + len) }
   // Original value of a: a - 1, original value of len: len + 1
   // Observed bounds context after assignment:  { a => bounds(a - 1, (a - 1) + (len + 1)) }
-  ++a, len--; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  ++a, len--; // expected-warning {{cannot prove declared bounds for 'a' are valid after increment}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(a - 1, a - 1 + len + 1U)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -565,11 +565,11 @@ void assign7(
   // Observed bounds context before assignemnt: { a => bounds(a, a + 1), b => bounds(a, a + 1), c => bounds(a + 1) }
   // Original value of a: null
   // Observed bounds context after assignment:  { a => bounds(unknown), b => bounds(unknown), c => bounds(unknown) }
-  a = b; // expected-error {{inferred bounds for 'a' are unknown after statement}} \
+  a = b; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
          // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'a'}} \
-         // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+         // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
          // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'b'}} \
-         // expected-error {{inferred bounds for 'c' are unknown after statement}} \
+         // expected-error {{inferred bounds for 'c' are unknown after assignment}} \
          // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'c'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -616,7 +616,7 @@ void assign7(
   // Observed bounds context before assignment: { a => bounds(a, a + 1), b => bounds(a, a + 1), c => bounds(a, a + 1) }
   // Original value of a: b
   // Observed bounds context after assignment:  { a => bounds(b, b + 1), b => bounds(b, b + 1), c => bounds(b, b + 1) }
-  a = c; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  a = c; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
          // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
          // expected-warning {{cannot prove declared bounds for 'c' are valid after statement}} \
          // expected-note 3 {{(expanded) inferred bounds are 'bounds(b, b + 1)'}}
@@ -1129,9 +1129,9 @@ void multiple_assign1(
   // Target bounds of b at assignment b = a: bounds(b, b + len)
   // Observed bounds of a at assignment b = a: bounds(a - 1, a - 1 + len)
   // Observed bounds context after assignments: { a => bounds(a - 1, a - 1 + len), b => bounds(a - 1, a - 1 + len) }
-  a++, b = a; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  a++, b = a; // expected-warning {{cannot prove declared bounds for 'a' are valid after increment}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(a - 1, a - 1 + len)'}} \
-              // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
+              // expected-warning {{cannot prove declared bounds for 'b' are valid after assignment}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(a - 1, a - 1 + len)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -1184,7 +1184,7 @@ void multiple_assign1(
   // Target bounds of a at assignment a = a: bounds(a, a + len)
   // Observed bounds of a at assignment a = a: bounds(a + 1, a + 1 + len)
   // Observed bounds context after assignments: { a => bounds(a + 1, a + 1 + len), b => bounds(b, b + len) }
-  a--, a = a; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  a--, a = a; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
               // expected-note {{(expanded) inferred bounds are 'bounds(a + 1, a + 1 + len)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -1233,10 +1233,10 @@ void multiple_assign1(
   // Target bounds of a at assignment a = b: bounds(a, a + len)
   // Observed bounds of b at assignment a = b: bounds(unknown)
   // Observed bounds context after assignments: { a => bounds(unknown), b => bounds(unknown) }
-  len = 0, a = b; // expected-error {{inferred bounds for 'a' are unknown after statement}} \
+  len = 0, a = b; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
                   // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
                   // expected-note {{assigned expression 'b' with unknown bounds to 'a'}} \
-                  // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+                  // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
                   // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(b, b + len)' of 'b'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -1343,9 +1343,9 @@ void multiple_assign2(
   // Observed bounds of a at memory access a[0]: bounds(unknown)
   // Observed bounds context after statement: { a => bounds(unknown), b => bounds(unknown) }
   len = 0, a[0]; // expected-error {{expression has unknown bounds}} \
-                 // expected-error {{inferred bounds for 'a' are unknown after statement}} \
+                 // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
                  // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
-                 // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+                 // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
                  // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'b'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -1386,9 +1386,9 @@ void multiple_assign2(
   // Observed bounds of b at memory access *b: bounds(unknown)
   // Observed bounds context after statement: { a => bounds(unknown), b => bounds(unknown) }
   a = b, *b; // expected-error {{expression has unknown bounds}} \
-             // expected-error {{inferred bounds for 'a' are unknown after statement}} \
+             // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
              // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
-             // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+             // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
              // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'b'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -1488,7 +1488,7 @@ void multiple_assign4(array_ptr<int> a : count(len), int len) { // expected-note
   // Observed bounds context before assignment: { a => bounds(a, a + len) }
   // Original value of len: null
   // Observed bounds context after assignment:  { a => bounds(unknown) }
-  len = 0; // expected-error {{inferred bounds for 'a' are unknown after statement}} \
+  len = 0; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
            // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1760,8 +1760,8 @@ void update_result_bounds1(
   // Observed bounds context before assignments: { a => bounds(b, b + 1), b => bounds(b, b + 1) }
   // Bounds of b = b + 1: bounds(b - 1, (b - 1) + 1)
   // Observed bounds context after assignments: { a => bounds(b - 1, (b - 1 + 1)), b => bounds(b - 1, (b - 1) + 1) }
-  a = (b = b + 1); // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
-                   // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  a = (b = b + 1); // expected-warning {{cannot prove declared bounds for 'b' are valid after assignment}} \
+                   // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
                    // expected-note 2 {{(expanded) inferred bounds are 'bounds(b - 1, b - 1 + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1823,8 +1823,8 @@ void update_result_bounds2(
   // Observed bounds context before assignments: { a => bounds(b, b + 1), b => bounds(b, b + 1) }
   // Bounds of b += 1: bounds(b - 1, (b - 1) + 1)
   // Observed bounds context after assignments: { a => bounds(b - 1, (b - 1 + 1)), b => bounds(b - 1, (b - 1) + 1) }
-  a = (b += 1); // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
-                // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  a = (b += 1); // expected-warning {{cannot prove declared bounds for 'b' are valid after assignment}} \
+                // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
                 // expected-note 2 {{(expanded) inferred bounds are 'bounds(b - 1, b - 1 + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1883,8 +1883,8 @@ void update_result_bounds3(
   // Observed bounds context before assignments: { a => bounds(b, b + 1), b => bounds(b, b + 1) }
   // Bounds of b++: bounds(b - 1, (b - 1) + 1)
   // Observed bounds context after assignments: { a => bounds(b - 1, (b - 1 + 1)), b => bounds(b - 1, (b - 1) + 1) }
-  a = b++; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
-           // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}} \
+  a = b++; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
+           // expected-warning {{cannot prove declared bounds for 'b' are valid after increment}} \
            // expected-note 2 {{(expanded) inferred bounds are 'bounds(b - 1, b - 1 + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1941,7 +1941,7 @@ void update_result_bounds3(
 void inc_dec_bounds1(nt_array_ptr<char> a) { // expected-note {{(expanded) declared bounds are 'bounds(a, a + 0)'}}
   // Observed bounds context before increment: { a => bounds(a, a + 0) }
   // Observed bounds context after increment:  { a => bounds(a - 1, (a - 1) + 0) }
-  ++a; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  ++a; // expected-warning {{cannot prove declared bounds for 'a' are valid after increment}} \
        // expected-note {{(expanded) inferred bounds are 'bounds(a - 1, a - 1 + 0)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
@@ -1971,7 +1971,7 @@ void inc_dec_bounds1(nt_array_ptr<char> a) { // expected-note {{(expanded) decla
 void inc_dec_bounds2(nt_array_ptr<int> a : bounds(a, a)) { // expected-note {{(expanded) declared bounds are 'bounds(a, a)'}}
   // Observed bounds context before increment: { a => bounds(a, a) }
   // Observed bounds context after increment:  { a => bounds(a - 1, a - 1) }
-  a++; // expected-error {{declared bounds for 'a' are invalid after statement}} \
+  a++; // expected-error {{declared bounds for 'a' are invalid after increment}} \
        // expected-note {{source bounds are an empty range}} \
        // expected-note {{destination upper bound is above source upper bound}} \
        // expected-note {{(expanded) inferred bounds are 'bounds(a - 1, a - 1)'}}
@@ -2004,7 +2004,7 @@ void inc_dec_bounds2(nt_array_ptr<int> a : bounds(a, a)) { // expected-note {{(e
 void inc_dec_bounds3(array_ptr<float> a : count(2)) { // expected-note {{(expanded) declared bounds are 'bounds(a, a + 2)'}}
   // Observed bounds context before decrement: { a => bounds(a, a + 2) }
   // Observed bounds context after decrement:  { a => bounds(a + 1, (a + 1) + 2) }
-  --a; // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+  --a; // expected-warning {{cannot prove declared bounds for 'a' are valid after decrement}} \
        // expected-note {{(expanded) inferred bounds are 'bounds(a + 1, a + 1 + 2)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
@@ -2034,7 +2034,7 @@ void inc_dec_bounds3(array_ptr<float> a : count(2)) { // expected-note {{(expand
 void inc_dec_bounds4(array_ptr<int> a : bounds(a, a)) { // expected-note {{(expanded) declared bounds are 'bounds(a, a)'}}
   // Observed bounds context before decrement: { a => bounds(a, a) }
   // Observed bounds context after decrement:  { a => bounds(a + 1, (a + 1)) }
-  a--; // expected-error {{declared bounds for 'a' are invalid after statement}} \
+  a--; // expected-error {{declared bounds for 'a' are invalid after decrement}} \
        // expected-note {{(expanded) inferred bounds are 'bounds(a + 1, a + 1)'}} \
        // expected-note {{source bounds are an empty range}} \
        // expected-note {{destination lower bound is below source lower bound}}
@@ -2176,7 +2176,7 @@ void killed_widened_bounds1(
 
     // This statement kills the widened bounds of p since it modifies i
     // Observed bounds context: { p => bounds(unknown) }
-    i++, --other; // expected-error {{inferred bounds for 'p' are unknown after statement}} \
+    i++, --other; // expected-error {{inferred bounds for 'p' are unknown after increment}} \
                   // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}}
     // CHECK: Statement S:
     // CHECK-NEXT: BinaryOperator {{.*}} ','
@@ -2412,9 +2412,9 @@ void killed_widened_bounds3(
 
       // This statement kills the widened bounds of p and q
       // Observed bounds context: { p => bounds(unknown), q => bounds(q - 1, q - 1 + 1 + 1) }
-      i = 0, q++; // expected-error {{inferred bounds for 'p' are unknown after statement}} \
+      i = 0, q++; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
                   // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}} \
-                  // expected-warning {{cannot prove declared bounds for 'q' are valid after statement}} \
+                  // expected-warning {{cannot prove declared bounds for 'q' are valid after increment}} \
                   // expected-note {{(expanded) inferred bounds are 'bounds(q - 1, q - 1 + 1 + 1)'}}
       // CHECK: Statement S:
       // CHECK-NEXT: BinaryOperator {{.*}} ','

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -535,7 +535,7 @@ void assign6(array_ptr<int> a : count(len), int len) { // expected-note {{(expan
   // Observed bounds context before assignment: { a => bounds(a, a + len) }
   // Original value of len: null
   // Observed bounds context after assignment:  { a => bounds(unknown) }
-  len = len * 2; // expected-error {{inferred bounds for 'a' are unknown after statement}} \
+  len = len * 2; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
                  // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -1428,7 +1428,7 @@ void multiple_assign2(
 
 // Multiple assignments involving constant-sized bounds that may result in memory access-related errors
 void multiple_assign3(
-  array_ptr<int> a : count(2), 
+  array_ptr<int> a : count(2),
   array_ptr<int> b : count(1)
 ) {
   // Observed bounds of a at memory access a[1]: bounds(b, b + 1)
@@ -1606,7 +1606,7 @@ void nested_assign2(
   nt_array_ptr<int> a : count(0),
   nt_array_ptr<int> b : count(0),
   ptr<nt_array_ptr<int>> p
-) {                                                                                                  
+) {
   // Observed bounds context after all assignments: { a => bounds(*p, *p + 0), b => bounds(*p, *p + 0) }
   a = (b = *p);
   // CHECK: Statement S:
@@ -2099,7 +2099,7 @@ void inc_dec_bounds5(nt_array_ptr<int> *p, struct S s, array_ptr<int> a) {
   // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: { }
-  
+
   // Observed bounds context after increment:  { }
   a--;
   // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/calls.c
+++ b/clang/test/CheckedC/inferred-bounds/calls.c
@@ -170,7 +170,7 @@ void f10(_Array_ptr<int> a, _Array_ptr<int> b) {
 void f11(_Array_ptr<int> a, _Array_ptr<int> b) {
     _Array_ptr<int> c : bounds(a, a+1) = f_bounds(b++, a); // \
     // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
-    // expected-error {{inferred bounds for 'c' are unknown after statement}} \
+    // expected-error {{inferred bounds for 'c' are unknown after initialization}} \
     // expected-note {{(expanded) declared bounds are 'bounds(a, a + 1)'}}
 }
 
@@ -231,7 +231,7 @@ void f12(int i, int j) {
 void f13(int i, int j) {
     _Array_ptr<int> b : count(i) = f_count(j++, i); // \
     // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
-    // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+    // expected-error {{inferred bounds for 'b' are unknown after initialization}} \
     // expected-note {{(expanded) declared bounds are 'bounds(b, b + i)'}}
 }
 
@@ -286,7 +286,7 @@ void f14(int i, int j) {
 void f15(int i, int j) {
     _Array_ptr<int> b : byte_count(i) = f_byte(j++, i); // \
     // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
-    // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+    // expected-error {{inferred bounds for 'b' are unknown after initialization}} \
     // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)b, (_Array_ptr<char>)b + i)'}}
 }
 
@@ -350,7 +350,7 @@ void f20(int* a, int* b) {
 void f21(int* a, int* b) {
     _Array_ptr<int> c : bounds(a, a+1) = f_boundsi(b++, a); // \
     // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
-    // expected-error {{inferred bounds for 'c' are unknown after statement}} \
+    // expected-error {{inferred bounds for 'c' are unknown after initialization}} \
     // expected-note {{(expanded) declared bounds are 'bounds(a, a + 1)'}}
 }
 
@@ -413,7 +413,7 @@ void f22(int i, int j) {
 void f23(int i, int j) {
     _Array_ptr<int> b : count(i) = f_counti(j++, i); // \
     // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
-    // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+    // expected-error {{inferred bounds for 'b' are unknown after initialization}} \
     // expected-note {{(expanded) declared bounds are 'bounds(b, b + i)'}}
 }
 
@@ -470,7 +470,7 @@ void f24(int i, int j) {
 void f25(int i, int j) {
     _Array_ptr<int> b : byte_count(i) = f_bytei(j++, i); // \
     // expected-error {{expression not allowed in argument for parameter used in function return bounds}} \
-    // expected-error {{inferred bounds for 'b' are unknown after statement}} \
+    // expected-error {{inferred bounds for 'b' are unknown after initialization}} \
     // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)b, (_Array_ptr<char>)b + i)'}}
 }
 

--- a/clang/test/CheckedC/inferred-bounds/compound-literals.c
+++ b/clang/test/CheckedC/inferred-bounds/compound-literals.c
@@ -110,10 +110,8 @@ void f2(_Array_ptr<struct S> arr : count(1), struct S s) {
   // CHECK:  `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 
   // Target LHS bounds: bounds(arr, arr + 1)
-  // Inferred RHS bounds: invalid
-  // TODO: checkedc-clang issue #870: once struct-typed compound literals are bound to temporaries,
-  // the inferred RHS bounds should be bounds(&temp((struct S){ 0 }), &temp((struct S){ 0 }) + 1)
-  arr = &(struct S){ 0 }; // expected-error {{inferred bounds for 'arr' are unknown after assignment}}
+  // Inferred RHS bounds: bounds(&value(temp((struct S){ 0 })), &value(temp((struct S){ 0 })) + 1)
+  arr = &(struct S){ 0 };
   // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>' '='
   // CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S>'
   // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <BitCast>

--- a/clang/test/CheckedC/inferred-bounds/compound-literals.c
+++ b/clang/test/CheckedC/inferred-bounds/compound-literals.c
@@ -113,7 +113,7 @@ void f2(_Array_ptr<struct S> arr : count(1), struct S s) {
   // Inferred RHS bounds: invalid
   // TODO: checkedc-clang issue #870: once struct-typed compound literals are bound to temporaries,
   // the inferred RHS bounds should be bounds(&temp((struct S){ 0 }), &temp((struct S){ 0 }) + 1)
-  arr = &(struct S){ 0 }; // expected-error {{inferred bounds for 'arr' are unknown after statement}}
+  arr = &(struct S){ 0 }; // expected-error {{inferred bounds for 'arr' are unknown after assignment}}
   // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<struct S>' '='
   // CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' lvalue ParmVar {{0x[0-9a-f]+}} 'arr' '_Array_ptr<struct S>'
   // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Array_ptr<struct S>' <BitCast>

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-check.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-check.c
@@ -13,7 +13,7 @@ void f1() {
   {}
 
   if (*p) {
-    p++; // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}}
+    p++; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}}
     if (*(p + 1)) // expected-error {{out-of-bounds memory access}}
     {}
   }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-strings-examples.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-strings-examples.c
@@ -12,7 +12,7 @@ int my_strlen(_Nt_array_ptr<char> p) {
   // s[i] implies that the count can increase
   // by 1.
   while (s[i])
-    ++i; // expected-error {{inferred bounds for 's' are unknown after statement}}
+    ++i; // expected-error {{inferred bounds for 's' are unknown after increment}}
   return i;
 
 // CHECK: In function: my_strlen
@@ -28,8 +28,8 @@ void squeeze(_Nt_array_ptr<char> p, char c) {
   // Create a temporary whose count of elements can
   // change.
   _Nt_array_ptr<char> s : count(i) = p;
-  for ( ; s[i]; i++) { // expected-error {{inferred bounds for 's' are unknown after statement}} \
-                       // expected-error {{inferred bounds for 'tmp' are unknown after statement}}
+  for ( ; s[i]; i++) { // expected-error {{inferred bounds for 's' are unknown after increment}} \
+                       // expected-error {{inferred bounds for 'tmp' are unknown after increment}}
     // We will widen the bounds of s so that we
     // can assign to s[j] when j == i.
     _Nt_array_ptr<char> tmp : count(i + 1) = s;
@@ -62,7 +62,7 @@ void reverse(_Nt_array_ptr<char> p) {
   int len = 0;
   // Calculate the length of the string.
   _Nt_array_ptr<char> s : count(len) = p;
-  for (; s[len]; len++); // expected-error {{inferred bounds for 's' are unknown after statement}}
+  for (; s[len]; len++); // expected-error {{inferred bounds for 's' are unknown after increment}}
 
   // Now that we know the length, use s just like we would use an array_ptr.
   for (int i = 0, j = len - 1; i < j; i++, j--) {

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -105,7 +105,7 @@ void f6(int i) {
   char p _Nt_checked[] : bounds(p + i, p)  = "abc";
 
   if (p[0]) {
-    i = 0; // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    i = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
     if (p[1]) {}
   }
 
@@ -212,7 +212,7 @@ void f11(int i, int j) {
   _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
 
   if (*(p + j)) {
-    i = 0; // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    i = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
     if (*(p + j + 1)) {}
   }
 
@@ -227,7 +227,7 @@ void f11(int i, int j) {
 // CHECK-NOT: upper_bound(p)
 
   if (*(p + j)) {
-    j = 0; // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    j = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
     if (*(p + j + 1)) {}
   }
 
@@ -470,7 +470,7 @@ void f19() {
 
 void f20() {
   // Declared bounds and deref offset are both INT_MAX. Valid widening.
-  _Nt_array_ptr<char> p : count(INT_MAX) = "";      // expected-error {{declared bounds for 'p' are invalid after statement}}
+  _Nt_array_ptr<char> p : count(INT_MAX) = "";      // expected-error {{declared bounds for 'p' are invalid after initialization}}
   if (*(p + INT_MAX))
   {}
 
@@ -526,7 +526,7 @@ void f20() {
 // CHECK: upper_bound(t) = 1
 
   // Declared bounds and deref offset are both (INT_MIN + -1). Integer underflow. No widening.
-  _Nt_array_ptr<char> u : count(INT_MIN + -1) = ""; // expected-error {{declared bounds for 'u' are invalid after statement}}
+  _Nt_array_ptr<char> u : count(INT_MIN + -1) = ""; // expected-error {{declared bounds for 'u' are invalid after initialization}}
   if (*(u + INT_MIN + -1))
   {}
 

--- a/clang/test/CheckedC/static-checking/bounds-decl-challenges.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-challenges.c
@@ -8,12 +8,12 @@ extern void check_assign(int val, int p[10], int q[], int r _Checked[10], int s 
                          int s2d _Checked[10][10], int v _Nt_checked[10], int w _Nt_checked[],
                          int w2d _Checked[10]_Nt_checked[10]) {
   int x2d _Checked[10]_Nt_checked[10];
-  _Nt_array_ptr<int> t13b = w2d[0];  // expected-warning {{cannot prove declared bounds for 't13b' are valid after statement}}
-  _Nt_array_ptr<int> t15b = x2d[0];  // expected-warning {{cannot prove declared bounds for 't15b' are valid after statement}}
+  _Nt_array_ptr<int> t13b = w2d[0];  // expected-warning {{cannot prove declared bounds for 't13b' are valid after initialization}}
+  _Nt_array_ptr<int> t15b = x2d[0];  // expected-warning {{cannot prove declared bounds for 't15b' are valid after initialization}}
 }
 
 // Creating a pointer with count bounds into an existing array.
 void passing_test_1(void) {
   int a _Checked[10] = { 9, 8, 7, 6, 5, 4, 3, 2, 1};
-  _Array_ptr<int> b : count(5) = &a[2];  // expected-warning {{cannot prove declared bounds for 'b' are valid after statement}}
+  _Array_ptr<int> b : count(5) = &a[2];  // expected-warning {{cannot prove declared bounds for 'b' are valid after initialization}}
 }

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
@@ -50,7 +50,7 @@ _Array_ptr<int> f11(unsigned num) {
 }
 
 _Array_ptr<int> f12(unsigned num1, unsigned num2){
-  _Array_ptr<int> p : count(num1) = test_f10(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Array_ptr<int> p : count(num1) = test_f10(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                                     // expected-note {{(expanded) declared bounds are 'bounds(p, p + num1)'}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds(value of test_f10(num2), value of test_f10(num2) + num2)'}}
   return p;
@@ -64,7 +64,7 @@ _Array_ptr<int> f14(unsigned num) {
 }
 
 _Array_ptr<int> f15(unsigned num1, unsigned num2){
-  _Array_ptr<int> p : byte_count(num1) = test_f13(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Array_ptr<int> p : byte_count(num1) = test_f13(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                                          // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + num1)'}} \
                                                          // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f13(num2), (_Array_ptr<char>)value of test_f13(num2) + num2)'}}
   return p;
@@ -78,7 +78,7 @@ _Array_ptr<int> f17(unsigned num) {
 }
 
 _Array_ptr<int> f18(unsigned num) {
-  _Array_ptr<int> p : count(2) = test_f16(num);         // expected-error {{declared bounds for 'p' are invalid after statement}} \
+  _Array_ptr<int> p : count(2) = test_f16(num);         // expected-error {{declared bounds for 'p' are invalid after initialization}} \
                                                         // expected-note {{destination bounds are wider than the source bounds}} \
                                                         // expected-note {{destination upper bound is above source upper bound}} \
                                                         // expected-note {{(expanded) declared bounds are 'bounds(p, p + 2)'}} \

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -88,17 +88,17 @@ void f20(_Array_ptr<int> p: count(5)) {
   _Array_ptr<int> q2 : bounds(p + 0, p + 5) = p; // No error expected
   _Array_ptr<int> q3 : bounds(p, p + 4) = p; // No error expected
   _Array_ptr<int> q4 : bounds(p + 1, p + 4) = p; // No error expected
-  _Array_ptr<int> r : bounds(p, p + 6) = p; // expected-error {{declared bounds for 'r' are invalid after statement}} \
+  _Array_ptr<int> r : bounds(p, p + 6) = p; // expected-error {{declared bounds for 'r' are invalid after initialization}} \
                                             // expected-note {{destination bounds are wider than the source bounds}} \
                                             // expected-note {{destination upper bound is above source upper bound}} \
                                             // expected-note {{(expanded) declared bounds are 'bounds(p, p + 6)'}} \
                                             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
-  _Array_ptr<int> s : bounds(p - 1, p + 5) = p;  // expected-error {{declared bounds for 's' are invalid after statement}} \
+  _Array_ptr<int> s : bounds(p - 1, p + 5) = p;  // expected-error {{declared bounds for 's' are invalid after initialization}} \
                                             // expected-note {{destination bounds are wider than the source bounds}} \
                                             // expected-note {{destination lower bound is below source lower bound}} \
                                             // expected-note {{(expanded) declared bounds are 'bounds(p - 1, p + 5)'}} \
                                             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
-  _Array_ptr<int> t : bounds(p - 1, p + 6) = p;  // expected-error {{declared bounds for 't' are invalid after statement}} \
+  _Array_ptr<int> t : bounds(p - 1, p + 6) = p;  // expected-error {{declared bounds for 't' are invalid after initialization}} \
                                             // expected-note {{destination bounds are wider than the source bounds}} \
                                             // expected-note {{destination lower bound is below source lower bound}} \
                                             // expected-note {{destination upper bound is above source upper bound}} \
@@ -126,17 +126,17 @@ void f21(_Array_ptr<int> p: count(5)) {
   _Array_ptr<int> q4 : bounds(p + 1, p + 4) = 0;
   q4 = p; // No error expected
   _Array_ptr<int> r : bounds(p, p + 6) = 0; // expected-note {{(expanded) declared bounds are 'bounds(p, p + 6)'}}
-  r = p; // expected-error {{declared bounds for 'r' are invalid after statement}} \
+  r = p; // expected-error {{declared bounds for 'r' are invalid after assignment}} \
          // expected-note {{destination bounds are wider than the source bounds}} \
          // expected-note {{destination upper bound is above source upper bound}} \
          // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
   _Array_ptr<int> s : bounds(p - 1, p + 5) = 0; // expected-note {{(expanded) declared bounds are 'bounds(p - 1, p + 5)'}}
-  s = p;  // expected-error {{declared bounds for 's' are invalid after statement}} \
+  s = p;  // expected-error {{declared bounds for 's' are invalid after assignment}} \
           // expected-note {{destination bounds are wider than the source bounds}} \
           // expected-note {{destination lower bound is below source lower bound}} \
           // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
   _Array_ptr<int> t : bounds(p - 1, p + 6) = 0; // expected-note {{(expanded) declared bounds are 'bounds(p - 1, p + 6)'}}
-  t = p;  // expected-error {{declared bounds for 't' are invalid after statement}} \
+  t = p;  // expected-error {{declared bounds for 't' are invalid after assignment}} \
           // expected-note {{destination bounds are wider than the source bounds}} \
           // expected-note {{destination lower bound is below source lower bound}} \
           // expected-note {{destination upper bound is above source upper bound}} \
@@ -295,7 +295,7 @@ int f31(_Ptr<void> p) {
 // It is related to incomplete types.
 _Array_ptr<struct S> f37_i(unsigned num) : count(num) {
   _Array_ptr<struct S> q : count(num) = 0;
-  _Array_ptr<struct S> p : count(0) = q; // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Array_ptr<struct S> p : count(0) = q; // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                          // expected-note {{(expanded) declared bounds are 'bounds(p, p + 0)'}} \
                                          // expected-note {{(expanded) inferred bounds are 'bounds(q, q + num)'}}
   return p;
@@ -366,7 +366,7 @@ _Array_ptr<int> f51(unsigned num) {
 }
 
 _Array_ptr<int> f52(unsigned num1, unsigned num2){
-  _Array_ptr<int> p : count(num1) = test_f50(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Array_ptr<int> p : count(num1) = test_f50(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                                     // expected-note {{(expanded) declared bounds are 'bounds(p, p + num1)'}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds(value of test_f50(num2), value of test_f50(num2) + num2)'}}
   return p;
@@ -380,7 +380,7 @@ _Array_ptr<int> f54(unsigned num) {
 }
 
 _Array_ptr<int> f55(unsigned num1, unsigned num2){
-  _Array_ptr<int> p : byte_count(num1) = test_f53(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Array_ptr<int> p : byte_count(num1) = test_f53(num2); // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                                          // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + num1)'}} \
                                                          // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f53(num2), (_Array_ptr<char>)value of test_f53(num2) + num2)'}}
   return p;
@@ -390,14 +390,14 @@ _Array_ptr<int> test_f70(int c) : byte_count(c);
 _Nt_array_ptr<int> test_f70_n(int c) : byte_count(c);
 
 _Array_ptr<int> f70(int num){
-  _Array_ptr<int> p : byte_count(0) = test_f70(num); // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Array_ptr<int> p : byte_count(0) = test_f70(num); // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                                      // expected-note {{declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 0)'}} \
                                                      // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f70(num), (_Array_ptr<char>)value of test_f70(num) + num)'}}
   return p;
 }
 
 _Nt_array_ptr<int> f70_n(int num){
-  _Nt_array_ptr<int> p : byte_count(0) = test_f70_n(num); // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+  _Nt_array_ptr<int> p : byte_count(0) = test_f70_n(num); // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                                           // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 0)'}} \
                                                           // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of test_f70_n(num), (_Array_ptr<char>)value of test_f70_n(num) + num)'}}
   return p;
@@ -416,7 +416,7 @@ _Nt_array_ptr<char> f57_n(unsigned num) {
 }
 
 _Array_ptr<int> f58(unsigned num) {
-  _Array_ptr<int> p : count(2) = test_f56(num);    // expected-error {{declared bounds for 'p' are invalid after statement}} \
+  _Array_ptr<int> p : count(2) = test_f56(num);    // expected-error {{declared bounds for 'p' are invalid after initialization}} \
                                                    // expected-note {{destination bounds are wider than the source bounds}} \
                                                    // expected-note {{destination upper bound is above source upper bound}} \
                                                    // expected-note {{(expanded) declared bounds are 'bounds(p, p + 2)'}} \
@@ -460,9 +460,9 @@ void a_f_1(int num1, int num2) {
   short n = num1/num2;
   _Array_ptr<long> v : count(n) = 0; // expected-note 2 {{(expanded) declared bounds are 'bounds(v, v + n)'}}
   _Array_ptr<int> v2 : count(n) = 0;
-  v = simulate_calloc<long>(n, sizeof(long));           // expected-warning {{cannot prove declared bounds for 'v' are valid after statement}} \
+  v = simulate_calloc<long>(n, sizeof(long));           // expected-warning {{cannot prove declared bounds for 'v' are valid after assignment}} \
                                                         // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, sizeof(long)), (_Array_ptr<char>)value of simulate_calloc(n, sizeof(long)) + (size_t)n * sizeof(long))'}}
-  v = simulate_calloc<long>(n, sizeof(unsigned long));  // expected-warning {{cannot prove declared bounds for 'v' are valid after statement}} \
+  v = simulate_calloc<long>(n, sizeof(unsigned long));  // expected-warning {{cannot prove declared bounds for 'v' are valid after assignment}} \
                                                         // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long)), (_Array_ptr<char>)value of simulate_calloc(n, sizeof(unsigned long)) + (size_t)n * sizeof(unsigned long))'}}
 }
 
@@ -484,19 +484,19 @@ void a_f_2(void) {
 
 extern _Array_ptr<long> v10 : count(k + 1); // expected-note {{(expanded) declared bounds are 'bounds(v10, v10 + k + 1)'}}
 void a_f_3(void) {
-  v10 = simulate_malloc<long>((k + 1) * -1); // expected-warning {{cannot prove declared bounds for 'v10' are valid after statement}} \
+  v10 = simulate_malloc<long>((k + 1) * -1); // expected-warning {{cannot prove declared bounds for 'v10' are valid after assignment}} \
                                              // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc((k + 1) * -1), (_Array_ptr<char>)value of simulate_malloc((k + 1) * -1) + (k + 1) * -1)'}}
 }
 
 extern _Array_ptr<long> v11 : count(k); // expected-note {{(expanded) declared bounds are 'bounds(v11, v11 + k)'}}
 void a_f_4(void) {
-  v11 = simulate_malloc<long>(k * 1); // expected-warning {{cannot prove declared bounds for 'v11' are valid after statement}} \
+  v11 = simulate_malloc<long>(k * 1); // expected-warning {{cannot prove declared bounds for 'v11' are valid after assignment}} \
                                       // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * 1), (_Array_ptr<char>)value of simulate_malloc(k * 1) + k * 1)'}}
 }
 
 extern _Array_ptr<long> v12 : count(k); // expected-note {{(expanded) declared bounds are 'bounds(v12, v12 + k)'}}
 void a_f_5(void) {
-  v12 = simulate_malloc<long>(k); // expected-warning {{cannot prove declared bounds for 'v12' are valid after statement}} \
+  v12 = simulate_malloc<long>(k); // expected-warning {{cannot prove declared bounds for 'v12' are valid after assignment}} \
                                   // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k), (_Array_ptr<char>)value of simulate_malloc(k) + k)'}}
 }
 
@@ -522,13 +522,13 @@ void a_f_8(void) {
 
 extern _Array_ptr<struct s2> v4 : count(k); // expected-note {{(expanded) declared bounds are 'bounds(v4, v4 + k)'}}
 void a_f_9(void) {
-  v4 = simulate_malloc<struct s2>(k * sizeof(int)); // expected-warning {{cannot prove declared bounds for 'v4' are valid after statement}} \
+  v4 = simulate_malloc<struct s2>(k * sizeof(int)); // expected-warning {{cannot prove declared bounds for 'v4' are valid after assignment}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(int)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(int)) + k * sizeof(int))'}}
 }
 
 extern _Array_ptr<int> v20 : count(k); // expected-note {{(expanded) declared bounds are 'bounds(v20, v20 + k)'}}
 void a_f_10(void) {
-  v20 = simulate_malloc<int>(k * sizeof(unsigned long long)); // expected-warning {{cannot prove declared bounds for 'v20' are valid after statement}} \
+  v20 = simulate_malloc<int>(k * sizeof(unsigned long long)); // expected-warning {{cannot prove declared bounds for 'v20' are valid after assignment}} \
                                                               // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_malloc(k * sizeof(unsigned long long)), (_Array_ptr<char>)value of simulate_malloc(k * sizeof(unsigned long long)) + k * sizeof(unsigned long long))'}}
 }
 
@@ -547,7 +547,7 @@ int v33;
 t2 v = 0, v22 = 0;
 _Array_ptr<struct s4> v24 : count(v33) = 0; // expected-note {{(expanded) declared bounds are 'bounds(v24, v24 + v33)'}}
 void a_f_11(void) {
-  v24 = simulate_calloc<struct s4>(v33, sizeof(*v22)); // expected-warning {{cannot prove declared bounds for 'v24' are valid after statement}} \
+  v24 = simulate_calloc<struct s4>(v33, sizeof(*v22)); // expected-warning {{cannot prove declared bounds for 'v24' are valid after assignment}} \
                                                        // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(v33, sizeof (*v22)), (_Array_ptr<char>)value of simulate_calloc(v33, sizeof (*v22)) + (size_t)v33 * sizeof (*v22))'}}
 }
 
@@ -560,7 +560,7 @@ void a_f_11_u(void) {
 static _Array_ptr<char> x1 : count(k); // expected-note {{(expanded) declared bounds are 'bounds(x1, x1 + k)'}}
 static _Array_ptr<char> x2 : count(3);
 void a_f_12(void) {
-  x1 = simulate_calloc<char>(32768, sizeof(char)); // expected-warning {{cannot prove declared bounds for 'x1' are valid after statement}} \
+  x1 = simulate_calloc<char>(32768, sizeof(char)); // expected-warning {{cannot prove declared bounds for 'x1' are valid after assignment}} \
                                                    // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)), (_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)) + (size_t)32768 * sizeof(char))'}}
   x2 = simulate_calloc<char>(3, sizeof(char));
 }
@@ -570,7 +570,7 @@ typedef struct ts1 {
 } ts1;
 
 void a_f_13(int n) {
-  _Array_ptr<_Ptr<ts1>> v22 : count(n) = simulate_calloc<_Ptr<ts1>>(n, (sizeof(_Ptr<ts1>))); // expected-warning {{cannot prove declared bounds for 'v22' are valid after statement}} \
+  _Array_ptr<_Ptr<ts1>> v22 : count(n) = simulate_calloc<_Ptr<ts1>>(n, (sizeof(_Ptr<ts1>))); // expected-warning {{cannot prove declared bounds for 'v22' are valid after initialization}} \
                                                                                              // expected-note {{(expanded) declared bounds are 'bounds(v22, v22 + n)'}} \
                                                                                              // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(n, (sizeof(_Ptr<ts1>))), (_Array_ptr<char>)value of simulate_calloc(n, (sizeof(_Ptr<ts1>))) + (size_t)n * (sizeof(_Ptr<ts1>)))'}}
 }
@@ -581,14 +581,14 @@ void a_f_13_u(size_t n) {
 
 void a_f_14(void) {
   long i;
-  _Array_ptr<long> v21 : count(i + 1) = simulate_malloc<long>((i + 1) * (i + 1) * sizeof(long)); // expected-warning {{cannot prove declared bounds for 'v21' are valid after statement}} \
+  _Array_ptr<long> v21 : count(i + 1) = simulate_malloc<long>((i + 1) * (i + 1) * sizeof(long)); // expected-warning {{cannot prove declared bounds for 'v21' are valid after initialization}} \
                                                                                                  // expected-note {{(expanded) declared bounds are 'bounds(v21, v21 + i + 1)'}} \
                                                                                                  // expected-note {{(expanded) inferred bounds}}
 }
 
 void a_f_15(void) {
   long i, j;
-  _Array_ptr<long> v : count(j + 1) = simulate_malloc<long>((i + 1) * sizeof(long)); // expected-warning {{cannot prove declared bounds for 'v' are valid after statement}} \
+  _Array_ptr<long> v : count(j + 1) = simulate_malloc<long>((i + 1) * sizeof(long)); // expected-warning {{cannot prove declared bounds for 'v' are valid after initialization}} \
                                                                                      // expected-note {{(expanded) declared bounds are 'bounds(v, v + j + 1)'}} \
                                                                                      // expected-note {{(expanded) inferred bounds}}
 }

--- a/clang/test/CheckedC/static-checking/bounds-side-effects.c
+++ b/clang/test/CheckedC/static-checking/bounds-side-effects.c
@@ -96,7 +96,7 @@ void f20(int len, _Array_ptr<int> p : count(len), int i) {
 
 void f21(int len, _Array_ptr<int> p : byte_count(len), int i) {
   len = i * sizeof(int), p = alloc(i * sizeof(int)); // correct
-  len = 10;                                          // expected-error {{inferred bounds for 'p' are unknown after statement}}
+  len = 10;                                          // expected-error {{inferred bounds for 'p' are unknown after assignment}}
 }
 
 void f22(_Array_ptr<int> p : bounds(low, high), _Array_ptr<int> low,
@@ -110,8 +110,8 @@ void f23(int len, _Array_ptr<int> p : count(len)) {
   {
      // Declare a bounds declaration that goes out of scope.
      _Array_ptr<int> t : count(len) = alloc(len * sizeof(int)); // correct
-     len = 5; // expected-error {{inferred bounds for 'p' are unknown after statement}} \
-              // expected-error {{inferred bounds for 't' are unknown after statement}}
+     len = 5; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
+              // expected-error {{inferred bounds for 't' are unknown after assignment}}
   }
 }
 
@@ -123,7 +123,7 @@ void f24(int len, _Array_ptr<int> p : count(len)) {
   {
      int mylen = 0;
      _Array_ptr<int> p : count(mylen) = 0;
-     len = 5;   // expected-error {{inferred bounds for 'p' are unknown after statement}}
+     len = 5;   // expected-error {{inferred bounds for 'p' are unknown after assignment}}
   }
 }
 
@@ -152,7 +152,7 @@ void f41(int i) {
   int len = 0;
    _Array_ptr<int> p : byte_count(len) = 0;
   len = i * sizeof(int), p = alloc(i * sizeof(int)); // correct
-  len = 10;                                          // expected-error {{inferred bounds for 'p' are unknown after statement}}
+  len = 10;                                          // expected-error {{inferred bounds for 'p' are unknown after assignment}}
 }
 
 void f42(void) {
@@ -170,8 +170,8 @@ void f43(void)  {
   {
      // Declare a bounds declaration that goes out of scope.
      _Array_ptr<int> t : count(len) = alloc(len * sizeof(int)); // correct
-     len = 5; // expected-error {{inferred bounds for 'p' are unknown after statement}} \
-              // expected-error {{inferred bounds for 't' are unknown after statement}}
+     len = 5; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
+              // expected-error {{inferred bounds for 't' are unknown after assignment}}
   }
 }
 
@@ -182,7 +182,7 @@ void f44(void) {
  {
     int mylen = 0;
     _Array_ptr<int> p : count(mylen) = 0;
-     len = 5;   // expected-error {{inferred bounds for 'p' are unknown after statement}}
+     len = 5;   // expected-error {{inferred bounds for 'p' are unknown after assignment}}
   }
 }
 
@@ -199,17 +199,17 @@ void f45(int i) {
 
 void f100(int len, _Array_ptr<int> p : count(len), int i) {
   if (len > 1)
-    len--; // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    len--; // expected-error {{inferred bounds for 'p' are unknown after decrement}}
 }
 
 void f101(int len, _Array_ptr<int> p : count(len), int i) {
   if (len > 1)
-    --len; // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    --len; // expected-error {{inferred bounds for 'p' are unknown after decrement}}
 }
 
 void f102(int len, _Array_ptr<int> p : count(len), int i) {
   if (len > 1)
-    len -= 1; // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    len -= 1; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
 }
 
 void f103(int len, _Array_ptr<int> p : count(len), int i) {


### PR DESCRIPTION
- In bounds checking related diagnostic messages, highlight the assignment within a top-level statement that causes the error or warning. This PR considers two types of bounds checking error messages for a variable V:
  1. The compiler cannot prove or can disprove the declared bounds for V are valid after an assignment to a variable in the bounds of V; and
  2. The inferred bounds of V become unknown after an assignment to a variable used in the declared bounds for V.
- Print 'assignment', 'increment', 'decrement' or 'initialization' in the error message depending on the "type" of the target expression. 

#### An example

```
array_ptr<int> p : count(len) = ...;
other = 0, len = len * 2;
```

Error message before the change (highlight the whole statement):
```
error: inferred bounds for 'p' are unknown after statement
  other = 0, len = len * 2;
  ^~~~~~~~~~~~~~~~~~~~~~~~~
```

After the change (blame the embedded assignment that caused the error; print 'assignment' instead of 'statement'):
```
error: inferred bounds for 'p' are unknown after assignment
  other = 0, len = len * 2;
             ^~~~~~~~~~~~~
```