### PR TITLE
[LValue Generalization] Make AbstractSetManager a non-static class [3/n]

### DIFF
--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -75,7 +75,7 @@ namespace clang {
     // to the AbstractSet whose CanonicalForm is P. This is used to retrieve
     // the AbstractSet whose CanonicalForm already exists in SortedPreorderASTs
     // (if any).
-    llvm::DenseMap<PreorderAST *, AbstractSet *> PreorderASTAbstractSetMap;
+    llvm::DenseMap<PreorderAST *, const AbstractSet *> PreorderASTAbstractSetMap;
 
   public:
     AbstractSetManager(Sema &S) : S(S) {}
@@ -84,10 +84,10 @@ namespace clang {
     // there is an AbstractSet A in SortedAbstractSets that contains E,
     // GetOrCreateAbstractSet returns A. Otherwise, it creates a new
     // AbstractSet for E.
-    AbstractSet *GetOrCreateAbstractSet(Expr *E);
+    const AbstractSet *GetOrCreateAbstractSet(Expr *E);
 
     // Returns the AbstractSet that contains a use of the VarDecl.
-    AbstractSet *GetOrCreateAbstractSet(const VarDecl *V);
+    const AbstractSet *GetOrCreateAbstractSet(const VarDecl *V);
   };
 } // end namespace clang
 

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -86,6 +86,8 @@ namespace clang {
     // AbstractSet for E.
     AbstractSet *GetOrCreateAbstractSet(Expr *E);
 
+    // Returns the AbstractSet that contains a use of the VarDecl.
+    AbstractSet *GetOrCreateAbstractSet(const VarDecl *V);
   };
 } // end namespace clang
 

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -6,6 +6,7 @@
 #include "clang/AST/CanonBounds.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/PreorderAST.h"
+#include "clang/Sema/Sema.h"
 
 namespace clang {
   using Result = Lexicographic::Result;
@@ -35,11 +36,8 @@ namespace clang {
     Expr *Representative;
 
   public:
-    AbstractSet(PreorderAST P) : CanonicalForm(P) {}
-
-    void SetRepresentative(Expr *E) {
-      Representative = E;
-    }
+    AbstractSet(PreorderAST P, Expr *Rep) :
+      CanonicalForm(P), Representative(Rep) {}
 
     Expr *GetRepresentative() const {
       return Representative;
@@ -61,6 +59,8 @@ namespace clang {
 
   class AbstractSetManager {
   private:
+    Sema &S;
+
     // Maintain a sorted set of PreorderASTs that have been created while
     // traversing a function. A binary search in this set is used to determine
     // whether an lvalue expression belongs to an existing AbstractSet (an
@@ -69,24 +69,23 @@ namespace clang {
     // Here, the PreorderASTComparer is used to sort the PreorderASTs
     // lexicographically. This avoids the need for a linear search through
     // SortedPreorderASTs in GetOrCreateAbstractSet.
-    static std::set<PreorderAST *, PreorderASTComparer> SortedPreorderASTs;
+    std::set<PreorderAST *, PreorderASTComparer> SortedPreorderASTs;
 
     // Map each PreorderAST P that has been created while traversing a function
     // to the AbstractSet whose CanonicalForm is P. This is used to retrieve
     // the AbstractSet whose CanonicalForm already exists in SortedPreorderASTs
     // (if any).
-    static llvm::DenseMap<PreorderAST *, AbstractSet *> PreorderASTAbstractSetMap;
+    llvm::DenseMap<PreorderAST *, AbstractSet *> PreorderASTAbstractSetMap;
 
   public:
+    AbstractSetManager(Sema &S) : S(S) {}
+
     // Returns the AbstractSet that contains the lvalue expression E. If
     // there is an AbstractSet A in SortedAbstractSets that contains E,
     // GetOrCreateAbstractSet returns A. Otherwise, it creates a new
     // AbstractSet for E.
-    static AbstractSet *GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx);
+    AbstractSet *GetOrCreateAbstractSet(Expr *E);
 
-    // Clears the contents of the AbstractSetManager, since storage of the
-    // AbstractSets should not persist across functions.
-    static void Clear(void);
   };
 } // end namespace clang
 

--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -37,6 +37,9 @@ public:
   static ImplicitCastExpr *CreateImplicitCast(Sema &SemaRef, Expr *E,
                                               CastKind CK, QualType T);
 
+  // Create a use of a VarDecl.
+  static DeclRefExpr *CreateVarUse(Sema &SemaRef, VarDecl *V);
+
   // If e is an rvalue, EnsureRValue returns e. Otherwise, EnsureRValue
   // returns a cast of e to an rvalue, based on the type of e.
   static Expr *EnsureRValue(Sema &SemaRef, Expr *E);

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -2,12 +2,10 @@
 
 using namespace clang;
 
-std::set<PreorderAST *, PreorderASTComparer> AbstractSetManager::SortedPreorderASTs;
-llvm::DenseMap<PreorderAST *, AbstractSet *> AbstractSetManager::PreorderASTAbstractSetMap;
 
-AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx) {
+AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
   // Create a canonical form for E.
-  PreorderAST *P = new PreorderAST(Ctx, E);
+  PreorderAST *P = new PreorderAST(S.getASTContext(), E);
   P->Normalize();
 
   // Search for an existing PreorderAST that is equivalent to the canonical
@@ -26,14 +24,10 @@ AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E, ASTContext &Ctx
 
   // If there is no existing AbstractSet that contains E, create a new
   // AbstractSet that contains E.
-  AbstractSet *A = new AbstractSet(*P);
-  A->SetRepresentative(E);
+  AbstractSet *A = new AbstractSet(*P, E);
   SortedPreorderASTs.emplace(P);
   PreorderASTAbstractSetMap[P] = A;
   return A;
 }
 
-void AbstractSetManager::Clear(void) {
-  SortedPreorderASTs.clear();
-  PreorderASTAbstractSetMap.clear();
 }

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -30,4 +30,11 @@ AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
   return A;
 }
 
+AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(const VarDecl *V) {
+  VarDecl *D = const_cast<VarDecl *>(V);
+  DeclRefExpr *VarUse =
+    DeclRefExpr::Create(S.getASTContext(), NestedNameSpecifierLoc(),
+                        SourceLocation(), D, false, SourceLocation(),
+                        D->getType(), ExprValueKind::VK_LValue);
+  return GetOrCreateAbstractSet(VarUse);
 }

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -3,7 +3,7 @@
 using namespace clang;
 
 
-AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
+const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
   // Create a canonical form for E.
   PreorderAST *P = new PreorderAST(S.getASTContext(), E);
   P->Normalize();
@@ -24,13 +24,13 @@ AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
 
   // If there is no existing AbstractSet that contains E, create a new
   // AbstractSet that contains E.
-  AbstractSet *A = new AbstractSet(*P, E);
+  const AbstractSet *A = new AbstractSet(*P, E);
   SortedPreorderASTs.emplace(P);
   PreorderASTAbstractSetMap[P] = A;
   return A;
 }
 
-AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(const VarDecl *V) {
+const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(const VarDecl *V) {
   VarDecl *D = const_cast<VarDecl *>(V);
   DeclRefExpr *VarUse =
     DeclRefExpr::Create(S.getASTContext(), NestedNameSpecifierLoc(),

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -32,9 +32,6 @@ const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
 
 const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(const VarDecl *V) {
   VarDecl *D = const_cast<VarDecl *>(V);
-  DeclRefExpr *VarUse =
-    DeclRefExpr::Create(S.getASTContext(), NestedNameSpecifierLoc(),
-                        SourceLocation(), D, false, SourceLocation(),
-                        D->getType(), ExprValueKind::VK_LValue);
+  DeclRefExpr *VarUse = ExprCreatorUtil::CreateVarUse(S, D);
   return GetOrCreateAbstractSet(VarUse);
 }

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -1,4 +1,5 @@
 #include "clang/AST/AbstractSet.h"
+#include "clang/AST/ExprUtils.h"
 
 using namespace clang;
 

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -47,6 +47,12 @@ ImplicitCastExpr *ExprCreatorUtil::CreateImplicitCast(Sema &SemaRef, Expr *E,
                                   ExprValueKind::VK_RValue);
 }
 
+DeclRefExpr *ExprCreatorUtil::CreateVarUse(Sema &SemaRef, VarDecl *V) {
+  return DeclRefExpr::Create(SemaRef.getASTContext(), NestedNameSpecifierLoc(),
+                             SourceLocation(), V, false, SourceLocation(),
+                             V->getType(), ExprValueKind::VK_LValue);
+}
+
 Expr *ExprCreatorUtil::EnsureRValue(Sema &SemaRef, Expr *E) {
   if (E->isRValue())
     return E;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2413,10 +2413,7 @@ namespace {
       if (Temp ||  S.CheckIsNonModifying(Src, Sema::NonModifyingContext::NMC_Unknown,
                                          Sema::NonModifyingMessage::NMM_None)) {
         // TODO: make sure variable being initialized isn't read by Src.
-        DeclRefExpr *TargetDeclRef =
-          DeclRefExpr::Create(S.getASTContext(), NestedNameSpecifierLoc(),
-                              SourceLocation(), D, false, SourceLocation(),
-                              D->getType(), ExprValueKind::VK_LValue);
+        DeclRefExpr *TargetDeclRef = ExprCreatorUtil::CreateVarUse(S, D);
         CastKind Kind;
         QualType TargetTy;
         if (D->getType()->isArrayType()) {
@@ -3756,10 +3753,7 @@ namespace {
 
         // Create an rvalue expression for v. v could be an array or
         // non-array variable.
-        DeclRefExpr *TargetDeclRef =
-          DeclRefExpr::Create(S.getASTContext(), NestedNameSpecifierLoc(),
-                              SourceLocation(), D, false, SourceLocation(),
-                              D->getType(), ExprValueKind::VK_LValue);
+        DeclRefExpr *TargetDeclRef = ExprCreatorUtil::CreateVarUse(S, D);
         CastKind Kind;
         QualType TargetTy;
         if (D->getType()->isArrayType()) {


### PR DESCRIPTION
This PR makes AbstractManager a non-static class. In the next stage of lvalue generalization, when using AbstractSets as the keys in CheckBoundsDeclarations and BoundsAnalysis, an AbstractSetManager instance will be created in CheckBoundsDeclarations::TraverseCFG and passed to BoundsAnalysis::WidenBounds and checking methods in CheckBoundsDeclarations.