### PR TITLE
Add clang 11 upgrade information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ On Feb 19, 2021 we updated the checkedc-clang sources to upstream release_110,
 specifically [this](https://github.com/llvm/llvm-project/commit/2e10b7a39b930ef8d9c4362509d8835b221fbc0a) commit.
 
 On Feb 18, 2020 we updated the checkedc-clang sources to upstream release_90,
-specifically [this](http://llvm.org/viewvc/llvm-project?view=revision&revision=366428) commit.
+specifically [this](https://github.com/llvm/llvm-project/commit/c89a3d78f43d81b9cff7b9248772ddf14d21b749) commit.
 
 ### Transition to monorepo
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ C specification is available at the
 
 ### Source code update
 
-On Feb 18, 2020 we updated the checkedc-clang sources to upstream release_90,
-specifically [this](http://llvm.org/viewvc/llvm-project?view=revision&revision=366428) commit.
+On Feb 19, 2021 we updated the checkedc-clang sources to upstream release_110,
+specifically [this](https://github.com/llvm/llvm-project/commit/2e10b7a39b930ef8d9c4362509d8835b221fbc0a) commit.
 
 ### Transition to monorepo
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ C specification is available at the
 On Feb 19, 2021 we updated the checkedc-clang sources to upstream release_110,
 specifically [this](https://github.com/llvm/llvm-project/commit/2e10b7a39b930ef8d9c4362509d8835b221fbc0a) commit.
 
+On Feb 18, 2020 we updated the checkedc-clang sources to upstream release_90,
+specifically [this](http://llvm.org/viewvc/llvm-project?view=revision&revision=366428) commit.
+
 ### Transition to monorepo
 
 Early in 2019, the LLVM community


### PR DESCRIPTION
Update the "source code update" section to reference the latest upgrade to clang 11 rather than the previous upgrade to clang 9.