### PR TITLE
[LValue Generalization] Add BoundsSiblingFields to CheckedCAnalysesPrepass [7/n]

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -265,6 +265,7 @@ BENIGN_LANGOPT(DumpInferredBounds, 1, 0, "dump inferred Checked C bounds for ass
 BENIGN_LANGOPT(DumpExtractedComparisonFacts, 1, 0, "dump extracted comparison facts")
 BENIGN_LANGOPT(DumpWidenedBounds, 1, 0, "dump widened bounds")
 BENIGN_LANGOPT(DumpBoundsVars, 1, 0, "dump bounds vars")
+BENIGN_LANGOPT(DumpBoundsSiblingFields, 1, 0, "dump bounds sibling fields")
 BENIGN_LANGOPT(DumpPreorderAST, 1, 0, "dump the preorder AST")
 BENIGN_LANGOPT(DumpCheckingState, 1, 0, "dump the state during bounds checking")
 LANGOPT(InjectVerifierCalls, 1, 0, "Injects calls to VERIFIER_assume and VERIFIER_error in the bitcode")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -856,6 +856,8 @@ def fdump_widened_bounds : Flag<["-"], "fdump-widened-bounds">, Group<f_Group>, 
   HelpText<"Dump widened bounds">;
 def fdump_boundsvars : Flag<["-"], "fdump-boundsvars">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump bounds vars">;
+def fdump_boundssiblingfields : Flag<["-"], "fdump-boundssiblingfields">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Dump bounds sibling fields">;
 def fdump_preorder_ast : Flag<["-"], "fdump-preorder-ast">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump the preorder AST">;
 def fdump_checking_state : Flag<["-"], "fdump-checking-state">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -31,8 +31,6 @@ namespace clang {
   // expressions Z occurs.
   using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>;
 
-  // VarListTy denotes a list of variables.
-  using VarListTy = llvm::SmallVector<const VarDecl *, 2>;
 
   struct PrepassInfo {
     // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -57,8 +57,22 @@ namespace clang {
     // iteration order we must remember to sort the keys as well as the values.
     BoundsVarsTy BoundsVars;
 
-    // BoundsSiblingFields maps each FieldDecl F in a struct declaration S to
-    // a set of fields in S in whose declared bounds F occurs.
+    // BoundsSiblingFields maps each FieldDecl F in a record declaration S to
+    // a set of fields in S in whose declared bounds F occurs. More precisely,
+    // if a function declares a variable with an associated record decl S,
+    // then for each field F in S, BoundsSiblingFields[F] will be a set of
+    // fields G in S, where:
+    // 1. The declared bounds of G use the value of a DeclRefExpr V, and:
+    // 2. The declaration of V is F.
+    // Note that this definition does not include G in S if G is accessed
+    // via a field of a MemberExpr. For example, in:
+    // struct S {
+    //   struct S *s;
+    //   int len;
+    //   _Array_ptr<int> p : count(s->len);
+    // };
+    // The field len will not be considered to occur in the declared bounds
+    // of p.
 
     // Note: BoundsSiblingFieldsTy is a map of keys to values which are sets.
     // As a result, there is no defined iteration order for either its keys or

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -62,9 +62,9 @@ namespace clang {
 
     // Note: BoundsSiblingFieldsTy is a map of keys to values which are sets.
     // As a result, there is no defined iteration order for either its keys or
-    // its values. So in case we want to iterate BoundsVars and need a
-    // deterministic iteration order we must remember to sort the keys as well
-    // as the values.
+    // its values. So in case we want to iterate BoundsSiblingFields and need
+    // a deterministic iteration order we must remember to sort the keys as
+    // well as the values.
     BoundsSiblingFieldsTy BoundsSiblingFields;
   };
 } // end namespace clang

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -31,6 +31,12 @@ namespace clang {
   // expressions Z occurs.
   using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>;
 
+  // FieldSetTy denotes a set of fields.
+  using FieldSetTy = llvm::SmallPtrSet<const FieldDecl *, 2>;
+
+  // BoundsSiblingFieldsTy maps a field F to the set of all sibling fields
+  // of F in whose declared bounds expressions F occurs.
+  using BoundsSiblingFieldsTy = llvm::DenseMap<const FieldDecl *, FieldSetTy>;
 
   struct PrepassInfo {
     // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)
@@ -50,6 +56,16 @@ namespace clang {
     // values. So in case we want to iterate BoundsVars and need a determinstic
     // iteration order we must remember to sort the keys as well as the values.
     BoundsVarsTy BoundsVars;
+
+    // BoundsSiblingFields maps each FieldDecl F in a struct declaration S to
+    // a set of fields in S in whose declared bounds F occurs.
+
+    // Note: BoundsSiblingFieldsTy is a map of keys to values which are sets.
+    // As a result, there is no defined iteration order for either its keys or
+    // its values. So in case we want to iterate BoundsVars and need a
+    // deterministic iteration order we must remember to sort the keys as well
+    // as the values.
+    BoundsSiblingFieldsTy BoundsSiblingFields;
   };
 } // end namespace clang
 #endif

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2849,6 +2849,9 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   if (Args.hasArg(OPT_fdump_boundsvars))
     Opts.DumpBoundsVars = true;
 
+  if (Args.hasArg(OPT_fdump_boundssiblingfields))
+    Opts.DumpBoundsSiblingFields = true;
+
   if (Args.hasArg(OPT_fdump_preorder_ast))
     Opts.DumpPreorderAST = true;
 

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -23,6 +23,7 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
   private:
     Sema &SemaRef;
     PrepassInfo &Info;
+    llvm::raw_ostream &OS;
 
     // VarWithBounds is a variable that has a bounds expression. It is used to
     // track:
@@ -39,7 +40,6 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     // int x = 1 _Where p : bounds(lower, upper);
 
     VarDecl *VarWithBounds = nullptr;
-    llvm::raw_ostream &OS;
 
   public:
     PrepassHelper(Sema &SemaRef, PrepassInfo &Info) :

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -41,6 +41,17 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
     VarDecl *VarWithBounds = nullptr;
 
+    // GetRecordDecl returns the struct declaration, if any, that is
+    // associated with the given type. For example, if the given type is
+    // struct S, struct S *, _Ptr<struct S>, etc., GetRecordDecl will
+    // return the declaration of S.
+    RecordDecl *GetRecordDecl(const QualType Ty) {
+      const Type *T = Ty.getTypePtr();
+      if (T->isPointerType())
+        T = T->getPointeeOrArrayElementType();
+      return T->getAsRecordDecl();
+    }
+
   public:
     PrepassHelper(Sema &SemaRef, PrepassInfo &Info) :
       SemaRef(SemaRef), Info(Info), OS(llvm::outs()) {}

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -57,11 +57,11 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
     // GetRecordDecl returns the record declaration, if any, that is
     // associated with the given type. For example, if the given type is
-    // struct S, struct S *, _Ptr<struct S>, etc., GetRecordDecl will
-    // return the declaration of S.
+    // struct S, struct S *, _Ptr<struct S>, struct S **, etc.,
+    // GetRecordDecl will return the declaration of S.
     RecordDecl *GetRecordDecl(const QualType Ty) {
       const Type *T = Ty.getTypePtr();
-      if (T->isPointerType())
+      while (T->isAnyPointerType() || T->isArrayType())
         T = T->getPointeeOrArrayElementType();
       return T->getAsRecordDecl();
     }

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -61,6 +61,10 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     // GetRecordDecl will return the declaration of S.
     RecordDecl *GetRecordDecl(const QualType Ty) {
       const Type *T = Ty.getTypePtr();
+      // If T is a pointer type T * or array type T[],
+      // getPointeeOrArrayElementType will return T, which itself may be a
+      // pointer or array type. Keep descending T until T is not a pointer
+      // or array type.
       while (T->isAnyPointerType() || T->isArrayType())
         T = T->getPointeeOrArrayElementType();
       return T->getAsRecordDecl();

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -224,6 +224,11 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
       PrintDeclMap<const VarDecl *>(FD, "BoundsVars", Info.BoundsVars);
     }
 
+    void DumpBoundsSiblingFields(FunctionDecl *FD) {
+      PrintDeclMap<const FieldDecl *>(FD, "BoundsSiblingFields",
+                                      Info.BoundsSiblingFields);
+    }
+
     // Print a map from a key of type T to a set of elements of type T,
     // where T should inherit from NamedDecl.
     // This method can be used to print the BoundsVars and
@@ -294,4 +299,7 @@ void Sema::CheckedCAnalysesPrepass(PrepassInfo &Info, FunctionDecl *FD,
 
   if (getLangOpts().DumpBoundsVars)
     Prepass.DumpBoundsVars(FD);
+
+  if (getLangOpts().DumpBoundsSiblingFields)
+    Prepass.DumpBoundsSiblingFields(FD);
 }

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -131,12 +131,11 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
       if (!V || V->isInvalidDecl())
         return true;
 
-      // If V declares a variable with a struct or union type (e.g.struct S,
+      // If V declares a variable with a struct or union type (e.g. struct S,
       // struct S *, etc.), traverse the fields in the declaration of S in
-      // the declaration of S in order to map to each field F in S to the
-      // fields in S in whose declared bounds F appears.
-      RecordDecl *S = GetRecordDecl(V->getType());
-      if (S)
+      // order to map to each field F in S to the fields in S in whose
+      // declared bounds F appears.
+      if (RecordDecl *S = GetRecordDecl(V->getType()))
         FillBoundsSiblingFields(S);
 
       // If V has a bounds expression, traverse it so we visit the
@@ -192,6 +191,22 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
         }
       }
 
+      return true;
+    }
+
+    // For a temporary binding with a struct type (or pointer to a struct
+    // type), fill in the bounds sibling fields for the record declaration.
+    bool VisitCHKCBindTemporaryExpr(CHKCBindTemporaryExpr *E) {
+      if (RecordDecl *S = GetRecordDecl(E->getType()))
+        FillBoundsSiblingFields(S);
+      return true;
+    }
+
+    // For a call expression with a struct type (or pointer to a struct
+    // type), fill in the bounds sibling fields for the record declaration.
+    bool VisitCallExpr(CallExpr *E) {
+      if (RecordDecl *S = GetRecordDecl(E->getType()))
+        FillBoundsSiblingFields(S);
       return true;
     }
 

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -127,7 +127,7 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
         return true;
 
       // If V declares a variable with type struct S or struct S *, traverse
-      // the fields in the declaration of S in order map each field F in S
+      // the fields in the declaration of S in order map to each field F in S
       // to the fields in S in whose declared bounds F appears.
       RecordDecl *StructDecl = GetRecordDecl(V->getType());
       if (StructDecl)

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -153,6 +153,15 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
     // We may modify the VarUses map when a DeclRefExpr is visited.
     bool VisitDeclRefExpr(DeclRefExpr *E) {
+      // If E is a use of a field declaration F, then we add FieldWithBounds
+      // to the set of all fields in whose bounds expressions F occurs.
+      if (FieldWithBounds) {
+        const FieldDecl *F = dyn_cast_or_null<FieldDecl>(E->getDecl());
+        if (F && !F->isInvalidDecl())
+          AddBoundsSiblingField(F);
+        return true;
+      }
+
       const VarDecl *V = dyn_cast_or_null<VarDecl>(E->getDecl());
       if (!V || V->isInvalidDecl())
         return true;

--- a/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
@@ -1,0 +1,82 @@
+// Tests for fields occuring in the declared bounds of sibling fields
+// (fields declared in the same struct).
+//
+// RUN: %clang_cc1 -fdump-boundssiblingfields -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+
+// expected-no-diagnostics
+
+struct C {
+  int len;
+  _Array_ptr<int> r : count(len);
+};
+
+struct B {
+  int i;
+  int j;
+  struct C *c;
+  _Array_ptr<int> q : count(c->len);
+};
+
+struct A {
+  struct B *b;
+  int i;
+  int j;
+  _Array_ptr<int> start;
+  _Array_ptr<int> end;
+  _Array_ptr<int> p : count(b->c->len + b->i);
+  _Array_ptr<int> q : bounds(start, end);
+  _Array_ptr<int> r : bounds(q, q + i);
+};
+
+void f1(struct A *a) {
+// CHECK-LABEL: In function: f1
+// CHECK: BoundsSiblingFields:
+// CHECK: A::b: { A::p }
+// CHECK: A::end: { A::q }
+// CHECK: A::i: { A::r }
+// CHECK: A::p: { A::p }
+// CHECK: A::q: { A::r }
+// CHECK: A::start: { A::q }
+// CHECK: B::c: { B::q }
+// CHECK: B::q: { B::q }
+// CHECK: C::len: { C::r }
+// CHECK: C::r: { C::r }
+}
+
+struct Node {
+  struct Node *n;
+  int len;
+  _Array_ptr<int> p : byte_count(n->len);
+};
+
+void f2() {
+  struct Node *node = 0;
+  // CHECK-LABEL: In function: f2
+  // CHECK: BoundsSiblingFields:
+  // CHECK: Node::n: { Node::p }
+  // CHECK: Node::p: { Node::p }
+}
+
+struct X;
+
+struct Y {
+  _Array_ptr<struct X> x;
+  _Array_ptr<struct X> p : bounds(x, x);
+};
+
+struct X {
+  struct Y *y;
+  int len;
+  int i;
+  int j;
+  _Array_ptr<int> q : bounds(y->p, y->p + y->x->len + i + j);
+};
+
+void f3(struct X x) {
+  // CHECK-LABEL: In function: f3
+  // CHECK: BoundsSiblingFields:
+  // CHECK: X::i: { X::q }
+  // CHECK: X::j: { X::q }
+  // CHECK: X::y: { X::q }
+  // CHECK: Y::x: { Y::p }
+}

--- a/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
@@ -80,3 +80,23 @@ void f3(struct X x) {
   // CHECK: X::y: { X::q }
   // CHECK: Y::x: { Y::p }
 }
+
+struct R {
+  int len;
+  _Array_ptr<int> q : count(len);
+};
+
+struct S {
+  _Array_ptr<_Ptr<struct R>> r;
+  _Array_ptr<int> p : count((*r)->len);
+};
+
+void f4(_Ptr<struct S> s[3][4]) {
+  // CHECK-LABEL: In function: f4
+  // CHECK: BoundsSiblingFields:
+  // CHECK: R::len: { R::q }
+  // CHECK: R::q: { R::q }
+  // CHECK: S::p: { S::p }
+  // CHECK: S::r: { S::p }
+
+}

--- a/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
@@ -29,18 +29,18 @@ struct A {
 };
 
 void f1(struct A *a) {
-// CHECK-LABEL: In function: f1
-// CHECK: BoundsSiblingFields:
-// CHECK: A::b: { A::p }
-// CHECK: A::end: { A::q }
-// CHECK: A::i: { A::r }
-// CHECK: A::p: { A::p }
-// CHECK: A::q: { A::r }
-// CHECK: A::start: { A::q }
-// CHECK: B::c: { B::q }
-// CHECK: B::q: { B::q }
-// CHECK: C::len: { C::r }
-// CHECK: C::r: { C::r }
+  // CHECK-LABEL: In function: f1
+  // CHECK: BoundsSiblingFields:
+  // CHECK: A::b: { A::p }
+  // CHECK: A::end: { A::q }
+  // CHECK: A::i: { A::r }
+  // CHECK: A::p: { A::p }
+  // CHECK: A::q: { A::r }
+  // CHECK: A::start: { A::q }
+  // CHECK: B::c: { B::q }
+  // CHECK: B::q: { B::q }
+  // CHECK: C::len: { C::r }
+  // CHECK: C::r: { C::r }
 }
 
 struct Node {
@@ -98,5 +98,32 @@ void f4(_Ptr<struct S> s[3][4]) {
   // CHECK: R::q: { R::q }
   // CHECK: S::p: { S::p }
   // CHECK: S::r: { S::p }
+}
 
+void f5(void) {
+  ((struct A){ 0 }).i = 0;
+  // CHECK-LABEL: In function: f5
+  // CHECK: BoundsSiblingFields:
+  // CHECK: A::b: { A::p }
+  // CHECK: A::end: { A::q }
+  // CHECK: A::i: { A::r }
+  // CHECK: A::p: { A::p }
+  // CHECK: A::q: { A::r }
+  // CHECK: A::start: { A::q }
+  // CHECK: B::c: { B::q }
+  // CHECK: B::q: { B::q }
+  // CHECK: C::len: { C::r }
+  // CHECK: C::r: { C::r }
+}
+
+struct X *getX(void) { return 0; }
+
+void f6(void) {
+  getX()->len = 0;
+  // CHECK-LABEL: In function: f6
+  // CHECK: BoundsSiblingFields:
+  // CHECK: X::i: { X::q }
+  // CHECK: X::j: { X::q }
+  // CHECK: X::y: { X::q }
+  // CHECK: Y::x: { Y::p }
 }


### PR DESCRIPTION
This PR modifies the CheckedCAnalysesPrepass to populate a map of fields `F` in a struct declaration `S` to the fields in `S` in whose declared bounds `F` appears.

We can use this map to synthesize AbstractSets for MemberExprs whose target bounds depend on a MemberExpr `M` that is being modified in an assignment. When synthesizing for a MemberExpr `s->f` (or `s.f`), we can check each sibling field `g` of `f` in whose declared bounds `f` appears, create a MemberExpr `s->g` (or `s.g`), and check whether `M` appears in the declared bounds of `g`.