### PR TITLE
Remove.gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf


### PR DESCRIPTION
The .gitattributes file causes some issues on Windows when attempting to upgrade to the latest clang/llvm sources. The cache fails to refresh for a random selection of files.