### PR TITLE
[LValue Generalization] GetLValueTargetBounds [2/n]

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5812,12 +5812,17 @@ namespace {
     // Values assigned through the lvalue must satisfy the target bounds.
     // Values read through the lvalue will meet the target bounds.
     BoundsExpr *GetLValueTargetBounds(Expr *E, CheckedScopeSpecifier CSS) {
+      if (!E->isLValue())
+        return CreateBoundsInferenceError();
+
       // The type for inferring the target bounds cannot ever be an array
       // type, as these are dealt with by an array conversion, not an lvalue
       // conversion. The bounds for an array conversion are the same as the
       // lvalue bounds of the array-typed expression.
       if (E->getType()->isArrayType())
         return CreateBoundsInferenceError();
+
+      E = E->IgnoreParens();
 
       switch (E->getStmtClass()) {
         case Expr::DeclRefExprClass:


### PR DESCRIPTION
Previously, bounds checking computed the bounds for the target of an lvalue expression using an out parameter in lvalue checking methods (`CheckLValue`, `CheckDeclRefExpr`, `CheckMemberExpr`, etc.). This PR refactors target bounds computation into a single `GetLValueTargetBounds` method that returns the bounds for the target of an lvalue expression.

In the process of lvalue generalization for bounds checking, the `ValidateBoundsContext` method will use `GetLValueTargetBounds` to get the target bounds for the representative expression of an `AbstractSet`. `ValidateBoundsContext` will then attempt to prove or disprove that the observed bounds for all lvalue expressions in the `AbstractSet` imply the target bounds.