### PR TITLE
Remove unused code to silence warning

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4040,11 +4040,8 @@ namespace {
 
       VarDecl *VD = dyn_cast<VarDecl>(E->getDecl());
       BoundsExpr *B = nullptr;
-      InteropTypeExpr *IT = nullptr;
-      if (VD) {
+      if (VD)
         B = VD->getBoundsExpr();
-        IT = VD->getInteropTypeExpr();
-      }
 
       if (E->getType()->isArrayType()) {
         if (!VD) {


### PR DESCRIPTION
In `SemaBounds.cpp`, we assign to variable `IT` but never use it. This results in
the following compile-time warning:
```
  warning: variable ‘IT’ set but not used [-Wunused-but-set-variable]
  InteropTypeExpr *IT = nullptr;
```