### PR TITLE
Class and type definitions for the dataflow analysis for bounds widening [1/n]

### DIFF
--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -39,9 +39,9 @@ namespace clang {
   using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>; 
 
   // The BoundsWideningAnalysis class represents the dataflow analysis for
-  // bounds widening. The sets Gen, Kill, In and Out that are used in the
-  // dataflow analysis are members of this class. The class also has methods
-  // that act on these sets to perform the dataflow analysis.
+  // bounds widening. The sets In, Out, Gen and Kill that are used by the
+  // analysis are members of this class. The class also has methods that act on
+  // these sets to perform the dataflow analysis.
   class BoundsWideningAnalysis {
   private:
     Sema &S;

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -1,0 +1,79 @@
+//===== BoundsWideningAnalysis.h - Dataflow analysis for bounds widening ====//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//  This file defines the interface for a dataflow analysis for bounds
+//  widening.
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_BOUNDS_WIDENING_ANALYSIS_H
+#define LLVM_CLANG_BOUNDS_WIDENING_ANALYSIS_H
+
+#include "clang/AST/CanonBounds.h"
+#include "clang/Analysis/Analyses/PostOrderCFGView.h"
+#include "clang/Sema/Sema.h"
+
+namespace clang {
+  // BoundsMapTy maps a null-terminated array variable to its bounds
+  // expression.
+  using BoundsMapTy = llvm::DenseMap<const VarDecl *, BoundsExpr *>;
+
+  // StmtBoundsMapTy maps each null-terminated array variable that occurs in a
+  // statement to its bounds expression.
+  using StmtBoundsMapTy = llvm::DenseMap<const Stmt *, BoundsMapTy>;
+
+  // VarSetTy denotes a set of variables.
+  using VarSetTy = llvm::DenseSet<const VarDecl *>;
+
+  // StmtVarSetTy denotes the set of null-terminated array variables whose
+  // bounds are killed by a statement.
+  using StmtVarSetTy = llvm::DenseMap<const Stmt *, VarSetTy>;
+
+  // BoundsVarsTy maps a variable Z to the set of all null-terminated array
+  // variables in whose bounds expressions Z occurs.
+  using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>; 
+
+  // The BoundsWideningAnalysis class represents the dataflow analysis for
+  // bounds widening. The sets Gen, Kill, In and Out that are used in the
+  // dataflow analysis are members of this class. The class also has methods
+  // that act on these sets to perform the dataflow analysis.
+  class BoundsWideningAnalysis {
+  private:
+    Sema &S;
+    CFG *Cfg;
+    ASTContext &Ctx;
+    Lexicographic Lex;
+    llvm::raw_ostream &OS;
+
+    class ElevatedCFGBlock {
+    public:
+      const CFGBlock *Block;
+      // The In and Out sets for a block.
+      BoundsMapTy In, Out;
+      // The Gen set for each statement in a block.
+      StmtBoundsMapTy Gen;
+      // The Kill set for each statement in a block.
+      StmtVarSetTy Kill;
+
+      ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
+    };
+  
+  public:
+    BoundsWideningAnalysis(Sema &S, CFG *Cfg) :
+      S(S), Cfg(Cfg), Ctx(S.Context),
+      Lex(Lexicographic(Ctx, nullptr)),
+      OS(llvm::outs()) {}
+
+    // A mapping of a variable Z to the set of all null-terminated array
+    // variables in whose bounds expressions Z occurs. We maintain this map
+    // only for variables that are mapped to non-empty sets.
+    BoundsVarsTy BoundsVars;
+  };
+
+} // end namespace clang
+#endif

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -30,8 +30,9 @@ namespace clang {
   // VarSetTy denotes a set of variables.
   using VarSetTy = llvm::DenseSet<const VarDecl *>;
 
-  // StmtVarSetTy denotes the set of null-terminated array variables whose
-  // bounds are killed by a statement.
+  // StmtVarSetTy denotes a set of null-terminated array variables that are
+  // associated with a statement. The set of variables whose bounds are killed
+  // by a statement has the type StmtVarSetTy.
   using StmtVarSetTy = llvm::DenseMap<const Stmt *, VarSetTy>;
 
   // BoundsVarsTy maps a variable Z to the set of all null-terminated array

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -1,0 +1,16 @@
+//===== BoundsWideningAnalysis.h - Dataflow analysis for bounds widening ====//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//  This file implements a dataflow analysis for bounds widening.
+//===---------------------------------------------------------------------===//
+
+#include "clang/Sema/BoundsWideningAnalysis.h"
+
+namespace clang {
+} // end namespace clang

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -7,7 +7,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===---------------------------------------------------------------------===//
-//  This file implements a dataflow analysis for bounds widening.
+// This file implements a dataflow analysis for bounds widening as described in
+// https://github.com/microsoft/checkedc-clang/blob/master/clang/docs/checkedc/Bounds-Widening-for-Null-Terminated-Arrays.md
 //===---------------------------------------------------------------------===//
 
 #include "clang/Sema/BoundsWideningAnalysis.h"

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -24,6 +24,7 @@ add_clang_library(clangSema
   AnalysisBasedWarnings.cpp
   AvailableFactsAnalysis.cpp
   BoundsAnalysis.cpp
+  BoundsWideningAnalysis.cpp
   CheckedCAlias.cpp
   CheckedCInterop.cpp
   CheckedCSubst.cpp


### PR DESCRIPTION
This PR adds the interface for the dataflow analysis for bounds widening of
null-terminated arrays, in presence of where clauses. We declare types, classes
and functions used by the analysis.

We declare the `BoundsWideningAnalysis` class that represents the dataflow
analysis for bounds widening. The sets `In`, `Out`, `Gen` and `Kill` that are used by
the analysis are members of this class. The class also has methods that act on
these sets to perform the dataflow analysis.