### PR TITLE
[LValue Generalization] Canonicalize MemberExprs [6/n]

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -51,8 +51,10 @@ namespace clang {
   class BinaryOperatorNode : public Node {
   public:
     BinaryOperator::Opcode Opc;
-    // Note: A BinaryOperatorNode has a list of children because the preorder
-    // AST is an n-ary tree.
+    // A BinaryOperatorNode representing a commutative and associative binary
+    // operation may have more than two children because of coalescing.
+    // Ex: a + (b + c) will be represented by one BinaryOperatorNode for +
+    // with three children nodes for a, b and c after coalescing.
     llvm::SmallVector<Node *, 2> Children;
 
     BinaryOperatorNode(BinaryOperator::Opcode Opc, Node *Parent) :
@@ -142,7 +144,7 @@ namespace clang {
     void Create(Expr *E, Node *Parent = nullptr);
 
     // Create a BinaryOperatorNode with an addition operator and two children
-    // (E and 0), and add the created BinaryOperatorNode to the Parent node.
+    // (E and 0), and attach the created BinaryOperatorNode to the Parent node.
     // @param[in] E is the expression that is one of the two children of
     // the created BinaryOperatorNode (the other child is 0).
     // @param[in] Parent is the parent of the created BinaryOperatorNode.
@@ -171,7 +173,8 @@ namespace clang {
     // to control when to stop recursive coalescing.
     void Coalesce(Node *N, bool &Changed);
 
-    // Sort the children expressions in a non-leaf Node of the AST.
+    // Recursively descend the PreorderAST to sort the children of all
+    // BinaryOperatorNodes if the binary operator is commutative.
     // @param[in] N is current node of the AST. Initial value is Root.
     void Sort(Node *N);
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -32,6 +32,7 @@ namespace clang {
     enum class NodeKind {
       OperatorNode,
       UnaryOperatorNode,
+      MemberNode,
       ImplicitCastNode,
       LeafExprNode
     };
@@ -75,6 +76,21 @@ namespace clang {
 
     static bool classof(const Node *N) {
       return N->Kind == NodeKind::UnaryOperatorNode;
+    }
+  };
+
+  class MemberNode : public Node {
+  public:
+    Node *Base = nullptr;
+    ValueDecl *Field = nullptr;
+    bool IsArrow;
+
+    MemberNode(ValueDecl *Field, bool IsArrow, Node *Parent) :
+      Node(NodeKind::MemberNode, Parent),
+      Field(Field), IsArrow(IsArrow) {}
+
+    static bool classof(const Node *N) {
+      return N->Kind == NodeKind::MemberNode;
     }
   };
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -23,14 +23,13 @@
 
 namespace clang {
   using Result = Lexicographic::Result;
-  class OperatorNode;
 
   class Node {
   public:
     // Nodes with two different kinds are sorted according to the order in
     // which their kinds appear in this enum.
     enum class NodeKind {
-      OperatorNode,
+      BinaryOperatorNode,
       UnaryOperatorNode,
       MemberNode,
       ImplicitCastNode,
@@ -44,19 +43,19 @@ namespace clang {
       Kind(Kind), Parent(Parent) {}
   };
 
-  class OperatorNode : public Node {
+  class BinaryOperatorNode : public Node {
   public:
     BinaryOperator::Opcode Opc;
-    // Note: An OperatorNode has a list of children because the preorder AST is
-    // an n-ary tree.
+    // Note: A BinaryOperatorNode has a list of children because the preorder
+    // AST is an n-ary tree.
     llvm::SmallVector<Node *, 2> Children;
 
-    OperatorNode(BinaryOperator::Opcode Opc, Node *Parent) :
-      Node(NodeKind::OperatorNode, Parent),
+    BinaryOperatorNode(BinaryOperator::Opcode Opc, Node *Parent) :
+      Node(NodeKind::BinaryOperatorNode, Parent),
       Opc(Opc) {}
 
     static bool classof(const Node *N) {
-      return N->Kind == NodeKind::OperatorNode;
+      return N->Kind == NodeKind::BinaryOperatorNode;
     }
 
     // Is the operator commutative and associative?
@@ -137,11 +136,11 @@ namespace clang {
     // @param[in] Parent is the parent of the new node.
     void Create(Expr *E, Node *Parent = nullptr);
 
-    // Create an OperatorNode with an addition operator and two children
-    // (E and 0), and add the created OperatorNode to the Parent node.
+    // Create a BinaryOperatorNode with an addition operator and two children
+    // (E and 0), and add the created BinaryOperatorNode to the Parent node.
     // @param[in] E is the expression that is one of the two children of
-    // the created OperatorNode (the other child is 0).
-    // @param[in] Parent is the parent of the created OperatorNode.
+    // the created BinaryOperatorNode (the other child is 0).
+    // @param[in] Parent is the parent of the created BinaryOperatorNode.
     void AddZero(Expr *E, Node *Parent);
 
     // Add a new node to the AST.
@@ -149,19 +148,19 @@ namespace clang {
     // @param[in] Parent is the parent of the node to be added.
     void AddNode(Node *N, Node *Parent);
 
-    // Coalesce the OperatorNode O with its parent. This involves moving the
-    // children (if any) of node O to its parent and then removing O.
-    // @param[in] O is the current node. O should be a OperatorNode.
-    void CoalesceNode(OperatorNode *O);
+    // Coalesce the BinaryOperatorNode B with its parent. This involves moving
+    // the children (if any) of node B to its parent and then removing B.
+    // @param[in] B is the current node. B should be a BinaryOperatorNode.
+    void CoalesceNode(BinaryOperatorNode *B);
 
-    // Determines if a OperatorNode could be coalesced into its parent.
-    // @param[in] O is the current node. O should be a OperatorNode.
-    // @return Return true if O can be coalesced into its parent, false
+    // Determines if a BinaryOperatorNode could be coalesced into its parent.
+    // @param[in] B is the current node. B should be a BinaryOperatorNode.
+    // @return Return true if B can be coalesced into its parent, false
     // otherwise.
-    bool CanCoalesceNode(OperatorNode *O);
+    bool CanCoalesceNode(BinaryOperatorNode *B);
 
-    // Recursively coalesce OperatorNodes having the same commutative and
-    // associative operator.
+    // Recursively coalesce BinaryOperatorNodes having the same commutative
+    // and associative operator.
     // @param[in] N is current node of the AST. Initial value is Root.
     // @param[in] Changed indicates whether a node was coalesced. We need this
     // to control when to stop recursive coalescing.
@@ -184,11 +183,11 @@ namespace clang {
     // this to control when to stop recursive constant folding.
     void ConstantFold(Node *N, bool &Changed);
 
-    // Constant fold integer expressions within an operator node.
+    // Constant fold integer expressions within a binary operator node.
     // @param[in] N is current node of the AST.
     // @param[in] Changed indicates whether constant folding was done. We need
     // this to control when to stop recursive constant folding.
-    void ConstantFoldOperator(OperatorNode *N, bool &Changed);
+    void ConstantFoldOperator(BinaryOperatorNode *N, bool &Changed);
 
     // Get the deref offset from the DerefExpr. The offset represents the
     // possible amount by which the bounds of an ntptr could be widened.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -137,6 +137,13 @@ namespace clang {
     // @param[in] Parent is the parent of the new node.
     void Create(Expr *E, Node *Parent = nullptr);
 
+    // Create an OperatorNode with an addition operator and two children
+    // (E and 0), and add the created OperatorNode to the Parent node.
+    // @param[in] E is the expression that is one of the two children of
+    // the created OperatorNode (the other child is 0).
+    // @param[in] Parent is the parent of the created OperatorNode.
+    void AddZero(Expr *E, Node *Parent);
+
     // Add a new node to the AST.
     // @param[in] Node is the current node to be added.
     // @param[in] Parent is the parent of the node to be added.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -126,6 +126,12 @@ namespace clang {
     // this to control when to stop recursive constant folding.
     void ConstantFold(Node *N, bool &Changed);
 
+    // Constant fold integer expressions within an operator node.
+    // @param[in] N is current node of the AST.
+    // @param[in] Changed indicates whether constant folding was done. We need
+    // this to control when to stop recursive constant folding.
+    void ConstantFoldOperator(OperatorNode *N, bool &Changed);
+
     // Get the deref offset from the DerefExpr. The offset represents the
     // possible amount by which the bounds of an ntptr could be widened.
     // @param[in] UpperExpr is the upper bounds expr for the ntptr.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -188,7 +188,7 @@ namespace clang {
     // this to control when to stop recursive constant folding.
     void ConstantFold(Node *N, bool &Changed);
 
-    // Constant fold integer expressions within a binary operator node.
+    // Constant fold integer expressions within a BinaryOperatorNode.
     // @param[in] N is current node of the AST.
     // @param[in] Changed indicates whether constant folding was done. We need
     // this to control when to stop recursive constant folding.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -23,6 +23,7 @@
 
 namespace clang {
   using Result = Lexicographic::Result;
+  class LeafExprNode;
 
   class Node {
   public:
@@ -40,7 +41,11 @@ namespace clang {
     Node *Parent;
 
     Node(NodeKind Kind, Node *Parent) :
-      Kind(Kind), Parent(Parent) {}
+      Kind(Kind), Parent(Parent) {
+        if (Parent)
+          assert(!isa<LeafExprNode>(Parent) &&
+                 "Parent node cannot be a LeafExprNode");
+      }
   };
 
   class BinaryOperatorNode : public Node {

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -31,6 +31,7 @@ namespace clang {
     // which their kinds appear in this enum.
     enum class NodeKind {
       OperatorNode,
+      UnaryOperatorNode,
       ImplicitCastNode,
       LeafExprNode
     };
@@ -60,6 +61,20 @@ namespace clang {
     // Is the operator commutative and associative?
     bool IsOpCommutativeAndAssociative() {
       return Opc == BO_Add || Opc == BO_Mul;
+    }
+  };
+
+  class UnaryOperatorNode : public Node {
+  public:
+    UnaryOperator::Opcode Opc;
+    Node *Child;
+
+    UnaryOperatorNode(UnaryOperator::Opcode Opc, Node *Parent) :
+      Node(NodeKind::UnaryOperatorNode, Parent),
+      Opc(Opc) {}
+
+    static bool classof(const Node *N) {
+      return N->Kind == NodeKind::UnaryOperatorNode;
     }
   };
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -27,7 +27,13 @@ namespace clang {
 
   class Node {
   public:
-    enum class NodeKind { OperatorNode, LeafExprNode };
+    // Nodes with two different kinds are sorted according to the order in
+    // which their kinds appear in this enum.
+    enum class NodeKind {
+      OperatorNode,
+      ImplicitCastNode,
+      LeafExprNode
+    };
 
     NodeKind Kind;
     Node *Parent;
@@ -54,6 +60,20 @@ namespace clang {
     // Is the operator commutative and associative?
     bool IsOpCommutativeAndAssociative() {
       return Opc == BO_Add || Opc == BO_Mul;
+    }
+  };
+
+  class ImplicitCastNode : public Node {
+  public:
+    CastKind CK;
+    Node *Child;
+
+    ImplicitCastNode(CastKind CK, Node *Parent) :
+      Node(NodeKind::ImplicitCastNode, Parent),
+      CK(CK) {}
+
+    static bool classof(const Node *N) {
+      return N->Kind == NodeKind::ImplicitCastNode;
     }
   };
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -30,9 +30,9 @@ namespace clang {
     enum class NodeKind { OperatorNode, LeafExprNode };
 
     NodeKind Kind;
-    OperatorNode *Parent;
+    Node *Parent;
 
-    Node(NodeKind Kind, OperatorNode *Parent) :
+    Node(NodeKind Kind, Node *Parent) :
       Kind(Kind), Parent(Parent) {}
   };
 
@@ -43,7 +43,7 @@ namespace clang {
     // an n-ary tree.
     llvm::SmallVector<Node *, 2> Children;
 
-    OperatorNode(BinaryOperator::Opcode Opc, OperatorNode *Parent) :
+    OperatorNode(BinaryOperator::Opcode Opc, Node *Parent) :
       Node(NodeKind::OperatorNode, Parent),
       Opc(Opc) {}
 
@@ -61,7 +61,7 @@ namespace clang {
   public:
     Expr *E;
 
-    LeafExprNode(Expr *E, OperatorNode *Parent) :
+    LeafExprNode(Expr *E, Node *Parent) :
       Node(NodeKind::LeafExprNode, Parent),
       E(E) {}
 
@@ -84,12 +84,12 @@ namespace clang {
     // Create a PreorderAST for the expression E.
     // @param[in] E is the sub expression to be added to a new node.
     // @param[in] Parent is the parent of the new node.
-    void Create(Expr *E, OperatorNode *Parent = nullptr);
+    void Create(Expr *E, Node *Parent = nullptr);
 
     // Add a new node to the AST.
     // @param[in] Node is the current node to be added.
     // @param[in] Parent is the parent of the node to be added.
-    void AddNode(Node *N, OperatorNode *Parent);
+    void AddNode(Node *N, Node *Parent);
 
     // Coalesce the OperatorNode O with its parent. This involves moving the
     // children (if any) of node O to its parent and then removing O.
@@ -102,14 +102,14 @@ namespace clang {
     // otherwise.
     bool CanCoalesceNode(OperatorNode *O);
 
-    // Recursively coalesce OperatoreNodes having the same commutative and
+    // Recursively coalesce OperatorNodes having the same commutative and
     // associative operator.
     // @param[in] N is current node of the AST. Initial value is Root.
     // @param[in] Changed indicates whether a node was coalesced. We need this
     // to control when to stop recursive coalescing.
     void Coalesce(Node *N, bool &Changed);
 
-    // Sort the children expressions in a OperatorNode of the AST.
+    // Sort the children expressions in a non-leaf Node of the AST.
     // @param[in] N is current node of the AST. Initial value is Root.
     void Sort(Node *N);
 

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -150,10 +150,10 @@ namespace clang {
     // @param[in] Parent is the parent of the created BinaryOperatorNode.
     void AddZero(Expr *E, Node *Parent);
 
-    // Add a new node to the AST.
-    // @param[in] Node is the current node to be added.
-    // @param[in] Parent is the parent of the node to be added.
-    void AddNode(Node *N, Node *Parent);
+    // Attach a new node to the AST. The node N is attached to the Parent node.
+    // @param[in] N is the current node to be attached.
+    // @param[in] Parent is the parent of the node to be attached.
+    void AttachNode(Node *N, Node *Parent);
 
     // Coalesce the BinaryOperatorNode B with its parent. This involves moving
     // the children (if any) of node B to its parent and then removing B.

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -78,8 +78,9 @@ void PreorderAST::CoalesceNode(BinaryOperatorNode *B) {
     return;
 
   // Remove the current node from the list of children of its parent.
-  for (auto I = BParent->Children.begin(),
-            E = BParent->Children.end(); I != E; ++I) {
+  // Since BParent is modified within the loop, we need to evaluate
+  // the loop end on each iteration.
+  for (auto I = BParent->Children.begin(); I != BParent->Children.end(); ++I) {
     if (*I == B) {
       BParent->Children.erase(I);
       break;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -266,6 +266,8 @@ void PreorderAST::Coalesce(Node *N, bool &Changed) {
   if (!N)
     return;
 
+  // TODO: GitHub checkedc-clang issue #1032. Each kind of Node should have
+  // its own Coalesce method.
   switch (N->Kind) {
     default:
       break;
@@ -305,6 +307,8 @@ bool PreorderAST::CompareNodes(const Node *N1, const Node *N2) {
   if (N1->Kind != N2->Kind)
     return N1->Kind < N2->Kind;
 
+  // TODO: GitHub checkedc-clang issue #1032. Each kind of Node should have
+  // its own CompareNodes method.
   switch (N1->Kind) {
     case Node::NodeKind::BinaryOperatorNode: {
       const auto *B1 = dyn_cast<BinaryOperatorNode>(N1);
@@ -373,6 +377,8 @@ void PreorderAST::Sort(Node *N) {
   if (!N)
     return;
 
+  // TODO: GitHub checkedc-clang issue #1032. Each kind of Node should have
+  // its own Sort method.
   switch (N->Kind) {
     default:
       break;
@@ -419,6 +425,8 @@ void PreorderAST::ConstantFold(Node *N, bool &Changed) {
   if (!N)
     return;
 
+  // TODO: GitHub checkedc-clang issue #1032. Each kind of Node should have
+  // its own ConstantFold method.
   switch (N->Kind) {
     default:
       break;
@@ -445,6 +453,9 @@ void PreorderAST::ConstantFold(Node *N, bool &Changed) {
   }
 }
 
+// TODO: GitHub checkedc-clang issue #1032. Each kind of Node should have
+// its own ConstantFold method, so there should no longer be a need for
+// a separate ConstantFoldOperator method.
 void PreorderAST::ConstantFoldOperator(BinaryOperatorNode *B, bool &Changed) {
   // Note: This function assumes that the children of each BinaryOperatorNode
   // of the preorder AST have already been sorted.
@@ -635,6 +646,8 @@ Result PreorderAST::Compare(const Node *N1, const Node *N2) const {
   if (N1->Kind != N2->Kind)
     return N1->Kind > N2->Kind ? Result::LessThan : Result::GreaterThan;
 
+  // TODO: GitHub checkedc-clang issue #1032. Each kind of Node should have
+  // its own Compare method.
   switch (N1->Kind) {
     case Node::NodeKind::BinaryOperatorNode: {
       const auto *B1 = dyn_cast<BinaryOperatorNode>(N1);

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -102,15 +102,7 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
     // and add 0 as a LeafExprNode child of this OperatorNode. This helps us
     // compare expressions like "p" and "p + 1" by normalizing "p" to "p + 0".
 
-    auto *N = new OperatorNode(BO_Add, Parent);
-    AddNode(N, Parent);
-
-    llvm::APInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
-    auto *ZeroLiteral = new (Ctx) IntegerLiteral(Ctx, Zero, Ctx.IntTy,
-                                                 SourceLocation());
-    auto *L = new LeafExprNode(ZeroLiteral, N);
-    AddNode(L, /*Parent*/ N);
-    Create(E, /*Parent*/ N);
+    AddZero(E, Parent);
 
   } else if (const auto *BO = dyn_cast<BinaryOperator>(E)) {
     BinaryOperator::Opcode BinOp = BO->getOpcode();

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -18,6 +18,13 @@
 using namespace clang;
 
 void PreorderAST::AddNode(Node *N, Node *Parent) {
+  // A LeafExprNode cannot be the parent of any node.
+  if (Parent && isa<LeafExprNode>(Parent)) {
+    assert(0 && "Attempting to add a node to a LeafExprNode");
+    SetError();
+    return;
+  }
+
   // If the root is null, make the current node the root.
   if (!Root)
     Root = N;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -209,6 +209,7 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
       AddNode(N, Parent);
       Create(Base, /*Parent*/ N);
     }
+
   } else if (auto *UO = dyn_cast<UnaryOperator>(E)) {
     UnaryOperatorKind Op = UO->getOpcode();
     if (Op == UnaryOperatorKind::UO_Deref) {
@@ -243,8 +244,9 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
     } else {
       auto *N = new UnaryOperatorNode(Op, Parent);
       AddNode(N, Parent);
-      Create(UO->getSubExpr(), /*Parent */ N);
+      Create(UO->getSubExpr(), /*Parent*/ N);
     }
+
   } else if (auto *AE = dyn_cast<ArraySubscriptExpr>(E)) {
     // e1[e2] has the same canonical form as *(e1 + e2).
     auto DerefExpr = BinaryOperator::Create(Ctx, AE->getBase(), AE->getIdx(),
@@ -254,10 +256,12 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
     auto *N = new UnaryOperatorNode(UnaryOperatorKind::UO_Deref, Parent);
     AddNode(N, Parent);
     Create(DerefExpr, /*Parent*/ N);
+
   } else if (auto *ICE = dyn_cast<ImplicitCastExpr>(E)) {
     auto *N = new ImplicitCastNode(ICE->getCastKind(), Parent);
     AddNode(N, Parent);
     Create(ICE->getSubExpr(), /*Parent*/ N);
+
   } else {
     auto *N = new LeafExprNode(E, Parent);
     AddNode(N, Parent);

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -267,6 +267,8 @@ void PreorderAST::Coalesce(Node *N, bool &Changed) {
     return;
 
   switch (N->Kind) {
+    default:
+      break;
     case Node::NodeKind::BinaryOperatorNode: {
       auto *B = dyn_cast<BinaryOperatorNode>(N);
 
@@ -295,8 +297,6 @@ void PreorderAST::Coalesce(Node *N, bool &Changed) {
       Coalesce(I->Child, Changed);
       break;
     }
-    default:
-      break;
   }
 }
 
@@ -374,6 +374,8 @@ void PreorderAST::Sort(Node *N) {
     return;
 
   switch (N->Kind) {
+    default:
+      break;
     case Node::NodeKind::BinaryOperatorNode: {
       auto *B = dyn_cast<BinaryOperatorNode>(N);
 
@@ -407,8 +409,6 @@ void PreorderAST::Sort(Node *N) {
       Sort(I->Child);
       break;
     }
-    default:
-      break;
   }
 }
 
@@ -420,6 +420,8 @@ void PreorderAST::ConstantFold(Node *N, bool &Changed) {
     return;
 
   switch (N->Kind) {
+    default:
+      break;
     case Node::NodeKind::BinaryOperatorNode: {
       auto *B = dyn_cast<BinaryOperatorNode>(N);
       ConstantFoldOperator(B, Changed);
@@ -440,8 +442,6 @@ void PreorderAST::ConstantFold(Node *N, bool &Changed) {
       ConstantFold(I->Child, Changed);
       break;
     }
-    default:
-      break;
   }
 }
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -26,8 +26,19 @@ void PreorderAST::AddNode(Node *N, Node *Parent) {
   }
 
   // If the root is null, make the current node the root.
-  if (!Root)
+  if (!Root) {
+    if (!isa<BinaryOperatorNode>(N)) {
+      assert(0 && "The root of a PreorderAST must be a BinaryOperatorNode");
+      SetError();
+      return;
+    }
+    if (Parent) {
+      assert(0 && "Parent node must be null if the PreorderAST root is null");
+      SetError();
+      return;
+    }
     Root = N;
+  }
 
   // Add the current node to the list of children of its parent.
   if (auto *B = dyn_cast_or_null<BinaryOperatorNode>(Parent))

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -264,6 +264,18 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
   }
 }
 
+void PreorderAST::AddZero(Expr *E, Node *Parent) {
+  auto *N = new OperatorNode(BO_Add, Parent);
+  AddNode(N, Parent);
+
+  llvm::APInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
+  auto *ZeroLiteral = new (Ctx) IntegerLiteral(Ctx, Zero, Ctx.IntTy,
+                                               SourceLocation());
+  auto *L = new LeafExprNode(ZeroLiteral, N);
+  AddNode(L, /*Parent*/ N);
+  Create(E, /*Parent*/ N);
+}
+
 void PreorderAST::Coalesce(Node *N, bool &Changed) {
   if (Error)
     return;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -234,14 +234,13 @@ void PreorderAST::Sort(Node *N) {
             });
 }
 
-void PreorderAST::ConstantFold(Node *N, bool &Changed) {
+void PreorderAST::ConstantFoldOperator(OperatorNode *O, bool &Changed) {
   // Note: This function assumes that the children of each OperatorNode of the
   // preorder AST have already been sorted.
 
   if (Error)
     return;
 
-  auto *O = dyn_cast_or_null<OperatorNode>(N);
   if (!O)
     return;
 
@@ -252,8 +251,8 @@ void PreorderAST::ConstantFold(Node *N, bool &Changed) {
   for (size_t I = 0; I != O->Children.size(); ++I) {
     auto *Child = O->Children[I];
 
-    // Recursively constant fold the children of a OperatorNode.
-    if (isa<OperatorNode>(Child)) {
+    // Recursively constant fold the non-leaf children of a OperatorNode.
+    if (!isa<LeafExprNode>(Child)) {
       ConstantFold(Child, Changed);
       continue;
     }

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -306,7 +306,7 @@ void PreorderAST::Coalesce(Node *N, bool &Changed) {
 }
 
 bool PreorderAST::CompareNodes(const Node *N1, const Node *N2) {
-  // OperatorNode < UnaryOperatorNode < ImplicitCastNode < LeafExprNode.
+  // OperatorNode < UnaryOperatorNode < MemberNode < ImplicitCastNode < LeafExprNode.
   if (N1->Kind != N2->Kind)
     return N1->Kind < N2->Kind;
 
@@ -370,6 +370,8 @@ bool PreorderAST::CompareNodes(const Node *N1, const Node *N2) {
       return Lex.CompareExpr(L1->E, L2->E) == Result::LessThan;
     }
   }
+
+  return true;
 }
 
 void PreorderAST::Sort(Node *N) {
@@ -634,7 +636,7 @@ Result PreorderAST::Compare(const Node *N1, const Node *N2) const {
   if (N1 && !N2)
     return Result::GreaterThan;
 
-  // LeafExprNode < ImplicitCastNode < UnaryOperatorNode < OperatorNode.
+  // LeafExprNode < ImplicitCastNode < MemberNode < UnaryOperatorNode < OperatorNode.
   if (N1->Kind != N2->Kind)
     return N1->Kind > N2->Kind ? Result::LessThan : Result::GreaterThan;
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -235,10 +235,13 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
         AddNode(N, Parent);
         Create(ChildPlusZero, /*Parent*/ N);
       }
-    } else if (Op == UnaryOperatorKind::UO_Plus ||
-               Op == UnaryOperatorKind::UO_Minus) {
-      // For expressions such as +e and -e, we create a LeafExprNode
-      // so that these expressions can be constant folded.
+    } else if ((Op == UnaryOperatorKind::UO_Plus ||
+               Op == UnaryOperatorKind::UO_Minus) &&
+               E->isIntegerConstantExpr(Ctx)) {
+      // For integer constant expressions of the form +e or -e, we create a
+      // LeafExprNode rather than a UnaryOperatorNode so that these expressions
+      // can be constant folded. Constant folding only folds LeafExprNodes that
+      // are children of an OperatorNode.
       auto *N = new LeafExprNode(E, Parent);
       AddNode(N, Parent);
     } else {

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -773,6 +773,15 @@ void PreorderAST::Cleanup(Node *N) {
     for (auto *Child : O->Children)
       Cleanup(Child);
 
+  if (auto *U = dyn_cast_or_null<UnaryOperatorNode>(N))
+    Cleanup(U->Child);
+
+  if (auto *M = dyn_cast_or_null<MemberNode>(N))
+    Cleanup(M->Base);
+
+  if (auto *I = dyn_cast_or_null<ImplicitCastNode>(N))
+    Cleanup(I->Child);
+
   if (N)
     delete N;
 }


### PR DESCRIPTION
This PR modifies PreorderAST so that it can create canonical forms for member expressions such as `a->f`, `(*a).f`, `a[0].f`, etc.

Three new `Node` kinds are introduced: `MemberNode` for canonicalizing member expressions, `UnaryOperatorNode` for canonicalizing unary operators and array subscripts such as `*p`, `*(p + i)`, `p[i]`, etc., and `ImplicitCastNode` for canonicalizing implicit cast expressions such as `LValueToRValue(e)`.

This is part of the ongoing work to generalize bounds checking to lvalue expressions. In order to create an `AbstractSet` for an lvalue expression `e` to use as the key in `ObservedBounds` to track the inferred bounds of the value produced by `e`, we need to use `PreorderAST` to create a canonical form for `e`.