### PR TITLE
Disable 3C tests on Windows

### DIFF
--- a/clang/test/3C/3d-allocation.c
+++ b/clang/test/3C/3d-allocation.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/basic.c
+++ b/clang/test/3C/basic.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/definedType.c
+++ b/clang/test/3C/definedType.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/dont_rewrite_header.c
+++ b/clang/test/3C/dont_rewrite_header.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr --output-postfix=checked %S/dont_rewrite_header.c %S/dont_rewrite_header.h
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/dont_rewrite_header.checked.c < %S/dont_rewrite_header.checked.c
 // RUN: test ! -f %S/dont_rewrite_header.checked.h

--- a/clang/test/3C/extstructfields.c
+++ b/clang/test/3C/extstructfields.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/graphs.c
+++ b/clang/test/3C/graphs.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/graphs2.c
+++ b/clang/test/3C/graphs2.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/linkedlist.c
+++ b/clang/test/3C/linkedlist.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/multivardecls.c
+++ b/clang/test/3C/multivardecls.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/rewrite_header.c
+++ b/clang/test/3C/rewrite_header.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr --output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c < %S/rewrite_header.checked.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h < %S/rewrite_header.checked.h

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: 3c -extra-arg="-Wno-everything" -alltypes -warn-root-cause %s 2>&1 1>/dev/null | FileCheck %s
 
 #include <stddef.h>


### PR DESCRIPTION
After microsoft#930 merged a number of 3C unit tests failed on Windows builds. These are temporarily disabled here to unblock the builds. Issue https://github.com/correctcomputation/checkedc-clang/issues/345 tracks this.