### PR TITLE
Use clang_cc1 instead of clang in verification codegen tests

### DIFF
--- a/clang/test/CheckedC/verification/codegen-checked.c
+++ b/clang/test/CheckedC/verification/codegen-checked.c
@@ -2,7 +2,7 @@
 // There should be a __VERIFIER_error at each dynamic check failed block.
 //
 //
-// RUN: %clang -finject-verifier-calls -emit-llvm -S %s -o - | FileCheck %s
+// RUN: %clang_cc1 -finject-verifier-calls -emit-llvm %s -o - | FileCheck %s
 
 extern void __VERIFIER_error (void);
 extern void __VERIFIER_assume (int);

--- a/clang/test/CheckedC/verification/codegen-unchecked.c
+++ b/clang/test/CheckedC/verification/codegen-unchecked.c
@@ -3,7 +3,7 @@
 // dynamic check failed block.
 //
 //
-// RUN: %clang -finject-verifier-calls -funchecked-pointers-dynamic-check -emit-llvm -S %s -o - | FileCheck %s
+// RUN: %clang_cc1 -finject-verifier-calls -funchecked-pointers-dynamic-check -emit-llvm %s -o - | FileCheck %s
 
 extern void __VERIFIER_error (void);
 extern void __VERIFIER_assume (int);


### PR DESCRIPTION
Tests in clang/test/CheckedC/verification check the IR, so they should use %clang_cc1 instead of %clang in their RUN commands.

The codegen-checked.c and codegen-unchecked.c tests failed after the clang 11 upgrade on Windows X86 builds with no asserts. This PR fixes those test failures so the tests pass on Windows X86.