### PR TITLE
Reset killed bounds for in-scope variables only

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2266,10 +2266,13 @@ namespace {
 
      // KilledBounds stores a mapping of statements to all variables whose
      // bounds are killed by each statement. Here we reset the bounds of all
-     // variables killed by the statement S to the normalized declared bounds.
+     // variables that are in scope at the statement S and whose bounds are
+     // killed by S to the normalized declared bounds.
      for (const VarDecl *V : I->second) {
-       if (BoundsExpr *Bounds = S.NormalizeBounds(V))
-         State.ObservedBounds[V] = Bounds;
+       if (State.ObservedBounds.find(V) != State.ObservedBounds.end()) {
+         if (BoundsExpr *Bounds = S.NormalizeBounds(V))
+           State.ObservedBounds[V] = Bounds;
+       }
      }
    }
 

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -1266,3 +1266,31 @@ void f34(_Nt_array_ptr<char> p : count(i), int i, int flag) {
 // CHECK:    2: *(p + i + 1)
 // CHECK: upper_bound(p) = 1
 }
+
+void f35(void) {
+  int i, j;
+  for (;;) {
+    i = 1;
+    j = 2;
+    _Nt_array_ptr<char> p : count(i + j) = 0;
+    if (p[i + j]) {
+      return;
+    }
+  }
+
+// CHECK: In function: f35
+// CHECK:  [B5]
+// CHECK:    1: int i;
+// CHECK:    2: int j;
+// CHECK:  [B4]
+// CHECK:    T: for (; ; )
+// CHECK:  [B3]
+// CHECK:    1: i = 1
+// CHECK:    2: j = 2
+// CHECK:    3: _Nt_array_ptr<char> p : count(i + j) = 0;
+// CHECK:    4: p[i + j] (ImplicitCastExpr, LValueToRValue, char)
+// CHECK:    T: if [B3.4]
+// CHECK:  [B2]
+// CHECK:    1: return;
+// CHECK: upper_bound(p) = 1
+}


### PR DESCRIPTION
Fixes #925 

This PR adjusts ResetKilledBounds to only reset a variable `v` whose widened bounds have been killed by statement `S` if `v` is in scope at `S`, i.e. if `v` is already present in `State.ObservedBounds`.

#### Testing:
* Added a function to widened-bounds.c to test this change.
* Passed automated testing on Linux.