### PR TITLE
isFunctionProtoType should be used with getAs, not dyn_cast.

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -184,7 +184,7 @@ PointerVariableConstraint::PointerVariableConstraint(
           OrigType = FD->getType().getTypePtr();
         }
         if (OrigType->isFunctionProtoType()) {
-          const FunctionProtoType *FPT = dyn_cast<FunctionProtoType>(OrigType);
+          const FunctionProtoType *FPT = OrigType->getAs<FunctionProtoType>();
           AnalyzeITypeExpr = (FPT->getReturnType() == QT);
         }
       }

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -154,7 +154,7 @@ bool getAbsoluteFilePath(std::string FileName, std::string &AbsoluteFp) {
 bool functionHasVarArgs(clang::FunctionDecl *FD) {
   if (FD && FD->getFunctionType()->isFunctionProtoType()) {
     const FunctionProtoType *SrcType =
-        dyn_cast<FunctionProtoType>(FD->getFunctionType());
+        FD->getFunctionType()->getAs<FunctionProtoType>();
     return SrcType->isVariadic();
   }
   return false;


### PR DESCRIPTION
PR to merge the (current) fix from CCI for the five failing 3C test cases, into the `implicit-include-of-hdrfiles` branch.