### PR TITLE
Skip free variable checking for member expressions

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1459,9 +1459,12 @@ namespace {
                                FreeVariablePosition Pos2,
                                EquivExprSets *EquivExprs,
                                FreeVariableListTy &FreeVars) {
-        // If E1 or E2 accesses memory via pointer, we skip because we cannot
+        // If E1 or E2 accesses memory via a pointer, we skip because we cannot
         // determine aliases for two indirect accesses soundly yet.
-        if (ReadsMemoryViaPointer(E1) || ReadsMemoryViaPointer(E2))
+        // We also skip checking free variables if E1 or E2 is or contains a
+        // non-arrow member expression, since the compiler currently does
+        // not track equality information for member expressions.
+        if (ReadsMemoryViaPointer(E1, true) || ReadsMemoryViaPointer(E2, true))
           return false;
 
         bool HasFreeVariables = false;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5596,12 +5596,12 @@ namespace {
           // e1.f reads memory via a pointer if and only if e1 reads
           // memory via a pointer.
           else
-            return ReadsMemoryViaPointer(ME->getBase());
+            return ReadsMemoryViaPointer(ME->getBase(), IncludeAllMemberExprs);
         }
         default: {
           for (auto I = E->child_begin(); I != E->child_end(); ++I) {
             if (Expr *SubExpr = dyn_cast<Expr>(*I)) {
-              if (ReadsMemoryViaPointer(SubExpr))
+              if (ReadsMemoryViaPointer(SubExpr, IncludeAllMemberExprs))
                 return true;
             }
           }

--- a/clang/test/CheckedC/inferred-bounds/member-reference.c
+++ b/clang/test/CheckedC/inferred-bounds/member-reference.c
@@ -10,6 +10,7 @@
 //
 // This line is for the clang test infrastructure:
 // RUN: %clang_cc1 -fcheckedc-extension -fdump-inferred-bounds -verify -verify-ignore-unexpected=warning -verify-ignore-unexpected=note -fdump-inferred-bounds %s | FileCheck %s
+// expected-no-diagnostics
 
 struct S1 {
   _Array_ptr<int> p : count(len);
@@ -100,7 +101,7 @@ void f1(struct S1 a1, struct S2 b2) {
 int global_arr1[5];
 void f2(struct S1 a3) {
   // TODO: need bundled block.
-  a3.p = global_arr1; // expected-error {{it is not possible to prove that the inferred bounds of a3.p imply the declared bounds of a3.p after assignment}}
+  a3.p = global_arr1;
   a3.len = 5;
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} '_Array_ptr<int>' '='
@@ -347,7 +348,7 @@ int global_arr2 _Checked[5];
 
 void f12(struct Interop_S1 a1) {
   // TODO: need bundled block.
-  a1.p = global_arr2; // expected-error {{it is not possible to prove that the inferred bounds of a1.p imply the declared bounds of a1.p after assignment}}
+  a1.p = global_arr2;
   a1.len = 5;
 }
 
@@ -380,7 +381,7 @@ void f12(struct Interop_S1 a1) {
 
 _Checked void f13(struct Interop_S1 a1) {
   // TODO: need bundled block.
-  a1.p = global_arr2; // expected-error {{it is not possible to prove that the inferred bounds of a1.p imply the declared bounds of a1.p after assignment}}
+  a1.p = global_arr2;
   a1.len = 5;
 }
 

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -117,19 +117,16 @@ void f1(struct S1 *s) {
 }
 
 void f2(struct S1 a3) {
-  //int l = a3->len2;
   struct S1 a4 = {};
   array_ptr<int> p : count(5) = 0;
-  //array_ptr<int> p : count(l) = local_arr1;
   a3 = a4;
 }
 
 void f3(struct S1 a3) {
-  //int l = a3->len2;
   struct S1 a4 = {};
   array_ptr<int> p : count(5) = 0;
 
-  // Warning but no free variables since a3.p is a member expression.
+  // We current do not detect free variables for member accesses.
   a3.p = p; // expected-warning {{cannot prove declared bounds for a3.p are valid after assignment}} \
             // expected-note {{(expanded) declared bounds are 'bounds(a3.p, a3.p + a3.len2)'}} \
             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -128,8 +128,9 @@ void f3(struct S1 a3) {
   //int l = a3->len2;
   struct S1 a4 = {};
   array_ptr<int> p : count(5) = 0;
-  a3.p = p; // expected-error {{it is not possible to prove that the inferred bounds of a3.p imply the declared bounds of a3.p after assignment}} \
-            // expected-note {{the declared upper bounds use the variable 'a3' and there is no relational information involving 'a3' and any of the expressions used by the inferred upper bounds}} \
+
+  // Warning but no free variables since a3.p is a member expression.
+  a3.p = p; // expected-warning {{cannot prove declared bounds for a3.p are valid after assignment}} \
             // expected-note {{(expanded) declared bounds are 'bounds(a3.p, a3.p + a3.len2)'}} \
             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
 }


### PR DESCRIPTION
Fixes #969

The compiler currently does not track equality information for member expressions of the form `a.f`. This can result in false positive errors when checking bounds for free variables (see issue #969 for an example).

This PR modifies the free variable checking logic to skip checking two expressions `E1` and `E2` for free variables if one or both of `E1` or `E2` is or contains a member expression. This extends the check that was already done to skip free variable checking if `E1` or `E2` read memory via a pointer.