### PR TITLE
[LValue Generalization] AbstractSet [1/n]

### DIFF
--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -41,7 +41,7 @@ namespace clang {
       Representative = E;
     }
 
-    Expr *GetRepresentative() {
+    Expr *GetRepresentative() const {
       return Representative;
     }
 

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -12,8 +12,8 @@ namespace clang {
 
   // The AbstractSet class represents an abstraction of memory. If two lvalue
   // expressions e1 and e2 belong to the same AbstractSet, then e1 and e2
-  // point to the same contiguous memory location (i.e. e1 and e2 point to
-  // the same location and range in memory).
+  // point to the same contiguous block of memory locations (i.e. e1 and e2
+  // point to the same location and range in memory).
   class AbstractSet {
   private:
     // Canonical form of all lvalue expressions that belong to this AbstractSet.
@@ -29,6 +29,9 @@ namespace clang {
     //    or disprove that the inferred bounds for the expressions in this
     //    AbstractSet imply the target bounds. All lvalue expressions in this
     //    AbstractSet have the same target bounds as the representative.
+    //    Bounds validation must use existing bounds checking methods in the
+    //    CheckBoundsDeclarations class to compute the target bounds for the
+    //    representative expression.
     Expr *Representative;
 
   public:

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -1,0 +1,81 @@
+#ifndef LLVM_CLANG_ABSTRACT_SET_H
+#define LLVM_CLANG_ABSTRACT_SET_H
+
+#include <set>
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/CanonBounds.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/PreorderAST.h"
+
+namespace clang {
+  using Result = Lexicographic::Result;
+
+  class AbstractSet {
+  private:
+    // Canonical form of all lvalue expressions that belong to this AbstractSet.
+    PreorderAST CanonicalForm;
+
+    // LValue expression that is a representative of all lvalue expressions that
+    // belong to this AbstractSet. This can be used in bounds validation to:
+    // 1. Get the Decl for the representative. This is used to determine the
+    //    location of the note that specifies the declared (target) bounds.
+    // 2. Get the target bounds for the representative. This is used to prove
+    //    or disprove that the inferred bounds for the expressions in this
+    //    AbstractSet imply the target bounds. All lvalue expressions in this
+    //    AbstractSet have the same target bounds as the representative.
+    Expr *Representative;
+
+  public:
+    AbstractSet(PreorderAST P) : CanonicalForm(P) {}
+
+    void SetRepresentative(Expr *E) {
+      Representative = E;
+    }
+
+    Expr *GetRepresentative() {
+      return Representative;
+    }
+
+    // The comparison between two AbstractSets is the same as the
+    // lexicographic comparison between their CanonicalForms.
+    Result Compare(AbstractSet &Other) {
+      return CanonicalForm.Compare(Other.CanonicalForm);
+    }
+
+    bool operator<(AbstractSet &Other) {
+      return Compare(Other) == Result::LessThan;
+    }
+    bool operator==(AbstractSet &Other) {
+      return Compare(Other) == Result::Equal;
+    }
+  };
+
+  // Custom comparison for SortedAbstractSets so that the AbstractSets are
+  // sorted lexicographically by their CanonicalForms.
+  struct AbstractSetComparer {
+    bool operator()(AbstractSet *A, AbstractSet *B) const {
+      return *A < *B;
+    }
+  };
+
+  class AbstractSetManager {
+  private:
+    // Maintain a sorted set of AbstractSets that have been created while
+    // traversing a function. A binary search in this set is used to determine
+    // whether an lvalue expression belongs to an existing AbstractSet.
+    static std::set<AbstractSet *, AbstractSetComparer> SortedAbstractSets;
+
+  public:
+    // Returns the AbstractSet that contains the lvalue expression E. If
+    // there is an AbstractSet A in SortedAbstractSets that contains E,
+    // GetOrCreateAbstractSet returns A. Otherwise, it creates a new
+    // AbstractSet for E.
+    static AbstractSet *GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx);
+
+    // Clears the contents of the AbstractSetManager, since storage of the
+    // AbstractSets should not persist across functions.
+    static void Clear(void);
+  };
+} // end namespace clang
+
+#endif

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -69,10 +69,17 @@ namespace clang {
 
   class AbstractSetManager {
   private:
-    // Maintain a sorted set of AbstractSets that have been created while
+    // Maintain a sorted set of PreorderASTs that have been created while
     // traversing a function. A binary search in this set is used to determine
-    // whether an lvalue expression belongs to an existing AbstractSet.
-    static std::set<AbstractSet *, AbstractSetComparer> SortedAbstractSets;
+    // whether an lvalue expression belongs to an existing AbstractSet (an
+    // AbstractSet whose CanonicalForm is in the SortedPreorderASTs set).
+    static std::set<PreorderAST *, PreorderASTComparer> SortedPreorderASTs;
+
+    // Map each PreorderAST P that has been created while traversing a function
+    // to the AbstractSet whose CanonicalForm is P. This is used to retrieve
+    // the AbstractSet whose CanonicalForm already exists in SortedPreorderASTs
+    // (if any).
+    static llvm::DenseMap<PreorderAST *, AbstractSet *> PreorderASTAbstractSetMap;
 
   public:
     // Returns the AbstractSet that contains the lvalue expression E. If

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -10,9 +10,15 @@
 namespace clang {
   using Result = Lexicographic::Result;
 
+  // The AbstractSet class represents an abstraction of memory. If two lvalue
+  // expressions e1 and e2 belong to the same AbstractSet, then e1 and e2
+  // point to the same contiguous memory location (i.e. e1 and e2 point to
+  // the same location and range in memory).
   class AbstractSet {
   private:
     // Canonical form of all lvalue expressions that belong to this AbstractSet.
+    // Two lvalue expressions e1 and e2 belong to the same AbstractSet if and
+    // only if e1 and e2 have the same canonical form.
     PreorderAST CanonicalForm;
 
     // LValue expression that is a representative of all lvalue expressions that

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -59,14 +59,6 @@ namespace clang {
     }
   };
 
-  // Custom comparison for SortedAbstractSets so that the AbstractSets are
-  // sorted lexicographically by their CanonicalForms.
-  struct AbstractSetComparer {
-    bool operator()(AbstractSet *A, AbstractSet *B) const {
-      return *A < *B;
-    }
-  };
-
   class AbstractSetManager {
   private:
     // Maintain a sorted set of PreorderASTs that have been created while

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -65,6 +65,10 @@ namespace clang {
     // traversing a function. A binary search in this set is used to determine
     // whether an lvalue expression belongs to an existing AbstractSet (an
     // AbstractSet whose CanonicalForm is in the SortedPreorderASTs set).
+    // An std::set is used for this set since std::sets are sorted by default.
+    // Here, the PreorderASTComparer is used to sort the PreorderASTs
+    // lexicographically. This avoids the need for a linear search through
+    // SortedPreorderASTs in GetOrCreateAbstractSet.
     static std::set<PreorderAST *, PreorderASTComparer> SortedPreorderASTs;
 
     // Map each PreorderAST P that has been created while traversing a function

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -198,6 +198,20 @@ namespace clang {
     // from outside this class and invokes Cleanup on the root node which
     // recursively deletes the AST.
     void Cleanup() { Cleanup(Root); }
+
+    bool operator<(PreorderAST &Other) {
+      return Compare(Other) == Result::LessThan;
+    }
+    bool operator==(PreorderAST &Other) {
+      return Compare(Other) == Result::Equal;
+    }
+  };
+
+  // This comparison allows PreorderASTs to be sorted lexicographically.
+  struct PreorderASTComparer {
+    bool operator()(PreorderAST *A, PreorderAST *B) const {
+      return *A < *B;
+    }
   };
 
 } // end namespace clang

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -1,0 +1,31 @@
+#include "clang/AST/AbstractSet.h"
+
+using namespace clang;
+
+std::set<AbstractSet *, AbstractSetComparer> AbstractSetManager::SortedAbstractSets;
+
+AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx) {
+  // Create a canonical form for E.
+  PreorderAST P(Ctx, E);
+  P.Normalize();
+
+  // Search for an existing AbstractSet in SortedAbstractSets that contains E,
+  // i.e. an AbstractSet whose CanonicalForm is equal to E's canonical form.
+  AbstractSet *Test = new AbstractSet(P);
+  auto It = SortedAbstractSets.find(Test);
+  if (It != SortedAbstractSets.end()) {
+    delete Test;
+    return *It;
+  }
+
+  // If there is no existing AbstractSet that contains E, create a new
+  // AbstractSet that contains E.
+  AbstractSet *A = new AbstractSet(P);
+  A->SetRepresentative(E);
+  SortedAbstractSets.emplace(A);
+  return A;
+}
+
+void AbstractSetManager::Clear(void) {
+  SortedAbstractSets.clear();
+}

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -2,30 +2,38 @@
 
 using namespace clang;
 
-std::set<AbstractSet *, AbstractSetComparer> AbstractSetManager::SortedAbstractSets;
+std::set<PreorderAST *, PreorderASTComparer> AbstractSetManager::SortedPreorderASTs;
+llvm::DenseMap<PreorderAST *, AbstractSet *> AbstractSetManager::PreorderASTAbstractSetMap;
 
 AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx) {
   // Create a canonical form for E.
-  PreorderAST P(Ctx, E);
-  P.Normalize();
+  PreorderAST *P = new PreorderAST(Ctx, E);
+  P->Normalize();
 
-  // Search for an existing AbstractSet in SortedAbstractSets that contains E,
-  // i.e. an AbstractSet whose CanonicalForm is equal to E's canonical form.
-  AbstractSet *Test = new AbstractSet(P);
-  auto It = SortedAbstractSets.find(Test);
-  if (It != SortedAbstractSets.end()) {
-    delete Test;
-    return *It;
+  // Search for an existing PreorderAST that is equivalent to the canonical
+  // form for E.
+  auto I = SortedPreorderASTs.find(P);
+  if (I != SortedPreorderASTs.end()) {
+    PreorderAST *ExistingCanonicalForm = *I;
+    // If an AbstractSet exists in PreorderASTAbstractSetMap whose CanonicalForm
+    // is equivalent to ExistingCanonicalForm, then that AbstractSet is the
+    // one that contains E.
+    auto It = PreorderASTAbstractSetMap.find(ExistingCanonicalForm);
+    if (It != PreorderASTAbstractSetMap.end()) {
+      return MapIt->second;
+    }
   }
 
   // If there is no existing AbstractSet that contains E, create a new
   // AbstractSet that contains E.
-  AbstractSet *A = new AbstractSet(P);
+  AbstractSet *A = new AbstractSet(*P);
   A->SetRepresentative(E);
-  SortedAbstractSets.emplace(A);
+  SortedPreorderASTs.emplace(P);
+  PreorderASTAbstractSetMap[P] = A;
   return A;
 }
 
 void AbstractSetManager::Clear(void) {
-  SortedAbstractSets.clear();
+  SortedPreorderASTs.clear();
+  PreorderASTAbstractSetMap.clear();
 }

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -20,7 +20,7 @@ AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx
     // one that contains E.
     auto It = PreorderASTAbstractSetMap.find(ExistingCanonicalForm);
     if (It != PreorderASTAbstractSetMap.end()) {
-      return MapIt->second;
+      return It->second;
     }
   }
 

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -14,6 +14,7 @@ clang_tablegen(Opcodes.inc
   TARGET Opcodes)
 
 add_clang_library(clangAST
+  AbstractSet.cpp
   APValue.cpp
   ASTConcept.cpp
   ASTConsumer.cpp


### PR DESCRIPTION
This PR adds the AbstractSet and AbstractSetManager classes as a foundation for the generalization of bounds checking from variables to lvalues.

The AbstractSet class represents an abstraction of memory. If two lvalue expressions `e1` and `e2` belong to the same AbstractSet, then `e1` and `e2` point to the same contiguous location in memory.

The AbstractSetManager class is responsible for determining the AbstractSet to which a given lvalue expression `e` belongs.

AbstractSet will be used as the key in the `ObservedBounds` map. `ObservedBounds` will map an `AbstractSet *` to the inferred bounds of all lvalue expressions that belong to the AbstractSet.