### PR TITLE
[Where Clause] Support where clauses on declarations [3/n]

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -78,6 +78,7 @@ class TypeLoc;
 class UnresolvedSetImpl;
 class VarTemplateDecl;
 class TypedefDecl;
+class WhereClause;
 
 /// The top declaration context.
 class TranslationUnitDecl : public Decl, public DeclContext {
@@ -1006,6 +1007,8 @@ private:
   };
   enum { NumVarDeclBits = 8 };
 
+  WhereClause *WClause;
+
 protected:
   enum { NumParameterIndexBits = 8 };
 
@@ -1664,6 +1667,9 @@ public:
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { return classofKind(D->getKind()); }
   static bool classofKind(Kind K) { return K >= firstVar && K <= lastVar; }
+
+  void setWhereClause(WhereClause *WC) { WClause = WC; }
+  WhereClause *getWhereClause() const { return WClause; }
 };
 
 class ImplicitParamDecl : public VarDecl {

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1843,6 +1843,9 @@ class ValueStmt : public Stmt {
 protected:
   using Stmt::Stmt;
 
+private:
+  WhereClause *WClause;
+
 public:
   const Expr *getExprStmt() const;
   Expr *getExprStmt() {
@@ -1854,6 +1857,9 @@ public:
     return T->getStmtClass() >= firstValueStmtConstant &&
            T->getStmtClass() <= lastValueStmtConstant;
   }
+
+  void setWhereClause(WhereClause *WC) { WClause = WC; }
+  WhereClause *getWhereClause() const { return WClause; }
 };
 
 /// LabelStmt - Represents a label, which has a substatement.  For example:

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1511,4 +1511,7 @@ def err_pragma_checked_scope_invalid_argument : Error<
   "unexpected argument '%0' to '#pragma CHECKED_SCOPE'; "
   "expected 'on','off', '_Bounds_only', 'push', or 'pop'">;
 
+def err_expected_expr_in_where_clause : Error<
+  "expected bounds declaration or equality expression in where clause">;
+
 } // end of Parser diagnostics

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1513,5 +1513,7 @@ def err_pragma_checked_scope_invalid_argument : Error<
 
 def err_expected_expr_in_where_clause : Error<
   "expected bounds declaration or equality expression in where clause">;
+def err_invalid_stmt_where_clause : Error<
+  "where clause attached to invalid statement">;
 
 } // end of Parser diagnostics

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2099,8 +2099,12 @@ private:
   /// Parse a pack expression of the form '_Pack(expr, existential_type, substitution_type)'.
   ExprResult ParsePackExpression();
 
-  /// Parse a Checked C where clause.
+  /// Enters and exits WhereClause scope. Invokes ParseWhereClauseHelper to parse a where
+  /// clause.
   WhereClause *ParseWhereClause();
+
+  /// Parse a Checked C where clause.
+  WhereClause *ParseWhereClauseHelper();
 
   /// Parse a Checked C where clause fact.
   WhereClauseFact *ParseWhereClauseFact();

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2109,8 +2109,8 @@ private:
   /// Parse a Checked C where clause fact.
   WhereClauseFact *ParseWhereClauseFact();
 
-  /// Attach a where clause to a Decl.
-  void AttachWhereClause(Decl *D);
+  /// Parse a where clause occurring on a declaration.
+  void ParseWhereClauseOnDecl(Decl *D);
 
   //===--------------------------------------------------------------------===//
   // clang Expressions

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2109,6 +2109,9 @@ private:
   /// Parse a Checked C where clause fact.
   WhereClauseFact *ParseWhereClauseFact();
 
+  /// Attach a where clause to a Decl.
+  void AttachWhereClause(Decl *D);
+
   //===--------------------------------------------------------------------===//
   // clang Expressions
 

--- a/clang/include/clang/Sema/Scope.h
+++ b/clang/include/clang/Sema/Scope.h
@@ -144,7 +144,10 @@ public:
     /// Checked C - Scope for an existential type
     /// e.g. when we write '_Exists(T, struct Foo<T>)', T's scope is exactly the
     /// type 'struct Foo<T>'.
-    ExistentialTypeScope = 0x8000000
+    ExistentialTypeScope = 0x8000000,
+
+    /// Checked C - Where clause scope.
+    WhereClauseScope = 0x10000000
   };
 
 private:
@@ -373,6 +376,11 @@ public:
 
   /// isExistentialTypeScope - Return true if this scope corresponds to an existential type.
   bool isExistentialTypeScope() const { return (getFlags() & Scope::ExistentialTypeScope); }
+
+  /// isWhereClauseScope - Return true if this scope is _Where scope.
+  bool isWhereClauseScope() const {
+    return getFlags() & Scope::WhereClauseScope;
+  }
 
   /// isInCXXInlineMethodScope - Return true if this scope is a C++ inline
   /// method scope or is inside one.

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1984,7 +1984,7 @@ VarDecl::VarDecl(Kind DK, ASTContext &C, DeclContext *DC,
                  IdentifierInfo *Id, QualType T, TypeSourceInfo *TInfo,
                  StorageClass SC)
     : DeclaratorDecl(DK, DC, IdLoc, Id, T, TInfo, StartLoc),
-      redeclarable_base(C) {
+      redeclarable_base(C), WClause(nullptr) {
   static_assert(sizeof(VarDeclBitfields) <= sizeof(unsigned),
                 "VarDeclBitfields too large!");
   static_assert(sizeof(ParmVarDeclBitfields) <= sizeof(unsigned),

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -1881,7 +1881,7 @@ void Parser::ExitQuantifiedTypeScope(DeclSpec &DS) {
   }
 }
 
-void Parser::AttachWhereClause(Decl *D) {
+void Parser::ParseWhereClauseOnDecl(Decl *D) {
   if (!getLangOpts().CheckedC || !Tok.is(tok::kw__Where))
     return;
 
@@ -2078,8 +2078,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
   D.complete(FirstDecl);
   if (FirstDecl) {
     DeclsInGroup.push_back(FirstDecl);
-    // If a where clause is declared, attached it to the variable declaration.
-    AttachWhereClause(FirstDecl);
+    // Parse a where clause occurring on the variable declaration.
+    ParseWhereClauseOnDecl(FirstDecl);
   }
 
   bool ExpectSemi = Context != DeclaratorContext::ForContext;
@@ -2127,9 +2127,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
       D.complete(ThisDecl);
       if (ThisDecl) {
         DeclsInGroup.push_back(ThisDecl);
-        // If a where clause is declared, attached it to the variable
-        // declaration.
-        AttachWhereClause(ThisDecl);
+        // Parse a where clause occurring on the variable declaration.
+        ParseWhereClauseOnDecl(ThisDecl);
       }
     }
   }
@@ -7303,9 +7302,8 @@ void Parser::ParseParameterDeclarationClause(
         }
       }
 
-      // If a where clause is declared, attached it to the parameter
-      // declaration.
-      AttachWhereClause(Param);
+      // Parse a where clause occurring on the parameter declaration.
+      ParseWhereClauseOnDecl(Param);
 
       ParamInfo.push_back(DeclaratorChunk::ParamInfo(ParmII,
                                           ParmDeclarator.getIdentifierLoc(),

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -686,8 +686,12 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
                                        isTypeCast,
                                        isVectorLiteral,
                                        NotPrimaryExpression);
-  if (NotCastExpr)
-    Diag(Tok, diag::err_expected_expression);
+  if (NotCastExpr) {
+    if (getCurScope()->isWhereClauseScope())
+      Diag(Tok, diag::err_expected_expr_in_where_clause);
+    else
+      Diag(Tok, diag::err_expected_expression);
+  }
   return Res;
 }
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2637,7 +2637,19 @@ WhereClauseFact *Parser::ParseWhereClauseFact() {
 
   // Parse an equality expression.
   SourceLocation ExprLoc = Tok.getLocation();
-  ExprResult ExprRes = Actions.CorrectDelayedTyposInExpr(ParseExpression());
+
+  // ParseExpression parses expressions including top-level commas. So
+  // declarations like the following are not parsed correctly.
+  // int a _Where a == 1, b;
+  // If fails because it parses "a == 1, b" as one expression.
+
+  // ParseAssignmentExpression parses an expression not including top-level
+  // commas. So the above declaration is parsed correctly. This is also useful
+  // for parsing multiple comma-separated declarations each having its own
+  // where clause as follows:
+  // int a _Where a < 1, b _Where b > 1, c, d, e _Where e == 1;
+
+  ExprResult ExprRes = ParseAssignmentExpression();
   if (ExprRes.isInvalid())
     return nullptr;
   return Actions.ActOnEqualityOpFact(ExprRes.get(), ExprLoc);

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -267,6 +267,7 @@ Retry:
   // Parse Checked C _Where token.
   case tok::kw__Where: {
     WhereClause *WClause = ParseWhereClause();
+
     if (!WClause)
       return StmtError();
 
@@ -2643,6 +2644,13 @@ WhereClauseFact *Parser::ParseWhereClauseFact() {
 }
 
 WhereClause *Parser::ParseWhereClause() {
+  EnterScope(getCurScope()->getFlags() | Scope::WhereClauseScope);
+  WhereClause *WClause = ParseWhereClauseHelper();
+  ExitScope();
+  return WClause;
+}
+
+WhereClause *Parser::ParseWhereClauseHelper() {
   SourceLocation WhereLoc = Tok.getLocation();
 
   // Consume the "_Where" token.

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2668,7 +2668,8 @@ WhereClauseFact *Parser::ParseWhereClauseFact() {
   // where clause as follows:
   // int a _Where a < 1, b _Where b > 1, c, d, e _Where e == 1;
 
-  ExprResult ExprRes = ParseAssignmentExpression();
+  ExprResult ExprRes =
+    Actions.CorrectDelayedTyposInExpr(ParseAssignmentExpression());
   if (ExprRes.isInvalid())
     return nullptr;
   return Actions.ActOnEqualityOpFact(ExprRes.get(), ExprLoc);

--- a/clang/lib/Sema/Scope.cpp
+++ b/clang/lib/Sema/Scope.cpp
@@ -170,6 +170,7 @@ void Scope::dumpImpl(raw_ostream &OS) const {
       {CatchScope, "CatchScope"},
       {ForanyScope, "ForanyScope"},
       {ItypeforanyScope, "ITypeForanyScope"},
+      {WhereClauseScope, "WhereClauseScope"},
   };
 
   for (auto Info : FlagInfo) {

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -5,19 +5,19 @@
 int f();
 
 void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
-  _Where ; // expected-error {{expected expression}}
-  _Where ;;;;; // expected-error {{expected expression}}
-  _Where _Where; // expected-error {{expected expression}} expected-error {{expected expression}}
-  _Where _And; // expected-error {{expected expression}} expected-error {{expected expression}}
-  _Where _And _And _And; // expected-error {{expected expression}} expected-error {{expected expression}} expected-error {{expected expression}} expected-error {{expected expression}}
+  _Where ; // expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where ;;;;; // expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where _Where; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where _And _And _And; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _Where a _Where a; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}}
-  _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected expression}}
+  _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where x; // expected-error {{use of undeclared identifier 'x'}}
   _Where p : ; // expected-error {{expected bounds expression}}
   _Where p : count(x); // expected-error {{use of undeclared identifier 'x'}}
   _Where q : count(0); // expected-error {{use of undeclared identifier q}}
-  _Where (); // expected-error {{expected expression}}
+  _Where (); // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where a = 0; // expected-error {{expected comparison operator in equality expression}}
   _Where a == 1 _And a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _And a == 1; // expected-error {{expected comparison operator in equality expression}}
@@ -34,5 +34,5 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where f() == 1; // expected-error {{call expression not allowed in expression}}
   _Where 1 != f(); // expected-error {{call expression not allowed in expression}}
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
-  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected expression}}
+  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -42,3 +42,7 @@ void invalid_cases_decl(_Nt_array_ptr<char> p) {
 }
 
 void f1(int a _Where a, _Nt_array_ptr<int> p : count(0) _Where p :); // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}}
+
+void f2(int a, _Nt_array_ptr<int> p) {
+  a = 0 _Where a _And p : _And q : count(0) _And x _Where d = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'd'}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{use of undeclared identifier 'x'}}
+}

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -40,3 +40,5 @@ void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
 void invalid_cases_decl(_Nt_array_ptr<char> p) {
   int a _Where a _And p : _And q : count(0) _And x, b, c, d _Where c = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }
+
+void f1(int a _Where a, _Nt_array_ptr<int> p : count(0) _Where p :); // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}}

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -4,7 +4,7 @@
 
 int f();
 
-void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
+void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
   _Where ; // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where ;;;;; // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where _Where; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
@@ -13,7 +13,7 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _Where a _Where a; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}}
   _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
-  _Where x; // expected-error {{use of undeclared identifier 'x'}}
+  _Where x; // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
   _Where p : ; // expected-error {{expected bounds expression}}
   _Where p : count(x); // expected-error {{use of undeclared identifier 'x'}}
   _Where q : count(0); // expected-error {{use of undeclared identifier q}}
@@ -21,10 +21,10 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where a = 0; // expected-error {{expected comparison operator in equality expression}}
   _Where a == 1 _And a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _And a == 1; // expected-error {{expected comparison operator in equality expression}}
-  _Where a < 0 _And x; // expected-error {{use of undeclared identifier 'x'}}
+  _Where a < 0 _And x; // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
   _Where 1; // expected-error {{expected comparison operator in equality expression}}
-  _Where x _And p : count(0); // expected-error {{use of undeclared identifier 'x'}}
-  _Where p : count(0) _And x; // expected-error {{use of undeclared identifier 'x'}}
+  _Where x _And p : count(0); // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
+  _Where p : count(0) _And x; // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
   _Where a == 1 _And p : Count(0); // expected-error {{expected bounds expression}}
   _Where p : Bounds(p, p + 1) _And a == 1; // expected-error {{expected bounds expression}}
   where a == 1; // expected-error {{use of undeclared identifier 'where'}}
@@ -34,5 +34,9 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where f() == 1; // expected-error {{call expression not allowed in expression}}
   _Where 1 != f(); // expected-error {{call expression not allowed in expression}}
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
-  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+}
+
+void invalid_cases_decl(_Nt_array_ptr<char> p) {
+  int a _Where a _And p : _And q : count(0) _And x, b, c, d _Where c = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -13,7 +13,7 @@ void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
   _Where a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _Where a _Where a; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}} expected-error {{expected comparison operator in equality expression}}
   _Where a _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
-  _Where x; // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
+  _Where x; // expected-error {{use of undeclared identifier 'x'}}
   _Where p : ; // expected-error {{expected bounds expression}}
   _Where p : count(x); // expected-error {{use of undeclared identifier 'x'}}
   _Where q : count(0); // expected-error {{use of undeclared identifier q}}
@@ -21,10 +21,10 @@ void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
   _Where a = 0; // expected-error {{expected comparison operator in equality expression}}
   _Where a == 1 _And a; // expected-error {{expected comparison operator in equality expression}}
   _Where a _And a == 1; // expected-error {{expected comparison operator in equality expression}}
-  _Where a < 0 _And x; // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
+  _Where a < 0 _And x; // expected-error {{use of undeclared identifier 'x'}}
   _Where 1; // expected-error {{expected comparison operator in equality expression}}
-  _Where x _And p : count(0); // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
-  _Where p : count(0) _And x; // expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}}
+  _Where x _And p : count(0); // expected-error {{use of undeclared identifier 'x'}}
+  _Where p : count(0) _And x; // expected-error {{use of undeclared identifier 'x'}}
   _Where a == 1 _And p : Count(0); // expected-error {{expected bounds expression}}
   _Where p : Bounds(p, p + 1) _And a == 1; // expected-error {{expected bounds expression}}
   where a == 1; // expected-error {{use of undeclared identifier 'where'}}
@@ -34,15 +34,15 @@ void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
   _Where f() == 1; // expected-error {{call expression not allowed in expression}}
   _Where 1 != f(); // expected-error {{call expression not allowed in expression}}
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
-  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }
 
 void invalid_cases_decl(_Nt_array_ptr<char> p) {
-  int a _Where a _And p : _And q : count(0) _And x, b, c, d _Where c = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+  int a _Where a _And p : _And q : count(0) _And x, b, c, d _Where c = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }
 
 void f1(int a _Where a, _Nt_array_ptr<int> p : count(0) _Where p :); // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}}
 
 void f2(int a, _Nt_array_ptr<int> p) {
-  a = 0 _Where a _And p : _And q : count(0) _And x _Where d = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{expected comparison operator in equality expression}} expected-error {{use of undeclared identifier 'd'}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{use of undeclared identifier 'x'}}
+  a = 0 _Where a _And p : _And q : count(0) _And x _Where d = 1 _And f() < 0 _And; // expected-error {{expected comparison operator in equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'd'}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{use of undeclared identifier 'x'}}
 }

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -4,6 +4,7 @@
 
 // expected-no-diagnostics
 
+// Test where clauses on null statements.
 void valid_cases_nullstmt(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
                           int a, int b) {
   _Where a < 0;
@@ -32,6 +33,7 @@ void valid_cases_nullstmt(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
 }
 
 int f();
+// Test where clauses on variable declarations inside a function.
 void valid_cases_decl(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q) {
   int a _Where a == 0 _And a != 0 _And p : bounds(p, p + a);
   int b = 0 _Where b != 0 _And p : count(b);
@@ -40,9 +42,11 @@ void valid_cases_decl(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q) {
   int e, f _Where e == 0 _And f == 0;
   int g _Where g == 0, h, i, j _Where j < 0;
   int k _Where k != 0 _And p : count(k), m, n, o _Where q : bounds(q, q + 1), r, s;
+  int arr1[3] = {1, 2, 3} _Where 0 < 1, arr2[2] = {1, 2} _Where 1 > 0;
+  _Nt_array_ptr<char> p1 : count(0) = "" _Where p1 : bounds(p1, p1 + 1);
 }
 
-// Test where clauses on declarations outside a function.
+// Test where clauses on variable declarations outside a function.
 _Nt_array_ptr<char> p;
 _Nt_array_ptr<char> q;
 int a _Where a == 0 _And a != 0 _And p : bounds(p, p + a);
@@ -51,3 +55,9 @@ int c _Where p : bounds(p, p + c) _And q : count(c) _And c == 0;
 int d, e _Where e == 0 _And d != 0;
 int g _Where g == 0, h, i, j _Where j < 0;
 int k _Where k != 0 _And p : count(k), m, n, o _Where q : bounds(q, q + 1), r, s;
+int arr1[3] = {1, 2, 3} _Where 0 < 1, arr2[2] = {1, 2} _Where 1 > 0;
+_Nt_array_ptr<char> p1 : count(0) = "" _Where p1 : bounds(p1, p1 + 1);
+
+// Test where clauses on function parameters.
+void f1(int a _Where a < 0, int b, int c _Where c < 0, int *d : itype(_Ptr<int>) _Where d == 0) {}
+void f2(int a _Where a < 0, int b, int c _Where c < 0, int *d : itype(_Ptr<int>) _Where d == 0);

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -61,3 +61,12 @@ _Nt_array_ptr<char> p1 : count(0) = "" _Where p1 : bounds(p1, p1 + 1);
 // Test where clauses on function parameters.
 void f1(int a _Where a < 0, int b, int c _Where c < 0, int *d : itype(_Ptr<int>) _Where d == 0) {}
 void f2(int a _Where a < 0, int b, int c _Where c < 0, int *d : itype(_Ptr<int>) _Where d == 0);
+
+// Test where clauses on ExprStmts.
+void f3(_Nt_array_ptr<char> p, int a) {
+  int b;
+  a = 0 _Where a < 1 _And a >= 0;
+  b = a _Where a > b _And a != b;
+  p = 0 _Where p : bounds(p, p + 1) _And a < 1;
+L1: a = 0 _Where a > 1;
+}

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -4,8 +4,8 @@
 
 // expected-no-diagnostics
 
-void valid_cases(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
-                 int a, int b) {
+void valid_cases_nullstmt(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
+                          int a, int b) {
   _Where a < 0;
   _Where a > 0;
   _Where a <= 0;
@@ -30,3 +30,24 @@ void valid_cases(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
   _Where (((((a == 0)))));
   _Where (a == 0) _And ((a == 0)) _And (((a == 0)));
 }
+
+int f();
+void valid_cases_decl(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q) {
+  int a _Where a == 0 _And a != 0 _And p : bounds(p, p + a);
+  int b = 0 _Where b != 0 _And p : count(b);
+  int c = f() _Where p : bounds(p, p + c) _And c < 0;
+  int d _Where p : bounds(p, p + d) _And q : count(d) _And d == 0;
+  int e, f _Where e == 0 _And f == 0;
+  int g _Where g == 0, h, i, j _Where j < 0;
+  int k _Where k != 0 _And p : count(k), m, n, o _Where q : bounds(q, q + 1), r, s;
+}
+
+// Test where clauses on declarations outside a function.
+_Nt_array_ptr<char> p;
+_Nt_array_ptr<char> q;
+int a _Where a == 0 _And a != 0 _And p : bounds(p, p + a);
+int b = 0 _Where b != 0 _And p : count(b);
+int c _Where p : bounds(p, p + c) _And q : count(c) _And c == 0;
+int d, e _Where e == 0 _And d != 0;
+int g _Where g == 0, h, i, j _Where j < 0;
+int k _Where k != 0 _And p : count(k), m, n, o _Where q : bounds(q, q + 1), r, s;


### PR DESCRIPTION
We add support for where clauses on variable and function parameter declarations like:
`int a = 1 _Where a > 0, b, c, d _Where d < 1;`
`void f(int a _Where a < 0, int b, int c _Where c > 0);`