### PR TITLE
Guard only an assert with NDEBUG check

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -4310,6 +4310,9 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
     if (getLangOpts().CheckedC)
       IRFuncTy = cast<llvm::FunctionType>(TypeFromVal);
     else {
+    // NOTE: This may cause merge conflicts during checkedc-clang source
+    // upgrades. For more details refer
+    // https://github.com/microsoft/checkedc-clang/pull/990
 #ifndef NDEBUG
       assert(IRFuncTy == TypeFromVal);
 #endif

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -4264,7 +4264,6 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         CGM, Loc, dyn_cast_or_null<FunctionDecl>(CurCodeDecl), FD, CallArgs);
   }
 
-#ifndef NDEBUG
   if (!(CallInfo.isVariadic() && CallInfo.getArgStruct())) {
     // For an inalloca varargs function, we don't expect CallInfo to match the
     // function pointer's type, because the inalloca struct a will have extra
@@ -4310,10 +4309,12 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
 
     if (getLangOpts().CheckedC)
       IRFuncTy = cast<llvm::FunctionType>(TypeFromVal);
-    else
+    else {
+#ifndef NDEBUG
       assert(IRFuncTy == TypeFromVal);
-  }
 #endif
+    }
+  }
 
   // 1. Set up the arguments.
 


### PR DESCRIPTION
In a release without asserts build, we hit the error "function type mismatch".
This was because of the code to determine the type of a _For_any function from
the CallInfo was being protected by the #ifndef NDEBUG flag and hence did not
execute. The main purpose of that check is to guard the assert at the end of
that code. So we moved the check to just before the assert.