### PR TITLE
Lexicographic ordering for PreorderASTs

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -138,11 +138,12 @@ namespace clang {
     bool GetDerefOffset(Node *UpperExpr, Node *DerefExpr,
                         llvm::APSInt &Offset);
 
-    // Check if the two AST nodes N1 and N2 are equal.
+    // Lexicographically compare two AST nodes N1 and N2.
     // @param[in] N1 is the first node.
     // @param[in] N2 is the second node.
-    // @return Returns a boolean indicating whether N1 and N2 are equal.
-    bool IsEqual(Node *N1, Node *N2);
+    // @return Returns a Lexicographic::Result indicating the comparison
+    // of N1 and N2.
+    Result Compare(Node *N1, Node *N2);
 
     // Set Error in case an error occurs during transformation of the AST.
     void SetError() { Error = true; }
@@ -178,13 +179,14 @@ namespace clang {
       return GetDerefOffset(/*UpperExpr*/ Root, /*DerefExpr*/ P.Root, Offset);
     }
 
-    // Check if the two ASTs are equal. This is intended to be called from
-    // outside this class and invokes IsEqual on the root nodes of the two ASTs
-    // to recursively compare the AST nodes.
+    // Lexicographically compare the two ASTs. This is intended to be called
+    // from outside this class and invokes Compare on the root nodes of the two
+    // ASTs to recursively compare the AST nodes.
     // @param[in] this is the first AST.
     // @param[in] P is the second AST.
-    // @return Returns a bool indicating whether the two ASTs are equal.
-    bool IsEqual(PreorderAST &P) { return IsEqual(Root, P.Root); }
+    // @return Returns a Lexicographic::Result indicating the comparison between
+    // the two ASTs.
+    Result Compare(PreorderAST &P) { return Compare(Root, P.Root); }
 
     // Check if an error has occurred during transformation of the AST. This
     // is intended to be called from outside this class to check if an error

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -279,7 +279,7 @@ bool Lexicographic::CompareExprSemantically(const Expr *Arg1,
      return CompareExpr(Arg1, Arg2) == Result::Equal;
    }
 
-  bool Res = P1.IsEqual(P2);
+  bool Res = P1.Compare(P2) == Result::Equal;
   P1.Cleanup();
   P2.Cleanup();
   return Res;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -427,8 +427,8 @@ Result PreorderAST::Compare(Node *N1, Node *N2) {
     if (O1->Opc > O2->Opc)
       return Result::GreaterThan;
 
-    unsigned ChildCount1 = O1->Children.size(),
-             ChildCount2 = O2->Children.size();
+    size_t ChildCount1 = O1->Children.size(),
+           ChildCount2 = O2->Children.size();
 
     // If the number of children of the two nodes mismatch.
     if (ChildCount1 < ChildCount2)


### PR DESCRIPTION
This PR implements lexicographic ordering for PreorderASTs that uses the existing ordering in CanonBounds.cpp. Previously, PreorderAST had an `IsEqual` method that returned true if two ASTs were equal (using `Lexicographic::CompareExpr` to compare expressions in leaf nodes). This PR replaces `IsEqual` with a `Compare` method that returns a `Lexicographic::Result` - `LessThan`, `Equal`, or `GreaterThan` that continues to use `Lexicographic::CompareExpr` to compare expressions in leaf nodes.

This ordering will be used in lvalue generalization work to avoid an expensive linear search when computing the `AbstractSet` to which an lvalue expression belongs (see the [lvalue generalization design doc](https://github.com/microsoft/checkedc-clang/blob/master/clang/docs/checkedc/Bounds-Checking-for-LValue-Expressions.md)).