### PR TITLE
RecursiveASTVisitor: Traverse the child of a BoundsValueExpr

### DIFF
--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2617,7 +2617,6 @@ DEF_TRAVERSE_STMT(NullaryBoundsExpr, {})
 DEF_TRAVERSE_STMT(RangeBoundsExpr, {})
 DEF_TRAVERSE_STMT(InteropTypeExpr, {})
 DEF_TRAVERSE_STMT(PositionalParameterExpr, {})
-DEF_TRAVERSE_STMT(BoundsValueExpr, {})
 DEF_TRAVERSE_STMT(CHKCBindTemporaryExpr, {})
 DEF_TRAVERSE_STMT(PackExpr, {})
 
@@ -2673,6 +2672,11 @@ DEF_TRAVERSE_STMT(AsTypeExpr, {})
 // CheckedC Bounds Casting
 DEF_TRAVERSE_STMT(BoundsCastExpr, {
   TRY_TO(TraverseTypeLoc(S->getTypeInfoAsWritten()->getTypeLoc()));
+})
+
+// CheckedC Bounds Value Expressions
+DEF_TRAVERSE_STMT(BoundsValueExpr, {
+  TRY_TO(TraverseStmt(S->getTemporaryBinding()));
 })
 
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -555,6 +555,15 @@ namespace {
           ++Count;
         return true;
       }
+
+      // Do not traverse the child of a BoundsValueExpr.
+      // If a BoundsValueExpr uses the variable V, this should not count
+      // toward the total occurrence count of V in the expression.
+      // For example, for the expression BoundsValue(TempBinding(v)) + v, the
+      // total occurrence count of the variable v should be 1, not 2.
+      bool TraverseBoundsValueExpr(BoundsValueExpr *E) {
+        return true;
+      }
   };
 
   // VariableOccurrenceCount returns the number of occurrences of V in E.
@@ -667,6 +676,14 @@ namespace {
         else
           return ExprCreatorUtil::CreateImplicitCast(SemaRef, Child,
                                                      CK, E->getType());
+      }
+
+      // Do not replace expressions within a BoundsValueExpr.
+      // For example, the result of replacing `v` with `v + 1` in
+      // BoundsValue(TempBinding(v)) should be BoundsValue(TempBinding(v)),
+      // not BoundsValue(TempBinding(v + 1)).
+      bool TraverseBoundsValueExpr(BoundsValueExpr *E) {
+        return true;
       }
   };
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -6573,6 +6573,14 @@ namespace {
       return true;
     }
 
+    // Do not traverse the children of a BoundsValueExpr. Any expressions
+    // that are wrapped in a BoundsValueExpr should not be considered
+    // modifying expressions. For example, BoundsValue(TempBinding(f()))
+    // should not be considered modifying.
+    bool TraverseBoundsValueExpr(BoundsValueExpr *E) {
+      return true;
+    }
+
 
   private:
     Sema &S;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -677,14 +677,6 @@ namespace {
           return ExprCreatorUtil::CreateImplicitCast(SemaRef, Child,
                                                      CK, E->getType());
       }
-
-      // Do not replace expressions within a BoundsValueExpr.
-      // For example, the result of replacing `v` with `v + 1` in
-      // BoundsValue(TempBinding(v)) should be BoundsValue(TempBinding(v)),
-      // not BoundsValue(TempBinding(v + 1)).
-      bool TraverseBoundsValueExpr(BoundsValueExpr *E) {
-        return true;
-      }
   };
 
   // If an original value is provided, ReplaceVariableReferences returns

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -172,3 +172,17 @@ void g(void) {
                                               // expected-note {{inferred bounds are}}
 }
 
+void f_itype(int *p : itype(ptr<int>));
+void f_arrayptr(array_ptr<int> p : count(2));
+
+void h(void) {
+  int *p = 0;
+  f_itype(_Assume_bounds_cast<ptr<int>>(p)); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+                                             // expected-note {{(expanded) expected argument bounds are 'bounds((_Array_ptr<int>)_Assume_bounds_cast<_Ptr<int>>p(count(1)), (_Array_ptr<int>)_Assume_bounds_cast<_Ptr<int>>p(count(1)) + 1)'}} \
+                                             // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<int>)value of p, (_Array_ptr<int>)value of p + 1)'}}
+
+  array_ptr<int> a : count(2) = 0;
+  f_arrayptr(_Assume_bounds_cast<array_ptr<int>>(a, count(2))); // expected-warning {{cannot prove argument meets declared bounds for 1st parameter}} \
+                                                                // expected-note {{(expanded) expected argument bounds are 'bounds(_Assume_bounds_cast<_Array_ptr<int>>a(count(2)), _Assume_bounds_cast<_Array_ptr<int>>a(count(2)) + 2)'}} \
+                                                                // expected-note {{(expanded) inferred bounds are 'bounds((_Array_ptr<int>)value of a, (_Array_ptr<int>)value of a + 2)'}}
+}


### PR DESCRIPTION
Fixes #974 
Fixes #977 

This PR modifies RecursiveASTVisitor to traverse the child (`E->getTemporaryBinding`) of a `BoundsValueExpr` by default. This allows the `CollectVarSetHelper` in SemaBounds.cpp to determine the correct set of variables involved in expressions that contain a `BoundsValueExpr`. For example, in the expression `BoundsValue(TempBinding(x)) + y`, `CollectVarSetHelper` will return the set `{ x, y }` rather than `{ y }`.

Two other classes in SemaBounds.cpp that use RecursiveASTVisitor now override this behavior so that they do not traverse the temporary binding of a `BoundsValueExpr`:
* NonModifyingExprSema: expressions within bounds values should not be considered modifying.
* VariableCountHelper: variables within bounds values should not contribute to the variable occurrence count within an expression. The ReplaceVariable method `ReplaceVariable(E, V, OriginalValue)` returns the original expression `E` if VariableCountHelper returns 0 as the variable occurrence count of `V` in `E`. If `V` occurs within a BoundsValueExpr within `E`, then ReplaceVariable should return `E` without traversing it. Therefore, for an expression such as `BoundsValue(TempBinding(x))`, VariableCountHelper should return 0 as the occurrence count of `x`.

Testing:
* Added test cases to clang/test/CheckedC/static-checking/free-variables.c that involve expressions containing bounds values. These test cases cover the example in #974.