### PR TITLE
Compare Expressions: Create a class hierarchy for AST node type [4/n]

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -92,10 +92,12 @@ namespace clang {
     // @param[in] Parent is the parent of the node to be coalesced.
     void CoalesceNode(BinaryNode *B, BinaryNode *Parent);
 
-    // Coalesce binary nodes having the same commutative and associative
-    // operator.
+    // Recursively coalesce binary nodes having the same commutative and
+    // associative operator.
     // @param[in] N is current node of the AST. Initial value is Root.
-    void Coalesce(Node *N);
+    // @param[in] Changed indicates whether a node was coalesced. We need this
+    // to control when to stop recursive coalescing.
+    void Coalesce(Node *N, bool &Changed);
 
     // Sort the children expressions in a binary node of the AST.
     // @param[in] N is current node of the AST. Initial value is Root.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -21,31 +21,31 @@
 #include "clang/AST/Expr.h"
 
 namespace clang {
-
   using Result = Lexicographic::Result;
 
-  // Each binary operator of an expression results in a new node of the
-  // PreorderAST. Each node contains the following fields:
+  class Node {
+  public:
+    enum class NodeKind { BinaryNode, LeafExprNode };
 
-  // Opc: The opcode of the operator.
-  // Vars: A list of variables in the sub expression.
-  // Const: Constants of the sub expression are folded.
-  // HasConst: Indicates whether there is a constant in the node. It is used to
-  // differentiate between the absence of a constant and a constant value of 0.
-  // Parent: A link to the parent node of the current node.
-  // Children: The preorder AST is an n-ary tree. Children is a list of all the
-  // child nodes of the current node.
-
-  struct Node {
-    BinaryOperator::Opcode Opc;
-    std::vector<const VarDecl *> Vars;
-    llvm::APSInt Const;
-    bool HasConst;
+    NodeKind Kind;
     Node *Parent;
+
+    Node(NodeKind Kind, Node *Parent) :
+      Kind(Kind), Parent(Parent) {}
+  };
+
+  class BinaryNode : public Node {
+  public:
+    BinaryOperator::Opcode Opc;
     llvm::SmallVector<Node *, 2> Children;
 
-    Node(Node *Parent) :
-      Opc(BO_Add), HasConst(false), Parent(Parent) {}
+    BinaryNode(BinaryOperator::Opcode Opc, Node *Parent) :
+      Node(NodeKind::BinaryNode, Parent),
+      Opc(Opc) {}
+
+    static bool classof(const Node *N) {
+      return N->Kind == NodeKind::BinaryNode;
+    }
 
     // Is the operator commutative and associative?
     bool IsOpCommutativeAndAssociative() {
@@ -53,6 +53,22 @@ namespace clang {
     }
   };
 
+  class LeafExprNode : public Node {
+  public:
+    Expr *E;
+
+    LeafExprNode(Expr *E, Node *Parent) :
+      Node(NodeKind::LeafExprNode, Parent),
+      E(E) {}
+
+    static bool classof(const Node *N) {
+      return N->Kind == NodeKind::LeafExprNode;
+    }
+  };
+
+} // end namespace clang
+
+namespace clang {
   class PreorderAST {
   private:
     ASTContext &Ctx;
@@ -62,13 +78,27 @@ namespace clang {
     Node *Root;
 
     // Create a PreorderAST for the expression E.
-    // @param[in] E is the sub expression which needs to be added to N.
-    // @param[in] N is the current node of the AST.
-    // @param[in] Parent is the parent node for N.
-    void Create(Expr *E, Node *N = nullptr, Node *Parent = nullptr);
+    // @param[in] E is the sub expression to be added to a new node.
+    // @param[in] Parent is the parent of the new node.
+    void Create(Expr *E, Node *Parent = nullptr);
 
-    // Sort the variables in a node of the AST.
-    // @param[in] N is current node of the AST.
+    // Add a new node to the AST.
+    // @param[in] Node is the current node to be added.
+    // @param[in] Parent is the parent of the node to be added.
+    void AddNode(Node *N, Node *Parent);
+
+    // Coalesce the BinaryNode with its parent.
+    // @param[in] B is the current BinaryNode.
+    // @param[in] Parent is the parent of the node to be coalesced.
+    void CoalesceNode(BinaryNode *B, BinaryNode *Parent);
+
+    // Coalesce binary nodes having the same commutative and associative
+    // operator.
+    // @param[in] N is current node of the AST. Initial value is Root.
+    void Coalesce(Node *N);
+
+    // Sort the children expressions in a binary node of the AST.
+    // @param[in] N is current node of the AST. Initial value is Root.
     void Sort(Node *N);
 
     // Check if the two AST nodes N1 and N2 are equal.
@@ -81,19 +111,12 @@ namespace clang {
     void SetError() { Error = true; }
 
     // Print the PreorderAST.
-    // @param[in] N is the current node of the AST.
+    // @param[in] N is the current node of the AST. Initial value is Root.
     void PrettyPrint(Node *N);
 
     // Cleanup the memory consumed by node N.
-    // @param[in] N is the current node of the AST.
+    // @param[in] N is the current node of the AST. Initial value is Root.
     void Cleanup(Node *N);
-
-    // A DeclRefExpr can be a reference either to an array subscript (in which
-    // case it is wrapped around a ArrayToPointerDecay cast) or to a pointer
-    // dereference (in which case it is wrapped around an LValueToRValue cast).
-    // @param[in] An expression E.
-    // @return Returns a DeclRefExpr if E is a DeclRefExpr, otherwise nullptr.
-    DeclRefExpr *GetDeclOperand(Expr *E);
 
   public:
     PreorderAST(ASTContext &Ctx, Expr *E) :

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -17,91 +17,119 @@
 
 using namespace clang;
 
-void PreorderAST::Create(Expr *E, Node *N, Node *Parent) {
-  if (!E)
-    return;
-
-  if (!N)
-    N = new Node(Parent);
-
-  // If the root is null, the current node is the root.
+void PreorderAST::AddNode(Node *N, Node *Parent) {
+  // If the root is null, make the current node the root.
   if (!Root)
     Root = N;
 
-  // If the parent is non-null add the current node to its list of children.
-  if (Parent)
-    Parent->Children.push_back(N);
+  // Add the current node to the list of children of its parent.
+  if (Parent) {
+    assert(isa<BinaryNode>(Parent) && "Invalid parent");
+    dyn_cast<BinaryNode>(Parent)->Children.push_back(N);
+  }
+}
 
-  E = Lex.IgnoreValuePreservingOperations(Ctx, E);
-
-  // If E is a variable, store it in the variable list for the current node.
-  if (DeclRefExpr *D = GetDeclOperand(E)) {
-    if (const auto *V = dyn_cast_or_null<VarDecl>(D->getDecl())) {
-      N->Vars.push_back(V);
-      return;
+void PreorderAST::CoalesceNode(BinaryNode *B, BinaryNode *Parent) {
+  // Remove the current node from the list of children of its parent.
+  for (auto I = Parent->Children.begin(),
+            E = Parent->Children.end(); I != E; ++I) {
+    if (*I == B) {
+      Parent->Children.erase(I);
+      break;
     }
   }
 
-  // If E is a constant, store it in the constant field of the current node and
-  // set the HasConst field.
-  llvm::APSInt IntVal;
-  if (E->isIntegerConstantExpr(IntVal, Ctx)) {
-    N->Const = IntVal;
-    N->HasConst = true;
+  // Move all children of the current node to its parent.
+  std::move(B->Children.begin(), B->Children.end(),
+            std::back_inserter(Parent->Children));
+
+  // Delete the current node.
+  delete B;
+}
+
+void PreorderAST::Create(Expr *E, Node *Parent) {
+  if (!E)
     return;
-  }
+
+  E = Lex.IgnoreValuePreservingOperations(Ctx, E->IgnoreParens());
 
   if (const auto *BO = dyn_cast<BinaryOperator>(E)) {
-    // Set the opcode for the current node.
-    N->Opc = BO->getOpcode();
+    auto *N = new BinaryNode(BO->getOpcode(), Parent);
+    AddNode(N, Parent);
 
-    Expr *LHS = BO->getLHS()->IgnoreParens();
-    Expr *RHS = BO->getRHS()->IgnoreParens();
-  
-    if (isa<BinaryOperator>(LHS))
-      // Create the LHS as a child of the current node.
-      Create(LHS, nullptr, N);
-    else
-      // Create the LHS in the current node.
-      Create(LHS, N);
-  
-    if (isa<BinaryOperator>(RHS))
-      // Create the RHS as a child of the current node.
-      Create(RHS, nullptr, N);
-    else
-      // Create the RHS in the current node.
-      Create(RHS, N);
-  
-    return;
+    Create(BO->getLHS(), /*Parent*/ N);
+    Create(BO->getRHS(), /*Parent*/ N);
+
+  } else {
+    auto *N = new LeafExprNode(E, Parent);
+    AddNode(N, Parent);
   }
+}
 
-  // Currently, we only handle expression which are either variables or
-  // constants.
-  // TODO: Handle expressions that are non-variables and non-constants.
-  // Possibly, add a field to the node to represent such expressions.
-  SetError();
+void PreorderAST::Coalesce(Node *N) {
+  auto *B = dyn_cast_or_null<BinaryNode>(N);
+  if (!B)
+    return;
+
+  // Coalesce the children first.
+  for (auto *Child : B->Children)
+    if (isa<BinaryNode>(Child))
+      Coalesce(Child);
+
+  // We can only coalesce if the operator is commutative and associative.
+  if (!B->IsOpCommutativeAndAssociative())
+    return;
+
+  auto *Parent = dyn_cast_or_null<BinaryNode>(B->Parent);
+  if (!Parent)
+    return;
+
+  // We can only coalesce if the parent has the same operator as the current
+  // node.
+  if (Parent->Opc != B->Opc)
+    return;
+
+  CoalesceNode(B, Parent);
 }
 
 void PreorderAST::Sort(Node *N) {
-  if (Error)
+  auto *B = dyn_cast_or_null<BinaryNode>(N);
+  if (!B)
     return;
 
-  if (!N || !N->Vars.size())
+  // Sort the children first.
+  for (auto *Child : B->Children)
+    if (isa<BinaryNode>(Child))
+      Sort(Child);
+
+  // We can only sort if the operator is commutative and associative.
+  if (!B->IsOpCommutativeAndAssociative())
     return;
 
-  if (!N->IsOpCommutativeAndAssociative()) {
-    SetError();
-    return;
-  }
+  // Sort the children.
+  llvm::sort(B->Children.begin(), B->Children.end(),
+  [&](const Node *N1, const Node *N2) {
 
-  // Sort the variables in the node lexicographically.
-  llvm::sort(N->Vars.begin(), N->Vars.end(),
-             [&](const VarDecl *V1, const VarDecl *V2) {
-               return Lex.CompareDecl(V1, V2) == Result::LessThan;
-             });
+    if (const auto *L1 = dyn_cast<LeafExprNode>(N1)) {
+      if (const auto *L2 = dyn_cast<LeafExprNode>(N2))
+        // If both nodes are LeafExprNodes compare the exprs.
+        return Lex.CompareExpr(L1->E, L2->E) == Result::LessThan;
+      // N2:BinaryNodeExpr < N1:LeafExprNode.
+      return false;
+    }
 
-  for (auto *Child : N->Children)
-    Sort(Child);
+    // N1:BinaryNodeExpr < N2:LeafExprNode.
+    if (isa<LeafExprNode>(N2))
+      return true;
+
+    // Compare N1:BinaryNode and N2:BinaryNode.
+    const auto *B1 = dyn_cast<BinaryNode>(N1);
+    const auto *B2 = dyn_cast<BinaryNode>(N2);
+
+    if (B1->Opc != B2->Opc)
+      return B1->Opc < B2->Opc;
+    return B1->Children.size() < B2->Children.size();
+  });
 }
 
 bool PreorderAST::IsEqual(Node *N1, Node *N2) {
@@ -113,92 +141,69 @@ bool PreorderAST::IsEqual(Node *N1, Node *N2) {
   if ((N1 && !N2) || (!N1 && N2))
     return false;
 
-  // If the Opcodes mismatch.
-  if (N1->Opc != N2->Opc)
-    return false;
-
-  // If the number of variables in the two nodes mismatch.
-  if (N1->Vars.size() != N2->Vars.size())
-    return false;
-
-  // If the values of the constants in the two nodes differ.
-  if (llvm::APSInt::compareValues(N1->Const, N2->Const) != 0)
-    return false;
-
-  // If the number of children of the two nodes mismatch.
-  if (N1->Children.size() != N2->Children.size())
-    return false;
-
-  // Match each variable occurring in the two nodes.
-  for (size_t I = 0; I != N1->Vars.size(); ++I) {
-    auto &V1 = N1->Vars[I];
-    auto &V2 = N2->Vars[I];
-
-    // If any variable differs between the two nodes.
-    if (Lex.CompareDecl(V1, V2) != Result::Equal)
+  if (const auto *B1 = dyn_cast<BinaryNode>(N1)) {
+    // If the types of the nodes mismatch.
+    if (!isa<BinaryNode>(N2))
       return false;
+
+    const auto *B2 = dyn_cast<BinaryNode>(N2);
+
+    // If the Opcodes mismatch.
+    if (B1->Opc != B2->Opc)
+      return false;
+
+    // If the number of children of the two nodes mismatch.
+    if (B1->Children.size() != B2->Children.size())
+      return false;
+
+    // Match each child of the two nodes.
+    for (size_t I = 0; I != B1->Children.size(); ++I) {
+      auto *Child1 = B1->Children[I];
+      auto *Child2 = B2->Children[I];
+  
+      // If any child differs between the two nodes.
+      if (!IsEqual(Child1, Child2))
+        return false;
+    }
   }
 
-  // Match each child of the two nodes.
-  for (size_t I = 0; I != N1->Children.size(); ++I) {
-    auto *Child1 = N1->Children[I];
-    auto *Child2 = N2->Children[I];
+  if (const auto *L1 = dyn_cast<LeafExprNode>(N1)) {
+    // If the expr differs between the two nodes.
+    if (const auto *L2 = dyn_cast<LeafExprNode>(N2))
+      return Lex.CompareExpr(L1->E, L2->E) == Result::Equal;
 
-    // If any child differs between the two nodes.
-    if (!IsEqual(Child1, Child2))
-      return false;
+    // Else if the types of the nodes mismatch.
+    return false;
   }
+
   return true;
 }
 
 void PreorderAST::Normalize() {
-  // TODO: Coalesce nodes having the same commutative and associative operator.
   // TODO: Constant fold the constants in the nodes.
   // TODO: Perform simple arithmetic optimizations/transformations on the
   // constants in the nodes.
 
+  Coalesce(Root);
   Sort(Root);
 }
 
-DeclRefExpr *PreorderAST::GetDeclOperand(Expr *E) {
-  if (auto *CE = dyn_cast_or_null<CastExpr>(E)) {
-    assert(CE->getSubExpr() && "Invalid CastExpr expression");
-
-    if (CE->getCastKind() == CastKind::CK_LValueToRValue ||
-        CE->getCastKind() == CastKind::CK_ArrayToPointerDecay) {
-      E = Lex.IgnoreValuePreservingOperations(Ctx, CE->getSubExpr());
-      return dyn_cast_or_null<DeclRefExpr>(E);
-    }
-  }
-  return nullptr;
-}
-
 void PreorderAST::PrettyPrint(Node *N) {
-  if (!N)
-    return;
+  if (const auto *B = dyn_cast_or_null<BinaryNode>(N)) {
+    OS << BinaryOperator::getOpcodeStr(B->Opc) << "\n";
 
-  OS << BinaryOperator::getOpcodeStr(N->Opc);
-
-  if (N->Vars.size()) {
-    OS << "[ ";
-    for (auto &V : N->Vars)
-      OS << V->getQualifiedNameAsString() << " ";
-    OS << "]\n";
+    for (auto *Child : B->Children)
+      PrettyPrint(Child);
   }
-
-  if (N->HasConst)
-    OS << " [const:" << N->Const << "]\n";
-
-  for (auto *Child : N->Children)
-    PrettyPrint(Child);
+  else if (const auto *L = dyn_cast_or_null<LeafExprNode>(N))
+    L->E->dump(OS);
 }
 
 void PreorderAST::Cleanup(Node *N) {
-  if (!N)
-    return;
+  if (auto *B = dyn_cast_or_null<BinaryNode>(N))
+    for (auto *Child : B->Children)
+      Cleanup(Child);
 
-  for (auto *Child : N->Children)
-    Cleanup(Child);
-
-  delete N;
+  if (N)
+    delete N;
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -34,3 +34,73 @@ void f3(int i, int j) {
 // CHECK:   2: *(p + (j * i))
 // CHECK: upper_bound(p) = 1
 }
+
+void f4(int i, int j, int k, int m, int n) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j + k + m + n) = "a";
+
+  if (*(n + m + k + j + i + p)) {}
+
+// CHECK: In function: f4
+// CHECK:   2: *(n + m + k + j + i + p)
+// CHECK: upper_bound(p) = 1
+}
+
+void f5(int i, int j, int k, int m, int n) {
+  _Nt_array_ptr<char> p : bounds(p, (p + i) + (j + k) + (m + n)) = "a";
+
+  if (*((n + m + k) + (j + i + p))) {}
+
+// CHECK: In function: f5
+// CHECK:   2: *((n + m + k) + (j + i + p))
+// CHECK: upper_bound(p) = 1
+}
+
+void f6(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j + i + j) = "a";
+
+  if (*(j + j + p + i + i)) {}
+
+// CHECK: In function: f6
+// CHECK:   2: *(j + j + p + i + i)
+// CHECK: upper_bound(p) = 1
+}
+
+void f7(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a";
+
+  if (*(p + i + j)) {}
+
+// CHECK: In function: f7
+// CHECK:   2: *(p + i + j)
+// CHECK-NOT: upper_bound(p)
+}
+
+void f8(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+
+  if (*(p + i + i)) {}
+
+// CHECK: In function: f8
+// CHECK:   2: *(p + i + i)
+// CHECK-NOT: upper_bound(p)
+}
+
+void f9(int i, int j, int k) {
+  _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
+
+  if (*((p + i) + (j * k))) {}
+
+// CHECK: In function: f9
+// CHECK:   2: *((p + i) + (j * k))
+// CHECK: upper_bound(p) = 1
+}
+
+void f10(int i, int j, int k) {
+  _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
+
+  if (*((p + i) + (j + k))) {}
+
+// CHECK: In function: f10
+// CHECK:   2: *((p + i) + (j + k))
+// CHECK-NOT: upper_bound(p)
+}


### PR DESCRIPTION
We generalize the node type into the following class hierarchy:

```
       Node
      /    \
     /      \
 BinaryNode LeafExprNode
```

`BinaryNode` can have two or more `Node`s as children. The `LeafExpreNode` type wraps
a clang AST expression.