### PR TITLE
Compare Expressions: Compare types lexicographically [3/n]

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -128,6 +128,7 @@ namespace clang {
     Result CompareDecl(const NamedDecl *D1, const NamedDecl *D2) const;
     Result CompareType(QualType T1, QualType T2) const;
     Result CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) const;
+    Result CompareTypeLexicographically(QualType QT1, QualType QT2) const;
 
     Result CompareAPInt(const llvm::APInt &I1, const llvm::APInt &I2) const;
     Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E);

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -474,14 +474,23 @@ Result Lexicographic::CheckEquivExprs(Result Current, const Expr *E1, const Expr
 
 
 Result
+Lexicographic::CompareTypeLexicographically(QualType QT1, QualType QT2) const {
+  assert(QT1 != QT2);
+
+  std::string S1 = QT1.getAsString();
+  std::string S2 = QT2.getAsString();
+  if (S1.compare(S2) < 0)
+    return Result::LessThan;
+  return Result::GreaterThan;
+}
+
+Result
 Lexicographic::CompareType(QualType QT1, QualType QT2) const {
   QT1 = QT1.getCanonicalType();
   QT2 = QT2.getCanonicalType();
   if (QT1 == QT2)
     return Result::Equal;
-  else
-    // TODO: fill this in
-    return Result::LessThan;
+  return CompareTypeLexicographically(QT1, QT2);
 }
 
 Result
@@ -490,9 +499,7 @@ Lexicographic::CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) const {
   QT2 = QT2.getCanonicalType();
   if (Context.isEqualIgnoringChecked(QT1, QT2))
     return Result::Equal;
-  else
-    // TODO: fill this in
-    return Result::LessThan;
+  return CompareTypeLexicographically(QT1, QT2);
 }
 
 Result


### PR DESCRIPTION
We are going to invoke the CompareExpr function to sort Exprs in the preorder
AST. This function in turn tries to compare Expr types. But currently, the
comparison of types is not implemented. A simple way to compare types is to
compare the string representations of the types.