### PR TITLE
Fix sarif-multi-diagnostic-test.c failure on Windows

### DIFF
--- a/clang/test/Analysis/lit.local.cfg
+++ b/clang/test/Analysis/lit.local.cfg
@@ -19,7 +19,7 @@ config.substitutions.append(('%normalize_plist',
 
 # Filtering command for testing SARIF output against reference output.
 config.substitutions.append(('%normalize_sarif',
-    "grep -Ev '^[[:space:]]*(%s|%s|%s)[[:space:]]*$'" %
+    "grep -Eva '^[[:space:]]*(%s|%s|%s)[[:space:]]*$'" %
         ('"uri": "file:.*%basename_t"',
          '"version": ".* version .*"',
          '"version": "2.1.0"')))


### PR DESCRIPTION
Some of the llvm/clang unit tests are non-portable to Windows because they were
mainly written for Linux by the community and somehow made to work on Windows.
The issue with the `sarif-multi-diagnostics` test seems to be due to grep. Due to
the presence of a Unicode string in this test grep considers this file as a
binary file instead of a text file and hence errors out with the following
message:
  `Binary file (standard input) matches`

So we need to tell grep to treat this file as a text file for comparison
purposes. This can be done via the `-a` flag to grep. With this fix the test now
passes on ADO.  The git log commit messages for the file
`clang/test/Analysis/lit.local.cfg` which I fixed mentions the non-portable
nature of these tests.