### PR TITLE
Validate that _Nt_checked array initializer is within size

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12466,7 +12466,7 @@ bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
       }
 
       if (InitializerString) {
-        if (*DeclaredArraySize < InitializerString->getLength()) {
+        if (*DeclaredArraySize <= InitializerString->getLength()) {
           const char *StringConstant = InitializerString->getString().data();
           if (StringConstant[*DeclaredArraySize - 1] != '\0') {
             Diag(


### PR DESCRIPTION
For an _Nt_checked array the declared size should be 1 greater than the size of
the initializer to accomodate the null terminator. Due to an off-by-one error
in logic this was not being caught.

This fixes issue #935