### PR TITLE
Compare initializer list exprs by address

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -77,6 +77,7 @@ namespace clang {
     Result CompareRelativeBoundsClause(const RelativeBoundsClause *RC1,
                                        const RelativeBoundsClause *RC2) const;
     Result CompareScope(const DeclContext *DC1, const DeclContext *DC2) const;
+    Result CompareAddress(const Expr *E1, const Expr *E2) const;
 
     Result CompareImpl(const PredefinedExpr *E1, const PredefinedExpr *E2) const;
     Result CompareImpl(const DeclRefExpr *E1, const DeclRefExpr *E2) const;

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -142,6 +142,15 @@ Lexicographic::CompareScope(const DeclContext *DC1, const DeclContext *DC2) cons
 }
 
 Result
+Lexicographic::CompareAddress(const Expr *E1, const Expr *E2) const {
+  if (E1 == E2)
+    return Result::Equal;
+  if (E1 < E2)
+    return Result::LessThan;
+  return Result::GreaterThan;
+}
+
+Result
 Lexicographic::CompareDecl(const CapturedDecl *CD1Arg,
                            const CapturedDecl *CD2Arg) const {
   const CapturedDecl *CD1 = dyn_cast<CapturedDecl>(CD1Arg->getCanonicalDecl());

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -441,6 +441,14 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) const {
      // case Expr::MSPropertyRefExprClass:
      // case Expr::MSPropertySubscriptExprClass:
 
+     // Expressions which currently do not have ordering implementations,
+     // but which may need to be lexicographically ordered by some consumer
+     // of Lexicographic. These expressions are compared by their addresses.
+     // This comparison will be deterministic for one compiler run, but is
+     // not guaranteed to be deterministic across compiler runs.
+     case Expr::InitListExprClass:
+     case Expr::ImplicitValueInitExprClass: return CompareAddress(E1, E2);
+
      default:
        llvm_unreachable("unexpected expression kind");
    }


### PR DESCRIPTION
For the lvalue generalization work, we need to create AbstractSets for member expressions, which may include initializer lists (e.g. in an assignment such as `((struct S){ 0 }).f = 0;`. The AbstractSetManager maintains a sorted set of PreorderASTs, so PreorderASTs need to be compared. This involves calling `Lexicographic::CompareExpr`. So if an initializer list expression is used to create a PreorderAST, we need to be able to lexicographically compare initializer list expressions.

This PR adds a `CompareAddress` method to CanonBounds.cpp as a fallback method of comparing two expressions which otherwise cannot be easily lexicographically compared. We compare `InitListExprs` and `ImplicitValueInitExprs` using `CompareAddress`.