### PR TITLE
[LValue Generalization] Use AbstractSets as keys in ObservedBounds [5/n]

### DIFF
--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -59,14 +59,14 @@ namespace clang {
 
     // The comparison between two AbstractSets is the same as the
     // lexicographic comparison between their CanonicalForms.
-    Result Compare(const AbstractSet Other) const {
+    Result Compare(AbstractSet &Other) const {
       return CanonicalForm.Compare(Other.CanonicalForm);
     }
 
-    bool operator<(const AbstractSet Other) const {
+    bool operator<(AbstractSet &Other) const {
       return Compare(Other) == Result::LessThan;
     }
-    bool operator==(const AbstractSet Other) const {
+    bool operator==(AbstractSet &Other) const {
       return Compare(Other) == Result::Equal;
     }
   };

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -107,10 +107,7 @@ namespace clang {
       S(S), VarUses(VarUses) {}
 
     ~AbstractSetManager() {
-      for (const auto &P : SortedPreorderASTs) {
-        P->Cleanup();
-        delete P;
-      }
+      Clear();
     }
 
     // Returns the AbstractSet that contains the lvalue expression E. If
@@ -124,6 +121,11 @@ namespace clang {
 
     // Clears the storage of the PreorderASTs and AbstractSets.
     void Clear() {
+      for (const auto &Pair : PreorderASTAbstractSetMap) {
+        Pair.first->Cleanup();
+        delete Pair.first;
+        delete Pair.second;
+      }
       SortedPreorderASTs.clear();
       PreorderASTAbstractSetMap.clear();
     }

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -106,6 +106,13 @@ namespace clang {
     AbstractSetManager(Sema &S, Sema::VarDeclUsage &VarUses) :
       S(S), VarUses(VarUses) {}
 
+    ~AbstractSetManager() {
+      for (const auto &P : SortedPreorderASTs) {
+        P->Cleanup();
+        delete P;
+      }
+    }
+
     // Returns the AbstractSet that contains the lvalue expression E. If
     // there is an AbstractSet A in SortedAbstractSets that contains E,
     // GetOrCreateAbstractSet returns A. Otherwise, it creates a new

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -102,6 +102,12 @@ namespace clang {
 
     // Returns the AbstractSet that contains a use of the VarDecl.
     const AbstractSet *GetOrCreateAbstractSet(const VarDecl *V);
+
+    // Clears the storage of the PreorderASTs and AbstractSets.
+    void Clear() {
+      SortedPreorderASTs.clear();
+      PreorderASTAbstractSetMap.clear();
+    }
   };
 } // end namespace clang
 

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -49,10 +49,10 @@ namespace clang {
       return CanonicalForm.Compare(Other.CanonicalForm);
     }
 
-    bool operator<(AbstractSet &Other) const {
+    bool operator<(const AbstractSet Other) const {
       return Compare(Other) == Result::LessThan;
     }
-    bool operator==(AbstractSet &Other) const {
+    bool operator==(const AbstractSet Other) const {
       return Compare(Other) == Result::Equal;
     }
   };

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -43,6 +43,20 @@ namespace clang {
       return Representative;
     }
 
+    // Returns the VarDecl, if any, associated with the Representative
+    // expression for this AbstractSet.
+    // This VarDecl is used by bounds declaration checking to emit
+    // diagnostics for statements that invalidate the inferred bounds of
+    // the lvalue expressions in the AbstractSet.
+    const VarDecl *GetVarDecl() const {
+      if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(Representative)) {
+        if (const VarDecl *V = dyn_cast<VarDecl>(DRE->getDecl()))
+          return V;
+        return nullptr;
+      }
+      return nullptr;
+    }
+
     // The comparison between two AbstractSets is the same as the
     // lexicographic comparison between their CanonicalForms.
     Result Compare(const AbstractSet Other) const {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5737,6 +5737,11 @@ public:
   // will expand it to a range bounds expression.
   BoundsExpr *ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B);
 
+  // Returns the declared bounds for the lvalue expression E. Assignments
+  // to E must satisfy these bounds. After checking a top-level statement,
+  // the inferred bounds of E must imply these declared bounds.
+  BoundsExpr *GetLValueDeclaredBounds(Expr *E);
+
   //
   // Track variables that in-scope bounds declarations depend upon.
   // TODO: generalize this to other lvalue expressions.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5818,12 +5818,19 @@ public:
    DependentBounds Tracker;
   };
 
+  // Map a VarDecl to its first use.
+  using VarDeclUsage = llvm::DenseMap<const VarDecl *, DeclRefExpr *>;
+
   /// \brief Compute a mapping from statements that modify lvalues to
   /// in-scope bounds declarations that depend on those lvalues.
   /// FD is the function being declared and Body is the body of the
   /// function.   They are passed in separately because Body hasn't
   /// been attached to FD yet.
+  /// ComputeBoundsDependencies also computes a mapping from VarDecls with
+  /// bounds expressions to the DeclRefExpr (if any) that is the first use
+  /// of the VarDecl.
   void ComputeBoundsDependencies(ModifiedBoundsDependencies &Tracker,
+                                 VarDeclUsage &VarUses,
                                  FunctionDecl *FD, Stmt *Body);
 
   /// \brief RAII class used to indicate that we are substituting an expression

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -3,7 +3,6 @@
 
 using namespace clang;
 
-
 const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
   // Create a canonical form for E.
   PreorderAST *P = new PreorderAST(S.getASTContext(), E);
@@ -18,9 +17,8 @@ const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
     // is equivalent to ExistingCanonicalForm, then that AbstractSet is the
     // one that contains E.
     auto It = PreorderASTAbstractSetMap.find(ExistingCanonicalForm);
-    if (It != PreorderASTAbstractSetMap.end()) {
+    if (It != PreorderASTAbstractSetMap.end())
       return It->second;
-    }
   }
 
   // If there is no existing AbstractSet that contains E, create a new

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -18,6 +18,7 @@ const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
     // one that contains E.
     auto It = PreorderASTAbstractSetMap.find(ExistingCanonicalForm);
     if (It != PreorderASTAbstractSetMap.end()) {
+      P->Cleanup();
       delete P;
       return It->second;
     }

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -32,7 +32,25 @@ const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
 }
 
 const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(const VarDecl *V) {
-  VarDecl *D = const_cast<VarDecl *>(V);
-  DeclRefExpr *VarUse = ExprCreatorUtil::CreateVarUse(S, D);
+  // Compute the DeclRefExpr that is a use of V. This DeclRefExpr is needed
+  // in order to get or create the AbstractSet that contains V.
+  // The VarUses map does not contain a key for V if V is never used in the
+  // body of a function. However, we still need to create an AbstractSet
+  // for V so that its bounds can be checked. For example, consider:
+  // void f(_Array_ptr<int> unused : count(i), unsigned i) {
+  //   i = 0;
+  // }
+  // The parameter declaration `unused` does not have a DeclRefExpr in the
+  // VarUses map, but the statement i = 0 invalidates the observed bounds
+  // of V.
+  DeclRefExpr *VarUse = nullptr;
+  auto It = VarUses.find(V);
+  if (It != VarUses.end()) {
+    VarUse = It->second;
+  } else {
+    VarDecl *D = const_cast<VarDecl *>(V);
+    VarUse = ExprCreatorUtil::CreateVarUse(S, D);
+    VarUses[V] = VarUse;
+  }
   return GetOrCreateAbstractSet(VarUse);
 }

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -17,8 +17,10 @@ const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
     // is equivalent to ExistingCanonicalForm, then that AbstractSet is the
     // one that contains E.
     auto It = PreorderASTAbstractSetMap.find(ExistingCanonicalForm);
-    if (It != PreorderASTAbstractSetMap.end())
+    if (It != PreorderASTAbstractSetMap.end()) {
+      delete P;
       return It->second;
+    }
   }
 
   // If there is no existing AbstractSet that contains E, create a new

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -249,7 +249,7 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) const
   Current = D2->getNextDeclInContext();
   while (Current != nullptr) {
     if (Current == D1)
-      return Result::LessThan;
+      return Result::GreaterThan;
     Current = Current->getNextDeclInContext();
   }
   llvm_unreachable("unable to order declarations in same context");

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -944,7 +944,7 @@ namespace {
           OrderedSets.push_back(Pair.first);
         llvm::sort(OrderedSets.begin(), OrderedSets.end(),
              [] (const AbstractSet *A, const AbstractSet *B) {
-               return *A < *B;
+               return *(const_cast<AbstractSet *>(A)) < *(const_cast<AbstractSet *>(B));
              });
 
         OS << "{\n";

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -759,11 +759,11 @@ namespace {
     private:
       Sema &SemaRef;
       BoundsContextTy &BoundsContextRef;
-      AbstractSetManager AbstractSetMgr;
+      AbstractSetManager &AbstractSetMgr;
 
     public:
       DeclaredBoundsHelper(Sema &SemaRef, BoundsContextTy &Context,
-                           AbstractSetManager AbstractSetMgr) :
+                           AbstractSetManager &AbstractSetMgr) :
         SemaRef(SemaRef),
         BoundsContextRef(Context),
         AbstractSetMgr(AbstractSetMgr) {}
@@ -783,8 +783,10 @@ namespace {
           return true;
         // The bounds expressions in the bounds context should be normalized
         // to range bounds.
-        if (BoundsExpr *Bounds = SemaRef.NormalizeBounds(D))
-          BoundsContextRef[D] = Bounds;
+        if (BoundsExpr *Bounds = SemaRef.NormalizeBounds(D)) {
+          const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(D);
+          BoundsContextRef[A] = Bounds;
+        }
         return true;
       }
   };
@@ -792,7 +794,7 @@ namespace {
   // GetDeclaredBounds modifies the bounds context to map any variables
   // declared in S to their declared bounds (if any).
   void GetDeclaredBounds(Sema &SemaRef, BoundsContextTy &Context, Stmt *S,
-                         AbstractSetManager AbstractSetMgr) {
+                         AbstractSetManager &AbstractSetMgr) {
     DeclaredBoundsHelper Declared(SemaRef, Context, AbstractSetMgr);
     Declared.TraverseStmt(S);
   }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -953,11 +953,8 @@ namespace {
           auto It = BoundsContext.find(A);
           if (It == BoundsContext.end())
             continue;
-          const VarDecl *V = A->GetVarDecl();
-          if (!V)
-            continue;
-          OS << "Variable:\n";
-          V->dump(OS);
+          OS << "LValue Expression:\n";
+          A->GetRepresentative()->dump(OS, Context);
           OS << "Bounds:\n";
           It->second->dump(OS, Context);
         }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -6649,3 +6649,17 @@ BoundsExpr *Sema::ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B) {
   return CBD.ExpandToRange(const_cast<VarDecl *>(D),
                            const_cast<BoundsExpr *>(B));
 }
+
+// Returns the declared bounds for the lvalue expression E. Assignments
+// to E must satisfy these bounds. After checking a top-level statement,
+// the inferred bounds of E must imply these declared bounds.
+BoundsExpr *Sema::GetLValueDeclaredBounds(Expr *E) {
+  if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
+    if (const VarDecl *V = dyn_cast_or_null<VarDecl>(DRE->getDecl()))
+      return NormalizeBounds(V);
+  }
+
+  std::pair<ComparisonSet, ComparisonSet> EmptyFacts;
+  CheckBoundsDeclarations CBD(*this, EmptyFacts);
+  return CBD.GetLValueTargetBounds(E, CheckedScopeSpecifier::CSS_Unchecked);
+}

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3305,11 +3305,8 @@ namespace {
             // observed bounds to be InvalidBounds to avoid extraneous errors
             // during bounds declaration validation.
             if (LHSVar && RightBounds->isInvalid()) {
-              VarDecl *V = dyn_cast_or_null<VarDecl>(LHSVar->getDecl());
-              if (V) {
-                const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(V);
-                State.ObservedBounds[A] = RightBounds;
-              }
+              const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(LHSVar);
+              State.ObservedBounds[A] = RightBounds;
             }
 
             // Check bounds declarations for assignments to a non-variable.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3311,8 +3311,10 @@ namespace {
             // during bounds declaration validation.
             if (LHSVar && RightBounds->isInvalid()) {
               VarDecl *V = dyn_cast_or_null<VarDecl>(LHSVar->getDecl());
-              if (V)
-                State.ObservedBounds[V] = RightBounds;
+              if (V) {
+                const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(V);
+                State.ObservedBounds[A] = RightBounds;
+              }
             }
 
             // Check bounds declarations for assignments to a non-variable.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3962,24 +3962,24 @@ namespace {
                                         StateFalseArm.ObservedBounds,
                                         State.ObservedBounds);
 
-        // For any variable v whose bounds were updated in the false arm
-        // but not in the true arm, the bounds of v in the true arm should
+        // For any AbstractSet A whose bounds were updated in the false arm
+        // but not in the true arm, the bounds of A in the true arm should
         // be validated as well. These bounds may be invalid, e.g. if the
-        // bounds of v were updated in the condition `e1`.
+        // bounds of A were updated in the condition `e1`.
         for (const auto &Pair : FalseBounds) {
-          const VarDecl *V = Pair.first;
-          if (TrueBounds.find(V) == TrueBounds.end())
-            TrueBounds[V] = StateTrueArm.ObservedBounds[V];
+          const AbstractSet *A = Pair.first;
+          if (TrueBounds.find(A) == TrueBounds.end())
+            TrueBounds[A] = StateTrueArm.ObservedBounds[A];
         }
         StateTrueArm.ObservedBounds = TrueBounds;
 
-        // For any variable v whose bounds were updated in the true arm
-        // but not in the false arm, the bounds of v in the false arm should
+        // For any variable A whose bounds were updated in the true arm
+        // but not in the false arm, the bounds of A in the false arm should
         // be validated as well.
         for (const auto &Pair : TrueBounds) {
-          const VarDecl *V = Pair.first;
-          if (FalseBounds.find(V) == FalseBounds.end())
-            FalseBounds[V] = StateFalseArm.ObservedBounds[V];
+          const AbstractSet *A = Pair.first;
+          if (FalseBounds.find(A) == FalseBounds.end())
+            FalseBounds[A] = StateFalseArm.ObservedBounds[A];
         }
         StateFalseArm.ObservedBounds = FalseBounds;
 
@@ -3990,14 +3990,16 @@ namespace {
         // For each variable v whose bounds were updated in the true or false arm,
         // reset the observed bounds of v to the declared bounds of v.
         for (const auto &Pair : StateTrueArm.ObservedBounds) {
-          const VarDecl *V = Pair.first;
-          BoundsExpr *DeclaredBounds = S.NormalizeBounds(V);
-          State.ObservedBounds[V] = DeclaredBounds;
+          const AbstractSet *A = Pair.first;
+          BoundsExpr *DeclaredBounds =
+            S.GetLValueDeclaredBounds(A->GetRepresentative());
+          State.ObservedBounds[A] = DeclaredBounds;
         }
         for (const auto &Pair : StateFalseArm.ObservedBounds) {
-          const VarDecl *V = Pair.first;
-          BoundsExpr *DeclaredBounds = S.NormalizeBounds(V);
-          State.ObservedBounds[V] = DeclaredBounds;
+          const AbstractSet *A = Pair.first;
+          BoundsExpr *DeclaredBounds =
+            S.GetLValueDeclaredBounds(A->GetRepresentative());
+          State.ObservedBounds[A] = DeclaredBounds;
         }
       }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5983,9 +5983,12 @@ namespace {
           // This also accounts for variables that have widened bounds.
           if (DeclRefExpr *V = GetRValueVariable(E)) {
             if (const VarDecl *D = dyn_cast_or_null<VarDecl>(V->getDecl())) {
-              auto It = State.ObservedBounds.find(D);
-              if (It != State.ObservedBounds.end())
-                return It->second;
+              if (D->hasBoundsExpr()) {
+                const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(V);
+                auto It = State.ObservedBounds.find(A);
+                if (It != State.ObservedBounds.end())
+                  return It->second;
+              }
             }
           }
           // If an lvalue to rvalue cast e is not the value of a variable
@@ -6000,9 +6003,12 @@ namespace {
           // widened bounds.
           if (DeclRefExpr *V = GetRValueVariable(E)) {
             if (const VarDecl *D = dyn_cast_or_null<VarDecl>(V->getDecl())) {
-              auto It = State.ObservedBounds.find(D);
-              if (It != State.ObservedBounds.end())
-                return It->second;
+              if (D->hasBoundsExpr()) {
+                const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(V);
+                auto It = State.ObservedBounds.find(A);
+                if (It != State.ObservedBounds.end())
+                  return It->second;
+              }
             }
           }
           // If an array to pointer cast e is not the value of a variable

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3791,6 +3791,8 @@ namespace {
 
       Expr *Init = D->getInit();
       BoundsExpr *InitBounds = nullptr;
+      const AbstractSet *A = nullptr;
+
       // If there is an initializer, check it, and update the state to record
       // expression equality implied by initialization. After checking Init,
       // State.SameValue will contain non-modifying expressions that produce
@@ -3801,6 +3803,7 @@ namespace {
         // Create an rvalue expression for v. v could be an array or
         // non-array variable.
         DeclRefExpr *TargetDeclRef = ExprCreatorUtil::CreateVarUse(S, D);
+        A = AbstractSetMgr.GetOrCreateAbstractSet(TargetDeclRef);
         CastKind Kind;
         QualType TargetTy;
         if (D->getType()->isArrayType()) {
@@ -3844,7 +3847,7 @@ namespace {
       if (Init && D->getType()->isScalarType()) {
         assert(D->getInitStyle() == VarDecl::InitializationStyle::CInit);
         InitBounds = S.CheckNonModifyingBounds(InitBounds, Init);
-        State.ObservedBounds[D] = InitBounds;
+        State.ObservedBounds[A] = InitBounds;
         if (InitBounds->isUnknown()) {
           if (CheckBounds)
             // TODO: need some place to record the initializer bounds

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -781,6 +781,12 @@ namespace {
           return true;
         if (!D->hasBoundsExpr())
           return true;
+        // Parameters declared within a statement (e.g. in a function pointer
+        // declaration) should not be added to the bounds context. Parameters
+        // to the current function will be added to the bounds context in
+        // TraverseCFG.
+        if (isa<ParmVarDecl>(D))
+          return true;
         // The bounds expressions in the bounds context should be normalized
         // to range bounds.
         if (BoundsExpr *Bounds = SemaRef.NormalizeBounds(D)) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2719,8 +2719,10 @@ namespace {
        ParmVarDecl *Param = *I;
        if (!Param->hasBoundsExpr())
          continue;
-       if (BoundsExpr *Bounds = S.NormalizeBounds(Param))
-         ParamsState.ObservedBounds[Param] = Bounds;
+       if (BoundsExpr *Bounds = S.NormalizeBounds(Param)) {
+         const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(Param);
+         ParamsState.ObservedBounds[A] = Bounds;
+       }
      }
 
      // Store a checking state for each CFG block in order to track

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -924,28 +924,28 @@ namespace {
         OS << "{ }\n";
       else {
         // The keys in an llvm::DenseMap are unordered.  Create a set of
-        // variable declarations in the context ordered first by name,
-        // then by location in order to guarantee a deterministic output
-        // so that printing the bounds context can be tested.
-        std::vector<const VarDecl *> OrderedDecls;
+        // abstract sets in the context sorted lexicographically in order
+        // to guarantee a deterministic output so that printing the bounds
+        // context can be tested.
+        std::vector<const AbstractSet *> OrderedSets;
         for (auto const &Pair : BoundsContext)
-          OrderedDecls.push_back(Pair.first);
-        llvm::sort(OrderedDecls.begin(), OrderedDecls.end(),
-             [] (const VarDecl *A, const VarDecl *B) {
-               if (A->getNameAsString() == B->getNameAsString())
-                 return A->getLocation() < B->getLocation();
-               else
-                 return A->getNameAsString() < B->getNameAsString();
+          OrderedSets.push_back(Pair.first);
+        llvm::sort(OrderedSets.begin(), OrderedSets.end(),
+             [] (const AbstractSet *A, const AbstractSet *B) {
+               return *A < *B;
              });
 
         OS << "{\n";
-        for (auto I = OrderedDecls.begin(); I != OrderedDecls.end(); ++I) {
-          const VarDecl *Variable = *I;
-          auto It = BoundsContext.find(Variable);
+        for (auto I = OrderedSets.begin(); I != OrderedSets.end(); ++I) {
+          const AbstractSet *A = *I;
+          auto It = BoundsContext.find(A);
           if (It == BoundsContext.end())
             continue;
+          const VarDecl *V = A->GetVarDecl();
+          if (!V)
+            continue;
           OS << "Variable:\n";
-          Variable->dump(OS);
+          V->dump(OS);
           OS << "Bounds:\n";
           It->second->dump(OS, Context);
         }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2806,14 +2806,14 @@ namespace {
             if (DumpState)
               DumpCheckingState(llvm::outs(), S, BlockState);
 
-            // For each variable v in ObservedBounds, check that the
-            // observed bounds of v imply the declared bounds of v.
+            // For each AbstractSet A in ObservedBounds, check that the
+            // observed bounds of A imply the declared bounds of A.
             ValidateBoundsContext(S, BlockState, CSS, Block);
 
             // The observed bounds that were updated after checking S should
             // only be used to check that the updated observed bounds imply
             // the declared variable bounds.  After checking the observed and
-            // declared bounds, the observed bounds for each variable should
+            // declared bounds, the observed bounds for each AbstractSet should
             // be reset to their observed bounds from before checking S.
             BlockState.ObservedBounds = InitialObservedBounds;
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -59,7 +59,7 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 
-  // Observed bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(b, b + size) }
+  // Observed bounds context: { a => bounds(a, a + 5), b => bounds(b, b + size), arr => bounds(arr, arr + len) }
   int b checked[] : count(size) = (int checked[]){ 0 };
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -86,20 +86,6 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 5
   // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} b
   // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -113,6 +99,20 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} arr
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 }
 
@@ -690,7 +690,7 @@ void assign7(
 // Scalar-typed variable declarations (array_ptr, nt_array_ptr) set the observed bounds to the initializer bounds
 void source_bounds1(array_ptr<int> a: count(1)) {
   // Initializer bounds for a: bounds(a, a + 1)
-  // Observed bounds context after declaration:  { a => bounds(a, a + 1), arr => bounds(a, a + 1) }
+  // Observed bounds context after declaration:  { arr => bounds(a, a + 1), a => bounds(a, a + 1) }
   array_ptr<int> arr : count(0) = a;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -701,18 +701,6 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} arr
   // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
@@ -725,21 +713,6 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: }
-
-  // Initializer bounds for "abc": bounds(temp("abc"), temp("abc") + 3)
-  // Observed bounds context after declaration:  { a => bounds(a, a + 1), arr => bounds(arr, arr + 0), buf => bounds(temp("abc"), temp("abc") + 3) }
-  nt_array_ptr<char> buf : count(2) = "abc";
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT:   VarDecl {{.*}} buf
-  // CHECK-NEXT:     CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
-  // CHECK-NEXT:       CHKCBindTemporaryExpr {{.*}} 'char [4]'
-  // CHECK-NEXT:         StringLiteral {{.*}} "abc"
-  // CHECK-NEXT: Observed bounds context after checking S:
-  // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: ParmVarDecl {{.*}} a
   // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
@@ -752,6 +725,21 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: }
+
+  // Initializer bounds for "abc": bounds(temp("abc"), temp("abc") + 3)
+  // Observed bounds context after declaration:  { arr => bounds(arr, arr + 0), buf => bounds(temp("abc"), temp("abc") + 3), a => bounds(a, a + 1) }
+  nt_array_ptr<char> buf : count(2) = "abc";
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} buf
+  // CHECK-NEXT:     CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
+  // CHECK-NEXT:       CHKCBindTemporaryExpr {{.*}} 'char [4]'
+  // CHECK-NEXT:         StringLiteral {{.*}} "abc"
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} arr
   // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
@@ -776,22 +764,6 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       BoundsValueExpr {{.*}} 'char [4]'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: }
-
-  // Initializer bounds for getArr(): bounds(temp(getArr()), temp(getArr()) + 4)
-  // Observed bounds context after declaration:  { a => bounds(a, a + 1), arr => bounds(arr, arr + 0), buf => bounds(buf, buf + 2), c => bounds(temp(getArr()), temp(getArr()) + 4) }
-  array_ptr<int> c : count(3) = getArr();
-  // CHECK: Statement S:
-  // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT:   VarDecl {{.*}} c
-  // CHECK-NEXT:     CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 3
-  // CHECK-NEXT:     CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT:       CallExpr {{.*}} '_Array_ptr<int>'
-  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
-  // CHECK-NEXT:           DeclRefExpr {{.*}} 'getArr'
-  // CHECK-NEXT: Observed bounds context after checking S:
-  // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: ParmVarDecl {{.*}} a
   // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
@@ -804,6 +776,22 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: }
+
+  // Initializer bounds for getArr(): bounds(temp(getArr()), temp(getArr()) + 4)
+  // Observed bounds context after declaration:  { arr => bounds(arr, arr + 0), buf => bounds(buf, buf + 2), c => bounds(temp(getArr()), temp(getArr()) + 4), a => bounds(a, a + 1) }
+  array_ptr<int> c : count(3) = getArr();
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} c
+  // CHECK-NEXT:     CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 3
+  // CHECK-NEXT:     CHKCBindTemporaryExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:       CallExpr {{.*}} '_Array_ptr<int>'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <FunctionToPointerDecay>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'getArr'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: VarDecl {{.*}} arr
   // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
@@ -838,6 +826,18 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} a
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 }
 
@@ -914,9 +914,9 @@ void source_bounds2(void) {
 // Assignments to variables set the observed bounds to the source bounds
 // where the LHS variable does not appear on the RHS of the assignment
 void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : count(1)) {
-  // Observed bounds context before assignment: { large => bounds(large, large + 1), small => bounds(small, small + 0) }
+  // Observed bounds context before assignment: { small => bounds(small, small + 0), large => bounds(large, large + 1) }
   // Source bounds for large: bounds(large, large + 1)
-  // Observed bounds context after assignment:  { large => bounds(large, large + 1), small => bounds(large, large + 1) }
+  // Observed bounds context after assignment:  { small => bounds(large, large + 1), large => bounds(large, large + 1) }
   small = large;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -925,6 +925,18 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} small
+  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:    IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: ParmVarDecl {{.*}} large
   // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
@@ -937,23 +949,11 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 
-  // Observed bounds context before assignment: { large => bounds(large, large + 1), small => bounds(small, small + 0) }
+  // Observed bounds context before assignment: { small => bounds(small, small + 0), large => bounds(large, large + 1),  }
   // Source bounds for NullToPointer(0): bounds(any)
-  // Observed bounds context after assignment:  { large = bounds(any), small => bounds(small, small + 0) }
+  // Observed bounds context after assignment:  { small => bounds(small, small + 0), large = bounds(any) }
   large = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -962,12 +962,6 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: Variable:
   // CHECK-NEXT: ParmVarDecl {{.*}} small
   // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
@@ -980,6 +974,12 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'small'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Variable:
+  // CHECK-NEXT: ParmVarDecl {{.*}} large
+  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 }
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -31,10 +31,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -43,11 +41,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -73,10 +68,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -85,11 +78,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -99,11 +89,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -132,11 +119,8 @@ void declared2(int flag, int x, int y) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -163,11 +147,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:           IntegerLiteral {{.*}} 0
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -177,11 +158,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -207,11 +185,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:           IntegerLiteral {{.*}} 0
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -221,11 +196,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -235,11 +207,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} b
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'b' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -266,11 +235,8 @@ void declared2(int flag, int x, int y) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -280,11 +246,8 @@ void declared2(int flag, int x, int y) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} c
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -317,10 +280,8 @@ void assign1(array_ptr<int> arr : count(1)) { // expected-note {{(expanded) decl
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -359,14 +320,8 @@ void assign2(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
-  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -382,11 +337,8 @@ void assign2(
   // CHECK-NEXT:           IntegerLiteral {{.*}} 3
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
   // CHECK-NEXT:         IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<char>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -413,15 +365,12 @@ void assign3(array_ptr<int> a : bounds(unknown), nt_array_ptr<char> b : count(1)
   // CHECK-NEXT:   IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   NullaryBoundsExpr {{.*}} Unknown
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<char>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -448,11 +397,8 @@ void assign4(array_ptr<int> a : count(len), unsigned len) { // expected-note {{(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -482,11 +428,8 @@ void assign5(array_ptr<int> a : count(len), int len, int size) { // expected-not
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -512,11 +455,8 @@ void assign5(array_ptr<int> a : count(len), int len, int size) { // expected-not
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -546,11 +486,8 @@ void assign6(array_ptr<int> a : count(len), int len) { // expected-note {{(expan
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -578,37 +515,16 @@ void assign7(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -629,15 +545,8 @@ void assign7(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -646,15 +555,8 @@ void assign7(
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -663,15 +565,8 @@ void assign7(
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -701,10 +596,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -713,10 +606,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -740,10 +631,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:         StringLiteral {{.*}} "abc"
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -752,10 +641,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} buf
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'buf' '_Nt_array_ptr<char>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -764,10 +651,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       BoundsValueExpr {{.*}} 'char [4]'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -792,10 +677,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:           DeclRefExpr {{.*}} 'getArr'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -804,10 +687,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} buf
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'buf' '_Nt_array_ptr<char>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -816,20 +697,16 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'buf'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} c
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -859,10 +736,8 @@ void source_bounds2(void) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' 'int _Checked[3]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -884,10 +759,8 @@ void source_bounds2(void) {
   // CHECK-NEXT:     StringLiteral {{.*}} "abcde"
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' 'int _Checked[3]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -896,10 +769,8 @@ void source_bounds2(void) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} buf
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'buf' 'char _Nt_checked[6]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -925,10 +796,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -937,10 +806,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -962,10 +829,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -974,10 +839,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'small'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
@@ -1001,10 +864,8 @@ void source_bounds4(array_ptr<int> arr : count(1)) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   CStyleCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
@@ -1030,10 +891,8 @@ void source_bounds4(array_ptr<int> arr : count(1)) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   CStyleCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
@@ -1061,10 +920,8 @@ void source_bounds4(array_ptr<int> arr : count(1)) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 4
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
@@ -1090,9 +947,9 @@ void source_bounds5(array_ptr<int> arr_array_literal : count(2)) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr_array_literal
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr_array_literal' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:     BoundsValueExpr {{.*}} 'int _Checked[2]' lvalue
@@ -1125,9 +982,9 @@ void source_bounds6() {
   // CHECK-NEXT:             IntegerLiteral {{.*}} 'int' 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr_struct_literal
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr_struct_literal' '_Array_ptr<struct a>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   UnaryOperator {{.*}} prefix '&'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} 'struct a':'struct a' lvalue
@@ -1162,11 +1019,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1176,11 +1030,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1209,11 +1060,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1227,11 +1075,8 @@ void multiple_assign1(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1262,11 +1107,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
@@ -1280,11 +1122,8 @@ void multiple_assign1(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1316,18 +1155,12 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1367,11 +1200,8 @@ void multiple_assign2(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1383,16 +1213,8 @@ void multiple_assign2(
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1428,23 +1250,12 @@ void multiple_assign2(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1470,23 +1281,12 @@ void multiple_assign2(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1528,16 +1328,12 @@ void multiple_assign3(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1562,11 +1358,8 @@ void multiple_assign4(array_ptr<int> a : count(len), int len) { // expected-note
   // CHECK-NEXT:   IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1590,11 +1383,8 @@ void multiple_assign4(array_ptr<int> a : count(len), int len) { // expected-note
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1628,10 +1418,8 @@ void nested_assign1(nt_array_ptr<int> a : count(1), nt_array_ptr<const int> b : 
   // CHECK-NEXT:             DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1640,10 +1428,8 @@ void nested_assign1(nt_array_ptr<int> a : count(1), nt_array_ptr<const int> b : 
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<const int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1652,10 +1438,8 @@ void nested_assign1(nt_array_ptr<int> a : count(1), nt_array_ptr<const int> b : 
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Nt_array_ptr<volatile int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1687,10 +1471,8 @@ void nested_assign2(
   // CHECK-NEXT:             DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1703,10 +1485,8 @@ void nested_assign2(
   // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1742,20 +1522,16 @@ void nested_assign3(array_ptr<int> b : count(2)) {
   // CHECK-NEXT:               DeclRefExpr {{.*}} 'getArr'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
@@ -1787,10 +1563,8 @@ void nested_assign4(array_ptr<int> a : count(2), array_ptr<int> b : count(3)) {
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1799,10 +1573,8 @@ void nested_assign4(array_ptr<int> a : count(2), array_ptr<int> b : count(3)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1841,15 +1613,8 @@ void update_result_bounds1(
   // CHECK-NEXT:         IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1862,10 +1627,8 @@ void update_result_bounds1(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1901,15 +1664,8 @@ void update_result_bounds2(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1922,10 +1678,8 @@ void update_result_bounds2(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1959,15 +1713,8 @@ void update_result_bounds3(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1980,10 +1727,8 @@ void update_result_bounds3(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2014,10 +1759,8 @@ void inc_dec_bounds1(nt_array_ptr<char> a) { // expected-note {{(expanded) decla
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<char>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2046,13 +1789,8 @@ void inc_dec_bounds2(nt_array_ptr<int> a : bounds(a, a)) { // expected-note {{(e
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2077,10 +1815,8 @@ void inc_dec_bounds3(array_ptr<float> a : count(2)) { // expected-note {{(expand
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<float>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
@@ -2109,13 +1845,8 @@ void inc_dec_bounds4(array_ptr<int> a : bounds(a, a)) { // expected-note {{(expa
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr {{.*}}
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
@@ -2198,11 +1929,8 @@ void killed_widened_bounds1(
     // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2222,11 +1950,8 @@ void killed_widened_bounds1(
     // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2252,11 +1977,8 @@ void killed_widened_bounds1(
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'other'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
     // CHECK-NEXT: }
@@ -2274,10 +1996,8 @@ void killed_widened_bounds2(nt_array_ptr<char> p : count(0), int other) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
     // CHECK:      Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2309,10 +2029,8 @@ void killed_widened_bounds2(nt_array_ptr<char> p : count(0), int other) {
     // CHECK-NEXT:     IntegerLiteral {{.*}} 1
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2341,10 +2059,8 @@ void killed_widened_bounds2(nt_array_ptr<char> p : count(0), int other) {
     // CHECK-NEXT:     IntegerLiteral {{.*}} 0
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
@@ -2367,11 +2083,8 @@ void killed_widened_bounds3(
     // CHECK:            DeclRefExpr {{.*}} 'i'
     // CHECK: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2381,10 +2094,8 @@ void killed_widened_bounds3(
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} q
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2406,11 +2117,8 @@ void killed_widened_bounds3(
       // CHECK:          IntegerLiteral {{.*}} 1
       // CHECK: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2422,10 +2130,8 @@ void killed_widened_bounds3(
       // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
       // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2444,11 +2150,8 @@ void killed_widened_bounds3(
       // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
       // CHECK-NEXT: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2460,10 +2163,8 @@ void killed_widened_bounds3(
       // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
       // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2491,17 +2192,12 @@ void killed_widened_bounds3(
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
       // CHECK: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2542,9 +2238,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2552,9 +2248,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2591,13 +2287,13 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 
@@ -2621,9 +2317,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2631,9 +2327,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2659,9 +2355,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2669,9 +2365,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2703,9 +2399,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2713,9 +2409,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2723,9 +2419,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
@@ -2733,9 +2429,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} d
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'd' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
@@ -2769,9 +2465,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2779,9 +2475,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2789,9 +2485,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
@@ -2799,9 +2495,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} d
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'd' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
@@ -2834,9 +2530,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2844,9 +2540,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2854,9 +2550,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
@@ -2864,9 +2560,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} d
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'd' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
@@ -2895,9 +2591,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK:      Bounds:
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+    // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
@@ -2910,9 +2606,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
     // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
     // CHECK-NEXT:         IntegerLiteral {{.*}} 'unsigned int' 1
     // CHECK-NEXT:       IntegerLiteral {{.*}} 'int' 1
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} q
-    // CHECK:      Bounds:
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<char>'
+    // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
@@ -2945,9 +2641,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
       // CHECK-NEXT: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK:      Bounds:
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+      // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
@@ -2956,9 +2652,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
       // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
       // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK:      Bounds:
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<char>'
+      // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
@@ -3001,9 +2697,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'medium'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
@@ -3011,9 +2707,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} medium
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'medium' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'medium'
@@ -3021,9 +2717,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'medium'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'small'
@@ -3051,9 +2747,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:         IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
@@ -3061,9 +2757,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} medium
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'medium' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'medium'
@@ -3071,9 +2767,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'medium'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'small'


### PR DESCRIPTION
This PR uses AbstractSets rather than VarDecls as keys in the ObservedBounds map. Variables are still the only lvalue expressions to be included in the ObservedBounds map, but this change will enable other kinds of lvalue expressions (e.g. MemberExprs) to be included in ObservedBounds in the future.