### PR TITLE
Move Node-specific behavior into Node subclasses

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -47,9 +47,35 @@ namespace clang {
                  "Parent node cannot be a LeafExprNode");
       }
 
+    // Recursively coalesce BinaryOperatorNodes having the same commutative
+    // and associative operator.
+    // @param[in] this is the current node of the AST.
+    // @param[in] Changed indicates whether a node was coalesced. We need this
+    // to control when to stop recursive coalescing.
+    // @param[in] Error indicates whether an error occurred during coalescing.
     virtual void Coalesce(bool &Changed, bool &Error) { }
+
+    // Recursively descend a Node to sort the children of all
+    // BinaryOperatorNodes if the binary operator is commutative.
+    // @param[in] this is the current node of the AST.
+    // @param[in] Lex is used to lexicographically compare Exprs and Decls
+    // that occur within nodes.
     virtual void Sort(Lexicographic Lex) { }
+
+    // Constant fold integer expressions.
+    // @param[in] this is the current node of the AST.
+    // @param[in] Changed indicates whether constant folding was done. We need
+    // this to control when to stop recursive constant folding.
+    // @param[in] Error indicates whether an error occurred during constant
+    // folding.
+    // @param[in] Ctx is used to create constant expressions.
     virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) { }
+
+    // Compare nodes according to their kind.
+    // @param[in] this is the current node of the AST.
+    // @param[in] Other is the node to compare to this.
+    // @return Returns a Lexicographic::Result indicating the comparison
+    // between this and Other according to their node kinds.
     Result CompareKinds(const Node *Other) const {
       if (Kind < Other->Kind)
         return Result::LessThan;
@@ -57,9 +83,20 @@ namespace clang {
         return Result::GreaterThan;
       return Result::Equal;
     }
+
+    // Compare two nodes lexicographically.
+    // @param[in] this is the current node of the AST.
+    // @param[in] Other the node to compare to this.
+    // @param[in] Lex is used to lexicographically compare Exprs and Decls
+    // that occur within nodes.
+    // @return Returns a Lexicographic::Result indicating the comparison
+    // between this and Other.
     virtual Result Compare(const Node *Other, Lexicographic Lex) const {
       return CompareKinds(Other);
     }
+
+    // Cleanup the memory consumed by this node.
+    // @param[in] this is the current node of the AST.
     virtual void Cleanup() {
       delete this;
     }
@@ -87,6 +124,10 @@ namespace clang {
       return Opc == BO_Add || Opc == BO_Mul;
     }
 
+    // Determines if the BinaryOperatorNode could be coalesced into its parent.
+    // @param[in] this is the current node.
+    // @return Returns true if this can be coalesced into its parent, false
+    // otherwise.
     bool CanCoalesce();
     void Coalesce(bool &Changed, bool &Error);
     void Sort(Lexicographic Lex);

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -46,6 +46,8 @@ namespace clang {
           assert(!isa<LeafExprNode>(Parent) &&
                  "Parent node cannot be a LeafExprNode");
       }
+
+    virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) { }
   };
 
   class BinaryOperatorNode : public Node {
@@ -69,6 +71,8 @@ namespace clang {
     bool IsOpCommutativeAndAssociative() {
       return Opc == BO_Add || Opc == BO_Mul;
     }
+
+    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
   };
 
   class UnaryOperatorNode : public Node {
@@ -83,6 +87,8 @@ namespace clang {
     static bool classof(const Node *N) {
       return N->Kind == NodeKind::UnaryOperatorNode;
     }
+
+    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
   };
 
   class MemberNode : public Node {
@@ -98,6 +104,8 @@ namespace clang {
     static bool classof(const Node *N) {
       return N->Kind == NodeKind::MemberNode;
     }
+
+    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
   };
 
   class ImplicitCastNode : public Node {
@@ -112,6 +120,8 @@ namespace clang {
     static bool classof(const Node *N) {
       return N->Kind == NodeKind::ImplicitCastNode;
     }
+
+    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
   };
 
   class LeafExprNode : public Node {
@@ -184,18 +194,6 @@ namespace clang {
     // @param[in] N2 is the second node to compare.
     // return A boolean indicating the relative ordering between N1 and N2.
     bool CompareNodes(const Node *N1, const Node *N2);
-
-    // Constant fold integer expressions.
-    // @param[in] N is current node of the AST. Initial value is Root.
-    // @param[in] Changed indicates whether constant folding was done. We need
-    // this to control when to stop recursive constant folding.
-    void ConstantFold(Node *N, bool &Changed);
-
-    // Constant fold integer expressions within a BinaryOperatorNode.
-    // @param[in] N is current node of the AST.
-    // @param[in] Changed indicates whether constant folding was done. We need
-    // this to control when to stop recursive constant folding.
-    void ConstantFoldOperator(BinaryOperatorNode *N, bool &Changed);
 
     // Get the deref offset from the DerefExpr. The offset represents the
     // possible amount by which the bounds of an ntptr could be widened.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -45,7 +45,9 @@ namespace clang {
         if (Parent)
           assert(!isa<LeafExprNode>(Parent) &&
                  "Parent node cannot be a LeafExprNode");
-      }
+    }
+
+    virtual ~Node() { }
 
     // Recursively coalesce BinaryOperatorNodes having the same commutative
     // and associative operator.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -268,6 +268,15 @@ namespace clang {
 
     // Create a BinaryOperatorNode with an addition operator and two children
     // (E and 0), and attach the created BinaryOperatorNode to the Parent node.
+    // This method is used to maintain an invariant that an expression `e` is
+    // equivalent to `e + 0`. This invariant must hold when:
+    // 1. `e` is the root expression that is used to create the PreorderAST.
+    // 2. `e` is the subexpression of a dereference expression. For example:
+    //   a. `*e` and `*(e + 0)` must have the same canonical form.
+    //   b. `e1[e2]` is equivalent to `*(e1 + e2)`, so `*(e1 + e2)` and
+    //       `*(e1 + e2 + 0)` must have the same canonical form.
+    //   c. `e->f`, `*e.f`, `(e + 0)->f`, `*(e + 0).f`, and `e[0].f` must have
+    //       the same canonical form.
     // @param[in] E is the expression that is one of the two children of
     // the created BinaryOperatorNode (the other child is 0).
     // @param[in] Parent is the parent of the created BinaryOperatorNode.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -47,6 +47,7 @@ namespace clang {
                  "Parent node cannot be a LeafExprNode");
       }
 
+    virtual void Coalesce(bool &Changed, bool &Error) { }
     virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) { }
     Result CompareKinds(Node *Other) {
       if (Kind < Other->Kind)
@@ -82,6 +83,8 @@ namespace clang {
       return Opc == BO_Add || Opc == BO_Mul;
     }
 
+    bool CanCoalesce();
+    void Coalesce(bool &Changed, bool &Error);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -99,6 +102,7 @@ namespace clang {
       return N->Kind == NodeKind::UnaryOperatorNode;
     }
 
+    void Coalesce(bool &Changed, bool &Error);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -117,6 +121,7 @@ namespace clang {
       return N->Kind == NodeKind::MemberNode;
     }
 
+    void Coalesce(bool &Changed, bool &Error);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -134,6 +139,7 @@ namespace clang {
       return N->Kind == NodeKind::ImplicitCastNode;
     }
 
+    void Coalesce(bool &Changed, bool &Error);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -180,24 +186,6 @@ namespace clang {
     // @param[in] N is the current node to be attached.
     // @param[in] Parent is the parent of the node to be attached.
     void AttachNode(Node *N, Node *Parent);
-
-    // Coalesce the BinaryOperatorNode B with its parent. This involves moving
-    // the children (if any) of node B to its parent and then removing B.
-    // @param[in] B is the current node. B should be a BinaryOperatorNode.
-    void CoalesceNode(BinaryOperatorNode *B);
-
-    // Determines if a BinaryOperatorNode could be coalesced into its parent.
-    // @param[in] B is the current node. B should be a BinaryOperatorNode.
-    // @return Return true if B can be coalesced into its parent, false
-    // otherwise.
-    bool CanCoalesceNode(BinaryOperatorNode *B);
-
-    // Recursively coalesce BinaryOperatorNodes having the same commutative
-    // and associative operator.
-    // @param[in] N is current node of the AST. Initial value is Root.
-    // @param[in] Changed indicates whether a node was coalesced. We need this
-    // to control when to stop recursive coalescing.
-    void Coalesce(Node *N, bool &Changed);
 
     // Recursively descend the PreorderAST to sort the children of all
     // BinaryOperatorNodes if the binary operator is commutative.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -48,6 +48,7 @@ namespace clang {
       }
 
     virtual void Coalesce(bool &Changed, bool &Error) { }
+    virtual void Sort(Lexicographic Lex) { }
     virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) { }
     Result CompareKinds(Node *Other) {
       if (Kind < Other->Kind)
@@ -85,6 +86,7 @@ namespace clang {
 
     bool CanCoalesce();
     void Coalesce(bool &Changed, bool &Error);
+    void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -103,6 +105,7 @@ namespace clang {
     }
 
     void Coalesce(bool &Changed, bool &Error);
+    void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -122,6 +125,7 @@ namespace clang {
     }
 
     void Coalesce(bool &Changed, bool &Error);
+    void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -140,6 +144,7 @@ namespace clang {
     }
 
     void Coalesce(bool &Changed, bool &Error);
+    void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
   };
@@ -186,11 +191,6 @@ namespace clang {
     // @param[in] N is the current node to be attached.
     // @param[in] Parent is the parent of the node to be attached.
     void AttachNode(Node *N, Node *Parent);
-
-    // Recursively descend the PreorderAST to sort the children of all
-    // BinaryOperatorNodes if the binary operator is commutative.
-    // @param[in] N is current node of the AST. Initial value is Root.
-    void Sort(Node *N);
 
     // Get the deref offset from the DerefExpr. The offset represents the
     // possible amount by which the bounds of an ntptr could be widened.

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -209,7 +209,7 @@ namespace clang {
       return N->Kind == NodeKind::LeafExprNode;
     }
 
-    Result Compare(Node *Other, Lexicographic Lex);
+    Result Compare(const Node *Other, Lexicographic Lex) const;
   };
 
 } // end namespace clang

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -95,6 +95,10 @@ namespace clang {
       return CompareKinds(Other);
     }
 
+    // Print the node.
+    // @param[in] this is the current node of the AST.
+    virtual void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const { }
+
     // Cleanup the memory consumed by this node.
     // @param[in] this is the current node of the AST.
     virtual void Cleanup() {
@@ -133,6 +137,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
+    void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
   };
 
@@ -153,6 +158,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
+    void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
   };
 
@@ -174,6 +180,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
+    void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
   };
 
@@ -194,6 +201,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
+    void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
   };
 
@@ -210,6 +218,7 @@ namespace clang {
     }
 
     Result Compare(const Node *Other, Lexicographic Lex) const;
+    void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
   };
 
 } // end namespace clang
@@ -283,13 +292,6 @@ namespace clang {
 
     // Set Error in case an error occurs during transformation of the AST.
     void SetError() { Error = true; }
-
-    // Print the PreorderAST.
-    // @param[in] N is the current node of the AST. Initial value is Root.
-    void PrettyPrint(Node *N);
-
-    // FOR DEBUGGING ONLY
-    std::string ToString(Node *N);
 
   public:
     PreorderAST(ASTContext &Ctx, Expr *E) :

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -50,14 +50,14 @@ namespace clang {
     virtual void Coalesce(bool &Changed, bool &Error) { }
     virtual void Sort(Lexicographic Lex) { }
     virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) { }
-    Result CompareKinds(Node *Other) {
+    Result CompareKinds(const Node *Other) const {
       if (Kind < Other->Kind)
         return Result::LessThan;
       if (Kind > Other->Kind)
         return Result::GreaterThan;
       return Result::Equal;
     }
-    virtual Result Compare(Node *Other, Lexicographic Lex) {
+    virtual Result Compare(const Node *Other, Lexicographic Lex) const {
       return CompareKinds(Other);
     }
     virtual void Cleanup() {
@@ -91,7 +91,7 @@ namespace clang {
     void Coalesce(bool &Changed, bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
-    Result Compare(Node *Other, Lexicographic Lex);
+    Result Compare(const Node *Other, Lexicographic Lex) const;
     void Cleanup();
   };
 
@@ -111,7 +111,7 @@ namespace clang {
     void Coalesce(bool &Changed, bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
-    Result Compare(Node *Other, Lexicographic Lex);
+    Result Compare(const Node *Other, Lexicographic Lex) const;
     void Cleanup();
   };
 
@@ -132,7 +132,7 @@ namespace clang {
     void Coalesce(bool &Changed, bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
-    Result Compare(Node *Other, Lexicographic Lex);
+    Result Compare(const Node *Other, Lexicographic Lex) const;
     void Cleanup();
   };
 
@@ -152,7 +152,7 @@ namespace clang {
     void Coalesce(bool &Changed, bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
-    Result Compare(Node *Other, Lexicographic Lex);
+    Result Compare(const Node *Other, Lexicographic Lex) const;
     void Cleanup();
   };
 
@@ -280,7 +280,9 @@ namespace clang {
     // @param[in] P is the second AST.
     // @return Returns a Lexicographic::Result indicating the comparison between
     // the two ASTs.
-    Result Compare(const PreorderAST P) const { return Root->Compare(P.Root, Lex); }
+    Result Compare(const PreorderAST P) const {
+      return Root->Compare(P.Root, Lex);
+    }
 
     // Check if an error has occurred during transformation of the AST. This
     // is intended to be called from outside this class to check if an error

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -60,6 +60,9 @@ namespace clang {
     virtual Result Compare(Node *Other, Lexicographic Lex) {
       return CompareKinds(Other);
     }
+    virtual void Cleanup() {
+      delete this;
+    }
   };
 
   class BinaryOperatorNode : public Node {
@@ -89,6 +92,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
+    void Cleanup();
   };
 
   class UnaryOperatorNode : public Node {
@@ -108,6 +112,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
+    void Cleanup();
   };
 
   class MemberNode : public Node {
@@ -128,6 +133,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
+    void Cleanup();
   };
 
   class ImplicitCastNode : public Node {
@@ -147,6 +153,7 @@ namespace clang {
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(Node *Other, Lexicographic Lex);
+    void Cleanup();
   };
 
   class LeafExprNode : public Node {
@@ -211,9 +218,8 @@ namespace clang {
     // @param[in] N is the current node of the AST. Initial value is Root.
     void PrettyPrint(Node *N);
 
-    // Cleanup the memory consumed by node N.
-    // @param[in] N is the current node of the AST. Initial value is Root.
-    void Cleanup(Node *N);
+    // FOR DEBUGGING ONLY
+    std::string ToString(Node *N);
 
   public:
     PreorderAST(ASTContext &Ctx, Expr *E) :
@@ -256,7 +262,7 @@ namespace clang {
     // Cleanup the memory consumed by the AST. This is intended to be called
     // from outside this class and invokes Cleanup on the root node which
     // recursively deletes the AST.
-    void Cleanup() { Cleanup(Root); }
+    void Cleanup() { Root->Cleanup(); }
 
     bool operator<(PreorderAST &Other) const {
       return Compare(Other) == Result::LessThan;

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -187,6 +187,35 @@ namespace clang {
     // @param[in] Parent is the parent of the new node.
     void Create(Expr *E, Node *Parent = nullptr);
 
+    // Create a BinaryOperatorNode for the expression E.
+    // @param[in] E is the expression whose LHS and RHS subexpressions
+    // will be added to a new node.
+    // @param[in] Parent is the parent of the new node.
+    void CreateBinaryOperator(BinaryOperator *E, Node *Parent);
+
+    // Create a UnaryOperatorNode or a LeafExprNode for the expression E.
+    // @param[in] E is the expression that is used to create a new node.
+    // @param[in] Parent is the parent of the new node.
+    void CreateUnaryOperator(UnaryOperator *E, Node *Parent);
+
+    // Create a UnaryOperatorNode with the sub expression Child and the
+    // Deref unary operator.
+    // @param[in] Child is the expression that is the child of a new node.
+    // @param[in] Parent is the parent of the new node.
+    void CreateDereference(Expr *Child, Node *Parent);
+
+    // Create a MemberNode for the expression E.
+    // @param[in] E is the expression whose Base and Field will be added to
+    // a new node.
+    // @param[in] Parent is the parent of the new node.
+    void CreateMember(MemberExpr *E, Node *Parent);
+
+    // Create an ImplicitCastNode for the expression.
+    // @param[in] E is the expression whose CastKind and sub expression will
+    // be added to a new node.
+    // @param[in] Parent is the parent of the new node.
+    void CreateImplicitCast(ImplicitCastExpr *E, Node *Parent);
+
     // Create a BinaryOperatorNode with an addition operator and two children
     // (E and 0), and attach the created BinaryOperatorNode to the Parent node.
     // @param[in] E is the expression that is one of the two children of

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -55,14 +55,14 @@ namespace clang {
     // @param[in] Changed indicates whether a node was coalesced. We need this
     // to control when to stop recursive coalescing.
     // @param[in] Error indicates whether an error occurred during coalescing.
-    virtual void Coalesce(bool &Changed, bool &Error) { }
+    virtual void Coalesce(bool &Changed, bool &Error) = 0;
 
     // Recursively descend a Node to sort the children of all
     // BinaryOperatorNodes if the binary operator is commutative.
     // @param[in] this is the current node of the AST.
     // @param[in] Lex is used to lexicographically compare Exprs and Decls
     // that occur within nodes.
-    virtual void Sort(Lexicographic Lex) { }
+    virtual void Sort(Lexicographic Lex) = 0;
 
     // Constant fold integer expressions.
     // @param[in] this is the current node of the AST.
@@ -71,7 +71,7 @@ namespace clang {
     // @param[in] Error indicates whether an error occurred during constant
     // folding.
     // @param[in] Ctx is used to create constant expressions.
-    virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) { }
+    virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) = 0;
 
     // Compare nodes according to their kind.
     // @param[in] this is the current node of the AST.
@@ -93,19 +93,15 @@ namespace clang {
     // that occur within nodes.
     // @return Returns a Lexicographic::Result indicating the comparison
     // between this and Other.
-    virtual Result Compare(const Node *Other, Lexicographic Lex) const {
-      return CompareKinds(Other);
-    }
+    virtual Result Compare(const Node *Other, Lexicographic Lex) const = 0;
 
     // Print the node.
     // @param[in] this is the current node of the AST.
-    virtual void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const { }
+    virtual void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const = 0;
 
     // Cleanup the memory consumed by this node.
     // @param[in] this is the current node of the AST.
-    virtual void Cleanup() {
-      delete this;
-    }
+    virtual void Cleanup() = 0;
   };
 
   class BinaryOperatorNode : public Node {
@@ -219,8 +215,12 @@ namespace clang {
       return N->Kind == NodeKind::LeafExprNode;
     }
 
+    void Coalesce(bool &Changed, bool &Error);
+    void Sort(Lexicographic Lex);
+    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
+    void Cleanup();
   };
 
 } // end namespace clang

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -101,7 +101,9 @@ namespace clang {
 
     // Cleanup the memory consumed by this node.
     // @param[in] this is the current node of the AST.
-    virtual void Cleanup() = 0;
+    virtual void Cleanup() {
+      delete this;
+    }
   };
 
   class BinaryOperatorNode : public Node {
@@ -220,7 +222,6 @@ namespace clang {
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
-    void Cleanup();
   };
 
 } // end namespace clang

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -256,8 +256,12 @@ void BinaryOperatorNode::Coalesce(bool &Changed, bool &Error) {
     return;
 
   // Coalesce the children first.
-  for (auto *Child : Children)
+  // Since Children is modified within the loop, we need to evaluate
+  // the loop end on each iteration.
+  for (size_t I = 0; I != Children.size(); ++I) {
+    auto *Child = Children[I];
     Child->Coalesce(Changed, Error);
+  }
 
   if (!CanCoalesce())
     return;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -335,7 +335,8 @@ void ImplicitCastNode::Sort(Lexicographic Lex) {
   Child->Sort(Lex);
 }
 
-void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) {
+void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
+                                      ASTContext &Ctx) {
   if (Error)
     return;
 
@@ -428,7 +429,8 @@ void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error, ASTContext &Ct
   Changed = true;
 }
 
-void UnaryOperatorNode::ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) {
+void UnaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
+                                     ASTContext &Ctx) {
   if (Error)
     return;
   Child->ConstantFold(Changed, Error, Ctx);
@@ -440,7 +442,8 @@ void MemberNode::ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) {
   Base->ConstantFold(Changed, Error, Ctx);
 }
 
-void ImplicitCastNode::ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) {
+void ImplicitCastNode::ConstantFold(bool &Changed, bool &Error,
+                                    ASTContext &Ctx) {
   if (Error)
     return;
   Child->ConstantFold(Changed, Error, Ctx);

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -720,7 +720,3 @@ void ImplicitCastNode::Cleanup() {
   Child->Cleanup();
   delete this;
 }
-
-void LeafExprNode::Cleanup() {
-  delete this;
-}

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -309,6 +309,8 @@ void ImplicitCastNode::Coalesce(bool &Changed, bool &Error) {
   Child->Coalesce(Changed, Error);
 }
 
+void LeafExprNode::Coalesce(bool &Changed, bool &Error) { }
+
 void BinaryOperatorNode::Sort(Lexicographic Lex) {
   // Sort the children first.
   for (auto *Child : Children)
@@ -336,6 +338,8 @@ void MemberNode::Sort(Lexicographic Lex) {
 void ImplicitCastNode::Sort(Lexicographic Lex) {
   Child->Sort(Lex);
 }
+
+void LeafExprNode::Sort(Lexicographic Lex) { }
 
 void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
                                       ASTContext &Ctx) {
@@ -450,6 +454,9 @@ void ImplicitCastNode::ConstantFold(bool &Changed, bool &Error,
     return;
   Child->ConstantFold(Changed, Error, Ctx);
 }
+
+void LeafExprNode::ConstantFold(bool &Changed, bool &Error,
+                                ASTContext &Ctx) { }
 
 bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
 				 llvm::APSInt &Offset) {
@@ -711,5 +718,9 @@ void MemberNode::Cleanup() {
 
 void ImplicitCastNode::Cleanup() {
   Child->Cleanup();
+  delete this;
+}
+
+void LeafExprNode::Cleanup() {
   delete this;
 }

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -60,7 +60,7 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
 
   E = Lex.IgnoreValuePreservingOperations(Ctx, E->IgnoreParens());
 
-  if (!Parent) {
+  if (!Root) {
     // The invariant is that the root node must be a BinaryOperatorNode with an
     // addition operator. So for expressions like "if (*p)", we don't have a
     // BinaryOperator. So when we enter this function there is no root and the

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -273,9 +273,7 @@ void BinaryOperatorNode::Coalesce(bool &Changed, bool &Error) {
     return;
 
   // Remove the current node from the list of children of its parent.
-  // Since BParent is modified within the loop, we need to evaluate
-  // the loop end on each iteration.
-  for (auto I = BParent->Children.begin(); I != BParent->Children.end(); ++I) {
+  for (auto I = BParent->Children.begin(), E = BParent->Children.end(); I != E; ++I) {
     if (*I == this) {
       BParent->Children.erase(I);
       break;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -656,20 +656,26 @@ void PreorderAST::PrettyPrint(Node *N) {
     L->E->dump(OS, Ctx);
 }
 
-void PreorderAST::Cleanup(Node *N) {
-  if (auto *B = dyn_cast_or_null<BinaryOperatorNode>(N))
-    for (auto *Child : B->Children)
-      Cleanup(Child);
 
-  if (auto *U = dyn_cast_or_null<UnaryOperatorNode>(N))
-    Cleanup(U->Child);
 
-  if (auto *M = dyn_cast_or_null<MemberNode>(N))
-    Cleanup(M->Base);
 
-  if (auto *I = dyn_cast_or_null<ImplicitCastNode>(N))
-    Cleanup(I->Child);
+void BinaryOperatorNode::Cleanup() {
+  for (auto *Child : Children)
+    Child->Cleanup();
+  delete this;
+}
 
-  if (N)
-    delete N;
+void UnaryOperatorNode::Cleanup() {
+  Child->Cleanup();
+  delete this;
+}
+
+void MemberNode::Cleanup() {
+  Base->Cleanup();
+  delete this;
+}
+
+void ImplicitCastNode::Cleanup() {
+  Child->Cleanup();
+  delete this;
 }

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -318,7 +318,7 @@ void BinaryOperatorNode::Sort(Lexicographic Lex) {
 
   // Sort the children.
   llvm::sort(Children.begin(), Children.end(),
-            [&](Node *N1, Node *N2) {
+            [&](const Node *N1, const Node *N2) {
               return N1->Compare(N2, Lex) == Result::LessThan;
             });
 }
@@ -522,12 +522,15 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   return true;
 }
 
-Result BinaryOperatorNode::Compare(Node *Other, Lexicographic Lex) {
+Result BinaryOperatorNode::Compare(const Node *Other, Lexicographic Lex) const {
   Result KindComparison = CompareKinds(Other);
   if (KindComparison != Result::Equal)
     return KindComparison;
 
-  BinaryOperatorNode *B = dyn_cast<BinaryOperatorNode>(Other);
+  const BinaryOperatorNode *B = dyn_cast<BinaryOperatorNode>(Other);
+  if (!B)
+    return Result::LessThan;
+
   // If the Opcodes mismatch.
   if (Opc < B->Opc)
     return Result::LessThan;
@@ -557,12 +560,14 @@ Result BinaryOperatorNode::Compare(Node *Other, Lexicographic Lex) {
   return Result::Equal;
 }
 
-Result UnaryOperatorNode::Compare(Node *Other, Lexicographic Lex) {
+Result UnaryOperatorNode::Compare(const Node *Other, Lexicographic Lex) const {
   Result KindComparison = CompareKinds(Other);
   if (KindComparison != Result::Equal)
     return KindComparison;
 
-  UnaryOperatorNode *U = dyn_cast<UnaryOperatorNode>(Other);
+  const UnaryOperatorNode *U = dyn_cast<UnaryOperatorNode>(Other);
+  if (!U)
+    return Result::LessThan;
 
   // If the Opcodes mismatch.
   if (Opc < U->Opc)
@@ -573,12 +578,14 @@ Result UnaryOperatorNode::Compare(Node *Other, Lexicographic Lex) {
   return Child->Compare(U->Child, Lex);
 }
 
-Result MemberNode::Compare(Node *Other, Lexicographic Lex) {
+Result MemberNode::Compare(const Node *Other, Lexicographic Lex) const {
   Result KindComparison = CompareKinds(Other);
   if (KindComparison != Result::Equal)
     return KindComparison;
 
-  MemberNode *M = dyn_cast<MemberNode>(Other);
+  const MemberNode *M = dyn_cast<MemberNode>(Other);
+  if (!M)
+    return Result::LessThan;
 
   // If the arrow flags mismatch.
   if (IsArrow && !M->IsArrow)
@@ -594,12 +601,14 @@ Result MemberNode::Compare(Node *Other, Lexicographic Lex) {
   return Base->Compare(M->Base, Lex);
 }
 
-Result ImplicitCastNode::Compare(Node *Other, Lexicographic Lex) {
+Result ImplicitCastNode::Compare(const Node *Other, Lexicographic Lex) const {
   Result KindComparison = CompareKinds(Other);
   if (KindComparison != Result::Equal)
     return KindComparison;
 
-  ImplicitCastNode *I = dyn_cast<ImplicitCastNode>(Other);
+  const ImplicitCastNode *I = dyn_cast<ImplicitCastNode>(Other);
+  if (!I)
+    return Result::LessThan;
 
   // If the cast kinds mismatch.
   if (CK < I->CK)
@@ -610,13 +619,16 @@ Result ImplicitCastNode::Compare(Node *Other, Lexicographic Lex) {
   return Child->Compare(I->Child, Lex);
 }
 
-Result LeafExprNode::Compare(Node *Other, Lexicographic Lex) {
+Result LeafExprNode::Compare(const Node *Other, Lexicographic Lex) const {
   Result KindComparison = CompareKinds(Other);
   if (KindComparison != Result::Equal)
     return KindComparison;
 
+  const LeafExprNode *L = dyn_cast<LeafExprNode>(Other);
+  if (!L)
+    return Result::LessThan;
+
   // Compare the exprs for two leaf nodes.
-  LeafExprNode *L = dyn_cast<LeafExprNode>(Other);
   return Lex.CompareExpr(E, L->E);
 }
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -64,7 +64,7 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
     // The invariant is that the root node must be a BinaryOperatorNode with an
     // addition operator. So for expressions like "if (*p)", we don't have a
     // BinaryOperator. So when we enter this function there is no root and the
-    // parent is null. So we create a new BinaryOperatorNode with + as the
+    // Root node is null. So we create a new BinaryOperatorNode with + as the
     // operator and add 0 as a LeafExprNode child of this BinaryOperatorNode.
     // This helps us compare expressions like "p" and "p + 1" by normalizing
     // "p" to "p + 0".


### PR DESCRIPTION
Fixes #1032 

This PR refactors PreorderAST to move Coalesce, Sort, ConstantFold, Compare, Cleanup, and PrettyPrint behavior into Node subclass methods.