### PR TITLE
Detect indirect relationships between variables

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10178,15 +10178,15 @@ def err_bounds_type_annotation_lost_checking : Error<
     "%select{assignment|decrement|increment|initialization|statement}0">;
 
   def note_free_variable_decl_or_inferred : Note<
-    "the %select{declared|inferred}0 %select{lower |upper |}1bounds use the value "
-    "of the variable '%2', and there is no relational information between '%2' "
-    "and any of the variables used by the %select{inferred|declared}0 "
+    "the %select{declared|inferred}0 %select{lower |upper |}1bounds use the "
+    "variable '%2' and there is no relational information involving '%2' "
+    "and any of the expressions used by the %select{inferred|declared}0 "
     "%select{lower |upper |}1bounds">;
 
   def note_free_variable_in_expected_args : Note<
-    "the %select{expected argument|inferred}0 %select{lower |upper |}1bounds use the value "
-    "of the variable '%2', and there is no relational information between '%2' "
-    "and any of the variables used by the %select{inferred|expected argument}0 "
+    "the %select{expected argument|inferred}0 %select{lower |upper |}1bounds use the "
+    "variable '%2' and there is no relational information involving '%2' "
+    "and any of the expressions used by the %select{inferred|expected argument}0 "
     "%select{lower |upper |}1bounds">;
 
   def error_bounds_declaration_invalid : Error<

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1435,13 +1435,16 @@ namespace {
       // GetFreeVariables gathers "free variables" in SrcVars.
       //
       // Given two variable sets SrcVars and DstVars, and a set of equivalent
-      // sets of Expr EquivExprs. A variable V in SrcVars is *free* if the two
+      // sets of Expr EquivExprs. A variable V in SrcVars is *free* if these
       // conditions are met:
-      //   1. either (1) V is not an integer type, or (2) there is no set in
-      //   EquivExprs that contains both V and a constant (i.e. an integer-typed
-      //   value); and
-      //   2. for each variable U in DstVars, there is not set in EquivExprs
-      //   that contains both V and U.
+      //   1. V is not equal to an integer constant, i.e. there is no set in
+      //      EquivExprs that contains V and an IntegerLiteral expression, and:
+      //   2. For each variable U in DstVars, V is not equivlaent to U, i.e.
+      //      there is no set in EquivExprs that contains both V and U, and:
+      //   3. For each variable U in DstVars, there is no indirect relationship
+      //      between V and U, i.e. there is no set in EquivExprs that contains
+      //      two different expressions e1 and e2, where e1 uses the value of
+      //      V and e2 uses the value of U.
       //
       // GetFreeVariables returns true if any free variable is found in SrcVars,
       // and appends the free variables to FreeVariables.
@@ -1483,7 +1486,7 @@ namespace {
       // DstVars, then there is a relationship between SrcV and DstV.
       //
       // For example, if DstV is a variable in DstVars and EquivExprs
-      // contains the set { SrcV + 1, *DstV }, then there is a relationship
+      // contains the set { SrcV + 1, &DstV }, then there is a relationship
       // between SrcV and DstV.
       static bool FindVarRelationship(Sema &S, DeclRefExpr *SrcV,
                                       const EqualExprTy &DstVars,

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1533,7 +1533,7 @@ namespace {
                                       FreeVariablePosition Pos2,
                                       EquivExprSets *EquivExprs,
                                       FreeVariableListTy &FreeVars) {
-        // If E1 or E2 accesses memory via poiter, we skip because we cannot
+        // If E1 or E2 accesses memory via pointer, we skip because we cannot
         // determine aliases for two indirect accesses soundly yet.
         if (ReadsMemoryViaPointer(E1) || ReadsMemoryViaPointer(E2))
           return false;
@@ -1542,24 +1542,10 @@ namespace {
         EqualExprTy Vars1 = CollectVariableSet(S, E1);
         EqualExprTy Vars2 = CollectVariableSet(S, E2);
 
-        // EquivVars holds sets of DeclRefExpr and IntegerLiteral filtered from
-        // EquivExprs.
-        EquivExprSets EquivVars;
-        for (auto ExprSet : *EquivExprs) {
-          EqualExprTy Vars;
-          auto It = ExprSet.begin();
-          for (; It != ExprSet.end(); It++) {
-            *It = (*It)->IgnoreParenCasts();
-            if (isa<IntegerLiteral>(*It) || (isa<DeclRefExpr>(*It)))
-              Vars.push_back(*It);
-          }
-          EquivVars.push_back(Vars);
-        }
-
-        if (AddFreeVariables(S, Vars1, Vars2, &EquivVars, Pos1, FreeVars))
+        if (AddFreeVariables(S, Vars1, Vars2, EquivExprs, Pos1, FreeVars))
           HasFreeVariables = true;
 
-        if (AddFreeVariables(S, Vars2, Vars1, &EquivVars, Pos2, FreeVars))
+        if (AddFreeVariables(S, Vars2, Vars1, EquivExprs, Pos2, FreeVars))
           HasFreeVariables = true;
 
         return HasFreeVariables;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1482,7 +1482,7 @@ namespace {
       // conditions are met:
       //   1. V is not equal to an integer constant, i.e. there is no set in
       //      EquivExprs that contains V and an IntegerLiteral expression, and:
-      //   2. For each variable U in DstVars, V is not equivlaent to U, i.e.
+      //   2. For each variable U in DstVars, V is not equivalent to U, i.e.
       //      there is no set in EquivExprs that contains both V and U, and:
       //   3. For each variable U in DstVars, there is no indirect relationship
       //      between V and U, i.e. there is no set in EquivExprs that contains

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1432,10 +1432,12 @@ namespace {
         return ProofResult::Maybe;
       }
 
-      // CheckFreeVarInExprs returns true if there are any free variables in
-      // E1 w.r.t E2, or if there are any free variables in E2 w.r.t E1.
-      // Any free variables in E1 with position Pos1 and any free variables in
-      // E2 with position Pos2 are appended to FreeVars.
+      // CheckFreeVarInExprs appends any free variables in E1 and any free
+      // variables in E2 to FreeVars, and returns true if there are any free
+      // variables in either E1 or E2.  Pos1 and Pos2 are the positions in
+      // which E1 and E2 appear in bounds expressions.  Free variables are
+      // appended with the position of the expression in which they are free
+      // (free variables in E1 are appended with Pos1, for example).
       bool CheckFreeVarInExprs(Expr *E1, Expr *E2,
                                FreeVariablePosition Pos1,
                                FreeVariablePosition Pos2,

--- a/clang/test/CheckedC/inferred-bounds/basic.c
+++ b/clang/test/CheckedC/inferred-bounds/basic.c
@@ -426,7 +426,7 @@ void f42(void) {
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 1
 
-  _Array_ptr<int> r : count(1) = &p[0]; // expected-error {{it is not possible to prove that the inferred bounds of 'r' imply the declared bounds of 'r' after initialization}}
+  _Array_ptr<int> r : count(1) = &p[0];
 
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} r '_Array_ptr<int>' cinit
 // CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
@@ -490,7 +490,7 @@ void f43(void) {
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5][5]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int [5][5]'
 // CHECK: `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 
-  p = arr[0]; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after assignment}}
+  p = arr[0];
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
 // CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
@@ -517,7 +517,7 @@ void f43(void) {
 // CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} 'int [5][5]' lvalue Var {{0x[0-9a-f]+}} 'arr' 'int [5][5]'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} 'int' 5
 
-  r = &p[0]; // expected-error {{it is not possible to prove that the inferred bounds of 'r' imply the declared bounds of 'r' after assignment}}
+  r = &p[0];
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
 // CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'r' '_Array_ptr<int>'

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -501,9 +501,7 @@ void assign5(array_ptr<int> a : count(len), int len, int size) { // expected-not
   // Observed bounds context before assignment: { a => bounds(a, a + len) }
   // Original value of len: size
   // Observed bounds context after assignment:  { a => bounds(a, a + size) }
-  len = len * 2; // expected-error {{it is not possible to prove that the inferred bounds of 'a' imply the declared bounds of 'a' after assignment}} \
-                 // expected-note {{the inferred upper bounds use the value of the variable 'size', and there is no relational information between 'size' and any of the variables used by the declared upper bounds}} \
-                 // expected-note {{the declared upper bounds use the value of the variable 'len', and there is no relational information between 'len' and any of the variables used by the inferred upper bounds}} \
+  len = len * 2; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
                  // expected-note {{(expanded) inferred bounds are 'bounds(a, a + size)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -619,8 +619,8 @@ void assign7(
   a = c; // expected-error {{it is not possible to prove that the inferred bounds of 'a' imply the declared bounds of 'a' after assignment}} \
          // expected-error {{it is not possible to prove that the inferred bounds of 'b' imply the declared bounds of 'b' after assignment}} \
          // expected-error {{it is not possible to prove that the inferred bounds of 'c' imply the declared bounds of 'c' after assignment}} \
-         // expected-note 3 {{the declared bounds use the variable 'a', and there is no relational information involving 'a' and any of the expressions used by the inferred bounds}} \
-         // expected-note 3 {{the inferred bounds use the variable 'b', and there is no relational information involving 'b' and any of the expressions used by the declared bounds}} \
+         // expected-note 3 {{the declared bounds use the variable 'a' and there is no relational information involving 'a' and any of the expressions used by the inferred bounds}} \
+         // expected-note 3 {{the inferred bounds use the variable 'b' and there is no relational information involving 'b' and any of the expressions used by the declared bounds}} \
          // expected-note 3 {{(expanded) inferred bounds are 'bounds(b, b + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -619,8 +619,8 @@ void assign7(
   a = c; // expected-error {{it is not possible to prove that the inferred bounds of 'a' imply the declared bounds of 'a' after assignment}} \
          // expected-error {{it is not possible to prove that the inferred bounds of 'b' imply the declared bounds of 'b' after assignment}} \
          // expected-error {{it is not possible to prove that the inferred bounds of 'c' imply the declared bounds of 'c' after assignment}} \
-         // expected-note 3 {{the declared bounds use the value of the variable 'a', and there is no relational information between 'a' and any of the variables used by the inferred bounds}} \
-         // expected-note 3 {{the inferred bounds use the value of the variable 'b', and there is no relational information between 'b' and any of the variables used by the declared bounds}} \
+         // expected-note 3 {{the declared bounds use the variable 'a', and there is no relational information involving 'a' and any of the expressions used by the inferred bounds}} \
+         // expected-note 3 {{the inferred bounds use the variable 'b', and there is no relational information involving 'b' and any of the expressions used by the declared bounds}} \
          // expected-note 3 {{(expanded) inferred bounds are 'bounds(b, b + 1)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='

--- a/clang/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
+++ b/clang/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
@@ -21,7 +21,7 @@ static void myfunc2(_Array_ptr<int> data : count(len), int len) {
 int main(void) {
   int a _Checked[5];
   myfunc1(a, 0);  // expected-error {{it is not possible to prove argument meets declared bounds for 1st parameter}} \
-                  // expected-note {{the inferred bounds use the value of the variable 'a', and there is no relational information between 'a' and any of the variables used by the expected argument bounds}} \
+                  // expected-note {{the inferred bounds use the variable 'a', and there is no relational information involving 'a' and any of the expressions used by the expected argument bounds}} \
                   // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)0, (_Array_ptr<char>)0 + 5)'}} \
                   // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 5)'}}
   myfunc2(0, 0);

--- a/clang/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
+++ b/clang/test/CheckedC/regression-cases/bug_457_null_ptr_warning.c
@@ -21,7 +21,7 @@ static void myfunc2(_Array_ptr<int> data : count(len), int len) {
 int main(void) {
   int a _Checked[5];
   myfunc1(a, 0);  // expected-error {{it is not possible to prove argument meets declared bounds for 1st parameter}} \
-                  // expected-note {{the inferred bounds use the variable 'a', and there is no relational information involving 'a' and any of the expressions used by the expected argument bounds}} \
+                  // expected-note {{the inferred bounds use the variable 'a' and there is no relational information involving 'a' and any of the expressions used by the expected argument bounds}} \
                   // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<char>)0, (_Array_ptr<char>)0 + 5)'}} \
                   // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 5)'}}
   myfunc2(0, 0);

--- a/clang/test/CheckedC/static-checking/bounds-decl-challenges.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-challenges.c
@@ -8,12 +8,12 @@ extern void check_assign(int val, int p[10], int q[], int r _Checked[10], int s 
                          int s2d _Checked[10][10], int v _Nt_checked[10], int w _Nt_checked[],
                          int w2d _Checked[10]_Nt_checked[10]) {
   int x2d _Checked[10]_Nt_checked[10];
-  _Nt_array_ptr<int> t13b = w2d[0];  // expected-error {{it is not possible to prove that the inferred bounds of 't13b' imply the declared bounds of 't13b' after initialization}}
-  _Nt_array_ptr<int> t15b = x2d[0];  // expected-error {{it is not possible to prove that the inferred bounds of 't15b' imply the declared bounds of 't15b' after initialization}}
+  _Nt_array_ptr<int> t13b = w2d[0];  // expected-warning {{cannot prove declared bounds for 't13b' are valid after initialization}}
+  _Nt_array_ptr<int> t15b = x2d[0];  // expected-warning {{cannot prove declared bounds for 't15b' are valid after initialization}}
 }
 
 // Creating a pointer with count bounds into an existing array.
 void passing_test_1(void) {
   int a _Checked[10] = { 9, 8, 7, 6, 5, 4, 3, 2, 1};
-  _Array_ptr<int> b : count(5) = &a[2];  // expected-error {{it is not possible to prove that the inferred bounds of 'b' imply the declared bounds of 'b' after initialization}}
+  _Array_ptr<int> b : count(5) = &a[2];  // expected-warning {{cannot prove declared bounds for 'b' are valid after initialization}}
 }

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
@@ -51,8 +51,8 @@ _Array_ptr<int> f11(unsigned num) {
 
 _Array_ptr<int> f12(unsigned num1, unsigned num2){
   _Array_ptr<int> p : count(num1) = test_f10(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                    // expected-note {{the declared upper bounds use the value of the variable 'num1', and there is no relational information between 'num1' and any of the variables used by the inferred upper bounds}} \
-                                                    // expected-note {{the inferred upper bounds use the value of the variable 'num2', and there is no relational information between 'num2' and any of the variables used by the declared upper bounds}} \
+                                                    // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                    // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                     // expected-note {{(expanded) declared bounds are 'bounds(p, p + num1)'}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds(value of test_f10(num2), value of test_f10(num2) + num2)'}}
   return p;
@@ -67,8 +67,8 @@ _Array_ptr<int> f14(unsigned num) {
 
 _Array_ptr<int> f15(unsigned num1, unsigned num2){
   _Array_ptr<int> p : byte_count(num1) = test_f13(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                         // expected-note {{the declared upper bounds use the value of the variable 'num1', and there is no relational information between 'num1' and any of the variables used by the inferred upper bounds}} \
-                                                         // expected-note {{the inferred upper bounds use the value of the variable 'num2', and there is no relational information between 'num2' and any of the variables used by the declared upper bounds}} \
+                                                         // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                         // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                          // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + num1)'}} \
                                                          // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f13(num2), (_Array_ptr<char>)value of test_f13(num2) + num2)'}}
   return p;

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking-bsi.c
@@ -51,8 +51,8 @@ _Array_ptr<int> f11(unsigned num) {
 
 _Array_ptr<int> f12(unsigned num1, unsigned num2){
   _Array_ptr<int> p : count(num1) = test_f10(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                    // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
-                                                    // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
+                                                    // expected-note {{the declared upper bounds use the variable 'num1' and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                    // expected-note {{the inferred upper bounds use the variable 'num2' and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                     // expected-note {{(expanded) declared bounds are 'bounds(p, p + num1)'}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds(value of test_f10(num2), value of test_f10(num2) + num2)'}}
   return p;
@@ -67,8 +67,8 @@ _Array_ptr<int> f14(unsigned num) {
 
 _Array_ptr<int> f15(unsigned num1, unsigned num2){
   _Array_ptr<int> p : byte_count(num1) = test_f13(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                         // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
-                                                         // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
+                                                         // expected-note {{the declared upper bounds use the variable 'num1' and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                         // expected-note {{the inferred upper bounds use the variable 'num2' and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                          // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + num1)'}} \
                                                          // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f13(num2), (_Array_ptr<char>)value of test_f13(num2) + num2)'}}
   return p;

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -367,8 +367,8 @@ _Array_ptr<int> f51(unsigned num) {
 
 _Array_ptr<int> f52(unsigned num1, unsigned num2){
   _Array_ptr<int> p : count(num1) = test_f50(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                    // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
-                                                    // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
+                                                    // expected-note {{the declared upper bounds use the variable 'num1' and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                    // expected-note {{the inferred upper bounds use the variable 'num2' and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                     // expected-note {{(expanded) declared bounds are 'bounds(p, p + num1)'}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds(value of test_f50(num2), value of test_f50(num2) + num2)'}}
   return p;
@@ -383,8 +383,8 @@ _Array_ptr<int> f54(unsigned num) {
 
 _Array_ptr<int> f55(unsigned num1, unsigned num2){
   _Array_ptr<int> p : byte_count(num1) = test_f53(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                         // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
-                                                         // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
+                                                         // expected-note {{the declared upper bounds use the variable 'num1' and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                         // expected-note {{the inferred upper bounds use the variable 'num2' and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                          // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + num1)'}} \
                                                          // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f53(num2), (_Array_ptr<char>)value of test_f53(num2) + num2)'}}
   return p;
@@ -395,7 +395,7 @@ _Nt_array_ptr<int> test_f70_n(int c) : byte_count(c);
 
 _Array_ptr<int> f70(int num){
   _Array_ptr<int> p : byte_count(0) = test_f70(num); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                     // expected-note {{the inferred upper bounds use the variable 'num', and there is no relational information involving 'num' and any of the expressions used by the declared upper bounds}} \
+                                                     // expected-note {{the inferred upper bounds use the variable 'num' and there is no relational information involving 'num' and any of the expressions used by the declared upper bounds}} \
                                                      // expected-note {{declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 0)'}} \
                                                      // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f70(num), (_Array_ptr<char>)value of test_f70(num) + num)'}}
   return p;
@@ -403,7 +403,7 @@ _Array_ptr<int> f70(int num){
 
 _Nt_array_ptr<int> f70_n(int num){
   _Nt_array_ptr<int> p : byte_count(0) = test_f70_n(num); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                          // expected-note {{the inferred upper bounds use the variable 'num', and there is no relational information involving 'num' and any of the expressions used by the declared upper bounds}} \
+                                                          // expected-note {{the inferred upper bounds use the variable 'num' and there is no relational information involving 'num' and any of the expressions used by the declared upper bounds}} \
                                                           // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 0)'}} \
                                                           // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of test_f70_n(num), (_Array_ptr<char>)value of test_f70_n(num) + num)'}}
   return p;
@@ -567,7 +567,7 @@ static _Array_ptr<char> x1 : count(k); // expected-note {{(expanded) declared bo
 static _Array_ptr<char> x2 : count(3);
 void a_f_12(void) {
   x1 = simulate_calloc<char>(32768, sizeof(char)); // expected-error {{it is not possible to prove that the inferred bounds of 'x1' imply the declared bounds of 'x1' after assignment}} \
-                                                   // expected-note {{the declared upper bounds use the variable 'k', and there is no relational information involving 'k' and any of the expressions used by the inferred upper bounds}} \
+                                                   // expected-note {{the declared upper bounds use the variable 'k' and there is no relational information involving 'k' and any of the expressions used by the inferred upper bounds}} \
                                                    // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)), (_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)) + (size_t)32768 * sizeof(char))'}}
   x2 = simulate_calloc<char>(3, sizeof(char));
 }
@@ -596,8 +596,8 @@ void a_f_14(void) {
 void a_f_15(void) {
   long i, j;
   _Array_ptr<long> v : count(j + 1) = simulate_malloc<long>((i + 1) * sizeof(long)); // expected-error {{it is not possible to prove that the inferred bounds of 'v' imply the declared bounds of 'v' after initialization}} \
-                                                                                     // expected-note {{the declared upper bounds use the variable 'j', and there is no relational information involving 'j' and any of the expressions used by the inferred upper bounds}} \
-                                                                                     // expected-note {{the inferred upper bounds use the variable 'i', and there is no relational information involving 'i' and any of the expressions used by the declared upper bounds}} \
+                                                                                     // expected-note {{the declared upper bounds use the variable 'j' and there is no relational information involving 'j' and any of the expressions used by the inferred upper bounds}} \
+                                                                                     // expected-note {{the inferred upper bounds use the variable 'i' and there is no relational information involving 'i' and any of the expressions used by the declared upper bounds}} \
                                                                                      // expected-note {{(expanded) declared bounds are 'bounds(v, v + j + 1)'}} \
                                                                                      // expected-note {{(expanded) inferred bounds}}
 }

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -367,8 +367,8 @@ _Array_ptr<int> f51(unsigned num) {
 
 _Array_ptr<int> f52(unsigned num1, unsigned num2){
   _Array_ptr<int> p : count(num1) = test_f50(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                    // expected-note {{the declared upper bounds use the value of the variable 'num1', and there is no relational information between 'num1' and any of the variables used by the inferred upper bounds}} \
-                                                    // expected-note {{the inferred upper bounds use the value of the variable 'num2', and there is no relational information between 'num2' and any of the variables used by the declared upper bounds}} \
+                                                    // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                    // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                     // expected-note {{(expanded) declared bounds are 'bounds(p, p + num1)'}} \
                                                     // expected-note {{(expanded) inferred bounds are 'bounds(value of test_f50(num2), value of test_f50(num2) + num2)'}}
   return p;
@@ -383,8 +383,8 @@ _Array_ptr<int> f54(unsigned num) {
 
 _Array_ptr<int> f55(unsigned num1, unsigned num2){
   _Array_ptr<int> p : byte_count(num1) = test_f53(num2); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                         // expected-note {{the declared upper bounds use the value of the variable 'num1', and there is no relational information between 'num1' and any of the variables used by the inferred upper bounds}} \
-                                                         // expected-note {{the inferred upper bounds use the value of the variable 'num2', and there is no relational information between 'num2' and any of the variables used by the declared upper bounds}} \
+                                                         // expected-note {{the declared upper bounds use the variable 'num1', and there is no relational information involving 'num1' and any of the expressions used by the inferred upper bounds}} \
+                                                         // expected-note {{the inferred upper bounds use the variable 'num2', and there is no relational information involving 'num2' and any of the expressions used by the declared upper bounds}} \
                                                          // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + num1)'}} \
                                                          // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f53(num2), (_Array_ptr<char>)value of test_f53(num2) + num2)'}}
   return p;
@@ -395,7 +395,7 @@ _Nt_array_ptr<int> test_f70_n(int c) : byte_count(c);
 
 _Array_ptr<int> f70(int num){
   _Array_ptr<int> p : byte_count(0) = test_f70(num); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                     // expected-note {{the inferred upper bounds use the value of the variable 'num', and there is no relational information between 'num' and any of the variables used by the declared upper bounds}} \
+                                                     // expected-note {{the inferred upper bounds use the variable 'num', and there is no relational information involving 'num' and any of the expressions used by the declared upper bounds}} \
                                                      // expected-note {{declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 0)'}} \
                                                      // expected-note {{inferred bounds are 'bounds((_Array_ptr<char>)value of test_f70(num), (_Array_ptr<char>)value of test_f70(num) + num)'}}
   return p;
@@ -403,7 +403,7 @@ _Array_ptr<int> f70(int num){
 
 _Nt_array_ptr<int> f70_n(int num){
   _Nt_array_ptr<int> p : byte_count(0) = test_f70_n(num); // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}} \
-                                                          // expected-note {{the inferred upper bounds use the value of the variable 'num', and there is no relational information between 'num' and any of the variables used by the declared upper bounds}} \
+                                                          // expected-note {{the inferred upper bounds use the variable 'num', and there is no relational information involving 'num' and any of the expressions used by the declared upper bounds}} \
                                                           // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)p, (_Array_ptr<char>)p + 0)'}} \
                                                           // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of test_f70_n(num), (_Array_ptr<char>)value of test_f70_n(num) + num)'}}
   return p;
@@ -567,7 +567,7 @@ static _Array_ptr<char> x1 : count(k); // expected-note {{(expanded) declared bo
 static _Array_ptr<char> x2 : count(3);
 void a_f_12(void) {
   x1 = simulate_calloc<char>(32768, sizeof(char)); // expected-error {{it is not possible to prove that the inferred bounds of 'x1' imply the declared bounds of 'x1' after assignment}} \
-                                                   // expected-note {{the declared upper bounds use the value of the variable 'k', and there is no relational information between 'k' and any of the variables used by the inferred upper bounds}} \
+                                                   // expected-note {{the declared upper bounds use the variable 'k', and there is no relational information involving 'k' and any of the expressions used by the inferred upper bounds}} \
                                                    // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)), (_Array_ptr<char>)value of simulate_calloc(32768, sizeof(char)) + (size_t)32768 * sizeof(char))'}}
   x2 = simulate_calloc<char>(3, sizeof(char));
 }
@@ -596,8 +596,8 @@ void a_f_14(void) {
 void a_f_15(void) {
   long i, j;
   _Array_ptr<long> v : count(j + 1) = simulate_malloc<long>((i + 1) * sizeof(long)); // expected-error {{it is not possible to prove that the inferred bounds of 'v' imply the declared bounds of 'v' after initialization}} \
-                                                                                     // expected-note {{the declared upper bounds use the value of the variable 'j', and there is no relational information between 'j' and any of the variables used by the inferred upper bounds}} \
-                                                                                     // expected-note {{the inferred upper bounds use the value of the variable 'i', and there is no relational information between 'i' and any of the variables used by the declared upper bounds}} \
+                                                                                     // expected-note {{the declared upper bounds use the variable 'j', and there is no relational information involving 'j' and any of the expressions used by the inferred upper bounds}} \
+                                                                                     // expected-note {{the inferred upper bounds use the variable 'i', and there is no relational information involving 'i' and any of the expressions used by the declared upper bounds}} \
                                                                                      // expected-note {{(expanded) declared bounds are 'bounds(v, v + j + 1)'}} \
                                                                                      // expected-note {{(expanded) inferred bounds}}
 }

--- a/clang/test/CheckedC/static-checking/bounds-side-effects.c
+++ b/clang/test/CheckedC/static-checking/bounds-side-effects.c
@@ -29,8 +29,7 @@ void f1(int i) {
   g1_len = i, g2 = alloc(i * sizeof(int));  // correct
   g1_len = 5;                               // incorrect
 
-  g3_len = i * sizeof(int), g4 = alloc(i * sizeof(int)); // correct \
-                                                         // expected-error {{it is not possible to prove that the inferred bounds of 'g4' imply the declared bounds of 'g4' after assignment}}
+  g3_len = i * sizeof(int), g4 = alloc(i * sizeof(int)); // correct
   g3_len = 10;                                           // incorrect
   g3_low = g6_arr + 2, g4_high = g6_arr + 6, g5 = g6_arr + 2;  // correct
   g3_low = g2;                                                 // incorrect.
@@ -96,8 +95,7 @@ void f20(int len, _Array_ptr<int> p : count(len), int i) {
 }
 
 void f21(int len, _Array_ptr<int> p : byte_count(len), int i) {
-  len = i * sizeof(int), p = alloc(i * sizeof(int)); // correct \
-                                                     // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after assignment}}
+  len = i * sizeof(int), p = alloc(i * sizeof(int)); // correct
   len = 10;                                          // expected-error {{inferred bounds for 'p' are unknown after assignment}}
 }
 
@@ -153,8 +151,7 @@ void f40(int i) {
 void f41(int i) {
   int len = 0;
    _Array_ptr<int> p : byte_count(len) = 0;
-  len = i * sizeof(int), p = alloc(i * sizeof(int)); // correct \
-                                                     // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after assignment}}
+  len = i * sizeof(int), p = alloc(i * sizeof(int)); // correct
   len = 10;                                          // expected-error {{inferred bounds for 'p' are unknown after assignment}}
 }
 


### PR DESCRIPTION
This PR modifies the definition of free variables so that, if:
* `x` is a variable appearing in declared (or inferred) bounds, and:
* `y` is a variable appearing in inferred (or declared) bounds, and:
* `e1` is an expression that uses the value of `x`, and:
* `e2` is an expression that uses the value of `y`, and:
* `EquivExprs` contains a set that contains both `e1` and `e2`

then `x` is *not* a free variable.

This change means that some bounds warnings that were converted to free variable errors are now back to being warnings. The free variable note messages are also reworded to mention expressions in declared/inferred bounds rather than variables.

#### Testing
* Modified tests to reflect free variable errors which are now back to being bounds warnings.
* Modified tests to reflect reworded free variable note messages.
* Modified checkedc tests in [checkedc/428](https://github.com/microsoft/checkedc/pull/428).
* Passed automated testing on Linux.