### PR TITLE
Compare Expressions: Fix normalization of exprs by adding zero

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -118,10 +118,6 @@ namespace clang {
     // this to control when to stop recursive constant folding.
     void ConstantFold(Node *N, bool &Changed);
 
-    // Normalize expressions which do not have any integer constants.
-    // @param[in] N is current node of the AST. Initial value is Root.
-    void NormalizeExprsWithoutConst(Node *N);
-
     // Get the deref offset from the DerefExpr. The offset represents the
     // possible amount by which the bounds of an ntptr could be widened.
     // @param[in] UpperExpr is the upper bounds expr for the ntptr.

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-multiple-derefs.c
@@ -328,7 +328,7 @@ void f15(int i) {
 // CHECK:    1: *(p - i + 1)
 // CHECK: upper_bound(p) = 1
 // CHECK:  [B11]
-// CHECK: upper_bound(p) = 1
+// CHECK: upper_bound(p) = 2
 
   _Nt_array_ptr<char> q : count(0) = "a";
   if (*q && *(q - 1))


### PR DESCRIPTION
Previously, in order to normalize exprs we added zero only to exprs not
containing any other constants. Also, for binary nodes with + operator we added
+0 and for nodes with * operator we added *1. This resulted in exprs like "p -
i" which do not contain constants but also do not have + or * operator to not
get normalized. So we simply the logic to add zero. Now we simply add a binary
node with the + operator and a 0 child at the root of the AST. This makes the
logic simpler and handles a wider variety of cases.

This fixes issue #933