### PR TITLE
Fix for handling CapturedDecl, which was causing the failure of certain

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -76,6 +76,8 @@ namespace clang {
     Result CompareInteger(unsigned I1, unsigned I2) const;
     Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
                                        const RelativeBoundsClause *RC2);
+    Result CompareLoc(const SourceLocation *SL1,
+                      const SourceLocation *SL2) const;
     Result CompareScope(const DeclContext *DC1, const DeclContext *DC2) const;
 
     Result CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2);
@@ -133,6 +135,7 @@ namespace clang {
     /// \brief Compare declarations that may be used by expressions or
     /// or types.
     Result CompareDecl(const NamedDecl *D1, const NamedDecl *D2) const;
+    Result CompareDecl(const CapturedDecl *D1, const CapturedDecl *D2) const;
     Result CompareType(QualType T1, QualType T2) const;
     Result CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) const;
     Result CompareTypeLexicographically(QualType QT1, QualType QT2) const;

--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -76,8 +76,6 @@ namespace clang {
     Result CompareInteger(unsigned I1, unsigned I2) const;
     Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
                                        const RelativeBoundsClause *RC2);
-    Result CompareLoc(const SourceLocation *SL1,
-                      const SourceLocation *SL2) const;
     Result CompareScope(const DeclContext *DC1, const DeclContext *DC2) const;
 
     Result CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2);

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -159,9 +159,6 @@ Lexicographic::CompareDecl(const CapturedDecl *CD1Arg,
     llvm_unreachable("unexpected captured scopes");
     return Result::LessThan;
   }
-  const SourceLocation SL1 = SList1->getSourceRange().getBegin();
-  const SourceLocation SL2 = SList2->getSourceRange().getBegin();
-
   // We resort to pointer comparison of statement lists to impose an ordering
   // between the two CapturedDecl contexts corresponding to the statement lists.
   // TODO: This is non-deterministic across compiler runs, and is an interim

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -204,25 +204,21 @@ Lexicographic::CompareDecl(const CapturedDecl *CD1Arg,
 
   if (!SL1.isInvalid() && !SL2.isInvalid())
     return CompareLoc(&SL1, &SL2);
-  else {
-    assert(false && "unexpected invalid source location(s)");
-    if (!SL2.isInvalid())
-      return Result::LessThan;
-    else if (!SL1.isInvalid())
-      return Result::GreaterThan;
-    else {
-      // We avoid an abnormal compiler exit due to invalid source locations by
-      // resorting to pointer comparison of two statement lists as a last resort
-      // to impose an ordering between the two CapturedDecl contexts corresponding
-      // to the statement lists.
-      if (SList1 == SList2)
-        return Result::Equal;
-      else if (SList1 < SList2)
-        return Result::LessThan;
-      else
-        return Result::GreaterThan;
-    }
-  }
+
+  assert(false && "unexpected invalid source location(s)");
+  if (!SL2.isInvalid())
+    return Result::LessThan;
+  if (!SL1.isInvalid())
+    return Result::GreaterThan;
+  // We avoid an abnormal compiler exit due to invalid source locations by
+  // resorting to pointer comparison of two statement lists as a last resort
+  // to impose an ordering between the two CapturedDecl contexts corresponding
+  // to the statement lists.
+  if (SList1 == SList2)
+    return Result::Equal;
+  if (SList1 < SList2)
+    return Result::LessThan;
+  return Result::GreaterThan;
 }
 
 Result

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -23,6 +23,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/PreorderAST.h"
 #include "clang/AST/Stmt.h"
+#include "clang/Basic/SourceManager.h"
 
 using namespace clang;
 using Result = Lexicographic::Result;
@@ -109,6 +110,43 @@ static Result ComparePointers(T *P1, T *P2, bool &ordered) {
   return Result::LessThan;
 }
 
+// \brief Order two source locations based on the lexicographic
+// ordering of filenames if the two source locations are in
+// different source files, and based on line/column numbers if
+// the two source locations are in the same source file.
+Result
+Lexicographic::CompareLoc(const SourceLocation *SL1,
+                          const SourceLocation *SL2) const {
+  if (SL1 && SL2) {
+    if (SL1 == SL2)
+      return Result::Equal;
+    const SourceManager *SM = &Context.getSourceManager();
+    if (!SM) {
+      llvm_unreachable("unexpected null SourceManager");
+      return Result::LessThan;
+    }
+    const SourceLocation SLoc1 = SM->getSpellingLoc(*SL1);
+    const SourceLocation SLoc2 = SM->getSpellingLoc(*SL2);
+    const PresumedLoc PLoc1 = SM->getPresumedLoc(SLoc1);
+    const PresumedLoc PLoc2 = SM->getPresumedLoc(SLoc2);
+    if (PLoc1.isInvalid() || PLoc2.isInvalid()) {
+      llvm_unreachable("unexpected invalid source locations");
+      return Result::LessThan;
+    }
+    Result Cmp = TranslateInt(strcmp(PLoc1.getFilename(), PLoc2.getFilename()));
+    if (Cmp != Result::Equal)
+      return Cmp;
+
+    Cmp = CompareInteger(PLoc1.getLine(), PLoc2.getLine());
+    if (Cmp != Result::Equal)
+      return Cmp;
+
+    return CompareInteger(PLoc1.getColumn(), PLoc2.getColumn());
+  }
+  llvm_unreachable("unexpected source locations");
+  return Result::LessThan;
+}
+
 Result
 Lexicographic::CompareScope(const DeclContext *DC1, const DeclContext *DC2) const {
    DC1 = DC1->getPrimaryContext();
@@ -123,7 +161,11 @@ Lexicographic::CompareScope(const DeclContext *DC1, const DeclContext *DC2) cons
 
   switch (DC1->getDeclKind()) {
     case Decl::TranslationUnit: return Result::Equal;
-    case Decl::Captured: return Result::Equal;
+    case Decl::Captured: {
+      const CapturedDecl *CD1 = dyn_cast<CapturedDecl>(DC1);
+      const CapturedDecl *CD2 = dyn_cast<CapturedDecl>(DC2);
+      return CompareDecl(CD1, CD2);
+    }
     case Decl::Function: 
     case Decl::Enum:
     case Decl::Record: {
@@ -135,6 +177,20 @@ Lexicographic::CompareScope(const DeclContext *DC1, const DeclContext *DC2) cons
       llvm_unreachable("unexpected scope type");
       return Result::LessThan;
   }
+}
+
+Result
+Lexicographic::CompareDecl(const CapturedDecl *CD1,
+                           const CapturedDecl *CD2) const {
+  Stmt *SList1 = CD1->getBody();
+  Stmt *SList2 = CD2->getBody();
+  if (SList1 && SList2) {
+    const SourceLocation SL1 = SList1->getSourceRange().getBegin();
+    const SourceLocation SL2 = SList2->getSourceRange().getBegin();
+    return CompareLoc(&SL1, &SL2);
+  }
+  llvm_unreachable("unexpected captured scopes");
+  return Result::LessThan;
 }
 
 Result


### PR DESCRIPTION
OpenMP test cases after upgrade.