### PR TITLE
Fix x64 Windows builds break

### DIFF
--- a/clang/lib/3C/CMakeLists.txt
+++ b/clang/lib/3C/CMakeLists.txt
@@ -9,6 +9,12 @@ set( LLVM_LINK_COMPONENTS
             DeclRewriter_5C.cpp
           )
         endif()
+
+        if (MSVC)
+          set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+          set_source_files_properties(ArrayBoundsInferenceConsumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+        endif()
+
         add_clang_library(clang3C
           ABounds.cpp
           AVarBoundsInfo.cpp

--- a/clang/lib/3C/CMakeLists.txt
+++ b/clang/lib/3C/CMakeLists.txt
@@ -11,8 +11,9 @@ set( LLVM_LINK_COMPONENTS
         endif()
 
         if (MSVC)
-          set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
           set_source_files_properties(ArrayBoundsInferenceConsumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+          set_source_files_properties(ConstraintBuilder.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+          set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
         endif()
 
         add_clang_library(clang3C


### PR DESCRIPTION
Add /bigobj flag to fix x64 Windows compile error for the 3C tool.