### PR TITLE
Move expr utility functions from SemaBounds.cpp to new file ExprUtils.cpp

### DIFF
--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -1,0 +1,65 @@
+//===----------- ExprUtils.h: Utility functions for expressions ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the utility functions for expressions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_EXPRUTILS_H
+#define LLVM_CLANG_EXPRUTILS_H
+
+#include "clang/AST/Expr.h"
+#include "clang/Sema/Sema.h"
+
+namespace clang {
+
+class ExprCreatorUtil {
+public:
+  // If Op is not a compound operator, CreateBinaryOperator returns a binary
+  // operator LHS Op RHS. If Op is a compound operator @=, CreateBinaryOperator
+  // returns a binary operator LHS @ RHS. LHS and RHS are cast to rvalues if
+  // necessary.
+  static BinaryOperator *CreateBinaryOperator(Sema &SemaRef,
+                                              Expr *LHS, Expr *RHS,
+                                              BinaryOperatorKind Op);
+
+  // Create an unsigned integer literal.
+  static IntegerLiteral *CreateUnsignedInt(Sema &SemaRef, unsigned Value);
+
+  // Create an implicit cast expression.
+  static ImplicitCastExpr *CreateImplicitCast(Sema &SemaRef, Expr *E,
+                                              CastKind CK, QualType T);
+
+  // If e is an rvalue, EnsureRValue returns e. Otherwise, EnsureRValue
+  // returns a cast of e to an rvalue, based on the type of e.
+  static Expr *EnsureRValue(Sema &SemaRef, Expr *E);
+
+  // Create an integer literal from I. I is interpreted as an unsigned
+  // integer.
+  static IntegerLiteral *CreateIntegerLiteral(ASTContext &Ctx,
+                                              const llvm::APInt &I);
+
+  // If Ty is a pointer type, CreateIntegerLiteral returns an integer literal
+  // with a target-dependent bit width. If Ty is an integer type (char,
+  // unsigned int, int, etc.), CreateIntegerLiteral returns an integer literal
+  // with Ty type.  Otherwise, it returns nullptr.
+  static IntegerLiteral *CreateIntegerLiteral(ASTContext &Ctx,
+                                              int Value, QualType Ty);
+
+  // Determine if the mathemtical value of I (an unsigned integer) fits within
+  // the range of Ty, a signed integer type. APInt requires that bitsizes
+  // match exactly, so if I does fit, return an APInt via Result with exactly
+  // the bitsize of Ty.
+  static bool Fits(ASTContext &Ctx, QualType Ty,
+                   const llvm::APInt &I, llvm::APInt &Result);
+};
+
+} // end namespace clang
+#endif

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -55,6 +55,7 @@ add_clang_library(clangAST
   ExprConstant.cpp
   ExprCXX.cpp
   ExprObjC.cpp
+  ExprUtils.cpp
   ExternalASTMerger.cpp
   ExternalASTSource.cpp
   FormatString.cpp

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -1,0 +1,125 @@
+//===--------- ExprUtils.cpp: Utility functions for expressions ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements utility functions for expressions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ExprUtils.h"
+
+using namespace clang;
+
+BinaryOperator *ExprCreatorUtil::CreateBinaryOperator(Sema &SemaRef,
+                                                      Expr *LHS, Expr *RHS,
+                                                      BinaryOperatorKind Op) {
+  assert(LHS && "expected LHS to exist");
+  assert(RHS && "expected RHS to exist");
+  LHS = EnsureRValue(SemaRef, LHS);
+  RHS = EnsureRValue(SemaRef, RHS);
+  if (BinaryOperator::isCompoundAssignmentOp(Op))
+    Op = BinaryOperator::getOpForCompoundAssignment(Op);
+  return BinaryOperator::Create(SemaRef.Context, LHS, RHS, Op,
+                                LHS->getType(), LHS->getValueKind(),
+                                LHS->getObjectKind(), SourceLocation(),
+                                FPOptionsOverride());
+}
+
+IntegerLiteral *ExprCreatorUtil::CreateUnsignedInt(Sema &SemaRef,
+                                                   unsigned Value) {
+  QualType T = SemaRef.Context.UnsignedIntTy;
+  llvm::APInt Val(SemaRef.Context.getIntWidth(T), Value);
+  return IntegerLiteral::Create(SemaRef.Context, Val,
+                                T, SourceLocation());
+}
+
+ImplicitCastExpr *ExprCreatorUtil::CreateImplicitCast(Sema &SemaRef, Expr *E,
+                                                      CastKind CK,
+                                                      QualType T) {
+  return ImplicitCastExpr::Create(SemaRef.Context, T,
+                                  CK, E, nullptr,
+                                  ExprValueKind::VK_RValue);
+}
+
+Expr *ExprCreatorUtil::EnsureRValue(Sema &SemaRef, Expr *E) {
+  if (E->isRValue())
+    return E;
+
+  CastKind Kind;
+  QualType TargetTy;
+  if (E->getType()->isArrayType()) {
+    Kind = CK_ArrayToPointerDecay;
+    TargetTy = SemaRef.getASTContext().getArrayDecayedType(E->getType());
+  } else {
+    Kind = CK_LValueToRValue;
+    TargetTy = E->getType();
+  }
+  return CreateImplicitCast(SemaRef, E, Kind, TargetTy);
+}
+
+IntegerLiteral *ExprCreatorUtil::CreateIntegerLiteral(ASTContext &Ctx,
+                                                      const llvm::APInt &I) {
+  QualType Ty;
+  // Choose the type of an integer constant following the rules in
+  // Section 6.4.4 of the C11 specification: the smallest integer
+  // type chosen from int, long int, long long int, unsigned long long
+  // in which the integer fits.
+  llvm::APInt ResultVal;
+  if (Fits(Ctx, Ctx.IntTy, I, ResultVal))
+    Ty = Ctx.IntTy;
+  else if (Fits(Ctx, Ctx.LongTy, I, ResultVal))
+    Ty = Ctx.LongTy;
+  else if (Fits(Ctx, Ctx.LongLongTy, I, ResultVal))
+    Ty = Ctx.LongLongTy;
+  else {
+    assert(I.getBitWidth() <=
+           Ctx.getIntWidth(Ctx.UnsignedLongLongTy));
+    ResultVal = I;
+    Ty = Ctx.UnsignedLongLongTy;
+  }
+  IntegerLiteral *Lit = IntegerLiteral::Create(Ctx, ResultVal, Ty,
+                                               SourceLocation());
+  return Lit;
+}
+
+IntegerLiteral *ExprCreatorUtil::CreateIntegerLiteral(ASTContext &Ctx,
+                                                      int Value, QualType Ty) {
+  if (Ty->isPointerType()) {
+    const llvm::APInt
+      ResultVal(Ctx.getTargetInfo().getPointerWidth(0), Value);
+    return CreateIntegerLiteral(Ctx, ResultVal);
+  }
+
+  if (!Ty->isIntegerType())
+    return nullptr;
+
+  unsigned BitSize = Ctx.getTypeSize(Ty);
+  unsigned IntWidth = Ctx.getIntWidth(Ty);
+  if (BitSize != IntWidth)
+    return nullptr;
+
+  const llvm::APInt ResultVal(BitSize, Value);
+  return IntegerLiteral::Create(Ctx, ResultVal, Ty, SourceLocation());
+}
+
+bool ExprCreatorUtil::Fits(ASTContext &Ctx, QualType Ty,
+                           const llvm::APInt &I, llvm::APInt &Result) {
+  assert(Ty->isSignedIntegerType());
+  unsigned bitSize = Ctx.getTypeSize(Ty);
+  if (bitSize < I.getBitWidth()) {
+    if (bitSize < I.getActiveBits())
+     // Number of bits in use exceeds bitsize
+     return false;
+    else Result = I.trunc(bitSize);
+  } else if (bitSize > I.getBitWidth())
+    Result = I.zext(bitSize);
+  else
+    Result = I;
+  return Result.isNonNegative();
+}


### PR DESCRIPTION
To make functions like `CreateBinaryOperator`, etc (which were defined in
`SemaBounds.cpp`) easier to call from other files we moved the class
`ExprCreatorUtil` to a new file called `ExprUtils.cpp`.  The two overloaded
versions of the function `CreateIntegerLiteral` have also been made members of
the `ExprCreatorUtil` class and moved to the same file.