### PR TITLE
Fix failing 3C test for Windows

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -228,10 +228,18 @@ private:
   void addArrayAnnotations(std::stack<std::string> &CheckedArrs,
                            std::deque<std::string> &EndStrs) const;
 
-  // Utility used by the constructor to extract string representation of the
-  // base type that preserves macros where possible.
+  // Utility used by the constructor to obtain a string representation of a
+  // declaration's base type. To preserve macros, this we first try to take
+  // the type directly from source code. Where that is not possible, the type
+  // is regenerated from the type in the clang AST.
   static std::string extractBaseType(DeclaratorDecl *D, QualType QT,
                                      const Type *Ty, const ASTContext &C);
+
+  // Try to extract string representation of the base type for a declaration
+  // from the source code. If the base type cannot be extracted from source, an
+  // empty string is returned instead.
+  static std::string tryExtractBaseType(DeclaratorDecl *D, QualType QT,
+                                        const Type *Ty, const ASTContext &C);
 
   // Flag to indicate that this constraint is a part of function prototype
   // e.g., Parameters or Return.

--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -88,13 +88,14 @@ public:
 
   SourceRange getSourceRange(SourceManager &SM) const override {
     TypeSourceInfo *TSInfo = Decl->getTypeSourceInfo();
-    if (!TSInfo)
+    FunctionTypeLoc TypeLoc;
+    if (TSInfo) {
+      auto TSInfoLoc = TSInfo->getTypeLoc();
+      TypeLoc = getBaseTypeLoc(TSInfoLoc).getAs<clang::FunctionTypeLoc>();
+    }
+    if (!TSInfo || TypeLoc.isNull())
       return SourceRange(Decl->getBeginLoc(),
                          getFunctionDeclarationEnd(Decl, SM));
-    FunctionTypeLoc TypeLoc =
-        getBaseTypeLoc(TSInfo->getTypeLoc()).getAs<clang::FunctionTypeLoc>();
-
-    assert("FunctionDecl doesn't have function type?" && !TypeLoc.isNull());
 
     // Function pointer are funky, and require special handling to rewrite the
     // return type.

--- a/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
@@ -15,6 +15,7 @@
 #include "clang/3C/ConstraintResolver.h"
 #include "clang/Analysis/Analyses/Dominators.h"
 #include "clang/Analysis/CFG.h"
+#include <cctype>
 #include <sstream>
 
 static std::set<std::string> LengthVarNamesPrefixes = {"len", "count", "size",

--- a/clang/lib/3C/Constraints.cpp
+++ b/clang/lib/3C/Constraints.cpp
@@ -611,7 +611,7 @@ Geq *Constraints::createGeq(Atom *Lhs, Atom *Rhs, const std::string &Rsn,
   if (PL != nullptr && PL->valid()) {
     // Make this invalid, if the source location is not absolute path
     // this is to avoid crashes in clangd.
-    if (PL->getFileName().c_str()[0] != '/')
+    if (!llvm::sys::path::is_absolute(PL->getFileName()))
       PL = nullptr;
   }
   assert("Shouldn't be constraining WILD >= VAR" && Lhs != getWild());

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -411,6 +411,7 @@ bool isZeroBoundsExpr(BoundsExpr *BE, const ASTContext &C) {
 }
 
 TypeLoc getBaseTypeLoc(TypeLoc T) {
+  assert(!T.isNull() && "Can't get base location from Null.");
   while (!T.getNextTypeLoc().isNull() &&
          (!T.getAs<ParenTypeLoc>().isNull() ||
           T.getTypePtr()->isPointerType() || T.getTypePtr()->isArrayType()))

--- a/clang/test/3C/3d-allocation.c
+++ b/clang/test/3C/3d-allocation.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/basic.c
+++ b/clang/test/3C/basic.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/definedType.c
+++ b/clang/test/3C/definedType.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
@@ -6,7 +5,7 @@
 // RUN: 3c -alltypes %S/definedType.checked.c -- | count 0
 // RUN: rm %S/definedType.checked.c
 
-#define size_t unsigned long
+#include <stddef.h>
 _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 // From issue 204

--- a/clang/test/3C/dont_rewrite_header.c
+++ b/clang/test/3C/dont_rewrite_header.c
@@ -1,6 +1,5 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr --output-postfix=checked %S/dont_rewrite_header.c %S/dont_rewrite_header.h
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/dont_rewrite_header.checked.c < %S/dont_rewrite_header.checked.c
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/dont_rewrite_header.checked.c --input-file=%S/dont_rewrite_header.checked.c
 // RUN: test ! -f %S/dont_rewrite_header.checked.h
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/dont_rewrite_header.checked.c
 // RUN: 3c -alltypes -addcr --output-postfix=checked2 %S/dont_rewrite_header.checked.c %S/dont_rewrite_header.h

--- a/clang/test/3C/dont_rewrite_header.c
+++ b/clang/test/3C/dont_rewrite_header.c
@@ -1,5 +1,5 @@
 // RUN: 3c -alltypes -addcr --output-postfix=checked %S/dont_rewrite_header.c %S/dont_rewrite_header.h
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/dont_rewrite_header.checked.c --input-file=%S/dont_rewrite_header.checked.c
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/dont_rewrite_header.checked.c --input-file %S/dont_rewrite_header.checked.c
 // RUN: test ! -f %S/dont_rewrite_header.checked.h
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/dont_rewrite_header.checked.c
 // RUN: 3c -alltypes -addcr --output-postfix=checked2 %S/dont_rewrite_header.checked.c %S/dont_rewrite_header.h

--- a/clang/test/3C/dont_rewrite_header.c
+++ b/clang/test/3C/dont_rewrite_header.c
@@ -1,8 +1,8 @@
-// RUN: 3c -alltypes -addcr --output-postfix=checked %S/dont_rewrite_header.c %S/dont_rewrite_header.h
+// RUN: 3c -base-dir=%S -alltypes -addcr -output-postfix=checked %S/dont_rewrite_header.c %S/dont_rewrite_header.h
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/dont_rewrite_header.checked.c --input-file %S/dont_rewrite_header.checked.c
 // RUN: test ! -f %S/dont_rewrite_header.checked.h
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/dont_rewrite_header.checked.c
-// RUN: 3c -alltypes -addcr --output-postfix=checked2 %S/dont_rewrite_header.checked.c %S/dont_rewrite_header.h
+// RUN: 3c -base-dir=%S -alltypes -addcr --output-postfix=checked2 %S/dont_rewrite_header.checked.c %S/dont_rewrite_header.h
 // RUN: test ! -f %S/dont_rewrite_header.checked.checked2.h -a ! -f %S/dont_rewrite_header.checked.checked2.c
 // RUN: rm %S/dont_rewrite_header.checked.c
 

--- a/clang/test/3C/extstructfields.c
+++ b/clang/test/3C/extstructfields.c
@@ -1,3 +1,8 @@
+// This regression test is for a 3C bug that affected vsftpd, which only builds
+// on Linux. Windows does not have `struct sigaction`, and we couldn't find a
+// reasonable way to write an analogous test that works on Windows.
+// UNSUPPORTED: system-windows
+
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/extstructfields.c
+++ b/clang/test/3C/extstructfields.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/graphs.c
+++ b/clang/test/3C/graphs.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/graphs2.c
+++ b/clang/test/3C/graphs2.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/linkedlist.c
+++ b/clang/test/3C/linkedlist.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -

--- a/clang/test/3C/multivardecls.c
+++ b/clang/test/3C/multivardecls.c
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
@@ -6,7 +5,7 @@
 // RUN: 3c -alltypes %S/multivardecls.checked.c -- | count 0
 // RUN: rm %S/multivardecls.checked.c
 
-typedef unsigned long size_t;
+#include <stddef.h>
 _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 void test() {

--- a/clang/test/3C/rewrite_header.c
+++ b/clang/test/3C/rewrite_header.c
@@ -1,9 +1,9 @@
-// RUN: 3c -alltypes -addcr --output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
+// RUN: 3c -base-dir=%S -alltypes -addcr -output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c --input-file %S/rewrite_header.checked.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h --input-file %S/rewrite_header.checked.h
 // RUN: sed -i -e "s!rewrite_header\.h!%S/rewrite_header\.checked\.h!" %S/rewrite_header.checked.c
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/rewrite_header.checked.c
-// RUN: 3c -alltypes -addcr --output-postfix=checked2 %S/rewrite_header.checked.c %S/rewrite_header.checked.h
+// RUN: 3c -base-dir=%S -alltypes -addcr --output-postfix=checked2 %S/rewrite_header.checked.c %S/rewrite_header.checked.h
 // RUN: test ! -f %S/rewrite_header.checked2.h -a ! -f %S/rewrite_header.checked2.c
 // RUN: rm %S/rewrite_header.checked.c %S/rewrite_header.checked.h
 

--- a/clang/test/3C/rewrite_header.c
+++ b/clang/test/3C/rewrite_header.c
@@ -1,7 +1,9 @@
 // RUN: 3c -base-dir=%S -alltypes -addcr -output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c --input-file %S/rewrite_header.checked.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h --input-file %S/rewrite_header.checked.h
-// RUN: sed -i -e "s!rewrite_header\.h!rewrite_header\.checked\.h!" %S/rewrite_header.checked.c
+// Avoid `sed -i` because GnuWin32's `sed -i` leaves its temporary file behind.
+// RUN: sed -e "s!rewrite_header\.h!rewrite_header\.checked\.h!" %S/rewrite_header.checked.c >%S/rewrite_header.checked.c.new
+// RUN: mv %S/rewrite_header.checked.c.new %S/rewrite_header.checked.c
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/rewrite_header.checked.c
 // RUN: 3c -base-dir=%S -alltypes -addcr --output-postfix=checked2 %S/rewrite_header.checked.c %S/rewrite_header.checked.h
 // RUN: test ! -f %S/rewrite_header.checked2.h -a ! -f %S/rewrite_header.checked2.c

--- a/clang/test/3C/rewrite_header.c
+++ b/clang/test/3C/rewrite_header.c
@@ -1,7 +1,6 @@
-// UNSUPPORTED: system-windows
 // RUN: 3c -alltypes -addcr --output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c < %S/rewrite_header.checked.c
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h < %S/rewrite_header.checked.h
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c --input-file=%S/rewrite_header.checked.c
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h --input-file=%S/rewrite_header.checked.h
 // RUN: sed -i -e "s!rewrite_header\.h!%S/rewrite_header\.checked\.h!" %S/rewrite_header.checked.c
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/rewrite_header.checked.c
 // RUN: 3c -alltypes -addcr --output-postfix=checked2 %S/rewrite_header.checked.c %S/rewrite_header.checked.h

--- a/clang/test/3C/rewrite_header.c
+++ b/clang/test/3C/rewrite_header.c
@@ -1,6 +1,6 @@
 // RUN: 3c -alltypes -addcr --output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c --input-file=%S/rewrite_header.checked.c
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h --input-file=%S/rewrite_header.checked.h
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c --input-file %S/rewrite_header.checked.c
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h --input-file %S/rewrite_header.checked.h
 // RUN: sed -i -e "s!rewrite_header\.h!%S/rewrite_header\.checked\.h!" %S/rewrite_header.checked.c
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/rewrite_header.checked.c
 // RUN: 3c -alltypes -addcr --output-postfix=checked2 %S/rewrite_header.checked.c %S/rewrite_header.checked.h

--- a/clang/test/3C/rewrite_header.c
+++ b/clang/test/3C/rewrite_header.c
@@ -1,7 +1,7 @@
 // RUN: 3c -base-dir=%S -alltypes -addcr -output-postfix=checked %S/rewrite_header.c %S/rewrite_header.h
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.c --input-file %S/rewrite_header.checked.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK" %S/rewrite_header.checked.h --input-file %S/rewrite_header.checked.h
-// RUN: sed -i -e "s!rewrite_header\.h!%S/rewrite_header\.checked\.h!" %S/rewrite_header.checked.c
+// RUN: sed -i -e "s!rewrite_header\.h!rewrite_header\.checked\.h!" %S/rewrite_header.checked.c
 // RUN: %clang -c -fcheckedc-extension -x c -o /dev/null %S/rewrite_header.checked.c
 // RUN: 3c -base-dir=%S -alltypes -addcr --output-postfix=checked2 %S/rewrite_header.checked.c %S/rewrite_header.checked.h
 // RUN: test ! -f %S/rewrite_header.checked2.h -a ! -f %S/rewrite_header.checked2.c

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -1,5 +1,4 @@
-// UNSUPPORTED: system-windows
-// RUN: 3c -extra-arg="-Wno-everything" -alltypes -warn-root-cause %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: 3c -extra-arg="-Wno-everything" -alltypes -warn-root-cause %s 2>&1 1>%t | FileCheck %s
 
 #include <stddef.h>
 extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -1,4 +1,4 @@
-// RUN: 3c -extra-arg="-Wno-everything" -alltypes -warn-root-cause %s 2>&1 1>%t | FileCheck %s
+// RUN: 3c -extra-arg="-Wno-everything" -alltypes -warn-root-cause %s 2>&1 >%t | FileCheck %s
 
 #include <stddef.h>
 extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);


### PR DESCRIPTION
Our previous PR #930 left some tests failing on windows (correctcomputation#345) . These changes should will hopefully fix those tests. We haven't been able to test these a windows build. 