### PR TITLE
[Where Clause] Support where clauses on declarations [3/n]

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -78,6 +78,7 @@ class TypeLoc;
 class UnresolvedSetImpl;
 class VarTemplateDecl;
 class TypedefDecl;
+class WhereClause;
 
 /// The top declaration context.
 class TranslationUnitDecl : public Decl, public DeclContext {
@@ -1006,6 +1007,8 @@ private:
   };
   enum { NumVarDeclBits = 8 };
 
+  WhereClause *WClause;
+
 protected:
   enum { NumParameterIndexBits = 8 };
 
@@ -1664,6 +1667,9 @@ public:
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { return classofKind(D->getKind()); }
   static bool classofKind(Kind K) { return K >= firstVar && K <= lastVar; }
+
+  void setWhereClause(WhereClause *WC) { WClause = WC; }
+  WhereClause *getWhereClause() const { return WClause; }
 };
 
 class ImplicitParamDecl : public VarDecl {

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1514,4 +1514,7 @@ def err_pragma_checked_scope_invalid_argument : Error<
 def err_expected_expr_in_where_clause : Error<
   "expected bounds declaration or equality expression in where clause">;
 
+def err_invalid_decl_where_clause : Error<
+  "where clause on invalid decl">;
+
 } // end of Parser diagnostics

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2115,7 +2115,8 @@ private:
   WhereClauseFact *ParseWhereClauseFact();
 
   /// Parse a where clause occurring on a declaration.
-  void ParseWhereClauseOnDecl(Decl *D);
+  /// Returns false on error, true otherwise.
+  bool ParseWhereClauseOnDecl(Decl *D);
 
   //===--------------------------------------------------------------------===//
   // clang Expressions

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2053,6 +2053,8 @@ private:
 
   bool StartsRelativeBoundsClause(Token &tok);
 
+  bool StartsWhereClause(const Token &tok);
+
   bool ParseRelativeBoundsClauseForDecl(ExprResult &Expr);
 
   RelativeBoundsClause *ParseRelativeBoundsClause(bool &isError,
@@ -2077,11 +2079,14 @@ private:
                               SourceLocation ColonLoc,
                               BoundsAnnotations &Result,
                               std::unique_ptr<CachedTokens> *DeferredToks = nullptr,
-                              bool IsReturn=false);
+                              bool IsReturn=false,
+                              Decl *ThisDecl = nullptr);
   bool ConsumeAndStoreBoundsExpression(CachedTokens &Toks);
+  bool ConsumeAndStoreWhereClause(CachedTokens &Toks);
   bool DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks,
                                      BoundsAnnotations &Result,
-                                     const Declarator &D);
+                                     const Declarator &D,
+                                     Decl *ThisDecl = nullptr);
 
   // Delay parse a return bounds expression in Toks.  Used to parse return
   // bounds after the return type has been constructed.  Stores the bounds
@@ -2108,6 +2113,9 @@ private:
 
   /// Parse a Checked C where clause fact.
   WhereClauseFact *ParseWhereClauseFact();
+
+  /// Parse a where clause occurring on a declaration.
+  void ParseWhereClauseOnDecl(Decl *D);
 
   //===--------------------------------------------------------------------===//
   // clang Expressions

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2081,12 +2081,12 @@ private:
                               std::unique_ptr<CachedTokens> *DeferredToks = nullptr,
                               bool IsReturn=false,
                               Decl *ThisDecl = nullptr);
+  bool DeferredParseBoundsAnnotations(std::unique_ptr<CachedTokens> Toks,
+                                      BoundsAnnotations &Result,
+                                      const Declarator &D,
+                                      Decl *ThisDecl = nullptr);
   bool ConsumeAndStoreBoundsExpression(CachedTokens &Toks);
   bool ConsumeAndStoreWhereClause(CachedTokens &Toks);
-  bool DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks,
-                                     BoundsAnnotations &Result,
-                                     const Declarator &D,
-                                     Decl *ThisDecl = nullptr);
 
   // Delay parse a return bounds expression in Toks.  Used to parse return
   // bounds after the return type has been constructed.  Stores the bounds

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1984,7 +1984,7 @@ VarDecl::VarDecl(Kind DK, ASTContext &C, DeclContext *DC,
                  IdentifierInfo *Id, QualType T, TypeSourceInfo *TInfo,
                  StorageClass SC)
     : DeclaratorDecl(DK, DC, IdLoc, Id, T, TInfo, StartLoc),
-      redeclarable_base(C) {
+      redeclarable_base(C), WClause(nullptr) {
   static_assert(sizeof(VarDeclBitfields) <= sizeof(unsigned),
                 "VarDeclBitfields too large!");
   static_assert(sizeof(ParmVarDeclBitfields) <= sizeof(unsigned),

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7361,19 +7361,11 @@ void Parser::ParseParameterDeclarationClause(
 
     BoundsAnnotations Annots;
     if (DeferredParseBoundsExpression(std::move(Tokens), Annots, D, Param)) {
-      if (IsWhereClause)
-        Param->setInvalidDecl();
-      else
+      if (!IsWhereClause)
         Actions.ActOnInvalidBoundsDecl(Param);
     } else {
-      if (IsWhereClause)
-        // Parse the deferred where clauses. These are where clauses on
-        // variable declarations, like:
-        // void f(int a _Where a > 0);
-        ParseWhereClauseOnDecl(Param);
-      else
+      if (!IsWhereClause)
         Actions.ActOnBoundsDecl(Param, Annots, true);
-    }
   }
 }
 

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4324,7 +4324,8 @@ void Parser::ParseStructDeclaration(
           StartsInteropTypeAnnotation(Tok))) {
         BoundsAnnotations BA;
         std::unique_ptr<CachedTokens> BoundsExprTokens(new CachedTokens);
-        if (ParseBoundsAnnotations(DeclaratorInfo.D, Loc, BA, &BoundsExprTokens, false))
+        if (ParseBoundsAnnotations(DeclaratorInfo.D, Loc, BA,
+                                   &BoundsExprTokens, false))
           SkipUntil(tok::semi, StopBeforeMatch);
         assert(BA.getBoundsExpr() == nullptr);
         DeclaratorInfo.InteropType = BA.getInteropTypeExpr();
@@ -4534,7 +4535,8 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
     FieldDecl *FieldDecl = Pair.first;
     std::unique_ptr<CachedTokens> Tokens = std::move(Pair.second);
     BoundsAnnotations Annots;
-    if (DeferredParseBoundsExpression(std::move(Tokens), Annots, DeclaratorsInfo.D))
+    if (DeferredParseBoundsAnnotations(std::move(Tokens),
+                                       Annots, DeclaratorsInfo.D))
       Actions.ActOnInvalidBoundsDecl(FieldDecl);
     else
       Actions.ActOnBoundsDecl(FieldDecl, Annots,/*MergeDeferredBounds=*/true);
@@ -4545,8 +4547,8 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
   // A member declaration in a checked scope cannot use unchecked types, unless
   // there is a bounds-safe interface,
 
-  // TODO: this should be invoked as part of semantic checking of struct defnitions,
-  // not directly by the parser.
+  // TODO: this should be invoked as part of semantic checking of struct
+  // definitions, not directly by the parser.
   if (getLangOpts().CheckedC) {
     for (ArrayRef<Decl *>::iterator i = FieldDecls.begin(),
                                   end = FieldDecls.end();
@@ -7360,8 +7362,8 @@ void Parser::ParseParameterDeclarationClause(
     bool IsWhereClause = StartsWhereClause(Tokens->front());
 
     BoundsAnnotations Annots;
-    bool Error = DeferredParseBoundsExpression(std::move(Tokens),
-                                               Annots, D, Param);
+    bool Error = DeferredParseBoundsAnnotations(std::move(Tokens),
+                                                Annots, D, Param);
 
     if (!IsWhereClause) {
       if (Error)

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7360,12 +7360,15 @@ void Parser::ParseParameterDeclarationClause(
     bool IsWhereClause = StartsWhereClause(Tokens->front());
 
     BoundsAnnotations Annots;
-    if (DeferredParseBoundsExpression(std::move(Tokens), Annots, D, Param)) {
-      if (!IsWhereClause)
+    bool Error = DeferredParseBoundsExpression(std::move(Tokens),
+                                               Annots, D, Param);
+
+    if (!IsWhereClause) {
+      if (Error)
         Actions.ActOnInvalidBoundsDecl(Param);
-    } else {
-      if (!IsWhereClause)
+      else
         Actions.ActOnBoundsDecl(Param, Annots, true);
+    }
   }
 }
 

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -4107,15 +4107,15 @@ bool Parser::ConsumeAndStoreBoundsExpression(CachedTokens &Toks) {
 
 /// Given a list of tokens that have the same shape as a bounds
 /// expression, parse them to create a bounds expression.  Delete
-/// the list of tokens at the end.
-///
+/// the list of tokens at the end. Also parses where clause occurring on a
+/// decl.
 /// Return true if there was an error; false otherwise.  The resulting
 /// bounds expression is stored in Result.
 bool
-Parser::DeferredParseBoundsExpression(std::unique_ptr<CachedTokens> Toks,
-                                      BoundsAnnotations &Result,
-                                      const Declarator &D,
-                                      Decl *ThisDecl) {
+Parser::DeferredParseBoundsAnnotations(std::unique_ptr<CachedTokens> Toks,
+                                       BoundsAnnotations &Result,
+                                       const Declarator &D,
+                                       Decl *ThisDecl) {
   Token LastBoundsExprToken = Toks->back();
   Token BoundsExprEnd;
   BoundsExprEnd.startToken();
@@ -4164,7 +4164,8 @@ bool Parser::ParseBoundsCallback(void *P,
 
   ParseScope PrototypeScope(TheParser, PrototypeScopeFlag);
   TheParser->Actions.ActOnSetupParametersAgain(TheParser->Actions.CurScope, Params);
-  bool Err = TheParser->DeferredParseBoundsExpression(std::move(Toks), Result, D);
+  bool Err = TheParser->DeferredParseBoundsAnnotations(std::move(Toks),
+                                                       Result, D);
   PrototypeScope.Exit();
   return Err;
 }

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -4105,12 +4105,12 @@ bool Parser::ConsumeAndStoreBoundsExpression(CachedTokens &Toks) {
   return result;
 }
 
-/// Given a list of tokens that have the same shape as a bounds
-/// expression, parse them to create a bounds expression.  Delete
-/// the list of tokens at the end. Also parses where clause occurring on a
-/// decl.
-/// Return true if there was an error; false otherwise.  The resulting
-/// bounds expression is stored in Result.
+/// Given a list of tokens that have the same shape as a bounds expression or
+/// a where clause parse them to create a bounds expression or a where clause
+/// respectively. Delete the list of tokens at the end. Return true if there
+/// was an error; false otherwise.
+/// If a bounds expression is parsed it is stored in Result.
+/// If a where clause is parsed it is attached to ThisDecl.
 bool
 Parser::DeferredParseBoundsAnnotations(std::unique_ptr<CachedTokens> Toks,
                                        BoundsAnnotations &Result,

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3679,6 +3679,10 @@ bool Parser::ParseBoundsAnnotations(const Declarator &D,
       // 2. Where clause after bounds-safe interfaces, like:
       // void f(int *p : itype(_Ptr<int>) _Where p == n, int n);
 
+      // 3. Where clause on parameters without any bounds declaration or
+      // bounds-safe interface, like:
+      // void f(int a _Where a > 0);
+
       // If we are currently deferring tokens, also defer any where clauses.
       if (DeferredToks)
         Error = !ConsumeAndStoreWhereClause(**DeferredToks);

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2637,7 +2637,20 @@ WhereClauseFact *Parser::ParseWhereClauseFact() {
 
   // Parse an equality expression.
   SourceLocation ExprLoc = Tok.getLocation();
-  ExprResult ExprRes = Actions.CorrectDelayedTyposInExpr(ParseExpression());
+
+  // ParseExpression parses expressions including top-level commas. So
+  // declarations like the following are not parsed correctly.
+  // int a _Where a == 1, b;
+  // If fails because it parses "a == 1, b" as one expression.
+
+  // ParseAssignmentExpression parses an expression not including top-level
+  // commas. So the above declaration is parsed correctly. This is also useful
+  // for parsing multiple comma-separated declarations each having its own
+  // where clause as follows:
+  // int a _Where a < 1, b _Where b > 1, c, d, e _Where e == 1;
+
+  ExprResult ExprRes =
+    Actions.CorrectDelayedTyposInExpr(ParseAssignmentExpression());
   if (ExprRes.isInvalid())
     return nullptr;
   return Actions.ActOnEqualityOpFact(ExprRes.get(), ExprLoc);

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -4,7 +4,7 @@
 
 int f();
 
-void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
+void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
   _Where ; // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where ;;;;; // expected-error {{expected bounds declaration or equality expression in where clause}}
   _Where _Where; // expected-error {{expected bounds declaration or equality expression in where clause}} expected-error {{expected bounds declaration or equality expression in where clause}}
@@ -36,3 +36,7 @@ void invalid_cases(_Nt_array_ptr<char> p, int a, int b) {
   _Where a++ < 1; // expected-error {{increment expression not allowed in expression}}
   _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }
+
+void f1(int a _Where a, _Nt_array_ptr<int> p : count(0) _Where p :); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}}
+
+void f2(int *p : itype(_Ptr<int>) _Where p, int n); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -46,3 +46,13 @@ void f3(int a _Where a == 1, a == 1); // expected-error {{unknown type name 'a'}
 void f4(int a _Where a == 1, b == 1); // expected-error {{unknown type name 'b'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
 
 void f5(int a _Where a,a); // expected-error {{redefinition of parameter 'a'}} expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-warning {{type specifier missing, defaults to 'int'}} expected-note {{previous declaration is here}}
+
+void f6(_Where 1 == 0); // expected-error {{expected parameter declarator}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+void f10(_Nt_array_ptr<int> p : count(n) _Where p : count(n)), int n); // expected-error {{use of undeclared identifier 'n'}} expected-error {{use of undeclared identifier 'n'}} expected-error {{expected identifier or '('}} expected-error {{expected ';' after top level declarator}} expected-error {{extraneous ')' before ';'}}
+
+void f7(int a _Where (1 == 0); // expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+void f8(int a _Where (1 == 0))); // expected-error {{expected function body after function declarator}}
+
+void f9(int a _Where ((((1 == 0); // expected-error {{expected ')'}} expected-note {{to match this '('}} // expected-error {{expected function body after function declarator}}

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -49,10 +49,10 @@ void f5(int a _Where a,a); // expected-error {{redefinition of parameter 'a'}} e
 
 void f6(_Where 1 == 0); // expected-error {{expected parameter declarator}} expected-error {{expected ')'}} expected-note {{to match this '('}}
 
-void f10(_Nt_array_ptr<int> p : count(n) _Where p : count(n)), int n); // expected-error {{use of undeclared identifier 'n'}} expected-error {{use of undeclared identifier 'n'}} expected-error {{expected identifier or '('}} expected-error {{expected ';' after top level declarator}} expected-error {{extraneous ')' before ';'}}
+void f7(_Nt_array_ptr<int> p : count(n) _Where p : count(n)), int n); // expected-error {{use of undeclared identifier 'n'}} expected-error {{use of undeclared identifier 'n'}} expected-error {{expected identifier or '('}} expected-error {{expected ';' after top level declarator}} expected-error {{extraneous ')' before ';'}}
 
-void f7(int a _Where (1 == 0); // expected-error {{expected ')'}} expected-note {{to match this '('}}
+void f8(int a _Where (1 == 0); // expected-error {{expected ')'}} expected-note {{to match this '('}}
 
-void f8(int a _Where (1 == 0))); // expected-error {{expected function body after function declarator}}
+void f9(int a _Where (1 == 0))); // expected-error {{expected function body after function declarator}}
 
-void f9(int a _Where ((((1 == 0); // expected-error {{expected ')'}} expected-note {{to match this '('}} // expected-error {{expected function body after function declarator}}
+void f10(int a _Where ((((1 == 0); // expected-error {{expected ')'}} expected-note {{to match this '('}} // expected-error {{expected function body after function declarator}}

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -40,3 +40,9 @@ void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
 void f1(int a _Where a, _Nt_array_ptr<int> p : count(0) _Where p :); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}}
 
 void f2(int *p : itype(_Ptr<int>) _Where p, int n); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}
+
+void f3(int a _Where a == 1, a == 1); // expected-error {{unknown type name 'a'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+void f4(int a _Where a == 1, b == 1); // expected-error {{unknown type name 'b'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+void f5(int a _Where a,a); // expected-error {{redefinition of parameter 'a'}} expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-warning {{type specifier missing, defaults to 'int'}} expected-note {{previous declaration is here}}

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -4,8 +4,9 @@
 
 // expected-no-diagnostics
 
-void valid_cases(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
-                 int a, int b) {
+// Test where clauses on null statements.
+void valid_cases_nullstmt(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
+                          int a, int b) {
   _Where a < 0;
   _Where a > 0;
   _Where a <= 0;
@@ -30,3 +31,37 @@ void valid_cases(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q,
   _Where (((((a == 0)))));
   _Where (a == 0) _And ((a == 0)) _And (((a == 0)));
 }
+
+int f();
+// Test where clauses on variable declarations inside a function.
+void valid_cases_decl(_Nt_array_ptr<char> p, _Nt_array_ptr<char> q) {
+  int a _Where a == 0 _And a != 0 _And p : bounds(p, p + a);
+  int b = 0 _Where b != 0 _And p : count(b);
+  int c = f() _Where p : bounds(p, p + c) _And c < 0;
+  int d _Where p : bounds(p, p + d) _And q : count(d) _And d == 0;
+  int e, f _Where e == 0 _And f == 0;
+  int g _Where g == 0, h, i, j _Where j < 0;
+  int k _Where k != 0 _And p : count(k), m, n, o _Where q : bounds(q, q + 1), r, s;
+  int arr1[3] = {1, 2, 3} _Where 0 < 1, arr2[2] = {1, 2} _Where 1 > 0;
+  _Nt_array_ptr<char> p1 : count(0) = "" _Where p1 : bounds(p1, p1 + 1);
+}
+
+// Test where clauses on variable declarations outside a function.
+_Nt_array_ptr<char> p;
+_Nt_array_ptr<char> q;
+int a _Where a == 0 _And a != 0 _And p : bounds(p, p + a);
+int b = 0 _Where b != 0 _And p : count(b);
+int c _Where p : bounds(p, p + c) _And q : count(c) _And c == 0;
+int d, e _Where e == 0 _And d != 0;
+int g _Where g == 0, h, i, j _Where j < 0;
+int k _Where k != 0 _And p : count(k), m, n, o _Where q : bounds(q, q + 1), r, s;
+int arr1[3] = {1, 2, 3} _Where 0 < 1, arr2[2] = {1, 2} _Where 1 > 0;
+_Nt_array_ptr<char> p1 : count(0) = "" _Where p1 : bounds(p1, p1 + 1);
+
+// Test where clauses on function parameters.
+void f1(int a _Where a < 0, int b, int c _Where c < 0, int *d : itype(_Ptr<int>) _Where d == 0) {}
+void f2(_Nt_array_ptr<char> p _Where p : bounds(p, p + n) _And n > 0, int n);
+void f3(_Nt_array_ptr<char> p : count(n) _Where n > 0 _And p : count(n), int n) {}
+void f4(_Nt_array_ptr<char> p : count(n) _Where p : count(n) _And p : count(n), int n);
+void f5(_Nt_array_ptr<char> p : count(n), int a _Where p : count(n) _And n > 0 _And a < 0, int n) {}
+void f6(int *p : itype(_Ptr<int>) _Where p == 0 _And n > 0, int n);

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -65,3 +65,4 @@ void f3(_Nt_array_ptr<char> p : count(n) _Where n > 0 _And p : count(n), int n) 
 void f4(_Nt_array_ptr<char> p : count(n) _Where p : count(n) _And p : count(n), int n);
 void f5(_Nt_array_ptr<char> p : count(n), int a _Where p : count(n) _And n > 0 _And a < 0, int n) {}
 void f6(int *p : itype(_Ptr<int>) _Where p == 0 _And n > 0, int n);
+void f7(int a _Where (((((a == 0))))));


### PR DESCRIPTION
We add support for where clauses:

1. For variable declarations, like:
```
int a = 1 _Where a > 0, b, c, d _Where d < 1;
```

2. For function parameters, like:
```
void f(int a _Where a < 0, int b, int c _Where c > 0);
void f(_Nt_Array_ptr<int> p _Where p : bounds(p, p + n), int n);
void f(int *p : itype(_Ptr<int>) _Where p == 0);
```