### PR TITLE
Compare Expressions: Fix the conditions for coalescing a node with its parent

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -88,20 +88,16 @@ namespace clang {
     // @param[in] Parent is the parent of the node to be added.
     void AddNode(Node *N, Node *Parent);
 
-    // Coalesce the BinaryNode B with its parent P. This involves moving the
+    // Coalesce the BinaryNode B with its parent. This involves moving the
     // children (if any) of node B to its parent and then removing B.
     // @param[in] B is the current node. B should be a BinaryNode.
-    // @param[in] P is the parent of the node to be removed. P should be a
-    // BinaryNode.
-    void CoalesceNode(BinaryNode *B, BinaryNode *P);
+    void CoalesceNode(BinaryNode *B);
 
     // Determines if a BinaryNode could be coalesced into its parent.
     // @param[in] B is the current node. B should be a BinaryNode.
-    // @param[in] P is the parent of the node to be removed. P should be a
-    // BinaryNode.
-    // @return Return true if B can be coalesced into its parent P, false
+    // @return Return true if B can be coalesced into its parent, false
     // otherwise.
-    bool CanCoalesceNode(BinaryNode *B, BinaryNode *P);
+    bool CanCoalesceNode(BinaryNode *B);
 
     // Recursively coalesce binary nodes having the same commutative and
     // associative operator.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -88,11 +88,20 @@ namespace clang {
     // @param[in] Parent is the parent of the node to be added.
     void AddNode(Node *N, Node *Parent);
 
-    // Move the children (if any) of node N to its parent and then remove N.
-    // @param[in] N is the current node.
+    // Coalesce the BinaryNode B with its parent P. This involves moving the
+    // children (if any) of node B to its parent and then removing B.
+    // @param[in] B is the current node. B should be a BinaryNode.
     // @param[in] P is the parent of the node to be removed. P should be a
     // BinaryNode.
-    void RemoveNode(Node *N, Node *P);
+    void CoalesceNode(BinaryNode *B, BinaryNode *P);
+
+    // Determines if a BinaryNode could be coalesced into its parent.
+    // @param[in] B is the current node. B should be a BinaryNode.
+    // @param[in] P is the parent of the node to be removed. P should be a
+    // BinaryNode.
+    // @return Return true if B can be coalesced into its parent P, false
+    // otherwise.
+    bool CanCoalesceNode(BinaryNode *B, BinaryNode *P);
 
     // Recursively coalesce binary nodes having the same commutative and
     // associative operator.

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -37,14 +37,7 @@ bool PreorderAST::CanCoalesceNode(BinaryNode *B) {
   if (!P)
     return false;
 
-  // We can coalesce a BinaryNode if any one of the following conditions are
-  // true:
-  // 1. The parent has the same operator as the current node OR
-  // 2. The current node has just one child (for example, as a result of
-  // constant folding) and the parent and current operators are commutative and
-  // associative.
-
-  // We can only coalesce if the operators on the current and parent nodes are
+  // We can only coalesce if the operator of the current and parent node is
   // commutative and associative. This is because after coalescing we later
   // need to sort the nodes and if the operator is not commutative and
   // associative then sorting would be incorrect.

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -42,14 +42,10 @@ void PreorderAST::RemoveNode(Node *N, Node *Parent) {
   // We will remove a BinaryNode only if its operator is equal to its
   // parent's operator and the operator is commutative and associative.
   if (auto *B = dyn_cast<BinaryNode>(N)) {
-    assert(B->Opc == P->Opc &&
-           "BinaryNode operator must equal parent operator");
-
     assert(B->IsOpCommutativeAndAssociative() &&
            "BinaryNode operator must be commutative and associative");
 
-    if (B->Opc != P->Opc ||
-       !B->IsOpCommutativeAndAssociative()) {
+    if (!B->IsOpCommutativeAndAssociative()) {
       SetError();
       return;
     }

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -39,8 +39,8 @@ void PreorderAST::RemoveNode(Node *N, Node *Parent) {
     return;
   }
 
-  // We will remove a BinaryNode only if its operator is equal to its
-  // parent's operator and the operator is commutative and associative.
+  // We will remove a BinaryNode only if its operator is commutative and
+  // associative.
   if (auto *B = dyn_cast<BinaryNode>(N)) {
     assert(B->IsOpCommutativeAndAssociative() &&
            "BinaryNode operator must be commutative and associative");

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -169,3 +169,15 @@ void f14(int i) {
 // CHECK:  [B1]
 // CHECK-NOT: upper_bound(p)
 }
+
+void f15(_Nt_array_ptr<char> p : count(6)) {
+  if (*(p + (1 * (2 * 3))))
+  {}
+
+// CHECK: In function: f15
+//  [B2]
+//    1: _Nt_array_ptr<char> p : count(6) = "a";
+//    2: *(p + (1 * (2 * 3)))
+//  [B1]
+// upper_bound(p) = 1
+}


### PR DESCRIPTION
We can coalesce a BinaryNode if any one of the following conditions are
true:
1. The parent has the same operator as the current node OR
2. The current node has just one child (for example, as a result of
constant folding) and the parent and current operators are commutative and
associative.

Fixes issue #932