### PR TITLE
Add a map from a VarDecl to its first use

### DIFF
--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -75,6 +75,12 @@ namespace clang {
   private:
     Sema &S;
 
+    // VarUses maps a VarDecl with a bounds expression to the DeclRefExpr
+    // (if any) that is the first use of the VarDecl.  If a VarDecl V has
+    // an entry in VarUses, the DeclRefExpr for V is used to get or create
+    // the AbstractSet for V.
+    Sema::VarDeclUsage &VarUses;
+
     // Maintain a sorted set of PreorderASTs that have been created while
     // traversing a function. A binary search in this set is used to determine
     // whether an lvalue expression belongs to an existing AbstractSet (an
@@ -92,7 +98,8 @@ namespace clang {
     llvm::DenseMap<PreorderAST *, const AbstractSet *> PreorderASTAbstractSetMap;
 
   public:
-    AbstractSetManager(Sema &S) : S(S) {}
+    AbstractSetManager(Sema &S, Sema::VarDeclUsage &VarUses) :
+      S(S), VarUses(VarUses) {}
 
     // Returns the AbstractSet that contains the lvalue expression E. If
     // there is an AbstractSet A in SortedAbstractSets that contains E,

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -78,7 +78,10 @@ namespace clang {
     // VarUses maps a VarDecl with a bounds expression to the DeclRefExpr
     // (if any) that is the first use of the VarDecl. If a VarDecl V has
     // an entry in VarUses, the DeclRefExpr for V is used to get or create
-    // the AbstractSet for V.
+    // the AbstractSet for V. Otherwise, a use of V is constructed and
+    // added to VarUses. This created use of V is currently not released.
+    // It should be rare that a use of V needs to be created, since this
+    // should only occur if V is unused within the body of a function.
     // In order to get or create the AbstractSet for V, any use of V would
     // be sufficient. We choose the first use of V.
     Sema::VarDeclUsage &VarUses;

--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -76,9 +76,11 @@ namespace clang {
     Sema &S;
 
     // VarUses maps a VarDecl with a bounds expression to the DeclRefExpr
-    // (if any) that is the first use of the VarDecl.  If a VarDecl V has
+    // (if any) that is the first use of the VarDecl. If a VarDecl V has
     // an entry in VarUses, the DeclRefExpr for V is used to get or create
     // the AbstractSet for V.
+    // In order to get or create the AbstractSet for V, any use of V would
+    // be sufficient. We choose the first use of V.
     Sema::VarDeclUsage &VarUses;
 
     // Maintain a sorted set of PreorderASTs that have been created while

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5819,7 +5819,7 @@ public:
   };
 
   // Map a VarDecl to its first use.
-  typedef llvm::DenseMap<const VarDecl *, DeclRefExpr *> VarDeclUsage;
+  using VarDeclUsage = llvm::DenseMap<const VarDecl *, DeclRefExpr *>;
 
   /// \brief Compute a mapping from statements that modify lvalues to
   /// in-scope bounds declarations that depend on those lvalues.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5826,6 +5826,9 @@ public:
   /// FD is the function being declared and Body is the body of the
   /// function.   They are passed in separately because Body hasn't
   /// been attached to FD yet.
+  /// ComputeBoundsDependencies also computes a mapping from VarDecls with
+  /// bounds expressions to the DeclRefExpr (if any) that is the first use
+  /// of the VarDecl.
   void ComputeBoundsDependencies(ModifiedBoundsDependencies &Tracker,
                                  VarDeclUsage &VarUses,
                                  FunctionDecl *FD, Stmt *Body);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5818,12 +5818,16 @@ public:
    DependentBounds Tracker;
   };
 
+  // Map a VarDecl to its first use.
+  typedef llvm::DenseMap<const VarDecl *, DeclRefExpr *> VarDeclUsage;
+
   /// \brief Compute a mapping from statements that modify lvalues to
   /// in-scope bounds declarations that depend on those lvalues.
   /// FD is the function being declared and Body is the body of the
   /// function.   They are passed in separately because Body hasn't
   /// been attached to FD yet.
   void ComputeBoundsDependencies(ModifiedBoundsDependencies &Tracker,
+                                 VarDeclUsage &VarUses,
                                  FunctionDecl *FD, Stmt *Body);
 
   /// \brief RAII class used to indicate that we are substituting an expression

--- a/clang/lib/AST/AbstractSet.cpp
+++ b/clang/lib/AST/AbstractSet.cpp
@@ -34,7 +34,7 @@ const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(Expr *E) {
 const AbstractSet *AbstractSetManager::GetOrCreateAbstractSet(const VarDecl *V) {
   // Compute the DeclRefExpr that is a use of V. This DeclRefExpr is needed
   // in order to get or create the AbstractSet that contains V.
-  // The VarUses map not contain a key for V if V is never used in the
+  // The VarUses map does not contain a key for V if V is never used in the
   // body of a function. However, we still need to create an AbstractSet
   // for V so that its bounds can be checked. For example, consider:
   // void f(_Array_ptr<int> unused : count(i), unsigned i) {


### PR DESCRIPTION
The AbstractSetManager method GetOrCreateAbstractSet for a VarDecl needs to compute a DeclRefExpr that is a use of the VarDecl. This DeclRefExpr is used to create a canonical form to search for an existing AbstractSet and, if necessary, is used as the representative expression when creating a new AbstractSet.

In order to avoid creating a new DeclRefExpr each time GetOrCreateAbstractSet(VarDecl *V) is called, we introduce a map called `VarUses` from a `VarDecl *` to the `DeclRefExpr *` (if any) that is the first use of the `VarDecl *` within a function body. This can help reduce the need to create a new DeclRefExpr in GetOrCreateAbstractSet.

Certain VarDecls may not have a DeclRefExpr use within a function. In that case, GetOrCreateAbstractSet will create a new DeclRefExpr and modify its VarUses member. This can occur for variable declarations with declared bounds that are not referenced within a function, but we still need to create AbstractSets for these variable declarations in order to store them in the ObservedBounds map.