### PR TITLE
[Where Clause] Introduce WhereClauseScope to emit better diagnostics [2/n]

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1511,4 +1511,7 @@ def err_pragma_checked_scope_invalid_argument : Error<
   "unexpected argument '%0' to '#pragma CHECKED_SCOPE'; "
   "expected 'on','off', '_Bounds_only', 'push', or 'pop'">;
 
+def err_expected_expr_in_where_clause : Error<
+  "expected bounds declaration or equality expression in where clause">;
+
 } // end of Parser diagnostics

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10912,6 +10912,9 @@ def err_probability_out_of_range : Error<
 def err_expected_comparison_op_in_equality_expr : Error<
   "expected comparison operator in equality expression">;
 
+def err_invalid_expr_in_where_clause : Error<
+  "invalid expr in where clause, expected bounds declaration or equality expression">;
+
 // Checked C diagnostic messages
 let CategoryName = "Checked C" in {
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10913,7 +10913,7 @@ def err_expected_comparison_op_in_equality_expr : Error<
   "expected comparison operator in equality expression">;
 
 def err_invalid_expr_in_where_clause : Error<
-  "invalid expr in where clause, expected bounds declaration or equality expression">;
+  "invalid expression in where clause, expected bounds declaration or equality expression">;
 
 // Checked C diagnostic messages
 let CategoryName = "Checked C" in {

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2099,8 +2099,12 @@ private:
   /// Parse a pack expression of the form '_Pack(expr, existential_type, substitution_type)'.
   ExprResult ParsePackExpression();
 
-  /// Parse a Checked C where clause.
+  /// Enters and exits WhereClause scope. Invokes ParseWhereClauseHelper to parse a where
+  /// clause.
   WhereClause *ParseWhereClause();
+
+  /// Parse a Checked C where clause.
+  WhereClause *ParseWhereClauseHelper();
 
   /// Parse a Checked C where clause fact.
   WhereClauseFact *ParseWhereClauseFact();

--- a/clang/include/clang/Sema/Scope.h
+++ b/clang/include/clang/Sema/Scope.h
@@ -144,7 +144,10 @@ public:
     /// Checked C - Scope for an existential type
     /// e.g. when we write '_Exists(T, struct Foo<T>)', T's scope is exactly the
     /// type 'struct Foo<T>'.
-    ExistentialTypeScope = 0x8000000
+    ExistentialTypeScope = 0x8000000,
+
+    /// Checked C - Where clause scope.
+    WhereClauseScope = 0x10000000
   };
 
 private:
@@ -373,6 +376,11 @@ public:
 
   /// isExistentialTypeScope - Return true if this scope corresponds to an existential type.
   bool isExistentialTypeScope() const { return (getFlags() & Scope::ExistentialTypeScope); }
+
+  /// isWhereClauseScope - Return true if this scope is _Where scope.
+  bool isWhereClauseScope() const {
+    return getFlags() & Scope::WhereClauseScope;
+  }
 
   /// isInCXXInlineMethodScope - Return true if this scope is a C++ inline
   /// method scope or is inside one.

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -686,8 +686,12 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
                                        isTypeCast,
                                        isVectorLiteral,
                                        NotPrimaryExpression);
-  if (NotCastExpr)
-    Diag(Tok, diag::err_expected_expression);
+  if (NotCastExpr) {
+    if (getCurScope()->isWhereClauseScope())
+      Diag(Tok, diag::err_expected_expr_in_where_clause);
+    else
+      Diag(Tok, diag::err_expected_expression);
+  }
   return Res;
 }
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -267,6 +267,7 @@ Retry:
   // Parse Checked C _Where token.
   case tok::kw__Where: {
     WhereClause *WClause = ParseWhereClause();
+
     if (!WClause)
       return StmtError();
 
@@ -2643,6 +2644,13 @@ WhereClauseFact *Parser::ParseWhereClauseFact() {
 }
 
 WhereClause *Parser::ParseWhereClause() {
+  EnterScope(getCurScope()->getFlags() | Scope::WhereClauseScope);
+  WhereClause *WClause = ParseWhereClauseHelper();
+  ExitScope();
+  return WClause;
+}
+
+WhereClause *Parser::ParseWhereClauseHelper() {
   SourceLocation WhereLoc = Tok.getLocation();
 
   // Consume the "_Where" token.

--- a/clang/lib/Sema/Scope.cpp
+++ b/clang/lib/Sema/Scope.cpp
@@ -170,6 +170,7 @@ void Scope::dumpImpl(raw_ostream &OS) const {
       {CatchScope, "CatchScope"},
       {ForanyScope, "ForanyScope"},
       {ItypeforanyScope, "ITypeForanyScope"},
+      {WhereClauseScope, "WhereClauseScope"},
   };
 
   for (auto Info : FlagInfo) {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -4557,7 +4557,8 @@ EqualityOpFact *Sema::ActOnEqualityOpFact(Expr *E, SourceLocation ExprLoc) {
   auto *BO = dyn_cast_or_null<BinaryOperator>(TmpE);
 
   if (!BO) {
-    Diag(ExprLoc, diag::err_invalid_expr_in_where_clause);
+    if (getCurScope()->isWhereClauseScope())
+      Diag(ExprLoc, diag::err_invalid_expr_in_where_clause);
     return nullptr;
   }
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -4556,8 +4556,13 @@ EqualityOpFact *Sema::ActOnEqualityOpFact(Expr *E, SourceLocation ExprLoc) {
 
   auto *BO = dyn_cast_or_null<BinaryOperator>(TmpE);
 
+  if (!BO) {
+    Diag(ExprLoc, diag::err_invalid_expr_in_where_clause);
+    return nullptr;
+  }
+
   // isComparisonOp checks for equality and relational operators.
-  if (!BO || !BO->isComparisonOp()) {
+  if (!BO->isComparisonOp()) {
     Diag(ExprLoc, diag::err_expected_comparison_op_in_equality_expr);
     return nullptr;
   }

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -10,19 +10,19 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where _Where; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where _And _And _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
-  _Where a; // expected-error {{expected comparison operator in equality expression}}
-  _Where a _Where a _Where a; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}}
-  _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where a; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
+  _Where a _Where a _Where a; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
+  _Where a _And; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where x; // expected-error {{use of undeclared identifier 'x'}}
   _Where p : ; // expected-error {{expected bounds expression}}
   _Where p : count(x); // expected-error {{use of undeclared identifier 'x'}}
   _Where q : count(0); // expected-error {{use of undeclared identifier q}}
   _Where (); // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where a = 0; // expected-error {{expected comparison operator in equality expression}}
-  _Where a == 1 _And a; // expected-error {{expected comparison operator in equality expression}}
-  _Where a _And a == 1; // expected-error {{expected comparison operator in equality expression}}
+  _Where a == 1 _And a; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
+  _Where a _And a == 1; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
   _Where a < 0 _And x; // expected-error {{use of undeclared identifier 'x'}}
-  _Where 1; // expected-error {{expected comparison operator in equality expression}}
+  _Where 1; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
   _Where x _And p : count(0); // expected-error {{use of undeclared identifier 'x'}}
   _Where p : count(0) _And x; // expected-error {{use of undeclared identifier 'x'}}
   _Where a == 1 _And p : Count(0); // expected-error {{expected bounds expression}}
@@ -30,9 +30,9 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   where a == 1; // expected-error {{use of undeclared identifier 'where'}}
   _Where a == 1 and a == 2; // expected-error {{expected ';'}} expected-error {{use of undeclared identifier 'and'}}
   _Where a == 1 // expected-error {{expected ';'}}
-  _Where f(); // expected-error {{expected comparison operator in equality expression}}
+  _Where f(); // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
   _Where f() == 1; // expected-error {{call expression not allowed in expression}}
   _Where 1 != f(); // expected-error {{call expression not allowed in expression}}
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
-  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -5,19 +5,19 @@
 int f();
 
 void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
-  _Where ; // expected-error {{expected expression}}
-  _Where ;;;;; // expected-error {{expected expression}}
-  _Where _Where; // expected-error {{expected expression}} expected-error {{expected expression}}
-  _Where _And; // expected-error {{expected expression}} expected-error {{expected expression}}
-  _Where _And _And _And; // expected-error {{expected expression}} expected-error {{expected expression}} expected-error {{expected expression}} expected-error {{expected expression}}
+  _Where ; // expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where ;;;;; // expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where _Where; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where _And _And _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _Where a _Where a; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}}
-  _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected expression}}
+  _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where x; // expected-error {{use of undeclared identifier 'x'}}
   _Where p : ; // expected-error {{expected bounds expression}}
   _Where p : count(x); // expected-error {{use of undeclared identifier 'x'}}
   _Where q : count(0); // expected-error {{use of undeclared identifier q}}
-  _Where (); // expected-error {{expected expression}}
+  _Where (); // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where a = 0; // expected-error {{expected comparison operator in equality expression}}
   _Where a == 1 _And a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _And a == 1; // expected-error {{expected comparison operator in equality expression}}
@@ -34,5 +34,5 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where f() == 1; // expected-error {{call expression not allowed in expression}}
   _Where 1 != f(); // expected-error {{call expression not allowed in expression}}
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
-  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected expression}}
+  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -10,19 +10,19 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where _Where; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where _And _And _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
-  _Where a; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
-  _Where a _Where a _Where a; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
-  _Where a _And; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where a; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
+  _Where a _Where a _Where a; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
+  _Where a _And; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where x; // expected-error {{use of undeclared identifier 'x'}}
   _Where p : ; // expected-error {{expected bounds expression}}
   _Where p : count(x); // expected-error {{use of undeclared identifier 'x'}}
   _Where q : count(0); // expected-error {{use of undeclared identifier q}}
   _Where (); // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where a = 0; // expected-error {{expected comparison operator in equality expression}}
-  _Where a == 1 _And a; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
-  _Where a _And a == 1; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
+  _Where a == 1 _And a; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
+  _Where a _And a == 1; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
   _Where a < 0 _And x; // expected-error {{use of undeclared identifier 'x'}}
-  _Where 1; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
+  _Where 1; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
   _Where x _And p : count(0); // expected-error {{use of undeclared identifier 'x'}}
   _Where p : count(0) _And x; // expected-error {{use of undeclared identifier 'x'}}
   _Where a == 1 _And p : Count(0); // expected-error {{expected bounds expression}}
@@ -30,9 +30,9 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   where a == 1; // expected-error {{use of undeclared identifier 'where'}}
   _Where a == 1 and a == 2; // expected-error {{expected ';'}} expected-error {{use of undeclared identifier 'and'}}
   _Where a == 1 // expected-error {{expected ';'}}
-  _Where f(); // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}}
+  _Where f(); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
   _Where f() == 1; // expected-error {{call expression not allowed in expression}}
   _Where 1 != f(); // expected-error {{call expression not allowed in expression}}
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
-  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{invalid expr in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }


### PR DESCRIPTION
We introduce a new scope for where clauses. Before parsing a where clause we
enter the `WhereClauseScope` and at the end of parsing we exit the scope. In `Sema`
we check if we are in the `WhereClauseScope` and emit the relevant diagnostics.