### PR TITLE
Fix for CompareDecl for strict weak ordering

### DIFF
--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -249,7 +249,7 @@ Lexicographic::CompareDecl(const NamedDecl *D1Arg, const NamedDecl *D2Arg) const
   Current = D2->getNextDeclInContext();
   while (Current != nullptr) {
     if (Current == D1)
-      return Result::LessThan;
+      return Result::GreaterThan;
     Current = Current->getNextDeclInContext();
   }
   llvm_unreachable("unable to order declarations in same context");


### PR DESCRIPTION
When a `Decl D1` occurs before `D2`, `CompareDecl` returns `Result::LessThan`. If `D1` occurs after `D2`, `CompareDecl` should return `Result::GreaterThan`. This helps ensure strict weak ordering on `Decls` so that, if `D1 < D2`, `D2 > D1`.