### PR TITLE
Add bounds declaration checking doc

### DIFF
--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -26,16 +26,19 @@ void f(array_ptr<int> p : count(i), array_ptr<int> q : count(j)) {
   // p has inferred bounds of bounds(q, q + j).
   p = q;
 
-  // Updating after modifying a variable used in declared bounds:
-  // The value of i is lost after this assignment, so the inferred
-  // bounds of p are bounds(unknown).
-  i = 0;
-
-  // Updating after modifying a variable used in declared bounds:
-  // The original value of i before this assignment was i - 1.
+  // Updating after an invertible modification to a variable used in declared
+  // bounds: The original value of i before this assignment is i - 1.
   // This original value is substituted for i in the inferred bounds
   // of p, so the inferred bounds of p are bounds(p, p + i - 1).
   i = i + 1;
+
+  // Updating after some uninvertible modifications to a variable used in
+  // declared bounds: The compiler cannot determine an original value for i
+  // after these assignments, so the inferred bounds of p are bounds(unknown).
+  i = 0;
+  i = p[1] / 3;
+  i = *q;
+  i = 2 * i;
 }
 ```
 

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -8,8 +8,35 @@ The bounds checking code uses the following definitions to reason about bounds e
 - **Declared bounds**: The bounds that the programmer has declared for a pointer expression. For example, in `array_ptr<int> p : bounds(p, p + 1) = 0`, the declared bounds of `p` are `bounds(p, p + 1)`.
 - **Inferred bounds**: The bounds that the compiler determines for a pointer expression at a particular point in checking a statement. For example, after checking `array_ptr<int> p : bounds(p, p + 1) = 0`, the inferred bounds of `p` are `bounds(any)` (since `0` by definition has bounds of `bounds(any)`).
 
+Examples:
+```
+// p has declared bounds of bounds(p, p + i).
+// q has declared bounds of bounds(q, q + j).
+void f(array_ptr<int> p : count(i), array_ptr<int> q : count(j)) {
+  // Updating after assignment: The inferred bounds of the left-hand side
+  // variable are the bounds of the right-hand side expression.
+  // p has inferred bounds of bounds(q, q + j).
+  p = q;
+
+  // Updating after modifying a variable used in declared bounds:
+  // The value of i is lost after this assignment, so the inferred
+  // bounds of p are bounds(unknown).
+  i = 0;
+
+  // Updating after modifying a variable used in declared bounds:
+  // The original value of i before this assignment was i - 1.
+  // This original value is substituted for i in the inferred bounds
+  // of p, so the inferred bounds of p are bounds(p, p + i - 1).
+  i = i + 1;
+}
+```
+
 ## Checking State
 The bounds checking methods use the [CheckingState](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L661) class to maintain state while recursively checking expressions. The members of CheckingState track information that is then used to prove or disprove that inferred bounds imply declared bounds. Some notable members of CheckingState include:
 - **ObservedBounds**: A map of variables to the current inferred bounds as determined by the bounds checker.
+  - Example: If ObservedBounds is `{ p => bounds(p, p + 1), q => bounds(unknown) }`, then the current inferred bounds of `p` are `bounds(p, p + 1)` and the current bounds of `q` are `bounds(unknown)`.
 - **EquivExprs**: A set of sets of expressions that produce the same value. If expressions `e1` and `e2` are in the same set in EquivExprs, then `e1` and `e2` produce the same value.
-- **SameValue**: a set of expressions that produce the same value as the expression that is currently being checked.
+  - Example: If EquivExprs is `{ { x, y, 1 }, { i + j, k } }`, then the variables `x` and `y` are equal to `1`, and the variable `k` is equal to `i + j`.
+- **SameValue**: A set of expressions that produce the same value as the expression that is currently being checked.
+  - Example: If SameValue is `{ x, y, 1 }` and the current expression being checked is the variable `y`, then `x`, `y`, and `1` all produce the same value as `y`.
+  

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -1,0 +1,15 @@
+# Bounds Declaration Checking
+
+## Checking Overview
+After each statement in the clang CFG, the inferred bounds for an expression must imply the expression's declared bounds. The algorithms for inferring and checking bounds for expressions are implemented in [SemaBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp).
+
+## Bounds Terminology
+The bounds checking code uses the following definitions to reason about bounds expressions:
+- **Declared bounds**: The bounds that the programmer has declared for a pointer expression. For example, in `array_ptr<int> p : bounds(p, p + 1) = 0`, the declared bounds of `p` are `bounds(p, p + 1)`.
+- **Inferred bounds**: The bounds that the compiler determines for a pointer expression at a particular point in checking a statement. For example, after checking `array_ptr<int> p : bounds(p, p + 1) = 0`, the inferred bounds of `p` are `bounds(any)` (since `0` by definition has bounds of `bounds(any)`).
+
+## Checking State
+The bounds checking methods use the [CheckingState](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L661) class to maintain state while recursively checking expressions. The members of CheckingState track information that is then used to prove or disprove that inferred bounds imply declared bounds. Some notable members of CheckingState include:
+- **ObservedBounds**: A map of variables to the current inferred bounds as determined by the bounds checker.
+- **EquivExprs**: A set of sets of expressions that produce the same value. If expressions `e1` and `e2` are in the same set in EquivExprs, then `e1` and `e2` produce the same value.
+- **SameValue**: a set of expressions that produce the same value as the expression that is currently being checked.

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -1,12 +1,20 @@
 # Bounds Declaration Checking
 
 ## Checking Overview
-After each statement in the clang CFG, the inferred bounds for an expression must imply the expression's declared bounds. The algorithms for inferring and checking bounds for expressions are implemented in [SemaBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp).
+After each statement in the clang CFG, the inferred bounds for an expression
+must imply the expression's declared bounds. The algorithms for inferring and
+checking bounds for expressions are implemented in [SemaBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp).
 
 ## Bounds Terminology
-The bounds checking code uses the following definitions to reason about bounds expressions:
-- **Declared bounds**: The bounds that the programmer has declared for a pointer expression. For example, in `array_ptr<int> p : bounds(p, p + 1) = 0`, the declared bounds of `p` are `bounds(p, p + 1)`.
-- **Inferred bounds**: The bounds that the compiler determines for a pointer expression at a particular point in checking a statement. For example, after checking `array_ptr<int> p : bounds(p, p + 1) = 0`, the inferred bounds of `p` are `bounds(any)` (since `0` by definition has bounds of `bounds(any)`).
+The bounds checking code uses the following definitions to reason about
+bounds expressions:
+- **Declared bounds**: The bounds that the programmer has declared for a
+pointer expression. For example, in `array_ptr<int> p : bounds(p, p + 1) = 0`,
+the declared bounds of `p` are `bounds(p, p + 1)`.
+- **Inferred bounds**: The bounds that the compiler determines for a pointer
+expression at a particular point in checking a statement. For example, after
+checking `array_ptr<int> p : bounds(p, p + 1) = 0`, the inferred bounds of `p`
+are `bounds(any)` (since `0` by definition has bounds of `bounds(any)`).
 
 Examples:
 ```
@@ -32,11 +40,25 @@ void f(array_ptr<int> p : count(i), array_ptr<int> q : count(j)) {
 ```
 
 ## Checking State
-The bounds checking methods use the [CheckingState](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L661) class to maintain state while recursively checking expressions. The members of CheckingState track information that is then used to prove or disprove that inferred bounds imply declared bounds. Some notable members of CheckingState include:
-- **ObservedBounds**: A map of variables to the current inferred bounds as determined by the bounds checker.
-  - Example: If ObservedBounds is `{ p => bounds(p, p + 1), q => bounds(unknown) }`, then the current inferred bounds of `p` are `bounds(p, p + 1)` and the current bounds of `q` are `bounds(unknown)`.
-- **EquivExprs**: A set of sets of expressions that produce the same value. If expressions `e1` and `e2` are in the same set in EquivExprs, then `e1` and `e2` produce the same value.
-  - Example: If EquivExprs is `{ { x, y, 1 }, { i + j, k } }`, then the variables `x` and `y` are equal to `1`, and the variable `k` is equal to `i + j`.
-- **SameValue**: A set of expressions that produce the same value as the expression that is currently being checked.
-  - Example: If SameValue is `{ x, y, 1 }` and the current expression being checked is the variable `y`, then `x`, `y`, and `1` all produce the same value as `y`.
+The bounds checking methods use the [CheckingState](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L661)
+class to maintain state while recursively checking expressions. The members
+of CheckingState track information that is then used to prove or disprove
+that inferred bounds imply declared bounds. Some notable members of
+CheckingState include:
+- **ObservedBounds**: A map of variables to the current inferred bounds as
+determined by the bounds checker.
+  - Example: If ObservedBounds is `{ p => bounds(p, p + 1), q => bounds(unknown) }`,
+  then the current inferred bounds of `p` are `bounds(p, p + 1)` and the
+  current bounds of `q` are `bounds(unknown)`.
+- **EquivExprs**: A set of sets of expressions that produce the same value. If
+expressions `e1` and `e2` are in the same set in EquivExprs, then `e1` and `e2`
+produce the same value.
+  - Example: If EquivExprs is `{ { x, y, 1 }, { i + j, k } }`, then the
+  variables `x` and `y` are equal to `1`, and the variable `k` is equal
+  to `i + j`.
+- **SameValue**: A set of expressions that produce the same value as the
+expression that is currently being checked.
+  - Example: If SameValue is `{ x, y, 1 }` and the current expression being
+  checked is the variable `y`, then `x`, `y`, and `1` all produce the same
+  value as `y`.
   

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -18,11 +18,13 @@ expression at a particular point in checking a statement.
   inferred bounds of `p` are `bounds(any)` (since `0` by definition has
   bounds of `bounds(any)`).
 - **RValue bounds**: The bounds of the value produced by an rvalue expression.
-  - Example: If `p` is a variable with declared bounds of `bounds(p, p + 1)`,
-  then the rvalue expression `p + 3` has rvalue bounds of `bounds(p, p + 1)`.
-  - Example: If `p` is a variable with declared bounds of `bounds(p, p + 5)`,
-  then the rvalue expression from reading the value of `*(p + 2)` has rvalue
-  bounds of `bounds(unknown)`.
+  - Example: If `p` is a variable of type `array_ptr<int>` with declared bounds
+  of `bounds(p, p + 1)`, then the rvalue expression `p + 3` has type
+  `array_ptr<int>` and rvalue bounds of `bounds(p, p + 1)`.
+  - Example: If `p` is a variable of type `array_ptr<int>` with declared bounds
+  of `bounds(p, p + 5)`, then the rvalue expression from reading the value of
+  `*(p + 2)` has rvalue bounds of `bounds(unknown)`. `*(p + 2)` has type `int`,
+  and integers do not have bounds.
 - **LValue bounds**: The bounds of an lvalue expression `e`. These bounds
 determine whether it is valid to access memory using `e`, and should be the
 range (or a subrange) of an object in memory. LValue bounds are used to check

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -10,11 +10,11 @@ The bounds checking code uses the following definitions to reason about
 bounds expressions:
 - **Declared bounds**: The bounds that the programmer has declared for a
 pointer expression.
-  -Example: In `array_ptr<int> p : bounds(p, p + 1) = 0;`, the declared bounds
+  - Example: In `array_ptr<int> p : bounds(p, p + 1) = 0;`, the declared bounds
   of `p` are `bounds(p, p + 1)`.
 - **Inferred bounds**: The bounds that the compiler determines for a pointer
 expression at a particular point in checking a statement.
-  -Example: After checking `array_ptr<int> p : bounds(p, p + 1) = 0`, the
+  - Example: After checking `array_ptr<int> p : bounds(p, p + 1) = 0`, the
   inferred bounds of `p` are `bounds(any)` (since `0` by definition has
   bounds of `bounds(any)`).
 - **RValue bounds**: The bounds of the value produced by an rvalue expression.
@@ -26,9 +26,9 @@ expression at a particular point in checking a statement.
   `*(p + 2)` has rvalue bounds of `bounds(unknown)`. `*(p + 2)` has type `int`,
   and integers do not have bounds.
 - **LValue bounds**: The bounds of an lvalue expression `e`. These bounds
-determine whether it is valid to access memory using `e`, and should be the
-range (or a subrange) of an object in memory. LValue bounds are used to check
-that a memory access is within bounds.
+determine whether it is valid to access memory using the lvalue produced by
+`e`, and should be the range (or a subrange) of an object in memory. LValue
+bounds are used to check that a memory access is within bounds.
   - Example: If `p` is a non-array-typed variable, then the lvalue bounds
   of `p` are `bounds(&p, &p + 1)`.
   - Example: If `p` is a variable with declared bounds of `bounds(p, p + 3)`,
@@ -97,18 +97,19 @@ a range with base `p`, lower offset `i`, and upper offset `j`.
 
 In order for an inferred bounds range with base `S`, lower offset `Sl`, and
 upper offset `Su` to imply a target bounds range with base `D`, lower offset
-`Dl`, and upper offset `du`, the following must be true:
+`Dl`, and upper offset `Du`, the following must be true:
 1. `S == D`, and:
 2. `Sl <= Dl`, and:
 3. `Du <= Su`
+
 In other words, the target bounds range must be contained within the inferred
 bounds range.
 
-If the compiler can prove that inferred bounds imply target bounds, no compile-
-time errors or warnings are emitted. If the compiler can prove that inferred
-bounds do not imply target bounds, a compile-time error is emitted. If the
-compiler can neither prove nor disprove that inferred bounds imply target
-bounds, a compile-time warning is emitted.
+If the compiler can prove that inferred bounds imply target bounds, no
+compile-time errors or warnings are emitted. If the compiler can prove that
+inferred bounds do not imply target bounds, a compile-time error is emitted.
+If the compiler can neither prove nor disprove that inferred bounds imply
+target bounds, a compile-time warning is emitted.
 
 Examples of inferred bounds provably implying target bounds:
 ```
@@ -193,7 +194,7 @@ recursively calling Check and/or CheckLValue on the subexpressions of `e`.
 2. If needed, use the inferred lvalue bounds to add a bounds check to an
 lvalue expression `e1` (`e1` could be `e` or one of its subexpressions).
 This check performs the following actions:
-  * Checks that the memory access that the `e1` is being used to perform
+  * Checks that the memory access that `e1` is being used to perform
   meets the lvalue bounds.
   * Sets the lvalue bounds of `e1`. During code generation, these lvalue
   bounds will be used to insert a dynamic check. At runtime, the dynamic

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -151,22 +151,30 @@ class to maintain state while recursively checking expressions. The members
 of CheckingState track information that is then used to prove or disprove
 that inferred bounds imply declared bounds. Some notable members of
 CheckingState include:
-- **ObservedBounds**: A map of variables to the current inferred bounds as
-determined by the bounds checker.
-  - Example: If ObservedBounds is `{ p => bounds(p, p + 1), q => bounds(unknown) }`,
-  then the current inferred bounds of `p` are `bounds(p, p + 1)` and the
-  current bounds of `q` are `bounds(unknown)`.
-- **EquivExprs**: A set of sets of expressions that produce the same value. If
-expressions `e1` and `e2` are in the same set in EquivExprs, then `e1` and `e2`
-produce the same value.
-  - Example: If EquivExprs is `{ { x, y, 1 }, { i + j, k } }`, then the
-  variables `x` and `y` are equal to `1`, and the variable `k` is equal
-  to `i + j`.
-- **SameValue**: A set of expressions that produce the same value as the
-expression that is currently being checked.
-  - Example: If SameValue is `{ x, y, 1 }` and the current expression being
-  checked is the variable `y`, then `x`, `y`, and `1` all produce the same
-  value as `y`.
+
+### ObservedBounds
+A map of variables to their current inferred bounds as determined by the
+bounds checker.
+
+Example: If ObservedBounds is `{ p => bounds(p, p + 1), q => bounds(unknown) }`,
+then the current inferred bounds of `p` are `bounds(p, p + 1)` and the current
+bounds of `q` are `bounds(unknown)`.
+
+### EquivExprs
+A set of sets of expressions that produce the same value. If expressions `e1`
+and `e2` are in the same set in EquivExprs, then `e1` and `e2` produce the
+same value.
+
+Example: If EquivExprs is `{ { x, y, 1 }, { i + j, k } }`, then the variables
+`x` and `y` are equal to `1`, and the variable `k` is equal to `i + j`.
+
+### SameValue
+A set of expressions that produce the same value as the expression that is 
+currently being checked.
+
+Example: If SameValue is `{ x, y, 1 }` and the current expression being
+checked is the variable `y`, then `x`, `y`, and `1` all produce the same
+value as `y`.
 
 ## Checking Methods
 The entry point for bounds checking is the method [TraverseCFG](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L2317). For each statement `S` in the

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -175,6 +175,23 @@ void f(_Array_ptr<int> small : count(2), _Array_ptr<int> large : count(5)) {
 }
 ```
 
+Examples where the bounds checker cannot prove that the inferred bounds
+imply the target bounds:
+
+```
+void f(_Array_ptr<int> p : count(2), _Array_ptr<int> q : count(3)) {
+  // Target LHS bounds: bounds(p, p + 2)
+  // Inferred RHS bounds: bounds(q, q + 3)
+  // Target LHS range: p with lower offset 0 and upper offset 2
+  // Inferred RHS range: q with lower offset 0 and upper offset 3
+  // The bases of these ranges (p and q) are not equivalent. After the
+  // assignment p = q + 1, p and q + 1 are equivalent, but p and q are
+  // not equivalent. Since the bases are not equivalent, the bounds checker
+  // cannot prove the validity of these bounds.
+  p = q + 1;
+}
+```
+
 ## Checking State
 The bounds checking methods use the [CheckingState](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L661)
 class to maintain state while recursively checking expressions. The members

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -13,7 +13,7 @@ The bounds checking code uses the following definitions to reason about
 bounds expressions:
 
 - **Declared bounds**: The bounds that the programmer has declared for a
-  pointer expression.
+  pointer-typed or array-typed expression.
   - Example: In `_Array_ptr<int> p : bounds(p, p + 1) = 0;`, the declared bounds
     of `p` are `bounds(p, p + 1)`.
 - **Inferred bounds**: The bounds that the compiler determines for a pointer
@@ -42,12 +42,13 @@ bounds expressions:
     `bounds(p, p + 3)`.
 - **Target bounds**: The target bounds of an lvalue expression `e`. Values
   assigned to `e` must satisfy these bounds. Values read through `e` will
-  meet these bounds.
+  meet these bounds. If an lvalue expression `e` has target bounds, then `e`
+  must either have pointer type or array type.
   - Example: If `p` is a variable with declared bounds of `bounds(p, p + 1)`,
     then the target bounds of `p` are `bounds(p, p + 1)`.
   - Example: If `p` is a pointer to a null-terminated array pointer, then
     the target bounds of `*p` are `bounds(*p, *p + 0)`.
-  - Example: If `p` is a pointer to a singleton `ptr<T>`, then the target
+  - Example: If `p` is a pointer to a singleton `_Ptr<T>`, then the target
     bounds of `*p` are `bounds((_Array_ptr<T>)*p, (_Array_ptr<T>)*p + 1)`.
   - Example: If S is a struct with members
     `{ _Array_ptr<int> f : count(len); int len; }` and `s` is a variable of

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -92,29 +92,40 @@ of each lvalue expression, and attempts to prove or disprove that the inferred
 bounds for the value produced by the lvalue expression imply the target bounds.
 
 ## Bounds Validity
-After checking each statement in the clang CFG, the compiler attempts to prove
-or disprove that the inferred bounds of each variable imply the target bounds
-of the variable. (The target bounds of a variable are always the declared
-bounds of the variable). In addition, after an assignment to a non-variable
-lvalue, the compiler attempts to prove that the inferred bounds of the
-right-hand side expression imply the target bounds of the left-hand side
-lvalue expression.
 
-For all bounds expressions `B`:
-1. Inferred bounds of `bounds(any)` imply target bounds of `B`.
-2. Inferred bounds of `B` imply target bounds of `bounds(unknown)`.
-3. Inferred bounds of `bounds(unknown)` do not imply target bounds
-other than `bounds(unknown)`.
+For a given inferred bounds expression `S` and a target bounds expression `D`,
+the bounds checker attempts to prove or disprove that `S` implies `D`. There
+are three possible results for this proof:
 
-If both the inferred and target bounds are neither `bounds(any)` or
-`bounds(unknown)`, they are converted to ranges. A range consists of a
-base expression, a lower offset expression, and an upper offset expression.
-For example, the bounds expression `bounds(p - i, p + j)` will be converted to
-a range with base `p`, lower offset `i`, and upper offset `j`.
+1. `True`: the bounds checker proved that `S` implies `D`.
+2. `False`: the bounds checker proved that `S` does not imply `D`.
+3. `Maybe`: the bounds checker could neither prove nor disprove that `S`
+   implies `D`. Some features of the bounds checker are not fully implemented,
+   so it will not be able to prove or disprove bounds validity for all inferred
+   and target bounds expressions.
+
+The bounds checker uses the following rules to determine whether `S` implies
+`D`:
+
+1. If `S` is `bounds(any)`, then `S` implies `D`.
+2. If `D` is `bounds(unknown)`, then `S` implies `D`.
+3. If `S` is `bounds(unknown)` and `D` is not `bounds(unknown)`, then `S`
+   does not imply `D`.
+
+If `S` and `D` are neither `bounds(any)` nor `bounds(unknown)`, they are
+converted to ranges. A range consists of:
+
+1. A base expression.
+2. A lower offset. This may be either an integer constant or an expression.
+3. An upper offset. This may be either an integer constant or an expression.
+
+For example, the bounds expression `bounds(p - 2, p + j)` will be converted to
+a range with base `p`, lower offset `2`, and upper offset `j`.
 
 In order for an inferred bounds range with base `S`, lower offset `Sl`, and
 upper offset `Su` to imply a target bounds range with base `D`, lower offset
 `Dl`, and upper offset `Du`, the following must be true:
+
 1. `S == D`, and:
 2. `Sl <= Dl`, and:
 3. `Du <= Su`

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -549,10 +549,10 @@ void f(_Array_ptr<int> a : count(i), unsigned i) {
 
 ### ValidateBoundsContext
 
-After checking a statement `S`, this method checks that, for each variable
-declaration `v` in `ObservedBounds`, the inferred bounds `ObservedBounds[v]`
-imply the declared bounds of `v` (`v->getBoundsExpr()`). The bounds validation
-uses the expression equality recorded in `EquivExprs`.
+After checking a statement `S`, this method checks that, for each `AbstractSet`
+`A` in `ObservedBounds`, the inferred bounds `ObservedBounds[A]` for all lvalue
+expressions in `A` imply the target bounds for all lvalue expressions in `A`.
+The bounds validation uses the expression equality recorded in `EquivExprs`.
 
 ## Checking Methods
 The entry point for bounds checking is the method [TraverseCFG](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp#L2317). For each statement `S` in the

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -150,7 +150,7 @@ Examples of inferred bounds provably implying target bounds:
 void f(_Array_ptr<int> small : count(2), _Array_ptr<int> large : count(5)) {
   // Target LHS bounds: bounds(small, small + 2)
   // Inferred RHS bounds: bounds(large + 5)
-  small = large + 7;
+  small = large;
 
   // Target LHS bounds: bounds(unknown)
   // Inferred RHS bounds: bounds(unknown)
@@ -316,7 +316,7 @@ bounds. For example:
 
 ```
 void f(_Array_ptr<_Nt_array_ptr<char>> p : count(10)) {
-  *p = "abc;
+  *p = "abc";
   p[0] = "xyz";
 }
 ```

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -1,9 +1,11 @@
 # Bounds Declaration Checking
 
 ## Checking Overview
-After each statement in the clang CFG, the inferred bounds for an expression
-must imply the expression's declared bounds. The algorithms for inferring and
-checking bounds for expressions are implemented in [SemaBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp).
+
+After each statement in the clang CFG, the inferred bounds for the value
+prodced by an lvalue expression must imply the target bounds for the lvalue.
+The algorithms for inferring and checking bounds for expressions are
+implemented in [SemaBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/Sema/SemaBounds.cpp).
 
 ## Bounds Terminology
 The bounds checking code uses the following definitions to reason about

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -425,29 +425,6 @@ void f(int flag) {
 }
 ```
 
-### UpdateCtxWithWidenedBounds
-
-Before checking a CFG block `B`, this method updates `ObservedBounds` to map
-each variable that has widened bounds in `B` to its widened bounds. For
-example:
-
-```
-void f(_Nt_array_ptr<char> p : count(1)) {
-  if (*(p + 1)) {
-    // CFG block B.
-    // Within this block, the bounds of p are widened by 1.
-
-    // p[1] is within the (widened) observed bounds of (p, p + 2).
-    char c = p[1];
-  }
-}
-```
-
-`p` initially has observed bounds of `bounds(p, p + 1)` (the declared bounds
-of `p`). In block `B`, `p` has widened bounds of `bounds(p, p + 2)`. Before
-checking block `B`, `UpdateCtxWithWidenedBounds` updates `ObservedBounds` so
-that `ObservedBounds[p] = bounds(p, p + 2)`.
-
 ### GetDeclaredBounds
 
 Before checking a statement `S` within a CFG block `B`, this method updates

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -423,6 +423,16 @@ Example: If `SameValue` is `{ x, y, 1 }` and the current expression being
 checked is the variable `y`, then `x`, `y`, and `1` all produce the same
 value as `y`.
 
+In addition, the `CheckingState` class also has several members that keep
+track of information that is used to emit diagnostic messages during bounds
+validation (if the bounds checker is not able to prove that a given inferred
+bounds expression implies a given target bounds expression). These members
+include:
+
+1. `LostLValues`
+2. `UnknownSrcBounds`
+3. `BlameAssignments`
+
 ## Updating the Checking State
 
 The `ObservedBounds` and `EquivExprs` members of the `CheckingState` instance

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -82,6 +82,15 @@ void f(_Array_ptr<int> p : count(i), _Array_ptr<int> q : count(j)) {
 }
 ```
 
+## Bounds Checking Implementation Overview
+
+The bounds checker traverses each top-level statement in the body of a
+function. During this traversal, the bounds checker determines the inferred
+bounds for the lvalue expressions that are currently in scope. At the end
+of traversing the statement, the bounds checker determines the target bounds
+of each lvalue expression, and attempts to prove or disprove that the inferred
+bounds for the value produced by the lvalue expression imply the target bounds.
+
 ## Bounds Validity
 After checking each statement in the clang CFG, the compiler attempts to prove
 or disprove that the inferred bounds of each variable imply the target bounds

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -140,8 +140,9 @@ If the compiler can neither prove nor disprove that inferred bounds imply
 target bounds, a compile-time warning is emitted.
 
 Examples of inferred bounds provably implying target bounds:
+
 ```
-void f(array_ptr<int> small : count(2), array_ptr<int> large : count(5)) {
+void f(_Array_ptr<int> small : count(2), _Array_ptr<int> large : count(5)) {
   // Target LHS bounds: bounds(small, small + 2)
   // Inferred RHS bounds: bounds(large + 5)
   small = large + 7;
@@ -156,20 +157,21 @@ void f(array_ptr<int> small : count(2), array_ptr<int> large : count(5)) {
 
   // Target LHS bounds: bounds(large, large + 5)
   // Inferred RHS bounds: bounds(small, small + 10)
-  large = _Dynamic_bounds_cast<array_ptr<int>>(small, bounds(small, small + 10));
+  large = _Dynamic_bounds_cast<_Array_ptr<int>>(small, bounds(small, small + 10));
 }
 ```
 
 Examples of inferred bounds provably not implying target bounds:
+
 ```
-void f(array_ptr<int> small : count(2), array_ptr<int> large : count(5)) {
+void f(_Array_ptr<int> small : count(2), _Array_ptr<int> large : count(5)) {
   // Target LHS bounds: bounds(large, large + 5)
   // Inferred RHS bounds: bounds(small, small + 2)
   large = small;
 
   // Target LHS bounds: bounds(large, large + 5)
   // Inferred RHS bounds: bounds(small, small + 3)
-  large = _Dynamic_bounds_cast<array_ptr<int>>(small, bounds(small, small + 3));
+  large = _Dynamic_bounds_cast<_Array_ptr<int>>(small, bounds(small, small + 3));
 }
 ```
 

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -372,9 +372,9 @@ each variable imply the declared bounds of the variable.
 After validating the bounds, `ObservedBounds` is reset to its value from before
 checking `S`. Any observed bounds that were updated while checking `S` are only
 used to validate the bounds. They do not persist across multiple statements in
-a CFG block. Finally, `ObservedBounds` is updated so that, for each variable
-`x` whose widened bounds in `B` were killed by `S`, `ObservedBounds[x]` is the
-declared bounds of `x`.
+a CFG block. Finally, `ObservedBounds` is updated so that, if a variable `v` is
+no longer in scope after `S`, the `AbstractSet` `V` containing `v` is removed
+from `ObservedBounds`. The value of `v` is also removed fro `EquivExprs`.
 
 The following methods are responsible for updating the `ObservedBounds` and
 `EquivExprs` members of the checking state.

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -328,18 +328,34 @@ The `ObservedBounds` and `EquivExprs` members of the `CheckingState` instance
 are updated before, during, and after checking each statement `S` in a CFG
 block `B`.
 
+**Before** checking the block `B`:
+
+The incoming `CheckingState` for a block `B` is determined by taking the
+intersection of the `CheckingStates` for each predecessor block of `B`.
+This intersection is computed in the method `GetIncomingBlockState`. To
+get the intersection of any two `CheckingState` instances `State1` and
+`State2`:
+
+1. The resulting `ObservedBounds` map contains a mapping for each `AbstractSet`
+   `A` that is a key in both `State1.ObservedBounds` and `State2.ObservedBounds`.
+   `ObservedBounds[A]` is the target bounds for all lvalue expressions in `A`.
+2. Each set in the resulting `EquivExprs` is the intersection of a set `F`
+   in `State1.EquivExprs` and a set `G` in `State2.EquivExprs`, if the
+   intersection of `F` and `G` contains more than one expression.
+
 **Before** checking `S`:
 
-`ObservedBounds` will contain a mapping for each variable `v` that:
+For each variable `v` that:
 
 1. Is in scope at `S` or is declared in `S`, and:
-2. Has declared bounds.
+2. Has declared bounds,
 
-For each variable `v` in `ObservedBounds`,
-`ObservedBounds[v]` will be either:
+`ObservedBounds` will contain an `AbstractSet` `V` that contains `v`.
 
-1. The widened bounds of `v`, if `v` has widened bounds in the block `B` and
-   the widened bounds of `v` were not killed by a previous statement in `B`, or:
+`ObservedBounds[V]` (where `V` contains a variable `v`) will be either:
+
+1. The widened bounds of `v`, if `v` has widened bounds at the statement `S`
+   (as determined by the [BoundsWideningAnalysis](https://github.com/microsoft/checkedc-clang/blob/master/clang/include/clang/Sema/BoundsWideningAnalysis.h)), or:
 2. The declared bounds of `v`.
 
 **While** checking `S`:

--- a/clang/docs/checkedc/Bounds-Declaration-Checking.md
+++ b/clang/docs/checkedc/Bounds-Declaration-Checking.md
@@ -64,7 +64,8 @@ Examples of declared and inferred bounds:
 ```
 // p has declared bounds of bounds(p, p + i).
 // q has declared bounds of bounds(q, q + j).
-void f(_Array_ptr<int> p : count(i), _Array_ptr<int> q : count(j)) {
+void f(_Array_ptr<int> p : count(i), _Array_ptr<int> q : count(j),
+       unsigned int i, unsigned int j) {
   // Updating after assignment: The inferred bounds of the left-hand side
   // variable are the bounds of the right-hand side expression.
   // p has inferred bounds of bounds(q, q + j).


### PR DESCRIPTION
This PR adds an initial document describing some aspects of bounds declaration checking. Currently, it contains sections on bounds terminology (declared vs inferred bounds) and the CheckingState class that is used to maintain state during checking. In future, this document can contain more detailed sections on the bounds checking algorithms.