### PR TITLE
Change expected error to 'increment' rather than 'statement'

### DIFF
--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -1244,7 +1244,7 @@ void f33() {
 
 void f34(_Nt_array_ptr<char> p : count(i), int i, int flag) {
   if (*(p + i)) {
-    flag ? i++ : i;  // expected-error {{inferred bounds for 'p' are unknown after statement}}
+    flag ? i++ : i;  // expected-error {{inferred bounds for 'p' are unknown after increment}}
 
     if (*(p + i + 1))
     {}


### PR DESCRIPTION
This PR updates the expected error message from 'inferred bounds of 'p' are unknown after statement' to 'inferred bounds of 'p' are unknown after increment' to reflect the changes in #893.