### PR TITLE
Compare Expressions: Normalize subtract operator & expressions w/o const [7/n]

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -105,6 +105,12 @@ namespace clang {
     // @param[in] N is current node of the AST. Initial value is Root.
     void Sort(Node *N);
 
+    // Compare nodes N1 and N2 to sort them. This function is invoked by a
+    // lambda which is passed to the llvm::sort function.
+    // @param[in] N1 is the first node to compare.
+    // @param[in] N2 is the second node to compare.
+    bool CompareNodes(const Node *N1, const Node *N2);
+
     // Constant fold integer expressions.
     // @param[in] N is current node of the AST. Initial value is Root.
     // @param[in] Changed indicates whether constant folding was done. We need

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -87,10 +87,10 @@ namespace clang {
     // @param[in] Parent is the parent of the node to be added.
     void AddNode(Node *N, Node *Parent);
 
-    // Coalesce the BinaryNode with its parent.
-    // @param[in] B is the current BinaryNode.
-    // @param[in] Parent is the parent of the node to be coalesced.
-    void CoalesceNode(BinaryNode *B, BinaryNode *Parent);
+    // Remove the node N.
+    // @param[in] N is the current node.
+    // @param[in] P is the parent of the node to be removed.
+    void RemoveNode(Node *N, Node *P);
 
     // Recursively coalesce binary nodes having the same commutative and
     // associative operator.
@@ -108,6 +108,10 @@ namespace clang {
     // @param[in] Changed indicates whether constant folding was done. We need
     // this to control when to stop recursive constant folding.
     void ConstantFold(Node *N, bool &Changed);
+
+    // Normalize expressions which do not have any integer constants.
+    // @param[in] N is current node of the AST. Initial value is Root.
+    void NormalizeExprsWithoutConst(Node *N);
 
     // Check if the two AST nodes N1 and N2 are equal.
     // @param[in] N1 is the first node.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -88,9 +88,10 @@ namespace clang {
     // @param[in] Parent is the parent of the node to be added.
     void AddNode(Node *N, Node *Parent);
 
-    // Remove the node N.
+    // Move the children (if any) of node N to its parent and then remove N.
     // @param[in] N is the current node.
-    // @param[in] P is the parent of the node to be removed.
+    // @param[in] P is the parent of the node to be removed. P should be a
+    // BinaryNode.
     void RemoveNode(Node *N, Node *P);
 
     // Recursively coalesce binary nodes having the same commutative and

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -17,6 +17,7 @@
 #define LLVM_CLANG_PREORDER_AST_H
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTDiagnostic.h"
 #include "clang/AST/CanonBounds.h"
 #include "clang/AST/Expr.h"
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -109,6 +109,7 @@ namespace clang {
     // lambda which is passed to the llvm::sort function.
     // @param[in] N1 is the first node to compare.
     // @param[in] N2 is the second node to compare.
+    // return A boolean indicating the relative ordering between N1 and N2.
     bool CompareNodes(const Node *N1, const Node *N2);
 
     // Constant fold integer expressions.

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -93,9 +93,9 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
     // and then check if the resultant expression -e2 overflows. If it
     // overflows, we undo the unary minus operator.
 
-    // TODO: Currently we only handle detection of overflow for integer
-    // constant expressions. We need to handle the case where e2 is a variable
-    // expression which is not known until run time.
+    // TODO: Currently, we can only prove that integer constant expressions do
+    // not overflow. We still need to handle proving that non-constant
+    // expressions do not overflow.
     if (BO->getOpcode() == BO_Sub &&
         RHS->isIntegerConstantExpr(Ctx)) {
       Expr *UOMinusRHS = new (Ctx) UnaryOperator(RHS, UO_Minus, RHS->getType(),

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -66,9 +66,15 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
     Expr *LHS = BO->getLHS();
     Expr *RHS = BO->getRHS();
 
-    // Generally, we can convert (e1 - e2) to (e1 + -e2). But in case -e2
-    // overflows we cannot do this transformation. So we peform this
-    // transformation here only if -e2 does not overflow.
+    // We can convert (e1 - e2) to (e1 + -e2) if -e2 does not overflow.  One
+    // instance where -e2 can overflow is if e2 is INT_MIN. Here, instead of
+    // specifically checking whether e2 is INT_MIN, we add a unary minus to e2
+    // and then check if the resultant expression -e2 overflows. If it
+    // overflows, we undo the unary minus operator.
+
+    // TODO: Currently we only handle detection of overflow for constant
+    // expressions. We need to handle the case where e2 is a variable
+    // expression which is not known until run time.
     if (BO->getOpcode() == BO_Sub) {
       RHS = new (Ctx) UnaryOperator(RHS, UO_Minus, RHS->getType(),
                                     RHS->getValueKind(),

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -275,8 +275,15 @@ void PreorderAST::ConstantFold(Node *N, bool &Changed) {
 }
 
 void PreorderAST::NormalizeExprsWithoutConst(Node *N) {
-  // Normalize expressions by adding an integer constant to expressions which
-  // do not have one. For example:
+  // Consider the following case:
+  // Upper bound expr: p
+  // Deref expr: p + 1
+  // In this case, we would not able able to extract the offset from the deref
+  // expression because the upper bound expression does not contain a constant.
+  // This is because the node-by-node comparison of the two expressions would
+  // fail. So we require that expressions be of the form "(variable + constant)".
+  // So, we normalize expressions by adding an integer constant to expressions
+  // which do not have one. For example:
   // p ==> (p + 0)
   // (p + i) ==> (p + i + 0)
   // (p * i) ==> (p * i * 1)
@@ -381,6 +388,8 @@ void PreorderAST::Normalize() {
       break;
     NormalizeExprsWithoutConst(Root);
   }
+
+  PrettyPrint(Root);
 }
 
 void PreorderAST::PrettyPrint(Node *N) {


### PR DESCRIPTION
We perform two normalizations of expressions:

1. Normalize `(e1 - e2)` to `(e1 + -e2)`. This will avoid the use of subtract
operators and ease constant folding.

2. Normalize expressions which do not have any integer constants. For example:
  `p ==> p + 0`
  `p + i ==> p + i + 0`
  `p * i ==> p * i * 1`
  This will make comparison of two expressions for equality easier.