### PR TITLE
Move funcs UpdateWidenedBounds and ResetKilledBounds to BoundsAnalysis [NFC]

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -17,6 +17,7 @@
 #define LLVM_CLANG_BOUNDS_ANALYSIS_H
 
 #include "clang/AST/CanonBounds.h"
+#include "clang/AST/ExprUtils.h"
 #include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Sema/Sema.h"
 #include <queue>
@@ -63,10 +64,16 @@ namespace clang {
   // Note: We use the shorthand "ntptr" to denote _Nt_array_ptr. We extract the
   // declaration of an ntptr as a VarDecl from a DeclRefExpr.
 
-  // BoundsMapTy denotes the widened bounds of an ntptr. Given VarDecl V with
-  // declared bounds (low, high), the bounds of V have been widened to (low,
-  // high + the unsigned integer).
+  // BoundsMapTy denotes the unsigned integer offset I by which the bounds of
+  // an ntptr should be widened. Given VarDecl V with declared bounds as bounds
+  // (low, high), the bounds of V should be widened to bounds (low, high + I).
   using BoundsMapTy = llvm::MapVector<const VarDecl *, unsigned>;
+
+  // BoundsExprMapTy denotes the widened bounds expression of an ntptr. Given
+  // VarDecl V with declared bounds (low, high), and an unsigned integer offset
+  // I by which the declared upper bound should be widened the widened bounds
+  // of V are denoted as bounds (low, high + I).
+  using BoundsExprMapTy = llvm::MapVector<const VarDecl *, BoundsExpr *>;
 
   // For each edge B1->B2, EdgeBoundsTy denotes the Gen and Out sets.
   using EdgeBoundsTy = llvm::DenseMap<const CFGBlock *, BoundsMapTy>;
@@ -189,10 +196,42 @@ namespace clang {
     // nested in another top-level statement.
     void WidenBounds(FunctionDecl *FD, StmtSet NestedStmts);
 
-    // Get the widened bounds for block B.
-    // @param[in] B is the block for which the widened bounds are needed.
-    // @return Widened bounds for ntptrs in block B.
-    BoundsMapTy GetWidenedBounds(const CFGBlock *B);
+    // Get a mapping of variables to the offsets by which their bounds should
+    // be widened in block B.
+    // @param[in] B is the block for which the widened bounds offsets are
+    // needed.
+    // @return A mapping of variables to the offsets by which their bounds
+    // should be widened in block B.
+    BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
+
+    // Are bounds widened but not killed in block B.
+    // @param[in] B is the block for which the widened bounds are checked.
+    // @param[in] St is the statement for which the killed bounds are checked.
+    // @param[in] V is the variable for which we need to determine whether
+    // widened bounds are killed.
+    // @return True if the bounds are widened but not killed.
+    bool AreBoundsWidenedAndNotKilled(const CFGBlock *B, const Stmt *St,
+                                      const VarDecl *V);
+
+    // Get the set of variables killed by the statement St in the block B.
+    // Note: This method is intended to be invoked from CheckBoundsDeclaration
+    // or a similar place which does bounds inference/checking.
+    // @param[in] B is the current CFGBlock.
+    // @param[in] St is the current statement in block B.
+    // return A set of variables whose bounds are killed by the statement St in
+    // block B.
+    DeclSetTy GetKilledBounds(const CFGBlock *B, const Stmt *St);
+
+    // Get a mapping of variables to their widened bounds expressions in block
+    // B. This function calls GetWidenedBoundsOffsets to get the offsets by
+    // which the bounds of each variable should be widened. It then applies
+    // these offsets to the declared upper bounds and creates an updated
+    // BoundsExpr for each variable in the block.
+    // @param[in] B is the block for which the widened bounds expressions are
+    // needed.
+    // @return A mapping of variables to their widened bounds expressions in
+    // block B.
+    BoundsExprMapTy GetWidenedBounds(const CFGBlock *B);
 
     // Pretty print the widen bounds analysis.
     // printing.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -71,7 +71,7 @@ namespace clang {
 
   // BoundsExprMapTy denotes the widened bounds expression of an ntptr. Given
   // VarDecl V with declared bounds (low, high), and an unsigned integer offset
-  // I by which the declared upper bounds should be widened the widened bounds
+  // I by which the declared upper bound should be widened, the widened bounds
   // of V are denoted as bounds (low, high + I).
   using BoundsExprMapTy = llvm::MapVector<const VarDecl *, BoundsExpr *>;
 

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -204,15 +204,13 @@ namespace clang {
     // should be widened in block B.
     BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
 
-    // Are bounds widened but not killed in block B? This function is invoked
-    // from SemaBounds.cpp and is used to control the emission of diagnostics.
+    // Get the set variables whose bounds widened but not killed in block B?
+    // This function is invoked from SemaBounds.cpp and is used to control the
+    // emission of diagnostics.
     // @param[in] B is the block for which the widened bounds are checked.
     // @param[in] St is the statement for which the killed bounds are checked.
-    // @param[in] V is the variable for which we need to determine whether
-    // widened bounds are killed.
-    // @return True if the bounds are widened but not killed.
-    bool AreBoundsWidenedAndNotKilled(const CFGBlock *B, const Stmt *St,
-                                      const VarDecl *V);
+    // @return A set of variables whose bounds are widened and not killed.
+    DeclSetTy GetBoundsWidenedAndNotKilled(const CFGBlock *B, const Stmt *St);
 
     // Get the set of variables killed by the statement St in the block B.
     // Note: This method is intended to be invoked from CheckBoundsDeclaration

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -204,9 +204,9 @@ namespace clang {
     // should be widened in block B.
     BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
 
-    // Get the set variables whose bounds are widened but not killed in block
-    // B? This function is invoked from SemaBounds.cpp and is used to control
-    // the emission of diagnostics.
+    // Get the set of variables whose bounds are widened but not killed in
+    // block B. This function is invoked from SemaBounds.cpp and is used to
+    // control the emission of diagnostics.
     // @param[in] B is the block for which the widened bounds are checked.
     // @param[in] St is the statement for which the killed bounds are checked.
     // @return A set of variables whose bounds are widened and not killed.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -204,9 +204,9 @@ namespace clang {
     // should be widened in block B.
     BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
 
-    // Get the set variables whose bounds widened but not killed in block B?
-    // This function is invoked from SemaBounds.cpp and is used to control the
-    // emission of diagnostics.
+    // Get the set variables whose bounds are widened but not killed in block
+    // B? This function is invoked from SemaBounds.cpp and is used to control
+    // the emission of diagnostics.
     // @param[in] B is the block for which the widened bounds are checked.
     // @param[in] St is the statement for which the killed bounds are checked.
     // @return A set of variables whose bounds are widened and not killed.

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -71,7 +71,7 @@ namespace clang {
 
   // BoundsExprMapTy denotes the widened bounds expression of an ntptr. Given
   // VarDecl V with declared bounds (low, high), and an unsigned integer offset
-  // I by which the declared upper bound should be widened the widened bounds
+  // I by which the declared upper bounds should be widened the widened bounds
   // of V are denoted as bounds (low, high + I).
   using BoundsExprMapTy = llvm::MapVector<const VarDecl *, BoundsExpr *>;
 
@@ -204,7 +204,8 @@ namespace clang {
     // should be widened in block B.
     BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
 
-    // Are bounds widened but not killed in block B.
+    // Are bounds widened but not killed in block B? This function is invoked
+    // from SemaBounds.cpp and is used to control the emission of diagnostics.
     // @param[in] B is the block for which the widened bounds are checked.
     // @param[in] St is the statement for which the killed bounds are checked.
     // @param[in] V is the variable for which we need to determine whether

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -106,6 +106,10 @@ namespace clang {
   // StmtSet denotes a set of Stmts.
   using StmtSet = llvm::SmallPtrSet<const Stmt *, 16>;
 
+  // The BoundsAnalysis class represents the dataflow analysis for bounds
+  // widening. The In, Out, Gen and Kill sets used in the dataflow analysis are
+  // members of this class. It also has methods that act on these sets to
+  // perform the actual analysis.
   class BoundsAnalysis {
   private:
     Sema &S;

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -556,22 +556,74 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
   }
 }
 
-StmtDeclSetTy BoundsAnalysis::GetKilledBounds(const CFGBlock *B) {
+DeclSetTy BoundsAnalysis::GetKilledBounds(const CFGBlock *B, const Stmt *St) {
   auto I = BlockMap.find(B);
   if (I == BlockMap.end())
-    return StmtDeclSetTy();
+    return DeclSetTy();
 
   ElevatedCFGBlock *EB = I->second;
-  return EB->Kill;
+  auto J = EB->Kill.find(St);
+  if (J == EB->Kill.end())
+    return DeclSetTy();
+
+  return J->second;
 }
 
-BoundsMapTy BoundsAnalysis::GetWidenedBounds(const CFGBlock *B) {
+BoundsMapTy BoundsAnalysis::GetWidenedBoundsOffsets(const CFGBlock *B) {
   auto I = BlockMap.find(B);
   if (I == BlockMap.end())
     return BoundsMapTy();
 
   ElevatedCFGBlock *EB = I->second;
   return EB->In;
+}
+
+BoundsExprMapTy BoundsAnalysis::GetWidenedBounds(const CFGBlock *B) {
+  // GetWidenedBoundsOffsets returns the mapping from _Nt_array_ptr to the
+  // offset by which its declared bounds should be widened. In this function we
+  // apply the offset to the declared upper bounds of the _Nt_array_ptr.
+
+  BoundsExprMapTy Result;
+  for (const auto item : GetWidenedBoundsOffsets(B)) {
+    const VarDecl *V = item.first;
+    unsigned Offset = item.second;
+
+    // We normalize the declared bounds to RangeBoundsExpr here so that we
+    // can easily apply the offset to the upper bound.
+    BoundsExpr *Bounds = S.NormalizeBounds(V);
+    if (RangeBoundsExpr *RBE = dyn_cast<RangeBoundsExpr>(Bounds)) {
+      const llvm::APInt
+        APIntOff(Ctx.getTargetInfo().getPointerWidth(0), Offset);
+      IntegerLiteral *WidenedOffset =
+        ExprCreatorUtil::CreateIntegerLiteral(Ctx, APIntOff);
+
+      Expr *Lower = RBE->getLowerExpr();
+      Expr *Upper = RBE->getUpperExpr();
+
+      // WidenedUpperBound = UpperBound + WidenedOffset.
+      Expr *WidenedUpper = ExprCreatorUtil::CreateBinaryOperator(
+                             S, Upper, WidenedOffset,
+                             BinaryOperatorKind::BO_Add);
+
+      RangeBoundsExpr *R = new (Ctx) RangeBoundsExpr(Lower, WidenedUpper,
+                                                     SourceLocation(),
+                                                     SourceLocation());
+
+      Result[V] = R;
+    }
+  }
+  return Result;
+}
+
+bool BoundsAnalysis::AreBoundsWidenedAndNotKilled(const CFGBlock *B,
+                                                  const Stmt *St,
+                                                  const VarDecl *V) {
+  BoundsExprMapTy WidenedBounds = GetWidenedBounds(B);
+  if (WidenedBounds.find(V) != WidenedBounds.end()) {
+    DeclSetTy KilledBounds = GetKilledBounds(B, St);
+    return KilledBounds.find(V) == KilledBounds.end();
+  }
+  return false;
 }
 
 Expr *BoundsAnalysis::GetTerminatorCondition(const Expr *E) const {
@@ -722,7 +774,7 @@ void BoundsAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
     OS << "--------------------------------------";
     B->print(OS, Cfg, S.getLangOpts(), /* ShowColors */ true);
 
-    BoundsMapTy Vars = GetWidenedBounds(B);
+    BoundsMapTy Vars = GetWidenedBoundsOffsets(B);
     using VarPairTy = std::pair<const VarDecl *, unsigned>;
 
     llvm::sort(Vars.begin(), Vars.end(),


### PR DESCRIPTION
We moved the functions `UpdateWidenedBounds` and `ResetKilledBounds` from
`SemaBounds.cpp` to `BoundsAnalysis.cpp` to create a cleaner separation between the
two files. `UpdateWidenedBounds` now returns a map of variables to their updated
bounds expressions, while `ResetKilledBounds` returns a set of variables killed
by the current statement. Inside `SemaBounds.cpp` we now simply update the
`CheckingState` with the updated bounds.