### PR TITLE
PreorderAST: refactor loops over child nodes

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -66,12 +66,12 @@ namespace clang {
 
     // Constant fold integer expressions.
     // @param[in] this is the current node of the AST.
-    // @param[in] Changed indicates whether constant folding was done. We need
-    // this to control when to stop recursive constant folding.
     // @param[in] Error indicates whether an error occurred during constant
     // folding.
     // @param[in] Ctx is used to create constant expressions.
-    virtual void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) = 0;
+    // @return Returns true if this node was deleted. The node is deleted if
+    // it is coalesced into its parent at the end of constant folding.
+    virtual bool ConstantFold(bool &Error, ASTContext &Ctx) = 0;
 
     // Compare nodes according to their kind.
     // @param[in] this is the current node of the AST.
@@ -135,7 +135,7 @@ namespace clang {
     bool CanCoalesce();
     bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
-    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
+    bool ConstantFold(bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
@@ -156,7 +156,7 @@ namespace clang {
 
     bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
-    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
+    bool ConstantFold(bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
@@ -178,7 +178,7 @@ namespace clang {
 
     bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
-    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
+    bool ConstantFold(bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
@@ -199,7 +199,7 @@ namespace clang {
 
     bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
-    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
+    bool ConstantFold(bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
     void Cleanup();
@@ -219,7 +219,7 @@ namespace clang {
 
     bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
-    void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
+    bool ConstantFold(bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
     void PrettyPrint(llvm::raw_ostream &OS, ASTContext &Ctx) const;
   };

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -52,10 +52,10 @@ namespace clang {
     // Recursively coalesce BinaryOperatorNodes having the same commutative
     // and associative operator.
     // @param[in] this is the current node of the AST.
-    // @param[in] Changed indicates whether a node was coalesced. We need this
-    // to control when to stop recursive coalescing.
     // @param[in] Error indicates whether an error occurred during coalescing.
-    virtual void Coalesce(bool &Changed, bool &Error) = 0;
+    // @return Returns true if this node was deleted. The node is deleted if
+    // it is coalesced into its parent.
+    virtual bool Coalesce(bool &Error) = 0;
 
     // Recursively descend a Node to sort the children of all
     // BinaryOperatorNodes if the binary operator is commutative.
@@ -133,7 +133,7 @@ namespace clang {
     // @return Returns true if this can be coalesced into its parent, false
     // otherwise.
     bool CanCoalesce();
-    void Coalesce(bool &Changed, bool &Error);
+    bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
@@ -154,7 +154,7 @@ namespace clang {
       return N->Kind == NodeKind::UnaryOperatorNode;
     }
 
-    void Coalesce(bool &Changed, bool &Error);
+    bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
@@ -176,7 +176,7 @@ namespace clang {
       return N->Kind == NodeKind::MemberNode;
     }
 
-    void Coalesce(bool &Changed, bool &Error);
+    bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
@@ -197,7 +197,7 @@ namespace clang {
       return N->Kind == NodeKind::ImplicitCastNode;
     }
 
-    void Coalesce(bool &Changed, bool &Error);
+    bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;
@@ -217,7 +217,7 @@ namespace clang {
       return N->Kind == NodeKind::LeafExprNode;
     }
 
-    void Coalesce(bool &Changed, bool &Error);
+    bool Coalesce(bool &Error);
     void Sort(Lexicographic Lex);
     void ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx);
     Result Compare(const Node *Other, Lexicographic Lex) const;

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -670,6 +670,23 @@ void PreorderAST::Normalize() {
   // TODO: Perform simple arithmetic optimizations/transformations on the
   // constants in the nodes.
 
+  // We only need one call to Coalesce, Sort and ConstantFold in order to
+  // normalize the tree, since:
+  // 1. For any Node N, calling N->Coalesce fully coalesces N and all children
+  //    of N.
+  // 2. For any Node N, calling N->Sort fully sorts N and all children of N.
+  // 3. For any Node N, calling N->ConstantFold fully constant folds N and all
+  //    children of N.
+  // 4. After calling Sort, there is no further coalescing to be done, since
+  //    Sort creates no new nodes.
+  // 5. After calling ConstantFold, there is no further coalescing to be done,
+  //    since ConstantFold does not create any new BinaryOperatorNodes. At
+  //    most, ConstantFold may create new LeafExprNodes.
+  // 6. After calling ConstantFold, there is no further sorting to be done,
+  //    since ConstantFold adds any newly created LeafExprNodes to the end of
+  //    the Children list. This may break sorting only among the constant
+  //    child nodes. The child nodes are sorted correctly when the Parent node
+  //    of the Children list is constant folded.
   Root->Coalesce(Error);
   if (!Error) {
     Root->Sort(Lex);

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -354,23 +354,30 @@ void ImplicitCastNode::Sort(Lexicographic Lex) {
 
 void LeafExprNode::Sort(Lexicographic Lex) { }
 
-void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
-                                      ASTContext &Ctx) {
+bool BinaryOperatorNode::ConstantFold(bool &Error, ASTContext &Ctx) {
   if (Error)
-    return;
+    return false;
 
   size_t ConstStartIdx = 0;
   unsigned NumConsts = 0;
   llvm::APSInt ConstFoldedVal;
 
-  for (size_t I = 0; I != Children.size(); ++I) {
-    auto *Child = Children[I];
+  size_t Idx = 0;
+  while (Idx != Children.size()) {
+    auto *Child = Children[Idx];
 
     // Recursively constant fold the non-leaf children of a BinaryOperatorNode.
     if (!isa<LeafExprNode>(Child)) {
-      Child->ConstantFold(Changed, Error, Ctx);
+      bool ChildDeleted = Child->ConstantFold(Error, Ctx);
+      // If Child was not deleted during constant folding, then we can
+      // increment Idx in order to process the next child node. Otherwise,
+      // if Child was deleted, then Children[Idx] still needs to be processed.
+      if (!ChildDeleted)
+        ++Idx;
       continue;
     }
+
+    ++Idx;
 
     // We can only constant fold if the operator is commutative and
     // associative.
@@ -391,7 +398,7 @@ void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
     if (NumConsts == 1) {
       // We will use ConstStartIdx later in this function to delete the
       // constant folded nodes.
-      ConstStartIdx = I;
+      ConstStartIdx = Idx - 1;
       ConstFoldedVal = CurrConstVal;
 
     } else {
@@ -410,14 +417,14 @@ void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
       // If we encounter an overflow during constant folding we cannot proceed.
       if (Overflow) {
         Error = true;
-        return;
+        return false;
       }
     }
   }
 
   // To fold constants we need at least 2 constants.
   if (NumConsts <= 1)
-    return;
+    return false;
 
   // Delete the folded constants and reclaim memory.
   // Note: We do not explicitly need to increment the iterator because after
@@ -441,35 +448,37 @@ void BinaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
   Children.push_back(new LeafExprNode(ConstFoldedExpr, this));
 
   // If the constant folded expr is the only child of this BinaryOperatorNode
-  // we can coalesce the node.
+  // we can coalesce the node. This node may be deleted during coalescing.
   if (Children.size() == 1 && CanCoalesce())
-    Coalesce(Changed, Error);
+    return Coalesce(Error);
 
-  Changed = true;
+  return false;
 }
 
-void UnaryOperatorNode::ConstantFold(bool &Changed, bool &Error,
-                                     ASTContext &Ctx) {
+bool UnaryOperatorNode::ConstantFold(bool &Error, ASTContext &Ctx) {
   if (Error)
-    return;
-  Child->ConstantFold(Changed, Error, Ctx);
+    return false;
+  Child->ConstantFold(Error, Ctx);
+  return false;
 }
 
-void MemberNode::ConstantFold(bool &Changed, bool &Error, ASTContext &Ctx) {
+bool MemberNode::ConstantFold(bool &Error, ASTContext &Ctx) {
   if (Error)
-    return;
-  Base->ConstantFold(Changed, Error, Ctx);
+    return false;
+  Base->ConstantFold(Error, Ctx);
+  return false;
 }
 
-void ImplicitCastNode::ConstantFold(bool &Changed, bool &Error,
-                                    ASTContext &Ctx) {
+bool ImplicitCastNode::ConstantFold(bool &Error, ASTContext &Ctx) {
   if (Error)
-    return;
-  Child->ConstantFold(Changed, Error, Ctx);
+    return false;
+  Child->ConstantFold(Error, Ctx);
+  return false;
 }
 
-void LeafExprNode::ConstantFold(bool &Changed, bool &Error,
-                                ASTContext &Ctx) { }
+bool LeafExprNode::ConstantFold(bool &Error, ASTContext &Ctx) {
+  return false;
+}
 
 bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
 				 llvm::APSInt &Offset) {

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -670,16 +670,10 @@ void PreorderAST::Normalize() {
   // TODO: Perform simple arithmetic optimizations/transformations on the
   // constants in the nodes.
 
-  bool Changed = true;
-  while (Changed) {
-    Changed = false;
-    Root->Coalesce(Changed, Error);
-    if (Error)
-      break;
+  Root->Coalesce(Error);
+  if (!Error) {
     Root->Sort(Lex);
-    Root->ConstantFold(Changed, Error, Ctx);
-    if (Error)
-      break;
+    Root->ConstantFold(Error, Ctx);
   }
 
   if (Ctx.getLangOpts().DumpPreorderAST) {

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -179,3 +179,15 @@ void f15(_Nt_array_ptr<char> p : count(6)) {
 //  [B1]
 // upper_bound(p) = 1
 }
+
+void f16(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j + 8) = "a";
+  if (*(p + (i + 3 * 2 + (j + 2)))) {}
+
+// CHECK: In function: f16
+//  [B2]
+//    1: _Nt_array_ptr<char> p : bounds(p, p + i + j + 8) = "a";
+//    2: *(p + (i + 3 * 2 + (j + 2)))
+//  [B1]
+// upper_bound(p) = 1
+}


### PR DESCRIPTION
This PR refactors the loops in `BinaryNode::Coalesce` and `BinaryNode::ConstantFold` to only increment the loop index if the current child node was not deleted from the list of child nodes. These changes also mean that the while loop in `PreorderAST::Normalize` can be removed. Coalescing, sorting, and constant folding can now be done in a single call to `Coalesce`, `Sort` and `ConstantFold` on the `Root` node of a PreorderAST.