### PR TITLE
Disable 3C definedType test on Windows again.

### DIFF
--- a/clang/test/3C/definedType.c
+++ b/clang/test/3C/definedType.c
@@ -1,3 +1,11 @@
+// This test currently fails on Windows X86, but the 3C team is waiting to try
+// to fix it until Microsoft addresses a problem that currently makes the tests
+// difficult to run on Windows X86:
+//
+// https://github.com/microsoft/checkedc-clang/pull/956#issuecomment-752317866
+//
+// UNSUPPORTED: system-windows
+
 // RUN: 3c -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -


### PR DESCRIPTION
As decided at https://github.com/microsoft/checkedc-clang/pull/956#issuecomment-752317866.

We can keep correctcomputation/checkedc-clang#345 open to track the real fix for this test failure.  I trust I'll be notified via #947 or a follow-up issue when the problem with running the Windows X86 tests has been fixed and we should retry the test.