### PR TITLE
Add expected errors in widened-bounds-semantic-compare

### DIFF
--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -1,12 +1,10 @@
 // Tests for bounds widening of _Nt_array_ptr's using function to semantically
 // compare two expressions.
 //
-// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s 2>&1 | FileCheck %s
-
-// expected-no-diagnostics
+// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
 
 void f1(int i) {
-  _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
+  _Nt_array_ptr<char> p : bounds(p, p + i) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
 
   if (*(i + p)) {}
 
@@ -16,7 +14,7 @@ void f1(int i) {
 }
 
 void f2(int i, int j) {
-  _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a";
+  _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
 
   if (*(p + (j + i))) {}
 
@@ -26,7 +24,7 @@ void f2(int i, int j) {
 }
 
 void f3(int i, int j) {
-  _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a";
+  _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
 
   if (*(p + (j * i))) {}
 
@@ -66,7 +64,7 @@ void f6(int i, int j) {
 }
 
 void f7(int i, int j) {
-  _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a";
+  _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
 
   if (*(p + i + j)) {}
 


### PR DESCRIPTION
After the changes in #903, the compiler will emit an error where free variables are found in the declared or inferred bounds. There are several places in the widened-bounds-semantic-compare test where the declared bounds involve free variables. The other cases in this test file do not result in errors because the compiler is not able to create a base range for the declared bounds (so a warning is emitted, which the test file ignores).