### PR TITLE
Conditional operators: update checking state [1/n]

### DIFF
--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -2454,3 +2454,464 @@ void killed_widened_bounds3(
     }
   }
 }
+
+////////////////////////////////////////////////////////////////////////
+// The bounds context is updated after checking conditional operators //
+////////////////////////////////////////////////////////////////////////
+
+// The observed bounds contexts in each arm are equivalent
+void conditionals1(array_ptr<int> a : count(1),
+                   array_ptr<int> b : count(2), // expected-note {{(expanded) declared bounds are 'bounds(b, b + 2)'}}
+                   int flag) {
+  // No assignments in either arm
+  // Observed bounds context: { a => bounds(a, a + 1), b => bounds(b, b + 2) }
+  flag ? a : b;
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'flag'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: }
+
+  // Observed bounds context: { a => bounds(any), b => bounds(any) }
+  1 ? (a = 0, b = 0) : (b = 0, a = 0);
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} ','
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} ','
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <NullToPointer>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
+  // CHECK-NEXT: }
+
+  // Observed bounds context: { a => bounds(a, a + 1), b => bounds(a, a + 1) }
+  1 ? (b = a) : (b = a); // expected-error {{declared bounds for 'b' are invalid after statement}} \
+                         // expected-note {{destination bounds are wider than the source bounds}} \
+                         // expected-note {{destination upper bound is above source upper bound}} \
+                         // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 1)'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: }
+
+  // Observed bounds context: { a => bounds(b, b + 2), b => bounds(b, b + 2) }
+  // Since a and b are not updated in the arms of the conditional operator, a and b are known to be equal
+  (a = b) ? a : b;
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: }
+}
+
+// The observed bounds contexts in each arm are not equivalent
+void conditional2(array_ptr<int> a : count(1), // expected-note {{(expanded) declared bounds are 'bounds(a, a + 1)'}}
+                  array_ptr<int> b : count(2), // expected-note {{(expanded) declared bounds are 'bounds(b, b + 2)'}}
+                  array_ptr<int> c : count(3), 
+                  array_ptr<int> d : count(4)) { // expected-note {{(expanded) declared bounds are 'bounds(d, d + 4)'}}
+  // Bounds updated in "true" arm: { a => bounds(b, b + 2) }
+  // Bounds updated in "false" arm: { }
+  // Observed bounds context: { a => bounds(a, a + 1), b => bounds(b, b + 2), c => bounds(c, c + 3), d => bounds(d, d + 4) }
+  1 ? (a = b) : a;
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} c
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} d
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: }
+
+  // Bounds written in "true" arm: { b => bounds(a, a + 1) }
+  // Bounds written in "false" arm: { d => bounds(c, c + 3) }
+  // Observed bounds context: { a => bounds(a, a + 1), b => bounds(b, b + 2), c => bounds(c, c + 3), d => bounds(d, d + 4) }
+  1 ? (b = a) : (d = c); // expected-error {{declared bounds for 'b' are invalid after statement}} \
+                         // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 1)'}} \
+                         // expected-error {{declared bounds for 'd' are invalid after statement}} \
+                         // expected-note {{(expanded) inferred bounds are 'bounds(c, c + 3)'}} \
+                         // expected-note 2 {{destination bounds are wider than the source bounds}} \
+                         // expected-note 2 {{destination upper bound is above source upper bound}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} c
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} d
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: }
+
+  // Bounds written in "true" arm: { a => bounds(b, b + 2) }
+  // Bounds written in "false" arm: { a => bounds(c, c + 3) }
+  // Observed bounds context: { a => bounds(d, d + 4), b => bounds(b, b + 2), c => bounds(c, c + 3), d => bounds(d, d + 4) }
+  // Since a is updated in the arms of the conditional operator, a and d are not known to be equal
+  (a = d) ? (a = b) : (a = c); // expected-warning {{cannot prove declared bounds for 'a' are valid after statement}} \
+                               // expected-note {{(expanded) inferred bounds are 'bounds(d, d + 4)'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} b
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} c
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} d
+  // CHECK:      Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'd'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: }
+}
+
+// Conditional operators with widened bounds
+void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded) declared bounds are 'bounds(p, p + i)'}}
+                  unsigned i, 
+                  nt_array_ptr<char> q : count(j), // expected-note 2 {{(expanded) declared bounds are 'bounds(q, q + j)'}}
+                  unsigned j) {
+  if (*(p + i)) {
+    // Observed bounds context: { p => bounds(p, p + i - 1 + 1), q => bounds(q, q + j) }
+    1 ? i++ : ++i; // expected-warning {{cannot prove declared bounds for 'p' are valid after statement}} \
+                   // expected-note {{(expanded) inferred bounds are 'bounds(p, p + i - 1U + 1)'}}
+    // CHECK: Statement S:
+    // CHECK:      ConditionalOperator
+    // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+    // CHECK-NEXT:   UnaryOperator {{.*}} postfix '++'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT:   UnaryOperator {{.*}} prefix '++'
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: Observed bounds context after checking S:
+    // CHECK-NEXT: {
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} p
+    // CHECK:      Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+    // CHECK-NEXT:       BinaryOperator {{.*}} '-'
+    // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT:         IntegerLiteral {{.*}} 'unsigned int' 1
+    // CHECK-NEXT:       IntegerLiteral {{.*}} 'int' 1
+    // CHECK-NEXT: Variable:
+    // CHECK-NEXT: ParmVarDecl {{.*}} q
+    // CHECK:      Bounds:
+    // CHECK-NEXT: RangeBoundsExpr
+    // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
+    // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'q'
+    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+    // CHECK-NEXT:       DeclRefExpr {{.*}} 'j'
+    // CHECK-NEXT: }
+
+    if (*(q + j)) {
+      // Bounds written in condition: { q => bounds(q - 2, q - 2 + j) }
+      // Bounds written in "true" arm: { q => bounds(any) }
+      // Bounds written in "false" arm: { q => bounds(q + 1 - 2, q + 1 - 2 + j) }
+      // Observed bounds context: {  p => bounds(p, p + i + 1), q => bounds(q - 2, q - 2 + j) }
+      (q += 2) ? (q = 0) : q--; // expected-warning {{cannot prove declared bounds for 'q' are valid after statement}} \
+                                // expected-note {{(expanded) inferred bounds are 'bounds(q + 1 - 2, q + 1 - 2 + j)'}} \
+                                // expected-warning {{cannot prove declared bounds for 'q' are valid after statement}} \
+                                // expected-note {{(expanded) inferred bounds are 'bounds(q - 2, q - 2 + j)'}}
+      // CHECK: Statement S:
+      // CHECK:      ConditionalOperator
+      // CHECK-NEXT:   ParenExpr
+      // CHECK-NEXT:     CompoundAssignOperator {{.*}} '+='
+      // CHECK-NEXT:       DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+      // CHECK-NEXT:   ParenExpr
+      // CHECK-NEXT:     BinaryOperator {{.*}} '='
+      // CHECK-NEXT:       DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT:       ImplicitCastExpr {{.*}} <NullToPointer>
+      // CHECK-NEXT:         IntegerLiteral {{.*}} 0
+      // CHECK-NEXT:   UnaryOperator {{.*}} postfix '--'
+      // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT: Observed bounds context after checking S:
+      // CHECK-NEXT: {
+      // CHECK-NEXT: Variable:
+      // CHECK-NEXT: ParmVarDecl {{.*}} p
+      // CHECK:      Bounds:
+      // CHECK-NEXT: RangeBoundsExpr
+      // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
+      // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+      // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+      // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+      // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: Variable:
+      // CHECK-NEXT: ParmVarDecl {{.*}} q
+      // CHECK:      Bounds:
+      // CHECK-NEXT: RangeBoundsExpr
+      // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:       DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+      // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+      // CHECK-NEXT:     BinaryOperator {{.*}} '-'
+      // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:         DeclRefExpr {{.*}} 'q'
+      // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+      // CHECK-NEXT:       DeclRefExpr {{.*}} 'j'
+      // CHECK-NEXT: }
+    }
+  }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -2877,3 +2877,356 @@ void control_flow5(int flag, int i, int j) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 }
+
+///////////////////////////
+// Conditional operators //
+///////////////////////////
+
+void conditional1(int x, int y, int z) {
+  // No assignments in either arm
+  // Updated EquivExprs: { { y, x } }
+  (x = y) ? 1 : 2;
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 2
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Different assignments in each arm
+  // Updated EquivExprs: { { 1, x } }
+  (x = 1) ? (y = 2) : (z = 3);
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 3
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+
+  // Same assignments in each arm
+  // Updated EquivExprs: { { 1, x, y }, { 2, z } }
+  (x = 1) ? (y = 1, z = 2) : (z = 2, y = 1);
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} ','
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} ','
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:       BinaryOperator {{.*}} '='
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:    DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Variables are overwritten in each conditional arm
+void conditional2(int x) {
+  // Overwritten with the same value
+  // Updated EquivExprs: { 2, x }
+  (x = 1) ? (x = 2) : (x = 2);
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  // Overwritten with different values
+  // Updated EquivExprs: { }
+  (x = 1) ? (x = 2) : (x = 3);
+  // CHECK: Statement S:
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     BinaryOperator {{.*}} '='
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 3
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: { }
+}
+
+// Conditional operators are added to the correct set in EquivExprs
+void conditional3(int flag, int x, int y, int z) {
+  int i = 0;
+  int a = 1;
+  x = 1;
+  y = 1;
+
+  // Updated EquivExprs: { { 0, i }, { 1, a, x, y, flag ? x : y, v } }
+  int v = flag ? x : y;
+  // CHECK: Statement S:
+  // CHECK: DeclStmt
+  // CHECK: VarDecl {{.*}} v
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'flag'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'flag'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'v'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}
+
+// Nested conditional expressions
+void conditional4(int a, int b, int x, int i) {
+  int y = 0;
+  int z = 0;
+  int j = 0;
+  int k = 0;
+
+  // Updated EquivExprs: { { 0, y, z, j, k, b ? (x ? y : z) : (i ? j : k), a } }
+  a = (b ? (x ? y : z) : (i ? j : k));
+  // CHECK: Statement S:
+  // CHECK: BinaryOperator {{.*}} '='
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: ParenExpr
+  // CHECK-NEXT:   ConditionalOperator
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     ParenExpr {{.*}}
+  // CHECK-NEXT:       ConditionalOperator
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       ConditionalOperator
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'k'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'k'
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ParenExpr {{.*}}
+  // CHECK-NEXT:     ConditionalOperator
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     ConditionalOperator
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'k'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+
+  y = 1, z = 1;
+
+  // Original value of y and z: j
+  // Updated EquivExprs: { { 0, j, k, b ? (x ? j : j) : (i ? j : k) }, 
+  //                       { 1, y, z, x ? y : z, b ? (x ? y : z) : (x ? y : z), a } }
+  a = (b ? (x ? y : z) : (x ? y : z));
+  // CHECK: Statement S:
+  // CHECK: BinaryOperator {{.*}} '='
+  // CHECK:      DeclRefExpr {{.*}} 'a'
+  // CHECK:      ParenExpr
+  // CHECK-NEXT:   ConditionalOperator
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:     ParenExpr {{.*}}
+  // CHECK-NEXT:       ConditionalOperator
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       ConditionalOperator
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'z'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'k'
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ParenExpr {{.*}}
+  // CHECK-NEXT:     ConditionalOperator
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     ConditionalOperator
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'j'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'k'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT: ConditionalOperator
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
+  // CHECK-NEXT:   ParenExpr {{.*}}
+  // CHECK-NEXT:     ConditionalOperator
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT:   ParenExpr
+  // CHECK-NEXT:     ConditionalOperator
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'y'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'z'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
This PR updates the checking state for conditional operators of the form `e1 ? e2 : e3`.

#### Notable changes:
The `CheckConditionalOperator` method is modified to update the checking state members:

##### ObservedBounds
The observed bounds context is updated as follows:
* Update the observed bounds context `State.ObservedBounds` by checking the test expression `e1`.
* Get the observed bounds context `StateTrueArm.ObservedBounds` by checking the true arm expression `e2`. The observed bounds context `State.ObservedBounds` from checking the test expression `e1` is used as the initial context to check `e2`.
* Get the observed bounds context `StateFalseArm.ObservedBounds` by checking the false arm expression `e3`. The observed bounds context `State.ObservedBounds` from checking the test expression `e1` is used as the initial context to check `e3`.
* If the contexts `StateTrueArm.ObservedBounds` and `StateFalseArm.ObservedBounds` are identical, the final observed bounds context is `StateTrueArm.ObservedBounds`.
* Otherwise:
  * For each context `UC` of `StateTrueArm.ObservedBounds` and `StateFalseArm.ObservedBounds`:
    * Get the set of variables whose bounds were modified in the arm context, i.e. the set of all variables `v` for which `UC[v] != State.ObservedBounds[v]`.
    * TODO: should this be the set of all variables `v` for which `UC[v] != declared bounds of v`? If so, then consider the example `(a = b) ? (c = d) : c`. The set of updated variables in the true arm `e2` would be `{ a, c  }` and the set of updated variables in the false arm `e3` would be `a`. If the bounds of `b` do not imply the declared bounds of `a`, an error will be emitted twice (once for each arm `e2` and `e3`).
    * For each variable `v` in the set, check that the observed bounds `UC[v]` that were updated in the arm `e2` or `e3` imply the declared bounds of `v`.
    * For each variable `v` in the set, set `State.ObservedBounds[v]` to the declared bounds of `v`.
  * The final observed bounds context `StateObservedBounds` will contain, for each variable `x`:
    * If the bounds of `x` were not modified in either arm `e2` or `e3`, the observed bounds of `x` will be the observed bounds of `x` from checking the test expression `e1`.
    * If the bounds of `x` were modified in either arm `e2` or `e3`, the observed bounds of `x` will be the declared bounds of `x`.

##### EquivExprs
The set of sets of equivalent expressions is updated as follows:
* Update the equivalent expressions set `State.EquivExprs` by checking the test expression `e1`.
* Update the equivalent expressions set `StateTrueArm.EquivExprs` by checking the true arm expression `e2`. The equivalent expressions set `State.EquivExprs` from checking the test expression `e1` is used as the initial set to check `e2`.
* Update the equivalent expressions set `StateFalseArm.EquivExprs` by checking the false arm expression `e3`. The equivalent expressions set `State.EquivExprs` from checking the test expression `e1` is used as the initial set to check `e3`.
* The final set of equivalent expressions `State.EquivExprs` is the intersection of `StateTrueArm.EquivExprs` and `StateFalseArm.EquivExprs`.

##### SameValue
The set of expressions that produce the same value as `e1 ? e2 : e3` is updated as follows:
* Update the set `StateTrueArm.SameValue` by checking the true arm `e2`.
* Update the set `StateFalseArm.SameValue` by checking the false arm `e3`.
* Update the final set `State.SameValue` to be the intersection of `StateTrueArm.SameValue` and `StateFalseArm.SameValue`.
* If `e1 ? e2 : e3` is a non-modifying expression that does not create a new object or read memory via a pointer, add `e1 ? e2 : e3` to the final set `State.SameValue`.

#### Note on resetting updated arm bounds to declared bounds:
The current implementation resets the observed bounds of any variables whose bounds were updated in either arm to the variable's declared bounds. For example:

```
int test;
array_ptr<int> large : count(3) = 0;
array_ptr<int> medium : count(2) = 0;
array_ptr<int> small : count(1) = 0;
(medium = small), test ? (medium = large) : medium;
```
At the end of checking the statement, `medium` has observed bounds `bounds(medium, medium + 2)`. The initial assignment `medium = small` does not result in an bounds checking error.

Note: if the answer to the TODO question above is true, i.e. the set of variables `v` whose bounds were modified in either arm `e2` or `e3` should be the set of all variables `v` for which `UC[v] != declared bounds of v`, then:
* The observed bounds context that is validated in the true arm `e2` would be `{ medium => bounds(large, large + 3) }` (no errors or warnings).
* The observed bounds context that is validated in the false arm `e3` would be `{ medium => bounds(small, small + 1) }` (error: inferred bounds `(small, small + 1)` do not imply declared bounds `(medium, medium + 2)`).
* The final observed bounds context after checking the statement would be `{ medium => bounds(medium, medium + 2), small => bounds(small, small + 1), large => bounds(large, large + 3) }` (no errors or warnings).

#### Testing:
* Added tests to bounds-context.c and equiv-expr-sets.c to test that the observed bounds context and set of sets of equivalent expressions are correctly updated when checking conditional operators.
* Passed manual testing on Windows.
* Passed automated testing on Windows/Linux.

#### Next steps:
* Infer rvalue bounds for conditional operators. The rvalue bounds for a conditional operator `e1 ? e2 : e3` is the greatest lower bound of the rvalue bounds of `e2` and `e3`.
* Handle uses of temporaries bound in only one arm.
* Treat logical operators `e1 && e2` and `e1 || e2` as forms of conditional operators.