### PR TITLE
Fix failing 3c tests on Clang 11 update

### DIFF
--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -595,6 +595,8 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
       if (Expr *ESE = dyn_cast<Expr>(Res)) {
         return getExprConstraintVars(ESE);
       }
+    } else if (DesignatedInitExpr *DIE = dyn_cast<DesignatedInitExpr>(E)) {
+      Ret = getExprConstraintVars(DIE->getInit());
     } else {
       if (Verbose) {
         llvm::errs() << "WARNING! Initialization expression ignored: ";


### PR DESCRIPTION
Fixes the 3c tests failing on `update-master-11-last`. All but one the failing tests were caused by the `VisitBinaryOperator` and `VisitUnaryOperator` changes the clang api. The other failing test was caused by a `DesignatedInitExpr` wrapper appearing on some structure initialization expressions where it was not present before. 