### PR TITLE
[LValue Generalization] Make AbstractSet::Compare const [4/n]

### DIFF
--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -47,14 +47,14 @@ namespace clang {
 
     // The comparison between two AbstractSets is the same as the
     // lexicographic comparison between their CanonicalForms.
-    Result Compare(AbstractSet &Other) {
+    Result Compare(AbstractSet &Other) const {
       return CanonicalForm.Compare(Other.CanonicalForm);
     }
 
-    bool operator<(AbstractSet &Other) {
+    bool operator<(AbstractSet &Other) const {
       return Compare(Other) == Result::LessThan;
     }
-    bool operator==(AbstractSet &Other) {
+    bool operator==(AbstractSet &Other) const {
       return Compare(Other) == Result::Equal;
     }
   };

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -47,7 +47,7 @@ namespace clang {
 
     // The comparison between two AbstractSets is the same as the
     // lexicographic comparison between their CanonicalForms.
-    Result Compare(AbstractSet &Other) const {
+    Result Compare(const AbstractSet Other) const {
       return CanonicalForm.Compare(Other.CanonicalForm);
     }
 

--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -59,7 +59,7 @@ namespace clang {
     bool Trace;
 
     template <typename T>
-    Lexicographic::Result Compare(const Expr *Raw1, const Expr *Raw2) {
+    Lexicographic::Result Compare(const Expr *Raw1, const Expr *Raw2) const {
       const T *E1 = dyn_cast<T>(Raw1);
       const T *E2 = dyn_cast<T>(Raw2);
       if (!E1 || !E2) {
@@ -70,47 +70,47 @@ namespace clang {
 
     // See if E1 and E2 are considered equivalent using EquivExprs.  If
     // they are not, return Current.
-    Result CheckEquivExprs(Result Current, const Expr *E1, const Expr *E2);
+    Result CheckEquivExprs(Result Current, const Expr *E1, const Expr *E2) const;
 
     Result CompareInteger(signed I1, signed I2) const;
     Result CompareInteger(unsigned I1, unsigned I2) const;
     Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
-                                       const RelativeBoundsClause *RC2);
+                                       const RelativeBoundsClause *RC2) const;
     Result CompareScope(const DeclContext *DC1, const DeclContext *DC2) const;
 
-    Result CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2);
-    Result CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2);
-    Result CompareImpl(const ConstantExpr *E1, const ConstantExpr *E2);
-    Result CompareImpl(const IntegerLiteral *E1, const IntegerLiteral *E2);
-    Result CompareImpl(const FloatingLiteral *E1, const FloatingLiteral *E2);
-    Result CompareImpl(const StringLiteral *E1, const StringLiteral *E2);
-    Result CompareImpl(const CharacterLiteral *E1, const CharacterLiteral *E2);
-    Result CompareImpl(const UnaryOperator *E1, const UnaryOperator *E2);
-    Result CompareImpl(const OffsetOfExpr *E1, const OffsetOfExpr *E2);
+    Result CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2) const;
+    Result CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2) const;
+    Result CompareImpl(const ConstantExpr *E1, const ConstantExpr *E2) const;
+    Result CompareImpl(const IntegerLiteral *E1, const IntegerLiteral *E2) const;
+    Result CompareImpl(const FloatingLiteral *E1, const FloatingLiteral *E2) const;
+    Result CompareImpl(const StringLiteral *E1, const StringLiteral *E2) const;
+    Result CompareImpl(const CharacterLiteral *E1, const CharacterLiteral *E2) const;
+    Result CompareImpl(const UnaryOperator *E1, const UnaryOperator *E2) const;
+    Result CompareImpl(const OffsetOfExpr *E1, const OffsetOfExpr *E2) const;
     Result CompareImpl(const UnaryExprOrTypeTraitExpr *E1,
-                   const UnaryExprOrTypeTraitExpr *E2);
-    Result CompareImpl(const MemberExpr *E1, const MemberExpr *E2);
-    Result CompareImpl(const BinaryOperator *E1, const BinaryOperator *E2);
+                   const UnaryExprOrTypeTraitExpr *E2) const;
+    Result CompareImpl(const MemberExpr *E1, const MemberExpr *E2) const;
+    Result CompareImpl(const BinaryOperator *E1, const BinaryOperator *E2) const;
     Result CompareImpl(const CompoundAssignOperator *E1,
-                   const CompoundAssignOperator *E2);
-    Result CompareImpl(const CastExpr *E1, const CastExpr *E2);
+                   const CompoundAssignOperator *E2) const;
+    Result CompareImpl(const CastExpr *E1, const CastExpr *E2) const;
     Result CompareImpl(const CompoundLiteralExpr *E1,
-                   const CompoundLiteralExpr *E2);
+                   const CompoundLiteralExpr *E2) const;
     Result CompareImpl(const GenericSelectionExpr *E1,
-                   const GenericSelectionExpr *E2);
+                   const GenericSelectionExpr *E2) const;
     Result CompareImpl(const NullaryBoundsExpr *E1,
-                       const NullaryBoundsExpr *E2);
-    Result CompareImpl(const CountBoundsExpr *E1, const CountBoundsExpr *E2);
-    Result CompareImpl(const RangeBoundsExpr *E1, const RangeBoundsExpr *E2);
-    Result CompareImpl(const InteropTypeExpr *E1, const InteropTypeExpr *E2);
+                       const NullaryBoundsExpr *E2) const;
+    Result CompareImpl(const CountBoundsExpr *E1, const CountBoundsExpr *E2) const;
+    Result CompareImpl(const RangeBoundsExpr *E1, const RangeBoundsExpr *E2) const;
+    Result CompareImpl(const InteropTypeExpr *E1, const InteropTypeExpr *E2) const;
     Result CompareImpl(const PositionalParameterExpr *E1,
-                   const PositionalParameterExpr *E2);
-    Result CompareImpl(const BoundsCastExpr *E1, const BoundsCastExpr *E2);
+                   const PositionalParameterExpr *E2) const;
+    Result CompareImpl(const BoundsCastExpr *E1, const BoundsCastExpr *E2) const;
     Result CompareImpl(const CHKCBindTemporaryExpr *E1,
-                       const CHKCBindTemporaryExpr *E2);
-    Result CompareImpl(const BoundsValueExpr *E1, const BoundsValueExpr *E2);
-    Result CompareImpl(const AtomicExpr *E1, const AtomicExpr *E2);
-    Result CompareImpl(const BlockExpr *E1, const BlockExpr *E2);
+                       const CHKCBindTemporaryExpr *E2) const;
+    Result CompareImpl(const BoundsValueExpr *E1, const BoundsValueExpr *E2) const;
+    Result CompareImpl(const AtomicExpr *E1, const AtomicExpr *E2) const;
+    Result CompareImpl(const BlockExpr *E1, const BlockExpr *E2) const;
 
 
   public:
@@ -118,17 +118,17 @@ namespace clang {
 
     /// \brief Lexicographic comparison of expressions that can occur in
     /// bounds expressions.
-    Result CompareExpr(const Expr *E1, const Expr *E2);
+    Result CompareExpr(const Expr *E1, const Expr *E2) const;
     /// \brief Semantic comparison of expressions that can occur in
     /// bounds expressions. A return value of true indicates that the two
     /// expressions are equivalent semantically.
-    bool CompareExprSemantically(const Expr *E1, const Expr *E2);
+    bool CompareExprSemantically(const Expr *E1, const Expr *E2) const;
 
     /// \brief Given the upper bound expr and the dereference expr for an
     /// _Nt_array_ptr gets the offset by which the pointer is dereferenced.
     /// The boolean return value indicates whether a valid offset exists.
     bool GetDerefOffset(const Expr *UpperExpr, const Expr *DerefExpr,
-                        llvm::APSInt &Offset);
+                        llvm::APSInt &Offset) const;
 
     /// \brief Compare declarations that may be used by expressions or
     /// or types.
@@ -139,7 +139,7 @@ namespace clang {
     Result CompareTypeLexicographically(QualType QT1, QualType QT2) const;
 
     Result CompareAPInt(const llvm::APInt &I1, const llvm::APInt &I2) const;
-    Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E);
+    Expr *IgnoreValuePreservingOperations(ASTContext &Ctx, Expr *E) const;
   };
 }  // end namespace clang
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -143,7 +143,7 @@ namespace clang {
     // @param[in] N2 is the second node.
     // @return Returns a Lexicographic::Result indicating the comparison
     // of N1 and N2.
-    Result Compare(Node *N1, Node *N2);
+    Result Compare(Node *N1, Node *N2) const;
 
     // Set Error in case an error occurs during transformation of the AST.
     void SetError() { Error = true; }
@@ -186,7 +186,7 @@ namespace clang {
     // @param[in] P is the second AST.
     // @return Returns a Lexicographic::Result indicating the comparison between
     // the two ASTs.
-    Result Compare(PreorderAST &P) { return Compare(Root, P.Root); }
+    Result Compare(PreorderAST &P) const { return Compare(Root, P.Root); }
 
     // Check if an error has occurred during transformation of the AST. This
     // is intended to be called from outside this class to check if an error
@@ -199,10 +199,10 @@ namespace clang {
     // recursively deletes the AST.
     void Cleanup() { Cleanup(Root); }
 
-    bool operator<(PreorderAST &Other) {
+    bool operator<(PreorderAST &Other) const {
       return Compare(Other) == Result::LessThan;
     }
-    bool operator==(PreorderAST &Other) {
+    bool operator==(PreorderAST &Other) const {
       return Compare(Other) == Result::Equal;
     }
   };

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -143,7 +143,7 @@ namespace clang {
     // @param[in] N2 is the second node.
     // @return Returns a Lexicographic::Result indicating the comparison
     // of N1 and N2.
-    Result Compare(Node *N1, Node *N2) const;
+    Result Compare(const Node *N1, const Node *N2) const;
 
     // Set Error in case an error occurs during transformation of the AST.
     void SetError() { Error = true; }
@@ -186,7 +186,7 @@ namespace clang {
     // @param[in] P is the second AST.
     // @return Returns a Lexicographic::Result indicating the comparison between
     // the two ASTs.
-    Result Compare(PreorderAST &P) const { return Compare(Root, P.Root); }
+    Result Compare(const PreorderAST P) const { return Compare(Root, P.Root); }
 
     // Check if an error has occurred during transformation of the AST. This
     // is intended to be called from outside this class to check if an error

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -257,7 +257,7 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) const
 }
 
 bool Lexicographic::CompareExprSemantically(const Expr *Arg1,
-                                            const Expr *Arg2) {
+                                            const Expr *Arg2) const {
    // Compare Arg1 and Arg2 semantically. If we hit an error during comparison
    // simply fallback to CompareExpr which compares two expressions
    // structurally.
@@ -287,7 +287,7 @@ bool Lexicographic::CompareExprSemantically(const Expr *Arg1,
 
 bool Lexicographic::GetDerefOffset(const Expr *UpperExpr,
                                    const Expr *DerefExpr,
-                                   llvm::APSInt &Offset) {
+                                   llvm::APSInt &Offset) const {
   Expr *E1 = const_cast<Expr *>(UpperExpr);
   Expr *E2 = const_cast<Expr *>(DerefExpr);
 
@@ -311,7 +311,7 @@ bool Lexicographic::GetDerefOffset(const Expr *UpperExpr,
   return Res;
 }
 
-Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
+Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) const {
    if (Trace) {
      raw_ostream &OS = llvm::outs();
      OS << "Lexicographic comparing expressions\n";
@@ -495,7 +495,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) {
 
 // See if the expressions are considered equivalent using the list of lists
 // of equivalent expressions.
-Result Lexicographic::CheckEquivExprs(Result Current, const Expr *E1, const Expr *E2) {
+Result Lexicographic::CheckEquivExprs(Result Current, const Expr *E1, const Expr *E2) const {
   if (!EquivExprs)
     return Current;
 
@@ -567,22 +567,22 @@ Lexicographic::CompareTypeIgnoreCheckedness(QualType QT1, QualType QT2) const {
 }
 
 Result
-Lexicographic::CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2) {
+Lexicographic::CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2) const {
   return CompareInteger(E1->getIdentKind(), E2->getIdentKind());
 }
 
 Result
-Lexicographic::CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2) {
+Lexicographic::CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2) const {
   return CompareDecl(E1->getDecl(), E2->getDecl());
 }
 
 Result
-Lexicographic::CompareImpl(const ConstantExpr *E1, const ConstantExpr *E2) {
+Lexicographic::CompareImpl(const ConstantExpr *E1, const ConstantExpr *E2) const {
   return CompareExpr(E1->getSubExpr(), E2->getSubExpr());
 }
 
 Result
-Lexicographic::CompareImpl(const IntegerLiteral *E1, const IntegerLiteral *E2) {
+Lexicographic::CompareImpl(const IntegerLiteral *E1, const IntegerLiteral *E2) const {
   BuiltinType::Kind Kind1 = E1->getType()->castAs<BuiltinType>()->getKind();
   BuiltinType::Kind Kind2 = E2->getType()->castAs<BuiltinType>()->getKind();
   Result Cmp = CompareInteger(Kind1, Kind2);
@@ -593,7 +593,7 @@ Lexicographic::CompareImpl(const IntegerLiteral *E1, const IntegerLiteral *E2) {
 
 Result
 Lexicographic::CompareImpl(const FloatingLiteral *E1,
-                           const FloatingLiteral *E2) {
+                           const FloatingLiteral *E2) const {
   BuiltinType::Kind Kind1 = E1->getType()->castAs<BuiltinType>()->getKind();
   BuiltinType::Kind Kind2 = E2->getType()->castAs<BuiltinType>()->getKind();
   Result Cmp = CompareInteger(Kind1, Kind2);
@@ -609,7 +609,7 @@ Lexicographic::CompareImpl(const FloatingLiteral *E1,
 
 Result
 Lexicographic::CompareImpl(const StringLiteral *E1,
-                           const StringLiteral *E2) {
+                           const StringLiteral *E2) const {
   Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -618,7 +618,7 @@ Lexicographic::CompareImpl(const StringLiteral *E1,
 
 Result
 Lexicographic::CompareImpl(const CharacterLiteral *E1,
-                           const CharacterLiteral *E2) {
+                           const CharacterLiteral *E2) const {
   Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -626,13 +626,13 @@ Lexicographic::CompareImpl(const CharacterLiteral *E1,
 }
 
 Result
-Lexicographic::CompareImpl(const UnaryOperator *E1, const UnaryOperator *E2) {
+Lexicographic::CompareImpl(const UnaryOperator *E1, const UnaryOperator *E2) const {
   return CompareInteger(E1->getOpcode(), E2->getOpcode());
 }
 
 Result
 Lexicographic::CompareImpl(const UnaryExprOrTypeTraitExpr *E1,
-                           const UnaryExprOrTypeTraitExpr *E2) {
+                           const UnaryExprOrTypeTraitExpr *E2) const {
   Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -648,13 +648,13 @@ Lexicographic::CompareImpl(const UnaryExprOrTypeTraitExpr *E1,
 }
 
 Result
-Lexicographic::CompareImpl(const OffsetOfExpr *E1, const OffsetOfExpr *E2) {
+Lexicographic::CompareImpl(const OffsetOfExpr *E1, const OffsetOfExpr *E2) const {
   // TODO: fill this in 
   return Result::Equal;
 }
 
 Result
-Lexicographic::CompareImpl(const MemberExpr *E1, const MemberExpr *E2) {
+Lexicographic::CompareImpl(const MemberExpr *E1, const MemberExpr *E2) const {
   Result Cmp = CompareInteger(E1->isArrow(), E2->isArrow());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -663,19 +663,19 @@ Lexicographic::CompareImpl(const MemberExpr *E1, const MemberExpr *E2) {
 
 Result
 Lexicographic::CompareImpl(const BinaryOperator *E1,
-                           const BinaryOperator *E2) {
+                           const BinaryOperator *E2) const {
   return CompareInteger(E1->getOpcode(), E2->getOpcode());
 }
 
 Result
 Lexicographic::CompareImpl(const CompoundAssignOperator *E1,
-                           const CompoundAssignOperator *E2) {
+                           const CompoundAssignOperator *E2) const {
   return CompareInteger(E1->getOpcode(), E2->getOpcode());
 }
 
 Result
 Lexicographic::CompareImpl(const CastExpr *E1,
-                           const CastExpr *E2) {
+                           const CastExpr *E2) const {
   Result Cmp = CompareInteger(E1->getCastKind(), E2->getCastKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -687,13 +687,13 @@ Lexicographic::CompareImpl(const CastExpr *E1,
 
 Result
 Lexicographic::CompareImpl(const CompoundLiteralExpr *E1,
-                           const CompoundLiteralExpr *E2) {
+                           const CompoundLiteralExpr *E2) const {
   return CompareInteger(E1->isFileScope(), E2->isFileScope());
 }
 
 Result
 Lexicographic::CompareImpl(const GenericSelectionExpr *E1,
-                           const GenericSelectionExpr *E2) {
+                           const GenericSelectionExpr *E2) const {
   unsigned E1AssocCount = E1->getNumAssocs();
   Result Cmp = CompareInteger(E1AssocCount, E2->getNumAssocs());
   if (Cmp != Result::Equal)
@@ -720,25 +720,25 @@ Lexicographic::CompareImpl(const GenericSelectionExpr *E1,
 }
 
 Result
-Lexicographic::CompareImpl(const AtomicExpr *E1, const AtomicExpr *E2) {
+Lexicographic::CompareImpl(const AtomicExpr *E1, const AtomicExpr *E2) const {
   return CompareInteger(E1->getOp(), E2->getOp());
 }
 
 Result
 Lexicographic::CompareImpl(const NullaryBoundsExpr *E1,
-                           const NullaryBoundsExpr *E2) {
+                           const NullaryBoundsExpr *E2) const {
   return CompareInteger(E1->getKind(), E2->getKind());
 }
 
 Result
 Lexicographic::CompareImpl(const CountBoundsExpr *E1,
-                           const CountBoundsExpr *E2) {
+                           const CountBoundsExpr *E2) const {
   return CompareInteger(E1->getKind(), E2->getKind());
 }
 
 Result
 Lexicographic::CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
-                                           const RelativeBoundsClause *RC2) {
+                                           const RelativeBoundsClause *RC2) const {
   bool ordered;
   Result Cmp = ComparePointers(RC1, RC2, ordered);
   if (ordered)
@@ -773,7 +773,7 @@ Lexicographic::CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
 
 Result
 Lexicographic::CompareImpl(const RangeBoundsExpr *E1,
-                           const RangeBoundsExpr *E2) {
+                           const RangeBoundsExpr *E2) const {
   Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -785,13 +785,13 @@ Lexicographic::CompareImpl(const RangeBoundsExpr *E1,
 
 Result
 Lexicographic::CompareImpl(const InteropTypeExpr *E1,
-                           const InteropTypeExpr *E2) {
+                           const InteropTypeExpr *E2) const {
   return CompareType(E1->getType(), E2->getType());
 }
 
 Result
 Lexicographic::CompareImpl(const PositionalParameterExpr *E1,
-                           const PositionalParameterExpr *E2) {
+                           const PositionalParameterExpr *E2) const {
   Result Cmp = CompareInteger(E1->getIndex(), E2->getIndex());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -800,7 +800,7 @@ Lexicographic::CompareImpl(const PositionalParameterExpr *E1,
 
 Result
 Lexicographic::CompareImpl(const BoundsCastExpr *E1,
-                           const BoundsCastExpr *E2) {
+                           const BoundsCastExpr *E2) const {
   Result Cmp = CompareInteger(E1->getCastKind(), E2->getCastKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -814,7 +814,7 @@ Lexicographic::CompareImpl(const BoundsCastExpr *E1,
 
 Result
 Lexicographic::CompareImpl(const CHKCBindTemporaryExpr *E1,
-                           const CHKCBindTemporaryExpr *E2) {
+                           const CHKCBindTemporaryExpr *E2) const {
   bool ordered;
   Result Cmp = ComparePointers(E1, E2, ordered);
   if (!ordered) {
@@ -831,7 +831,7 @@ Lexicographic::CompareImpl(const CHKCBindTemporaryExpr *E1,
 
 Result
 Lexicographic::CompareImpl(const BoundsValueExpr *E1,
-                           const BoundsValueExpr *E2) {
+                           const BoundsValueExpr *E2) const {
   Result Cmp = CompareInteger(E1->getKind(), E2->getKind());
   if (Cmp != Result::Equal)
     return Cmp;
@@ -846,7 +846,7 @@ Lexicographic::CompareImpl(const BoundsValueExpr *E1,
 }
 
 Result
-Lexicographic::CompareImpl(const BlockExpr *E1, const BlockExpr *E2) {
+Lexicographic::CompareImpl(const BlockExpr *E1, const BlockExpr *E2) const {
   return Result::Equal;
 }
 
@@ -858,7 +858,7 @@ Lexicographic::CompareImpl(const BlockExpr *E1, const BlockExpr *E2) {
 // do enough filtering (it'll ignore LValueToRValue casts for example).
 // TODO: reconcile with CheckValuePreservingCast
 Expr *Lexicographic::IgnoreValuePreservingOperations(ASTContext &Ctx,
-                                                     Expr *E) {
+                                                     Expr *E) const {
   while (true) {
     E = E->IgnoreParens();
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -403,7 +403,7 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   return true;
 }
 
-Result PreorderAST::Compare(Node *N1, Node *N2) const {
+Result PreorderAST::Compare(const Node *N1, const Node *N2) const {
   // If both the nodes are null.
   if (!N1 && !N2)
     return Result::Equal;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -403,7 +403,7 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   return true;
 }
 
-Result PreorderAST::Compare(Node *N1, Node *N2) {
+Result PreorderAST::Compare(Node *N1, Node *N2) const {
   // If both the nodes are null.
   if (!N1 && !N2)
     return Result::Equal;


### PR DESCRIPTION
This PR makes AbstractSet::Compare a `const` method. In order to do so, it also makes PreorderAST::Compare `const`. This also necessitates making methods in CanonBounds.cpp such as Lexicographic::CompareExpr `const`.