### PR TITLE
Fix x64 Windows builds break.

### DIFF
--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -15,6 +15,7 @@
 #include "clang/CConv/ArrayBoundsInferenceConsumer.h"
 #include "clang/CConv/ConstraintResolver.h"
 #include <sstream>
+#include <cctype>
 
 static std::set<std::string> LengthVarNamesPrefixes = {"len", "count",
                                                                "size", "num",

--- a/clang/lib/CConv/CMakeLists.txt
+++ b/clang/lib/CConv/CMakeLists.txt
@@ -3,6 +3,11 @@ set( LLVM_LINK_COMPONENTS
         Option
         Support
         )
+
+if (MSVC)
+  set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
         add_clang_library(CConv
           ABounds.cpp
           AVarBoundsInfo.cpp

--- a/clang/lib/CConv/CMakeLists.txt
+++ b/clang/lib/CConv/CMakeLists.txt
@@ -6,6 +6,7 @@ set( LLVM_LINK_COMPONENTS
 
 if (MSVC)
   set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+  set_source_files_properties(ArrayBoundsInferenceConsumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
         add_clang_library(CConv


### PR DESCRIPTION
After merging the work on the Checked C converter, two failures appeared only on automated debug x64 Windows build.

One error was that the compiler was trying to create an object file that had too many sections.  This adds the /bigobj flag for some files, which allows a newer object file format to be used.  The other error was that an include file was missing in the Checked C converter tool.

With these changes, the automated testing passes again for the debug x64 Windows build.
