### PR TITLE
Compute BoundsVars in CheckedCAnalysesPrepass

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1844,7 +1844,7 @@ protected:
   using Stmt::Stmt;
 
 private:
-  WhereClause *WClause;
+  WhereClause *WClause = nullptr;
 
 public:
   const Expr *getExprStmt() const;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -264,6 +264,7 @@ BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables
 BENIGN_LANGOPT(DumpInferredBounds, 1, 0, "dump inferred Checked C bounds for assignments and declarations")
 BENIGN_LANGOPT(DumpExtractedComparisonFacts, 1, 0, "dump extracted comparison facts")
 BENIGN_LANGOPT(DumpWidenedBounds, 1, 0, "dump widened bounds")
+BENIGN_LANGOPT(DumpBoundsVars, 1, 0, "dump bounds vars")
 BENIGN_LANGOPT(DumpPreorderAST, 1, 0, "dump the preorder AST")
 BENIGN_LANGOPT(DumpCheckingState, 1, 0, "dump the state during bounds checking")
 LANGOPT(InjectVerifierCalls, 1, 0, "Injects calls to VERIFIER_assume and VERIFIER_error in the bitcode")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -854,6 +854,8 @@ def fdump_extracted_comparison_facts : Flag<["-"], "fdump-extracted-comparison-f
   HelpText<"Dump extracted comparison facts">;
 def fdump_widened_bounds : Flag<["-"], "fdump-widened-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump widened bounds">;
+def fdump_boundsvars : Flag<["-"], "fdump-boundsvars">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Dump bounds vars">;
 def fdump_preorder_ast : Flag<["-"], "fdump-preorder-ast">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump the preorder AST">;
 def fdump_checking_state : Flag<["-"], "fdump-checking-state">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -16,6 +16,7 @@
 
 #include "clang/AST/CanonBounds.h"
 #include "clang/Analysis/Analyses/PostOrderCFGView.h"
+#include "clang/Sema/CheckedCAnalysesPrepass.h"
 #include "clang/Sema/Sema.h"
 
 namespace clang {
@@ -27,17 +28,10 @@ namespace clang {
   // statement to its bounds expression.
   using StmtBoundsMapTy = llvm::DenseMap<const Stmt *, BoundsMapTy>;
 
-  // VarSetTy denotes a set of variables.
-  using VarSetTy = llvm::DenseSet<const VarDecl *>;
-
   // StmtVarSetTy denotes a set of null-terminated array variables that are
   // associated with a statement. The set of variables whose bounds are killed
   // by a statement has the type StmtVarSetTy.
   using StmtVarSetTy = llvm::DenseMap<const Stmt *, VarSetTy>;
-
-  // BoundsVarsTy maps a variable Z to the set of all null-terminated array
-  // variables in whose bounds expressions Z occurs.
-  using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>; 
 
   // The BoundsWideningAnalysis class represents the dataflow analysis for
   // bounds widening. The sets In, Out, Gen and Kill that are used by the
@@ -69,11 +63,6 @@ namespace clang {
       S(S), Cfg(Cfg), Ctx(S.Context),
       Lex(Lexicographic(Ctx, nullptr)),
       OS(llvm::outs()) {}
-
-    // A mapping of a variable Z to the set of all null-terminated array
-    // variables in whose bounds expressions Z occurs. We maintain this map
-    // only for variables that are mapped to non-empty sets.
-    BoundsVarsTy BoundsVars;
   };
 
 } // end namespace clang

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -43,9 +43,14 @@ namespace clang {
 
     // BoundsVars maps each variable Z in a function to the set of all
     // variables in whose bounds expressions Z occurs. A variable Z can occur
-    // in the bounds expression of a V in the following conditions:
+    // in the bounds expression of a variable V if
     // 1. Z occurs in the declared bounds expression of V, or
     // 2. A where clause declares bounds B of V and Z occurs in B.
+
+    // Note: BoundsVarsTy is a map of keys to values which are sets. As a
+    // result, there is no defined iteration order for either its keys or its
+    // values. So in case we want to iterate BoundsVars and need a determinstic
+    // iteration order we must remember to sort the keys as well as the values.
     BoundsVarsTy BoundsVars;
   };
 } // end namespace clang

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -24,12 +24,29 @@ namespace clang {
   // VarUsageTy maps a VarDecl to a DeclRefExpr that is a use of the VarDecl.
   using VarUsageTy = llvm::DenseMap<const VarDecl *, DeclRefExpr *>;
 
+  // VarSetTy denotes a set of variables.
+  using VarSetTy = llvm::SmallPtrSet<const VarDecl *, 2>;
+
+  // BoundsVarsTy maps a variable Z to the set of all variables in whose bounds
+  // expressions Z occurs.
+  using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>;
+
+  // VarListTy denotes a list of variables.
+  using VarListTy = llvm::SmallVector<const VarDecl *, 2>;
+
   struct PrepassInfo {
     // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)
     // that is the first use of V, if V fulfills the following conditions:
     // 1. V is used in a declared bounds expression, or:
     // 2. V has a declared bounds expression.
     VarUsageTy VarUses;
+
+    // BoundsVars maps each variable Z in a function to the set of all
+    // variables in whose bounds expressions Z occurs. A variable Z can occur
+    // in the bounds expression of a V in the following conditions:
+    // 1. Z occurs in the declared bounds expression of V, or
+    // 2. A where clause declares bounds B of V and Z occurs in B.
+    BoundsVarsTy BoundsVars;
   };
 } // end namespace clang
 #endif

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2846,6 +2846,9 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   if (Args.hasArg(OPT_fdump_widened_bounds))
     Opts.DumpWidenedBounds = true;
 
+  if (Args.hasArg(OPT_fdump_boundsvars))
+    Opts.DumpBoundsVars = true;
+
   if (Args.hasArg(OPT_fdump_preorder_ast))
     Opts.DumpPreorderAST = true;
 

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -23,27 +23,35 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
   private:
     Sema &SemaRef;
     PrepassInfo &Info;
-    // InBoundsExpr tracks whether the expressions being visited are
-    // within a declared bounds expression.
-    bool InBoundsExpr = false;
+
+    // VarWithBounds is a variable that has a bounds expression. It is used to
+    // keep track of the following:
+    // 1. Whether the expressions being visited are within a declared bounds
+    // expression.
+    // 2. The variable with which a bounds declared by a where clause is
+    // associated.
+    VarDecl *VarWithBounds = nullptr;
+    llvm::raw_ostream &OS;
 
   public:
     PrepassHelper(Sema &SemaRef, PrepassInfo &Info) :
-      SemaRef(SemaRef), Info(Info) {}
+      SemaRef(SemaRef), Info(Info), OS(llvm::outs()) {}
 
     bool VisitVarDecl(VarDecl *V) {
-      if (V->isInvalidDecl())
+      if (!V || V->isInvalidDecl())
         return true;
       // If V has a bounds expression, traverse it so we visit the
       // DeclRefExprs within the bounds.
       if (V->hasBoundsExpr()) {
         if (BoundsExpr *B = SemaRef.NormalizeBounds(V)) {
-          InBoundsExpr = true;
+          VarWithBounds = V;
           TraverseStmt(B);
-          InBoundsExpr = false;
+          VarWithBounds = nullptr;
         }
       }
-      return true;
+      // Process any where clause attached to this VarDecl. For example,
+      // int x = 1 _Where p : bounds(p, p + 1);
+      return ProcessWhereClause(V->getWhereClause());
     }
 
     // We may modify the VarUses map when a DeclRefExpr is visited.
@@ -54,12 +62,103 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
       // We only add the V => E pair to the VarUses map if:
       // 1. E is within a declared bounds expression, or:
       // 2. V has a declared bounds expression.
-      if (!InBoundsExpr && !V->hasBoundsExpr())
-        return true;
-      if (Info.VarUses.count(V))
-        return true;
-      Info.VarUses[V] = E;
+      if (VarWithBounds || V->hasBoundsExpr()) {
+        if (!Info.VarUses.count(V))
+          Info.VarUses[V] = E;
+      }
+
+      // We add VarWithBounds to the set of all variables in whose bounds
+      // expressions V occurs.
+      if (VarWithBounds) {
+        auto It = Info.BoundsVars.find(V);
+        if (It != Info.BoundsVars.end())
+          It->second.insert(VarWithBounds);
+        else {
+          VarSetTy Vars;
+          Vars.insert(VarWithBounds);
+          Info.BoundsVars[V] = Vars;
+        }
+      }
+
       return true;
+    }
+
+    bool ProcessWhereClause(WhereClause *WC) {
+      if (!WC)
+        return true;
+
+      for (WhereClauseFact *Fact : WC->getFacts()) {
+        if (BoundsDeclFact *BDF = dyn_cast<BoundsDeclFact>(Fact)) {
+          VarDecl *V = BDF->Var;
+          BoundsExpr *B = BDF->Bounds;
+
+          VisitVarDecl(V);
+          VarWithBounds = V;
+          TraverseStmt(B);
+          VarWithBounds = nullptr;
+        }
+      }
+
+      return true;
+    }
+
+    bool VisitNullStmt(NullStmt *S) {
+      // Process any where clause attached to a NullStmt. For example,
+      // _Where p : bounds(p, p + 1);
+      return ProcessWhereClause(S->getWhereClause());
+    }
+
+    bool VisitValueStmt(ValueStmt *S) {
+      // Process any where clause attached to a ValueStmt. For example,
+      // x = 1 _Where p : bounds(p, p + 1);
+      return ProcessWhereClause(S->getWhereClause());
+    }
+
+    void DumpBoundsVars(FunctionDecl *FD) {
+      OS << "--------------------------------------\n"
+         << "In function: " << FD->getName() << "\n"
+         << "BoundsVars:\n";
+
+      // Info.BoundsVars is a map of VarDecls (keys) to a set of VarDecls
+      // (values). So there is no defined iteration order for its keys or
+      // values. So we copy the keys to a vector, sort the vector and then
+      // iterate it. While iterating each key we also copy its value (which is
+      // a set of VarDecls) to a vector, sort the vector and iterate it.
+      VarListTy Vars;
+      for (const auto item : Info.BoundsVars)
+        Vars.push_back(item.first);
+
+      SortVars(Vars);
+
+      for (const auto V : Vars) {
+        OS << V->getQualifiedNameAsString() << ": { ";
+
+        VarListTy InnerVars;
+        for (const auto item : Info.BoundsVars[V])
+          InnerVars.push_back(item);
+
+        SortVars(InnerVars);
+
+        for (const auto InnerV : InnerVars)
+          OS << InnerV->getQualifiedNameAsString() << " ";
+        OS << "}\n";
+      }
+      OS << "--------------------------------------\n";
+    }
+
+    void SortVars(VarListTy &Vars) {
+      // Sort variables by their name. If two variables in a function have the
+      // same name (for example, a variable in a nested scope that shadows a
+      // variable from an outer scope), then we sort them by their source
+      // locations.
+      llvm::sort(Vars.begin(), Vars.end(),
+                 [](const VarDecl *A, const VarDecl *B) {
+                   int StrCompare = A->getQualifiedNameAsString().compare(
+                                    B->getQualifiedNameAsString());
+                   return StrCompare != 0 ?
+                          StrCompare < 0 :
+                          A->getLocation() < B->getLocation();
+                 });
     }
 };
 
@@ -73,5 +172,7 @@ void Sema::CheckedCAnalysesPrepass(PrepassInfo &Info, FunctionDecl *FD,
     Prepass.VisitVarDecl(Param);
   }
   Prepass.TraverseStmt(Body);
-}
 
+  if (getLangOpts().DumpBoundsVars)
+    Prepass.DumpBoundsVars(FD);
+}

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -49,8 +49,11 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
           VarWithBounds = nullptr;
         }
       }
-      // Process any where clause attached to this VarDecl. For example,
+      // Process any where clause attached to this VarDecl.
+      // Note: This also handles function parameters.
+      // For example,
       // int x = 1 _Where p : bounds(p, p + 1);
+      // void f(_Nt_array_ptr<char> p : bounds(p, p + 1) {}
       return ProcessWhereClause(V->getWhereClause());
     }
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-vars.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-vars.c
@@ -1,0 +1,52 @@
+// Tests for variables occurring in bounds expressions for checked pointers
+// like _Array_ptr and _Nt_array_ptr.
+//
+// RUN: %clang_cc1 -fdump-boundsvars -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+
+// expected-no-diagnostics
+
+void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
+        _Nt_array_ptr<char> param2 : bounds(param2, param2 + 1),
+        int x, int y) {
+  _Array_ptr<char> p : bounds(p, p + 1) = "a";
+  _Nt_array_ptr<char> q : bounds(q, q + 1) = "a";
+
+  _Where p : bounds(p + x, p + y);
+  _Where q : count(x);
+  _Where param1 : count(x + y);
+  _Where param2 : bounds(param2, param2 + y);
+
+  {
+    int z;
+    _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
+    _Nt_array_ptr<char> q : bounds(q, q + 1) = "a";
+    _Nt_array_ptr<char> m : bounds(m, m + 1) = "a";
+
+    _Where q : bounds(p, p + z) _And p : bounds(p, p + z);
+    _Where m : bounds(q, q + z);
+  }
+
+  {
+    int w;
+    _Nt_array_ptr<char> a : bounds(a, a + 1) = "a";
+
+    w = 1 _Where a : bounds(a, a + 1);
+    x = 2 _Where a : count(x + y + w);
+    y = 3 _Where param2 : bounds(param1, param1 + w);
+  }
+
+// CHECK: In function: f1
+// CHECK: BoundsVars:
+// CHECK: a: { a }
+// CHECK: m: { m }
+// CHECK: p: { p }
+// CHECK: p: { p q }
+// CHECK: param1: { param1 param2 }
+// CHECK: param2: { param2 }
+// CHECK: q: { q }
+// CHECK: q: { m q }
+// CHECK: w: { a param2 }
+// CHECK: x: { a p param1 q }
+// CHECK: y: { a p param1 param2 }
+// CHECK: z: { m p q }
+}

--- a/clang/test/CheckedC/inferred-bounds/bounds-vars.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-vars.c
@@ -35,7 +35,7 @@ void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
     y = 3 _Where param2 : bounds(param1, param1 + w);
   }
 
-// CHECK: In function: f1
+// CHECK-LABEL: In function: f1
 // CHECK: BoundsVars:
 // CHECK: a: { a }
 // CHECK: m: { m }


### PR DESCRIPTION
BoundsVars maps each variable Z in a function to the set of all variables in
whose bounds expressions Z occurs. A variable Z can occur in the bounds
expression of a variable V in the following conditions:
  1. Z occurs in the declared bounds expression of V, or
  2. Z occurs in the bounds of V declared by a where clause.

One of the uses of BoundsVars is in the bounds widening analysis.