### PR TITLE
Compare Expressions: Perform constant folding on the preorder AST [5/n]

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -103,6 +103,12 @@ namespace clang {
     // @param[in] N is current node of the AST. Initial value is Root.
     void Sort(Node *N);
 
+    // Constant fold integer expressions.
+    // @param[in] N is current node of the AST. Initial value is Root.
+    // @param[in] Changed indicates whether constant folding was done. We need
+    // this to control when to stop recursive constant folding.
+    void ConstantFold(Node *N, bool &Changed);
+
     // Check if the two AST nodes N1 and N2 are equal.
     // @param[in] N1 is the first node.
     // @param[in] N2 is the second node.


### PR DESCRIPTION
We recursively constant fold the constants in the preorder AST. Constants are
only folded if the operator is commutative and associative. We also recursively
coalesce and sort the nodes that are constant folded.