### PR TITLE
Compare Expressions: Create a class hierarchy for AST node type [3/n]

### DIFF
--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -17,91 +17,72 @@
 
 using namespace clang;
 
-void PreorderAST::Create(Expr *E, Node *N, Node *Parent) {
+void PreorderAST::Create(Expr *E, Node *Parent) {
   if (!E)
     return;
 
-  if (!N)
-    N = new Node(Parent);
-
-  // If the root is null, the current node is the root.
-  if (!Root)
-    Root = N;
-
-  // If the parent is non-null add the current node to its list of children.
-  if (Parent)
-    Parent->Children.push_back(N);
-
-  E = Lex.IgnoreValuePreservingOperations(Ctx, E);
-
-  // If E is a variable, store it in the variable list for the current node.
-  if (DeclRefExpr *D = GetDeclOperand(E)) {
-    if (const auto *V = dyn_cast_or_null<VarDecl>(D->getDecl())) {
-      N->Vars.push_back(V);
-      return;
-    }
-  }
-
-  // If E is a constant, store it in the constant field of the current node and
-  // set the HasConst field.
-  llvm::APSInt IntVal;
-  if (E->isIntegerConstantExpr(IntVal, Ctx)) {
-    N->Const = IntVal;
-    N->HasConst = true;
-    return;
-  }
+  E = Lex.IgnoreValuePreservingOperations(Ctx, E->IgnoreParens());
 
   if (const auto *BO = dyn_cast<BinaryOperator>(E)) {
-    // Set the opcode for the current node.
-    N->Opc = BO->getOpcode();
+    auto *N = new BinaryNode(Parent, BO->getOpcode());
+    if (!Root)
+      Root = N;
 
-    Expr *LHS = BO->getLHS()->IgnoreParens();
-    Expr *RHS = BO->getRHS()->IgnoreParens();
-  
-    if (isa<BinaryOperator>(LHS))
-      // Create the LHS as a child of the current node.
-      Create(LHS, nullptr, N);
-    else
-      // Create the LHS in the current node.
-      Create(LHS, N);
-  
-    if (isa<BinaryOperator>(RHS))
-      // Create the RHS as a child of the current node.
-      Create(RHS, nullptr, N);
-    else
-      // Create the RHS in the current node.
-      Create(RHS, N);
-  
-    return;
+    if (Parent)
+      Parent->Children.push_back(N);
+
+    Create(BO->getLHS(), /*Parent*/ N);
+    Create(BO->getRHS(), /*Parent*/ N);
+
+  } else {
+    LeafExprNode *N = nullptr;
+
+    if (Parent) {
+      for (auto *Child : Parent->Children) {
+        if (auto *L = dyn_cast<LeafExprNode>(Child)) {
+          N = L;
+          break;
+        }
+      }
+    }
+
+    if (!N) {
+      N = new LeafExprNode(Parent);
+      if (!Root)
+        Root = N;
+    
+      if (Parent)
+        Parent->Children.push_back(N);
+    }
+        
+    N->Exp.push_back(E);
   }
-
-  // Currently, we only handle expression which are either variables or
-  // constants.
-  // TODO: Handle expressions that are non-variables and non-constants.
-  // Possibly, add a field to the node to represent such expressions.
-  SetError();
 }
 
 void PreorderAST::Sort(Node *N) {
   if (Error)
     return;
 
-  if (!N || !N->Vars.size())
+  if (!N)
     return;
 
-  if (!N->IsOpCommutativeAndAssociative()) {
-    SetError();
-    return;
+  if (auto *B = dyn_cast<BinaryNode>(N)) {
+    if (!B->IsOpCommutativeAndAssociative()) {
+      SetError();
+      return;
+    }
+
+    for (auto *Child : N->Children)
+      Sort(Child);
   }
 
-  // Sort the variables in the node lexicographically.
-  llvm::sort(N->Vars.begin(), N->Vars.end(),
-             [&](const VarDecl *V1, const VarDecl *V2) {
-               return Lex.CompareDecl(V1, V2) == Result::LessThan;
-             });
-
-  for (auto *Child : N->Children)
-    Sort(Child);
+  if (auto *L = dyn_cast<LeafExprNode>(N)) {
+    // Sort the exprs in the node lexicographically.
+    llvm::sort(L->Exp.begin(), L->Exp.end(),
+               [&](const Expr *E1, const Expr *E2) {
+                 return Lex.CompareExpr(E1, E2) == Result::LessThan;
+               });
+  }
 }
 
 bool PreorderAST::IsEqual(Node *N1, Node *N2) {
@@ -113,41 +94,54 @@ bool PreorderAST::IsEqual(Node *N1, Node *N2) {
   if ((N1 && !N2) || (!N1 && N2))
     return false;
 
-  // If the Opcodes mismatch.
-  if (N1->Opc != N2->Opc)
-    return false;
-
-  // If the number of variables in the two nodes mismatch.
-  if (N1->Vars.size() != N2->Vars.size())
-    return false;
-
-  // If the values of the constants in the two nodes differ.
-  if (llvm::APSInt::compareValues(N1->Const, N2->Const) != 0)
-    return false;
-
-  // If the number of children of the two nodes mismatch.
-  if (N1->Children.size() != N2->Children.size())
-    return false;
-
-  // Match each variable occurring in the two nodes.
-  for (size_t I = 0; I != N1->Vars.size(); ++I) {
-    auto &V1 = N1->Vars[I];
-    auto &V2 = N2->Vars[I];
-
-    // If any variable differs between the two nodes.
-    if (Lex.CompareDecl(V1, V2) != Result::Equal)
+  if (auto *B1 = dyn_cast<BinaryNode>(N1)) {
+    // If the types of the nodes mismatch.
+    if (!isa<BinaryNode>(N2))
       return false;
+
+    auto *B2 = dyn_cast<BinaryNode>(N2);
+
+    // If the Opcodes mismatch.
+    if (B1->Opc != B2->Opc)
+      return false;
+
+    // If the number of children of the two nodes mismatch.
+    if (B1->Children.size() != B2->Children.size())
+      return false;
+
+    // Match each child of the two nodes.
+    for (size_t I = 0; I != B1->Children.size(); ++I) {
+      auto *Child1 = B1->Children[I];
+      auto *Child2 = B2->Children[I];
+  
+      // If any child differs between the two nodes.
+      if (!IsEqual(Child1, Child2))
+        return false;
+    }
   }
 
-  // Match each child of the two nodes.
-  for (size_t I = 0; I != N1->Children.size(); ++I) {
-    auto *Child1 = N1->Children[I];
-    auto *Child2 = N2->Children[I];
-
-    // If any child differs between the two nodes.
-    if (!IsEqual(Child1, Child2))
+  if (auto *L1 = dyn_cast<LeafExprNode>(N1)) {
+    // If the types of the nodes mismatch.
+    if (!isa<LeafExprNode>(N2))
       return false;
+
+    auto *L2 = dyn_cast<LeafExprNode>(N2);
+
+    // If the number of exprs in the two nodes mismatch.
+    if (L1->Exp.size() != L2->Exp.size())
+      return false;
+
+    // Match each expr occurring in the two nodes.
+    for (size_t I = 0; I != L1->Exp.size(); ++I) {
+      auto &E1 = L1->Exp[I];
+      auto &E2 = L2->Exp[I];
+  
+      // If any expr differs between the two nodes.
+      if (Lex.CompareExpr(E1, E2) != Result::Equal)
+        return false;
+    }
   }
+
   return true;
 }
 
@@ -177,28 +171,26 @@ void PreorderAST::PrettyPrint(Node *N) {
   if (!N)
     return;
 
-  OS << BinaryOperator::getOpcodeStr(N->Opc);
+  if (const auto *B = dyn_cast<BinaryNode>(N)) {
+    OS << BinaryOperator::getOpcodeStr(B->Opc) << "\n";
 
-  if (N->Vars.size()) {
-    OS << "[ ";
-    for (auto &V : N->Vars)
-      OS << V->getQualifiedNameAsString() << " ";
-    OS << "]\n";
+    for (auto *Child : B->Children)
+      PrettyPrint(Child);
   }
-
-  if (N->HasConst)
-    OS << " [const:" << N->Const << "]\n";
-
-  for (auto *Child : N->Children)
-    PrettyPrint(Child);
+  else if (const auto *L = dyn_cast<LeafExprNode>(N)) {
+    for (auto &E : L->Exp)
+      E->dump(OS);
+  }
 }
 
 void PreorderAST::Cleanup(Node *N) {
   if (!N)
     return;
 
-  for (auto *Child : N->Children)
-    Cleanup(Child);
+  if (const auto *B = dyn_cast<BinaryNode>(N)) {
+    for (auto *Child : B->Children)
+      Cleanup(Child);
+  }
 
   delete N;
 }


### PR DESCRIPTION
We generalize the node type into the following class hierarchy:

```
       Node
      /    \
     /      \
 BinaryNode LeafExprNode
```

The `LeafExpreNode` type wraps a clang AST expression.