### PR TITLE
Free variables: fix check for integer constant expressions

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1597,7 +1597,8 @@ namespace {
         }
 
         for (const auto &E : EquivSet) {
-          if (isa<IntegerLiteral>(E))
+          llvm::APSInt Val;
+          if (E->isIntegerConstantExpr(Val, S.Context))
             return true;
         }
 

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -149,6 +149,25 @@ void f4(void) {
                                        // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 2)'}}
 }
 
+// Variables that are equivalent to integer constant expressions are not free variables.
+void f5(_Array_ptr<int> p : count(0)) {
+  // i is equivalent to (unsigned int)0.
+  unsigned int i = 0;
+  _Array_ptr<int> q : count(i) = p;  // expected-warning {{cannot prove declared bounds for 'q' are valid after initialization}} \
+                                     // expected-note {{(expanded) declared bounds are 'bounds(q, q + i)'}} \
+                                     // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 0)'}}
+
+  unsigned int j = 1 + 2;
+  _Array_ptr<int> r : count(j) = p; // expected-warning {{cannot prove declared bounds for 'r' are valid after initialization}} \
+                                    // expected-note {{(expanded) declared bounds are 'bounds(r, r + j)'}} \
+                                    // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 0)'}}
+
+  unsigned int k = -(2 * 3) + (8 / 4);
+  _Array_ptr<int> s : count(k) = p; // expected-warning {{cannot prove declared bounds for 's' are valid after initialization}} \
+                                    // expected-note {{(expanded) declared bounds are 'bounds(s, s + k)'}} \
+                                    // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 0)'}}
+}
+
 void g(void) {
   int a, b, c, d, e;
   a = b = 0;


### PR DESCRIPTION
When checking for free variables in bounds expressions, a variable `v` should not be considered free if it is equivalent to some integer constant expression.

The previous check `isa<IntegerLiteral>(E)` was not sufficient to determine that an expression `E` equivalent to the value of `v` is an integer constant expression. This check will fail for expressions such `(unsigned int)0`, `1 + 2`, etc. This PR uses `isIntegerConstantExpression(E)` instead.