### PR TITLE
Free variables: fix #909 and #911 by ignoring casts in EquivExprs

### DIFF
--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -310,7 +310,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
 #include "clang/AST/StmtNodes.inc"
        llvm_unreachable("cannot compare a statement");  
      case Expr::PredefinedExprClass: Cmp = Compare<PredefinedExpr>(E1, E2); break;
-     case Expr::DeclRefExprClass: return Compare<DeclRefExpr>(E1, E2);
+     case Expr::DeclRefExprClass: Cmp = Compare<DeclRefExpr>(E1, E2); break;
      case Expr::IntegerLiteralClass: return Compare<IntegerLiteral>(E1, E2);
      case Expr::FloatingLiteralClass: return Compare<FloatingLiteral>(E1, E2);
      case Expr::ImaginaryLiteralClass: break;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1494,7 +1494,7 @@ namespace {
           EqualExprTy Vars;
           auto It = ExprSet.begin();
           for (; It != ExprSet.end(); It++) {
-            *It = (*It)->IgnoreCasts();
+            *It = (*It)->IgnoreParenCasts();
             if (isa<IntegerLiteral>(*It) || (isa<DeclRefExpr>(*It)))
               Vars.push_back(*It);
           }


### PR DESCRIPTION
On checking free variables, create a temporary `EquivVars` that only holds DecRefExpr and IntegerLiteral from the `EquivExprs`, with casts ignored. The variables in `EquivVars` are then used to compare with the variables (DecRefExpr) collected from bounds expressions.

IntegerLiterals from `EquivExprs` are also kept in `EquivVars` so we can check whether a variable equals to a constant.