### PR TITLE
Update LValue Design Document

### DIFF
--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -30,18 +30,18 @@ bounds checking behavior is the same for all lvalue expressions.
 
 This document uses the following terms for two lvalue expressions `e1` and `e2`.
 
-`e1` and `e2` are **canonically equivalent** if and
-only if `e1` and `e2` have the same canonical form; that is, if the normalized
-PreorderASTs for `e1` and `e2` are equivalent. For example:
+`e1` and `e2` are **canonically equivalent** if and only if `e1` and `e2`
+have the same canonical form; that is, if the normalized PreorderASTs for
+`e1` and `e2` are equivalent. For example:
 
 - `a->f` and `*a.f` are canonically equivalent.
 - `*p` and `p[0]` are canonically equivalent.
 - `a->f` and `b->f` are not canonically equivalent.
 - `*p` and `*q` are not canonically equivalent.
 
-`e1` and `e2` are **identical** if and only if `e1`
-and `e2` both point to the same contiguous memory location, i.e. if `e1` and
-`e2` both point to the same location and range of memory.
+`e1` and `e2` are **identical** if and only if `e1` and `e2` both point to
+the same contiguous memory location, i.e. if `e1` and `e2` both point to
+the same location and range of memory.
 
 `e1` and `e2` **must alias** if it is guaranteed that `e1` and `e2` are
 identical.
@@ -54,8 +54,8 @@ identical.
 
 `e1` and `e2` **do not alias** if is not the case that `e1` and `e2` may alias.
 
-An lvalue expression `e` **belongs** to an AbstractSet `A` if and only if
-the canonical form (PreorderAST) `P` for `e` is equivalent to `A.CanonicalForm`.
+An lvalue expression `e` **belongs** to an AbstractSet `A` if and only if the
+canonical form (PreorderAST) `P` for `e` is equivalent to `A.CanonicalForm`.
 If `e` belongs to `A`, then `A` **contains** `e`.
 
 The bounds for expressions belonging to an AbstractSet `A` are **killed**

--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -176,7 +176,9 @@ as all other lvalue expressions that are identical to `e`).
 The AbstractSet class is an abstraction of memory. If two lvalue expressions
 `e1` and `e2` both belong to an AbstractSet `A`, then `e1` and `e2` are in
 the set of lvalue expressions that point to the same contiguous memory
-location.
+location. In addition, `e1` and `e2` must be canonically equivalent. The
+AliasAnalysis class determines, for AbstractSets `A1` and `A2`, whether
+the expressions in `A1` must or may alias with expressions in `A2`.
 
 ### AbstractSet Implementation
 

--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -210,8 +210,6 @@ The AbstractSet class contains the following members:
    described above.
 2. Implement lexicographic ordering for PreorderASTs. This is necessary
    to avoid an expensive linear search in GetOrCreateAbstractSet.
-   Lexicographic ordering for PreorderASTs leverages the ordering implemented
-   in [CanonBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/AST/CanonBounds.cpp).
 3. Replace the current `VarDecl *` keys in `ObservedBounds` with `AbstractSet *`.
    This should result in no changes in compiler behavior (since only
    `DeclRefExpr *` will have an AbstractSet representation).
@@ -258,3 +256,21 @@ kind of lvalue expression.
   likely than `MemberExpr *` to have unknown target bounds.
 - Priority 3: `ImplicitCastExpr *` and `CHKCBindTemporaryExpr *`. These kinds
   are less common in example code.
+
+## Lexicographic Ordering for PreorderASTs
+
+Lexicographic ordering for PreorderASTs leverages the ordering implemented in
+[CanonBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/AST/CanonBounds.cpp).
+particularly the CompareExpr method.
+
+For two leaf nodes `N1` and `N2` of a PreorderAST, the result of
+lexicographically comparing `N1` and `N2` is `CompareExpr(E1, E1)` for the
+underlying expressions `E1` and `E2` of `N1` and `N2`.
+
+As a possible future optimization, the PreorderAST class can maintain a set
+of VarDecls that identify the set of variables that it uses. This can be used
+to more quickly order two PreorderASTs `P1` and `P2` by comparing the set of
+variables involved in `P1` and `P2`. This can help avoid expensive comparisons
+for deeply nested PreorderASTs that differ only in the last expression.
+For example, `P1` may be constructed from the expression `a->b->c->d` and
+`P2` may be constructed from the expression `a->b->c->d->e`.

--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -201,21 +201,17 @@ The AbstractSet class contains the following members:
 
 ## Work Item Overview
 
-1. Define the representation that the AbstractSet API returns. What will be
-   the type of the representation? What are some examples of the representation
-   for different kinds of expressions (`DeclRefExpr *`, `MemberExpr *`, etc.)?
-   (As described above, the representation may use the `PreorderAST` for
-   canonicalization. We may also consider using the comparison in
-   [CanonBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/AST/CanonBounds.cpp)).
-2. Implement the AbstractSet API for `DeclRefExpr *`. This is necessary to
-   maintain the current behavior for checking variable bounds.
-3. Replace the current `VarDecl *` keys in `ObservedBounds` with the
-   AbstractSet representation. This should result in no changes in compiler
-   behavior (since only `DeclRefExpr *` have AbstractSet representations).
-4. Implement AbstractSet representations for other kinds of lvalue
-   expressions (see below for the suggested prioritized expression kinds).
-   This should result in the compiler behavior for the implemented lvalue
-   expressions to be identical to the current behavior for variables.
+1. Implement the AbstractSet class and GetOrCreateAbstractSet method as
+   described above.
+2. Implement lexicographic ordering for PreorderASTs. This is necessary
+   to avoid an expensive linear search in GetOrCreateAbstractSet.
+3. Replace the current `VarDecl *` keys in `ObservedBounds` with `AbstractSet *`.
+   This should result in no changes in compiler behavior (since only
+   `DeclRefExpr *` will have an AbstractSet representation).
+4. Implement PreorderAST canonicalization for other kinds of lvalue expressions
+   (see below for the suggested prioritized expression kinds). This should
+   result in the compiler behavior for the implemented lvalue expressions
+   to be identical to the current behavior for variables.
 5. For each lvalue expression kind that has an AbstractSet representation,
    remove the current bounds checking behavior that deals with lvalue
    expressions that are not a `DeclRefExpr *`. For example, the

--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -210,6 +210,8 @@ The AbstractSet class contains the following members:
    described above.
 2. Implement lexicographic ordering for PreorderASTs. This is necessary
    to avoid an expensive linear search in GetOrCreateAbstractSet.
+   Lexicographic ordering for PreorderASTs leverages the ordering implemented
+   in [CanonBounds.cpp](https://github.com/microsoft/checkedc-clang/blob/master/clang/lib/AST/CanonBounds.cpp).
 3. Replace the current `VarDecl *` keys in `ObservedBounds` with `AbstractSet *`.
    This should result in no changes in compiler behavior (since only
    `DeclRefExpr *` will have an AbstractSet representation).

--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -97,18 +97,23 @@ structures and methods:
     `AbstractSet * A`. It uses the `AbstractSetExprs` map to determine the set
     of expressions.
 - GetLValueTargetBounds method
-  - This method returns the normalized target bounds for an `Expr * E`. It is
-    used in ValidateBoundsContext to determine the target bounds for all lvalue
+  - This method returns the target bounds for an lvalue `Expr * E`. It is used
+    in ValidateBoundsContext to determine the target bounds for all lvalue
     expressions in an `AbstractSet * A`, in order to prove or disprove that
     `ObservedBounds[A]` imply the target bounds for `A`.
+  - Note: the target bounds that GetLValueTargetBounds returns are normalized
+    (if possible) to a `RangeBoundsExpr *`. For example, for the `DeclRefExpr *`
+    `p` which has declared bounds of `count(2)` (a `CountBoundsExpr *`),
+    GetLValueTargetBounds will return the `RangeBoundsExpr * bounds(p, p + 2)`.
 - SynthesizeMemberExprs method
-  - This method takes a `MemberExpr * e` and creates a sets of MemberExprs
-    whose target bounds use the value of `e`. It then sets `ObservedBounds[m]`
-    to the target bounds of `m` for each expression `m` in the created set.
+  - This method takes a `MemberExpr * e` and creates a set of MemberExprs
+    whose target bounds use the value of `e`. For each `MemberExpr * m` in
+    the resulting set of MemberExprs, `ObservedBounds[M]` are set to the
+    target bounds of `m`, where `M` is the `AbstractSet *` that contains `m`.
 - AliasAnalysis class
   - This class performs dataflow analysis to determine aliasing relationships
-    between lvalue expressions. Given an AbstractSet `E` which contains an
-    lvalue expression `e`, AliasAnalysis determines:
+    between lvalue expressions. For an AbstractSet `E` which contains an lvalue
+    expression `e`, the AliasAnalysis class supports queries for::
     - MustAlias: the set `S` of AbstractSets where, for each AbstractSet `A`
       in `S`, each expression belonging to `A` must alias with each expression
       that belongs to `E`.
@@ -238,8 +243,7 @@ the following kinds of lvalue expressions (in the `CheckLValue` method):
 - `CHKCBindTemporaryExpr *`. Examples: `TempBinding({ 0 })`.
 
 The following priorities are proposed for AbstractSet implementations for each
-kind of lvalue expression. Priority 0 and Priority 1 expressions should be
-implemented before the April release of the Checked C compiler.
+kind of lvalue expression.
 
 - Priority 0: `DeclRefExpr *`. This is necessary to maintain the current
   bounds checking behavior for variables. It will also serve to test the

--- a/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
+++ b/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md
@@ -26,6 +26,41 @@ occurs immediately after checking an assignment to the expression. The goal
 is to generalize the work that was previously done for variables so that the
 bounds checking behavior is the same for all lvalue expressions.
 
+## Definitions
+
+This document uses the following terms for two lvalue expressions `e1` and `e2`.
+
+`e1` and `e2` are **canonically equivalent** if and
+only if `e1` and `e2` have the same canonical form; that is, if the normalized
+PreorderASTs for `e1` and `e2` are equivalent. For example:
+
+- `a->f` and `*a.f` are canonically equivalent.
+- `*p` and `p[0]` are canonically equivalent.
+- `a->f` and `b->f` are not canonically equivalent.
+- `*p` and `*q` are not canonically equivalent.
+
+`e1` and `e2` are **identical** if and only if `e1`
+and `e2` both point to the same contiguous memory location, i.e. if `e1` and
+`e2` both point to the same location and range of memory.
+
+`e1` and `e2` **must alias** if it is guaranteed that `e1` and `e2` are
+identical.
+
+`e1` and `e2` **may alias** if `e1` points to a range `[L1, U1]` in memory,
+`e2` points to a range `[L2, U2]` in memory, and it is possible that:
+
+- `L1 <= L2 <= U1`, or:
+- `L2 <= L1 <= U2`.
+
+`e1` and `e2` **do not alias** if is not the case that `e1` and `e2` may alias.
+
+An lvalue expression `e` **belongs** to an AbstractSet `A` if and only if
+the canonical form (PreorderAST) `P` for `e` is equivalent to `A.CanonicalForm`.
+If `e` belongs to `A`, then `A` **contains** `e`.
+
+The bounds for expressions belonging to an AbstractSet `A` are **killed**
+if `ObservedBounds[A]` is set to `bounds(unknown)`.
+
 ## Bounds Checking for Variables
 
 The compiler tracks the inferred bounds for each in-scope variable while
@@ -34,8 +69,8 @@ for tracking, updating, and using the inferred bounds:
 
 - **Tracking:** the `ObservedBounds` member of the `CheckingState` class.
 - **Updating:** the `TraverseCFG`, `GetIncomingBlockState`,
-`UpdateCtxWithWidenedBounds`, `GetDeclaredBounds`, `ResetKilledBounds`,
-and `UpdateAfterAssignment` methods.
+  `UpdateCtxWithWidenedBounds`, `GetDeclaredBounds`, `ResetKilledBounds`,
+  and `UpdateAfterAssignment` methods.
 - **Using:** the `ValidateBoundsContext` and `RValueCastBounds` methods.
 
 ## AbstractSet: LValue Expression Equality


### PR DESCRIPTION
Update the design document for generalizing bounds checking from variables to lvalues, based on design discussions.