### PR TITLE
Free variables: get all variables in BoundsValueExprs

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -605,14 +605,21 @@ namespace {
 
       return true;
     }
+
+    // Ensure that any variables within bounds value expressions are detected
+    // by explicitly traversing the child of a bounds value expression.
+    bool VisitBoundsValueExpr(BoundsValueExpr *E) {
+      TraverseStmt(E->getTemporaryBinding());
+      return true;
+    }
   };
 
   // Collect variables in E without duplication. If E is nullptr, return an
   // empty vector.
   EqualExprTy CollectVariableSet(Sema &SemaRef, Expr *E) {
-      CollectVariableSetHelper Helper(SemaRef);
-      Helper.TraverseStmt(E);
-      return Helper.GetVariableList();
+    CollectVariableSetHelper Helper(SemaRef);
+    Helper.TraverseStmt(E);
+    return Helper.GetVariableList();
   }
 }
 

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -172,3 +172,17 @@ void g(void) {
                                               // expected-note {{inferred bounds are}}
 }
 
+void f_itype(int *p : itype(ptr<int>));
+void f_arrayptr(array_ptr<int> p : count(2));
+
+void h(void) {
+  int *p = 0;
+  f_itype(_Assume_bounds_cast<ptr<int>>(p)); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+                                             // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<int>)_Assume_bounds_cast<_Ptr<int>>p(count(1)), (_Array_ptr<int>)_Assume_bounds_cast<_Ptr<int>>p(count(1)) + 1)'}} \
+                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<int>)value of p, (_Array_ptr<int>)value of p + 1)'}}
+
+  array_ptr<int> a : count(2) = 0;
+  f_arrayptr(_Assume_bounds_cast<array_ptr<int>>(a, count(2))); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+                                                                // expected-note {{(expanded) expected argument bounds are 'bounds(_Assume_bounds_cast<_Array_ptr<int>>a(count(2)), _Assume_bounds_cast<_Array_ptr<int>>a(count(2)) + 2)'}} \
+                                                                // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<int>)value of a, (_Array_ptr<int>)value of a + 2)'}}
+}


### PR DESCRIPTION
Fixes #974 

The RecursiveASTVisitor does not seem to traverse the child of a `BoundsExpr` (`E->getTemporaryBinding()`). If an expression uses a variable that is a child of a `BoundsExpr`, then CollectVariableSetHelper will not include it in the set of variables involved in the expression. This can result in spurious free variable errors when checking bounds.

This PR overrides CollectVariableSetHelper::VisitBoundsValueExpr to traverse the bounds value expression's temporary binding.