### PR TITLE
Implement an updated dataflow analysis for bounds widening of null-terminated arrays

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -25,10 +25,10 @@ namespace clang {
   // Note: We use the shorthand "ntptr" to denote _Nt_array_ptr. We extract the
   // declaration of an ntptr as a VarDecl from a DeclRefExpr.
 
-  // BoundsMapTy denotes the unsigned integer offset I by which the bounds of
+  // BoundsMapOffsetTy denotes the unsigned integer offset I by which the bounds of
   // an ntptr should be widened. Given VarDecl V with declared bounds as bounds
   // (low, high), the bounds of V should be widened to bounds (low, high + I).
-  using BoundsMapTy = llvm::MapVector<const VarDecl *, unsigned>;
+  using BoundsMapOffsetTy = llvm::MapVector<const VarDecl *, unsigned>;
 
   // BoundsExprMapTy denotes the widened bounds expression of an ntptr. Given
   // VarDecl V with declared bounds (low, high), and an unsigned integer offset
@@ -37,7 +37,7 @@ namespace clang {
   using BoundsExprMapTy = llvm::MapVector<const VarDecl *, BoundsExpr *>;
 
   // For each edge B1->B2, EdgeBoundsTy denotes the Gen and Out sets.
-  using EdgeBoundsTy = llvm::DenseMap<const CFGBlock *, BoundsMapTy>;
+  using EdgeBoundsTy = llvm::DenseMap<const CFGBlock *, BoundsMapOffsetTy>;
 
   // DeclSetTy denotes a set of VarDecls.
   using DeclSetTy = llvm::DenseSet<const VarDecl *>;
@@ -83,7 +83,7 @@ namespace clang {
     public:
       const CFGBlock *Block;
       // The In set for the block.
-      BoundsMapTy In;
+      BoundsMapOffsetTy In;
       // The Gen and Out sets for the block.
       EdgeBoundsTy Gen, Out;
       // The Kill set for the block.
@@ -148,7 +148,7 @@ namespace clang {
 
     // So we initialize the In and Out sets of all blocks, except the Entry
     // block, as "Top".
-    BoundsMapTy Top;
+    BoundsMapOffsetTy Top;
 
   public:
     BoundsAnalysis(Sema &S, CFG *Cfg) :
@@ -167,7 +167,7 @@ namespace clang {
     // needed.
     // @return A mapping of variables to the offsets by which their bounds
     // should be widened in block B.
-    BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
+    BoundsMapOffsetTy GetWidenedBoundsOffsets(const CFGBlock *B);
 
     // Get the set of variables whose bounds are widened but not killed in
     // block B. This function is invoked from SemaBounds.cpp and is used to

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -15,23 +15,34 @@
 #define LLVM_CLANG_BOUNDS_WIDENING_ANALYSIS_H
 
 #include "clang/AST/CanonBounds.h"
+#include "clang/AST/ExprUtils.h"
 #include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Sema/CheckedCAnalysesPrepass.h"
 #include "clang/Sema/Sema.h"
 
 namespace clang {
-  // BoundsMapTy maps a null-terminated array variable to its bounds
-  // expression.
+  // BoundsMapTy maps a variable that is a pointer to a null-terminated array
+  // to its bounds expression.
   using BoundsMapTy = llvm::DenseMap<const VarDecl *, BoundsExpr *>;
 
-  // StmtBoundsMapTy maps each null-terminated array variable that occurs in a
-  // statement to its bounds expression.
+  // StmtBoundsMapTy maps each variable that is a pointer to a null-terminated
+  // array that occurs in a statement to its bounds expression.
   using StmtBoundsMapTy = llvm::DenseMap<const Stmt *, BoundsMapTy>;
 
-  // StmtVarSetTy denotes a set of null-terminated array variables that are
-  // associated with a statement. The set of variables whose bounds are killed
-  // by a statement has the type StmtVarSetTy.
+  // StmtVarSetTy denotes a set of variables that are pointers to
+  // null-terminated arrays and that are associated with a statement. The set
+  // of variables whose bounds are killed by a statement has the type
+  // StmtVarSetTy.
   using StmtVarSetTy = llvm::DenseMap<const Stmt *, VarSetTy>;
+ 
+  // StmtSetTy denotes a set of statements.
+  using StmtSetTy = llvm::SmallPtrSet<const Stmt *, 16>;
+
+  // ExprVarsTy maps an expression to a set of variables. If E is an expression
+  // dereferencing a null-terminated array, then ExprVarsTy maps the expression
+  // (E + 1) to a set of null-terminated arrays whose bounds may potentially be
+  // widened to (E + 1).
+  using ExprVarsTy = llvm::DenseMap<Expr *, const VarDecl *>;
 
   // The BoundsWideningAnalysis class represents the dataflow analysis for
   // bounds widening. The sets In, Out, Gen and Kill that are used by the
@@ -39,31 +50,180 @@ namespace clang {
   // these sets to perform the dataflow analysis.
   class BoundsWideningAnalysis {
   private:
-    Sema &S;
+    Sema &SemaRef;
     CFG *Cfg;
     ASTContext &Ctx;
+    BoundsVarsTy &BoundsVarsLower;
+    BoundsVarsTy &BoundsVarsUpper;
     Lexicographic Lex;
     llvm::raw_ostream &OS;
 
     class ElevatedCFGBlock {
     public:
       const CFGBlock *Block;
-      // The In and Out sets for a block.
-      BoundsMapTy In, Out;
-      // The Gen set for each statement in a block.
-      StmtBoundsMapTy Gen;
+      // The In, Out and Gen sets for a block.
+      BoundsMapTy In, Out, Gen;
+      // The Kill set for a block.
+      VarSetTy Kill;
+      // The In and Gen sets for each statement in a block.
+      StmtBoundsMapTy StmtIn, StmtGen;
       // The Kill set for each statement in a block.
-      StmtVarSetTy Kill;
+      StmtVarSetTy StmtKill;
 
       ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
-    };
+    }; // end class ElevatedCFGBlock
+
+  private:
+    // BlockMapTy denotes the mapping from CFGBlocks to ElevatedCFGBlocks.
+    using BlockMapTy = llvm::DenseMap<const CFGBlock *, ElevatedCFGBlock *>;
+
+    // BlockMap maps a CFGBlock to an ElevatedCFGBlock. Given a CFGBlock it is
+    // used to lookup an ElevatedCFGBlock.
+    BlockMapTy BlockMap;
   
   public:
-    BoundsWideningAnalysis(Sema &S, CFG *Cfg) :
-      S(S), Cfg(Cfg), Ctx(S.Context),
+    BoundsWideningAnalysis(Sema &SemaRef, CFG *Cfg,
+                           BoundsVarsTy &BoundsVarsLower,
+                           BoundsVarsTy &BoundsVarsUpper) :
+      SemaRef(SemaRef), Cfg(Cfg), Ctx(SemaRef.Context),
+      BoundsVarsLower(BoundsVarsLower), BoundsVarsUpper(BoundsVarsUpper),
       Lex(Lexicographic(Ctx, nullptr)),
       OS(llvm::outs()) {}
-  };
+
+    // Run the dataflow analysis to widen bounds for null-terminated arrays.
+    // @param[in] FD is the current function.
+    // @param[in] NestedStmts is a set of top-level statements that are
+    // nested in another top-level statement.
+    void WidenBounds(FunctionDecl *FD, StmtSetTy NestedStmts);
+
+  private:
+    // Compute the Kill and Gen sets for the block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    void ComputeGenKillSets(ElevatedCFGBlock *EB);
+
+    // Compute the StmtGen and StmtKill sets for a statement in a block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] S is the current statement.
+    // @param[in] IsLastStmt indicates whether S is the last statement in the
+    // block.
+    void ComputeStmtGenKillSets(ElevatedCFGBlock *EB, const Stmt *S,
+                                bool IsLastStmt);
+
+    // Update the Gen and Kill sets for the block after computing the StmtGen
+    // and StmtKill for the current statement.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] S is the current statement.
+    void UpdateBlockGenKillSets(ElevatedCFGBlock *EB, const Stmt *S);
+
+    // Fill the StmtKill set when a variable occurring in the bounds expression
+    // of a null-terminated array is modified.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] S is the current statement.
+    void FillStmtKillSetForModifiedVars(ElevatedCFGBlock *EB, const Stmt *S);
+
+    // Fill StmtGen and StmtKill sets for the bounds declaration of a
+    // null-terminated array.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] S is the current statement.
+    // @param[in] V is a variable that is a pointer to a null-terminated array.
+    void FillStmtGenKillSetsForBoundsDecl(ElevatedCFGBlock *EB, const Stmt *S,
+                                          const VarDecl *V);
+
+    // Fill StmtGen and StmtKill sets for bounds declaration in a where clause.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] S is the current statement.
+    // @param[in] WC is the where clause that annotates S.
+    void FillStmtGenKillSetsForWhereClause(ElevatedCFGBlock *EB, const Stmt *S,
+                                           WhereClause *WC);
+
+    // Fill StmtGen and StmtKill sets for dereference of a variable that is a
+    // pointer to a null-terminated array.
+    // null-terminated array V at E.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] S is the current statement.
+    void FillStmtGenKillSetsForPtrDeref(ElevatedCFGBlock *EB, const Stmt *S);
+
+    // Get the set of variables that can be potentially widened in an
+    // expression E.
+    // @param[in] E is the given expression.
+    // @param[out] VarsToWiden is a set of variables that can be potentially
+    // widened in expression E.
+    void GetVarsToWiden(Expr *E, VarSetTy &VarsToWiden);
+
+    // Get all variables modfied by statement S or statements nested in S.
+    // @param[in] S is a given statement.
+    // @param[out] ModifiedVars is a set of variables modified by S or
+    // statements nested in S.
+    void GetModifiedVars(const Stmt *S, VarSetTy &ModifiedVars);
+
+    // Add an offset to a given expression to get the widened expression.
+    // @param[in] E is the given expression.
+    // @param[in] Offset is the given offset.
+    // @return Returns the expression E + Offset.
+    Expr *GetWidenedExpr(Expr *E, unsigned Offset) const;
+
+    // From a given terminating condition extract the terminating condition for
+    // the current block. Given an expression like "if (e1 && e2)" this
+    // function returns e2 which is the terminating condition for the current
+    // block.
+    // @param[in] E is given terminating condition.
+    // @return The terminating condition for the block.
+    Expr *GetTerminatorCondition(const Expr *E) const;
+
+    // Use the last statement in a block to get the terminating condition for
+    // the block. This could be an expression of the form "if (e1 && e2)".
+    // @param[in] B is the block for which we need the terminating condition.
+    // @return Expression for the terminating condition of block B.
+    Expr *GetTerminatorCondition(const CFGBlock *B) const;
+
+    // From the given expression get the dereference expression. A dereference
+    // expression can be of the form "*(p + 1)" or "p[1]".
+    // @param[in] E is the given expression.
+    // @return Returns the dereference expression, if it exists.
+    Expr *GetDerefExpr(Expr *E) const;
+
+    // Get the variables occurring in an expression.
+    // @param[in] E is the given expression.
+    // @param[out] VarsInExpr is a set of variables that occur in E.
+    void GetVarsInExpr(Expr *E, VarSetTy &VarsInExpr) const;
+
+    // Invoke IgnoreValuePreservingOperations to strip off casts.
+    // @param[in] E is the expression whose casts must be stripped.
+    // @return E with casts stripped off.
+    Expr *IgnoreCasts(const Expr *E) const;
+
+    // We do not want to run dataflow analysis on null blocks or the exit
+    // block. So we skip them.
+    // @param[in] B is the block which may need to be skipped from dataflow
+    // analysis.
+    // @return Whether B should be skipped.
+    bool SkipBlock(const CFGBlock *B) const;
+
+    // Check if V is an _Nt_array_ptr or an _Nt_checked array.
+    // @param[in] V is a VarDecl.
+    // @return Whether V is an _Nt_array_ptr or an _Nt_checked array.
+    bool IsNtArrayType(const VarDecl *V) const;
+
+    // Compute the set difference of sets A and B.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return The set difference of sets A and B.
+    template<class T, class U> T Difference(T &A, U &B) const;
+
+    // Compute the intersection of sets A and B.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return The intersection of sets A and B.
+    template<class T> T Intersect(T &A, T &B) const;
+
+    // Determine whether sets A and B are equal. Equality is determined by
+    // comparing each element in the two input sets.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return Whether sets A and B are equal.
+    template<class T> bool IsEqual(T &A, T &B) const;
+
+  }; // end class BoundsWideningAnalysis
 
 } // end namespace clang
 #endif

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -41,17 +41,25 @@ namespace clang {
     // 2. V has a declared bounds expression.
     VarUsageTy VarUses;
 
-    // BoundsVars maps each variable Z in a function to the set of all
-    // variables in whose bounds expressions Z occurs. A variable Z can occur
-    // in the bounds expression of a variable V if
-    // 1. Z occurs in the declared bounds expression of V, or
-    // 2. A where clause declares bounds B of V and Z occurs in B.
-
     // Note: BoundsVarsTy is a map of keys to values which are sets. As a
     // result, there is no defined iteration order for either its keys or its
-    // values. So in case we want to iterate BoundsVars and need a determinstic
-    // iteration order we must remember to sort the keys as well as the values.
-    BoundsVarsTy BoundsVars;
+    // values. So in case we want to iterate BoundsVarsLower or BoundsVarsUpper
+    // and need a determinstic iteration order we must remember to sort the
+    // keys as well as the values.
+
+    // BoundsVarsLower maps each variable Z in a function to the set of all
+    // variables in whose lower bounds expressions Z occurs. A variable Z can
+    // occur in the lower bounds expression of a variable V if
+    // 1. Z occurs in the declared lower bounds expression of V, or
+    // 2. A where clause declares lower bounds B of V and Z occurs in B.
+    BoundsVarsTy BoundsVarsLower;
+
+    // BoundsVarsUpper maps each variable Z in a function to the set of all
+    // variables in whose upper bounds expressions Z occurs. A variable Z can
+    // occur in the upper bounds expression of a variable V if
+    // 1. Z occurs in the declared upper bounds expression of V, or
+    // 2. A where clause declares upper bounds B of V and Z occurs in B.
+    BoundsVarsTy BoundsVarsUpper;
   };
 } // end namespace clang
 #endif

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -489,7 +489,7 @@ void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB,
 void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
   // In[B1] = n Out[B*->B1], where B* are all preds of B1.
 
-  BoundsMapTy Intersections;
+  BoundsMapOffsetTy Intersections;
   bool FirstIntersection = true;
 
   for (const CFGBlock *pred : EB->Block->preds()) {
@@ -520,13 +520,13 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
     KilledVars.insert(Vars.begin(), Vars.end());
   }
 
-  BoundsMapTy InMinusKill = Difference(EB->In, KilledVars);
+  BoundsMapOffsetTy InMinusKill = Difference(EB->In, KilledVars);
 
   for (const CFGBlock *succ : EB->Block->succs()) {
     if (SkipBlock(succ))
       continue;
 
-    BoundsMapTy OldOut = EB->Out[succ];
+    BoundsMapOffsetTy OldOut = EB->Out[succ];
 
     // Here's how we compute (In - Kill) u Gen:
 
@@ -569,10 +569,10 @@ DeclSetTy BoundsAnalysis::GetKilledBounds(const CFGBlock *B, const Stmt *St) {
   return J->second;
 }
 
-BoundsMapTy BoundsAnalysis::GetWidenedBoundsOffsets(const CFGBlock *B) {
+BoundsMapOffsetTy BoundsAnalysis::GetWidenedBoundsOffsets(const CFGBlock *B) {
   auto I = BlockMap.find(B);
   if (I == BlockMap.end())
-    return BoundsMapTy();
+    return BoundsMapOffsetTy();
 
   ElevatedCFGBlock *EB = I->second;
   return EB->In;
@@ -617,7 +617,7 @@ BoundsExprMapTy BoundsAnalysis::GetWidenedBounds(const CFGBlock *B) {
 
 DeclSetTy BoundsAnalysis::GetBoundsWidenedAndNotKilled(const CFGBlock *B,
                                                        const Stmt *St) {
-  BoundsMapTy WidenedBounds = GetWidenedBoundsOffsets(B);
+  BoundsMapOffsetTy WidenedBounds = GetWidenedBoundsOffsets(B);
   if (!WidenedBounds.size())
     return DeclSetTy();
 
@@ -779,7 +779,7 @@ void BoundsAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
     OS << "--------------------------------------";
     B->print(OS, Cfg, S.getLangOpts(), /* ShowColors */ true);
 
-    BoundsMapTy Vars = GetWidenedBoundsOffsets(B);
+    BoundsMapOffsetTy Vars = GetWidenedBoundsOffsets(B);
     using VarPairTy = std::pair<const VarDecl *, unsigned>;
 
     llvm::sort(Vars.begin(), Vars.end(),

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -14,4 +14,472 @@
 #include "clang/Sema/BoundsWideningAnalysis.h"
 
 namespace clang {
+
+void
+BoundsWideningAnalysis::WidenBounds(FunctionDecl *FD, StmtSetTy NestedStmts) {
+  assert(Cfg && "expected CFG to exist");
+
+  // Add each block to WorkList and create a mapping from CFGBlock to
+  // ElevatedCFGBlock.
+  // Note: By default, PostOrderCFGView iterates in reverse order. So we always
+  // get a reverse post order when we iterate PostOrderCFGView.
+  for (const CFGBlock *B : PostOrderCFGView(Cfg)) {
+    // SkipBlock will skip all null blocks and the exit block. PostOrderCFGView
+    // does not traverse any unreachable blocks. So at the end of this loop
+    // BlockMap only contains reachable blocks.
+    if (SkipBlock(B))
+      continue;
+
+    auto EB = new ElevatedCFGBlock(B);
+    BlockMap[B] = EB;
+
+    // Compute Gen and Kill sets for the block.
+    ComputeGenKillSets(EB);
+  }
+}
+
+void
+BoundsWideningAnalysis::ComputeGenKillSets(ElevatedCFGBlock *EB) {
+  // Compute Gen and Kill sets for the block.
+
+  bool IsLastStmt = true;
+
+  // Note: We iterate the statements in a block in reverse because it makes it
+  // easier to compute the union of Kill sets for statement S_i+1 through
+  // statement S_n.
+  for (CFGBlock::const_reverse_iterator RI = EB->Block->rbegin(),
+                                        RE = EB->Block->rend();
+       RI != RE; ++RI) {
+    CFGElement Elem = *RI;
+    if (Elem.getKind() == CFGElement::Statement) {
+      const Stmt *S = Elem.castAs<CFGStmt>().getStmt();
+      if (!S)
+        continue;
+
+      ComputeStmtGenKillSets(EB, S, IsLastStmt);
+      UpdateBlockGenKillSets(EB, S);
+
+      IsLastStmt = false;
+    }
+  }
+}
+
+void
+BoundsWideningAnalysis::ComputeStmtGenKillSets(ElevatedCFGBlock *EB,
+                                               const Stmt *S,
+                                               bool IsLastStmt) {
+  // Initialize the Gen and Kill sets for the statement.
+  EB->StmtGen[S] = BoundsMapTy();
+  EB->StmtKill[S] = VarSetTy();
+
+  // Determine whether statement S generates a dataflow fact.
+  if (const auto *DS = dyn_cast<DeclStmt>(S)) {
+    for (const Decl *D : DS->decls()) {
+      if (const auto *V = dyn_cast<VarDecl>(D)) {
+        // A bounds declaration of a null-terminated array generates a
+        // dataflow fact. For example:
+        // _Nt_array_ptr<char> p : bounds(p, p + 1);
+        FillStmtGenKillSetsForBoundsDecl(EB, S, V);
+
+        // A where clause on a declaration can generate a dataflow fact.
+        // For example: int x = strlen(p) _Where p : bounds(p, p + x);
+        FillStmtGenKillSetsForWhereClause(EB, S, V->getWhereClause());
+      }
+    }
+
+  // A where clause on an expression statement (which is represented in the
+  // AST as a ValueStmt) can generate a dataflow fact.
+  // For example: x = strlen(p) _Where p : bounds(p, p + x);
+  } else if (const auto *VS = dyn_cast<ValueStmt>(S)) {
+    FillStmtGenKillSetsForWhereClause(EB, S, VS->getWhereClause());
+
+  // A conditional statement that dereferences a variable that is a pointer to
+  // a null-terminated array can generate a dataflow fact. For example: if (*(p
+  // + 1)) The conditional will always be the last statement in the block.
+  } else if (IsLastStmt) {
+    FillStmtGenKillSetsForPtrDeref(EB, S);
+  }
+
+  // If a variable modified by statement S occurs in the bounds expression of a
+  // null-terminated array then the bounds of that null-terminated array should
+  // be killed.
+  FillStmtKillSetForModifiedVars(EB, S);
+}
+
+void
+BoundsWideningAnalysis::UpdateBlockGenKillSets(ElevatedCFGBlock *EB,
+                                               const Stmt *S) {
+  // Update the Gen set for the block. If we are currently processing statement
+  // S_i in ComputeGenKillSets, then at this point EB->Kill is the union of the
+  // Kill sets of statements S_i+1 through S_n. This is why we iterate the
+  // statements in reverse in ComputeGenKillSets as it makes it easier to
+  // compute the union of Kill sets of statements S_i+1 through S_n.
+  BoundsMapTy Diff = Difference(EB->StmtGen[S], EB->Kill);
+  for (auto Item : Diff)
+    EB->Gen.insert(Item);
+
+  // Add the Kill set of statement S_i to the Kill set of the block.
+  for (const VarDecl *V : EB->StmtKill[S])
+    EB->Kill.insert(V);
+}
+
+void
+BoundsWideningAnalysis::FillStmtKillSetForModifiedVars(ElevatedCFGBlock *EB,
+                                                       const Stmt *S) {
+  // Get variables modified by statement S or statements nested in S.
+  VarSetTy ModifiedVars;
+  GetModifiedVars(S, ModifiedVars);
+
+  // If a modified variable occurs in the bounds expression of a
+  // null-terminated array then the bounds of that null-terminated array should
+  // be killed.
+  for (const VarDecl *ModifiedVar : ModifiedVars) {
+    auto It = BoundsVarsLower.find(ModifiedVar);
+    if (It != BoundsVarsLower.end()) {
+      for (const VarDecl *V : It->second)
+        EB->StmtKill[S].insert(V);
+    }
+
+    It = BoundsVarsUpper.find(ModifiedVar);
+    if (It != BoundsVarsUpper.end()) {
+      for (const VarDecl *V : It->second)
+        EB->StmtKill[S].insert(V);
+    }
+  }
+}
+
+void
+BoundsWideningAnalysis::FillStmtGenKillSetsForBoundsDecl(ElevatedCFGBlock *EB,
+                                                         const Stmt *S,
+                                                         const VarDecl *V) {
+  if (IsNtArrayType(V) && V->hasBoundsExpr()) {
+    EB->StmtGen[S][V] = SemaRef.NormalizeBounds(V);
+    EB->StmtKill[S].insert(V);
+  }
+}
+
+void
+BoundsWideningAnalysis::FillStmtGenKillSetsForWhereClause(ElevatedCFGBlock *EB,
+                                                          const Stmt *S,
+                                                          WhereClause *WC) {
+  if (!WC)
+    return;
+
+  for (const auto *Fact : WC->getFacts()) {
+    auto *BF = dyn_cast<BoundsDeclFact>(Fact);
+    if (!BF)
+      continue;
+
+    VarDecl *V = BF->Var;
+    if (IsNtArrayType(V)) {
+      EB->StmtGen[S][V] = SemaRef.ExpandBoundsToRange(V, BF->Bounds);
+      EB->StmtKill[S].insert(V);
+    }
+  }
+}
+
+void
+BoundsWideningAnalysis::FillStmtGenKillSetsForPtrDeref(ElevatedCFGBlock *EB,
+                                                       const Stmt *S) {
+  // Get the terminating condition of the block.
+  Expr *TermCond = GetTerminatorCondition(EB->Block);
+  if (!TermCond)
+    return;
+
+  // If the terminating condition is a dereference expression get that
+  // expression.
+  Expr *DerefExpr = GetDerefExpr(TermCond);
+  if (!DerefExpr)
+    return;
+
+  // Get the set of null-terminated arrays that the dereference expression
+  // potentially widens. A dereference expression can only widen the bounds of
+  // those null-terminated arrays whose upper bounds expression contains all
+  // variables that occur in the dereference expression. For example: *(p + i +
+  // j) can widen p iff p, i and j all occur in upper_bound(p).
+  VarSetTy VarsToWiden;
+  GetVarsToWiden(DerefExpr, VarsToWiden);
+
+  RangeBoundsExpr *R = nullptr;
+  for (const VarDecl *V : VarsToWiden) {
+    if (!IsNtArrayType(V))
+      continue;
+
+    if (!R) {
+      BoundsExpr *Bounds = SemaRef.NormalizeBounds(V);
+      RangeBoundsExpr *RBE = dyn_cast<RangeBoundsExpr>(Bounds);
+      assert(RBE && "invalid bounds for null-terminated array");
+
+      // DerefExpr potentially widens V. So we add
+      // "V:bounds(lower, DerefExpr + 1)" to the Gen set.
+      R = new (Ctx) RangeBoundsExpr(RBE->getLowerExpr(),
+                                    GetWidenedExpr(DerefExpr, 1),
+                                    SourceLocation(), SourceLocation());
+    }
+
+    EB->StmtGen[S][V] = R;
+    EB->StmtKill[S].insert(V);
+  }
+}
+
+void BoundsWideningAnalysis::GetVarsToWiden(Expr *E, VarSetTy &VarsToWiden) {
+  // Determine the set of variables that can be widened in an expression.
+  if (!E)
+    return;
+
+  // Get all variables that occur in the expression.
+  VarSetTy VarsInExpr;
+  GetVarsInExpr(E, VarsInExpr);
+
+  VarSetTy CommonNullTermArrays;
+  for (const VarDecl *V : VarsInExpr) {
+    // Get the set of null-terminated arrays in whose upper bounds expressions
+    // V occurs.
+    auto It = BoundsVarsUpper.find(V);
+
+    // If V does not appear in the upper bounds expression of any
+    // null-terminated array then expression E cannot potentially widen the
+    // bounds of any null-terminated array.
+    if (It == BoundsVarsUpper.end())
+      return;
+
+    if (CommonNullTermArrays.empty())
+      CommonNullTermArrays = It->second;
+    else
+      CommonNullTermArrays = Intersect(CommonNullTermArrays, It->second);
+
+    // If the intersection of CommonNullTermArrays is empty then expression E
+    // cannot potentially widen the bounds of any null-terminated array.
+    if (CommonNullTermArrays.empty())
+      return;
+  }
+
+  for (const VarDecl *V : CommonNullTermArrays) {
+    // Gather the set of variables occurring in the upper bound expression of
+    // V.
+
+    // TODO: This lookup can be optimized by storing the set of variables
+    // occurring in the upper bounds expression of a null-terminated array
+    // while computing BoundsVarsUpper in CheckedCAnalysesPrepass.cpp.
+    VarSetTy VarsInBounds;
+    for (auto Pair : BoundsVarsUpper) {
+      if (Pair.second.count(V))
+        VarsInBounds.insert(Pair.first);
+    }
+
+    if (IsEqual(VarsInExpr, VarsInBounds))
+      VarsToWiden.insert(V);
+  }
+}
+
+void BoundsWideningAnalysis::GetModifiedVars(const Stmt *S,
+                                             VarSetTy &ModifiedVars) {
+  // Get all variables modified by statement S or statements nested in S.
+  if (!S)
+    return;
+
+  Expr *E = nullptr;
+
+  // If the variable is modified using a unary operator, like ++I or I++.
+  if (const auto *UO = dyn_cast<const UnaryOperator>(S)) {
+    if (UO->isIncrementDecrementOp()) {
+      assert(UO->getSubExpr() && "invalid UnaryOperator expression");
+      E = IgnoreCasts(UO->getSubExpr());
+    }
+
+  // Else if the variable is being assigned to, like I = ...
+  } else if (const auto *BO = dyn_cast<const BinaryOperator>(S)) {
+    if (BO->isAssignmentOp())
+      E = IgnoreCasts(BO->getLHS());
+  }
+
+  if (const auto *D = dyn_cast_or_null<DeclRefExpr>(E))
+    if (const auto *V = dyn_cast_or_null<VarDecl>(D->getDecl()))
+      ModifiedVars.insert(V);
+
+  for (const Stmt *NestedS : S->children())
+    GetModifiedVars(NestedS, ModifiedVars);
+}
+
+Expr *BoundsWideningAnalysis::GetWidenedExpr(Expr *E, unsigned Offset) const {
+  // Returns the expression E + Offset.
+  // Note: This function only returns the expression E + Offset and does not
+  // actually evaluate the expression. So if E does not overflow then E +
+  // Offset does not overflow here. However, E + Offset may later overflow when
+  // the preorder AST performs constant folding, for example in case E is e +
+  // MAX_INT and Offset is 1.
+
+  const llvm::APInt
+    APIntOff(Ctx.getTargetInfo().getPointerWidth(0), Offset);
+
+  IntegerLiteral *WidenedOffset =
+    ExprCreatorUtil::CreateIntegerLiteral(Ctx, APIntOff);
+
+  return ExprCreatorUtil::CreateBinaryOperator(SemaRef, E, WidenedOffset,
+                                               BinaryOperatorKind::BO_Add);
+}
+
+Expr *BoundsWideningAnalysis::GetTerminatorCondition(const Expr *E) const {
+  if (!E)
+    return nullptr;
+
+  if (const auto *BO = dyn_cast<BinaryOperator>(E->IgnoreParens()))
+    return GetTerminatorCondition(BO->getRHS());
+
+  // According to C11 standard section 6.5.13, the logical AND Operator shall
+  // yield 1 if both of its operands compare unequal to 0; otherwise, it yields
+  // 0. The result has type int.  An IntegralCast is generated for "if (*p &&
+  // *(p + 1))", where p is _Nt_array_ptr<T>.  Here we strip off the
+  // IntegralCast.
+  if (auto *CE = dyn_cast<CastExpr>(E))
+    if (CE->getCastKind() == CastKind::CK_IntegralCast)
+      return const_cast<Expr *>(CE->getSubExpr());
+  return const_cast<Expr *>(E);
+}
+
+Expr *BoundsWideningAnalysis::GetTerminatorCondition(const CFGBlock *B) const {
+  if (!B)
+    return nullptr;
+
+  if (const Stmt *S = B->getTerminatorStmt()) {
+    if (const auto *BO = dyn_cast<BinaryOperator>(S))
+      return GetTerminatorCondition(BO->getLHS());
+
+    if (const auto *IfS = dyn_cast<IfStmt>(S))
+      return GetTerminatorCondition(IfS->getCond());
+
+    if (const auto *WhileS = dyn_cast<WhileStmt>(S))
+      return const_cast<Expr *>(WhileS->getCond());
+
+    if (const auto *ForS = dyn_cast<ForStmt>(S))
+      return const_cast<Expr *>(ForS->getCond());
+
+    if (const auto *SwitchS = dyn_cast<SwitchStmt>(S))
+      return const_cast<Expr *>(SwitchS->getCond());
+  }
+  return nullptr;
+}
+
+Expr *BoundsWideningAnalysis::GetDerefExpr(Expr *E) const {
+  // A dereference expression can contain an array subscript or a pointer
+  // dereference.
+  if (!E)
+    return nullptr;
+
+  if (auto *CE = dyn_cast<CastExpr>(E))
+    if (CE->getCastKind() == CastKind::CK_LValueToRValue)
+      E = CE->getSubExpr();
+
+  E = IgnoreCasts(E);
+
+  // If a dereference expression is of the form "*(p + i)".
+  if (auto *UO = dyn_cast<UnaryOperator>(E)) {
+    if (UO->getOpcode() == UO_Deref)
+      return IgnoreCasts(UO->getSubExpr());
+
+  // Else if a dereference expression is an array access. An array access can
+  // be written A[i] or i[A] (both are equivalent).  getBase() and getIdx()
+  // always present the normalized view: A[i]. In this case getBase() returns
+  // "A" and getIdx() returns "i".
+
+  // TODO: Currently we normalize A[i] to "A + i" and return that as the
+  // dereference expression because we need to extract the variables that occur
+  // in the deref expression in the function GetVarsInExpr. But once we change
+  // this analysis to use AbstractSets we no longer need to normalize the
+  // expression here and can simply return the ArraySubscriptExpr from this
+  // function.
+  } else if (auto *AE = dyn_cast<ArraySubscriptExpr>(E)) {
+    return ExprCreatorUtil::CreateBinaryOperator(SemaRef, AE->getBase(),
+                                                 AE->getIdx(),
+                                                 BinaryOperatorKind::BO_Add);
+  }
+  return nullptr;
+}
+
+void BoundsWideningAnalysis::GetVarsInExpr(Expr *E,
+                                           VarSetTy &VarsInExpr) const {
+  // Get the VarDecls of all variables occurring in an expression.
+
+  // TODO: Currently this function returns a subset of all variables that occur
+  // in an expression. It returns only the top-level variables that appear in
+  // an expression. For example, in the expression "a + b - c" it returns {a,
+  // b, c}. It does not return variables that are members of a struct or
+  // arguments of a function call, etc.
+  // In future, when we change this analysis to use AbstractSets, this function
+  // can handle an expression like "s->f + func(x)" and return {s, f, x} as the
+  // set of variables that occur in the expression.
+
+  if (!E)
+    return;
+
+  E = IgnoreCasts(E);
+
+  // Get variables in an expression like *(e1 + e2).
+  if (const auto *UO = dyn_cast<const UnaryOperator>(E)) {
+      GetVarsInExpr(UO->getSubExpr(), VarsInExpr);
+
+  // Get variables in an expression like e1 + e2.
+  } else if (const auto *BO = dyn_cast<BinaryOperator>(E)) {
+    GetVarsInExpr(BO->getLHS(), VarsInExpr);
+    GetVarsInExpr(BO->getRHS(), VarsInExpr);
+  }
+
+  if (const auto *D = dyn_cast<DeclRefExpr>(E)) {
+    if (const auto *V = dyn_cast<VarDecl>(D->getDecl()))
+      VarsInExpr.insert(V);
+  }
+}
+
+Expr *BoundsWideningAnalysis::IgnoreCasts(const Expr *E) const {
+  return Lex.IgnoreValuePreservingOperations(Ctx, const_cast<Expr *>(E));
+}
+
+bool BoundsWideningAnalysis::SkipBlock(const CFGBlock *B) const {
+  return !B || B == &Cfg->getExit();
+}
+
+bool BoundsWideningAnalysis::IsNtArrayType(const VarDecl *V) const {
+  return V && (V->getType()->isCheckedPointerNtArrayType() ||
+               V->getType()->isNtCheckedArrayType());
+}
+
+template<class T, class U>
+T BoundsWideningAnalysis::Difference(T &A, U &B) const {
+  if (!A.size() || !B.size())
+    return A;
+
+  auto Ret = A;
+  for (auto I : A) {
+    const auto *V = I.first;
+    if (B.count(V))
+      Ret.erase(V);
+  }
+  return Ret;
+}
+
+template<class T>
+T BoundsWideningAnalysis::Intersect(T &A, T &B) const {
+  if (!A.size())
+    return A;
+
+  auto Ret = A;
+  if (!B.size()) {
+    Ret.clear();
+    return Ret;
+  }
+
+  for (auto Item : Ret) {
+    if (!B.count(Item))
+      Ret.erase(Item);
+  }
+
+  return Ret;
+}
+
+template<class T>
+bool BoundsWideningAnalysis::IsEqual(T &A, T &B) const {
+  return A.size() == B.size() &&
+         A.size() == Intersect(A, B).size();
+}
+
 } // end namespace clang

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -39,6 +39,19 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     // int x = 1 _Where p : bounds(lower, upper);
 
     VarDecl *VarWithBounds = nullptr;
+
+    // InBoundsExprLower indicates that we are currently processing the lower
+    // bounds expression of a BoundsExpr that has been expanded to a
+    // RangeBoundsExpr. This flag is used to determine whether a variable
+    // occurs in the lower bounds expression of a VarWithBounds.
+    bool InBoundsExprLower = false;
+
+    // InBoundsExprUpper indicates that we are currently processing the upper
+    // bounds expression of a BoundsExpr that has been expanded to a
+    // RangeBoundsExpr. This flag is used to determine whether a variable
+    // occurs in the upper bounds expression of a VarWithBounds.
+    bool InBoundsExprUpper = false;
+
     llvm::raw_ostream &OS;
 
   public:
@@ -80,15 +93,45 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
       // We add VarWithBounds to the set of all variables in whose bounds
       // expressions V occurs.
-      if (VarWithBounds) {
-        auto It = Info.BoundsVars.find(V);
-        if (It != Info.BoundsVars.end())
+      if (!VarWithBounds)
+        return true;
+
+      if (InBoundsExprLower) {
+        auto It = Info.BoundsVarsLower.find(V);
+        if (It != Info.BoundsVarsLower.end())
           It->second.insert(VarWithBounds);
         else {
           VarSetTy Vars;
           Vars.insert(VarWithBounds);
-          Info.BoundsVars[V] = Vars;
+          Info.BoundsVarsLower[V] = Vars;
         }
+      } else if (InBoundsExprUpper) {
+        auto It = Info.BoundsVarsUpper.find(V);
+        if (It != Info.BoundsVarsUpper.end())
+          It->second.insert(VarWithBounds);
+        else {
+          VarSetTy Vars;
+          Vars.insert(VarWithBounds);
+          Info.BoundsVarsUpper[V] = Vars;
+        }
+      }
+
+      return true;
+    }
+
+    bool VisitBoundsExpr(BoundsExpr *B) {
+      if (!VarWithBounds)
+        return true;
+
+      BoundsExpr *Bounds = SemaRef.ExpandBoundsToRange(VarWithBounds, B);
+      if (auto *RBE = dyn_cast<RangeBoundsExpr>(Bounds)) {
+        InBoundsExprLower = true;
+        TraverseStmt(RBE->getLowerExpr());
+        InBoundsExprLower = false;
+
+        InBoundsExprUpper = true;
+        TraverseStmt(RBE->getUpperExpr());
+        InBoundsExprUpper = false;
       }
 
       return true;
@@ -126,44 +169,59 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     }
 
     void DumpBoundsVars(FunctionDecl *FD) {
+      PrintDeclMap<const VarDecl *>(FD, "BoundsVars Lower",
+                                    Info.BoundsVarsLower);
+      PrintDeclMap<const VarDecl *>(FD, "BoundsVars Upper",
+                                    Info.BoundsVarsUpper);
+    }
+    // Print a map from a key of type T to a set of elements of type T,
+    // where T should inherit from NamedDecl.
+    // This method can be used to print the BoundsVars and
+    // BoundsSiblingFields maps.
+    template<class T>
+    void PrintDeclMap(FunctionDecl *FD, const char *Message,
+                      llvm::DenseMap<T, llvm::SmallPtrSet<T, 2>> Map) {
       OS << "--------------------------------------\n"
          << "In function: " << FD->getName() << "\n"
-         << "BoundsVars:\n";
+         << Message << ":\n";
 
-      // Info.BoundsVars is a map of VarDecls (keys) to a set of VarDecls
-      // (values). So there is no defined iteration order for its keys or
-      // values. So we copy the keys to a vector, sort the vector and then
-      // iterate it. While iterating each key we also copy its value (which is
-      // a set of VarDecls) to a vector, sort the vector and iterate it.
-      VarListTy Vars;
-      for (const auto item : Info.BoundsVars)
-        Vars.push_back(item.first);
+      // Decls is a map of NamedDecls (keys) to a set of NamedDecls (values).
+      // So there is no defined iteration order for its keys or values.
+      // So we copy the keys to a vector, sort the vector and then iterate it.
+      // While iterating each key we also copy its value (which is a set of
+      // NamedDecls) to a vector, sort the vector and iterate it.
+      llvm::SmallVector<T, 2> Decls;
+      for (const auto item : Map)
+        Decls.push_back(item.first);
 
-      SortVars(Vars);
+      SortDecls(Decls);
 
-      for (const auto V : Vars) {
-        OS << V->getQualifiedNameAsString() << ": { ";
+      for (const auto D : Decls) {
+        OS << D->getQualifiedNameAsString() << ": { ";
 
-        VarListTy InnerVars;
-        for (const auto item : Info.BoundsVars[V])
-          InnerVars.push_back(item);
+        llvm::SmallVector<T, 2> InnerDecls;
+        for (const auto item : Map[D])
+          InnerDecls.push_back(item);
 
-        SortVars(InnerVars);
+        SortDecls(InnerDecls);
 
-        for (const auto InnerV : InnerVars)
-          OS << InnerV->getQualifiedNameAsString() << " ";
+        for (const auto InnerD : InnerDecls)
+          OS << InnerD->getQualifiedNameAsString() << " ";
         OS << "}\n";
       }
       OS << "--------------------------------------\n";
     }
 
-    void SortVars(VarListTy &Vars) {
-      // Sort variables by their name. If two variables in a function have the
-      // same name (for example, a variable in a nested scope that shadows a
-      // variable from an outer scope), then we sort them by their source
-      // locations.
-      llvm::sort(Vars.begin(), Vars.end(),
-                 [](const VarDecl *A, const VarDecl *B) {
+    // Sort a list of elements of type T, where T should inherit
+    // from NamedDecl.
+    template<class T>
+    void SortDecls(llvm::SmallVector<T, 2> &Decls) {
+      // Sort decls by their name. If two decls in a program have the same
+      // name (for example, a variable in a nested scope that shadows a
+      // variable from an outer scope, or fields from different structs that
+      // have the same name), then we sort them by their source locations.
+      llvm::sort(Decls.begin(), Decls.end(),
+                 [](T A, T B) {
                    int StrCompare = A->getQualifiedNameAsString().compare(
                                     B->getQualifiedNameAsString());
                    return StrCompare != 0 ?

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -46,6 +46,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Sema/AvailableFactsAnalysis.h"
 #include "clang/Sema/BoundsAnalysis.h"
+#include "clang/Sema/BoundsWideningAnalysis.h"
 #include "clang/Sema/CheckedCAnalysesPrepass.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -839,6 +840,11 @@ namespace {
     // for bounds-widening and get back the bounds-widening info needed for
     // bounds inference/checking.
     BoundsAnalysis BoundsAnalyzer;
+
+    // Having a BoundsWideningAnalysis object here allows us to easily invoke
+    // methods for bounds widening and get back the needed info for bounds
+    // inference/checking.
+    BoundsWideningAnalysis BoundsWideningAnalyzer;
 
     // Having an AbstractSetManager object here allows us to create
     // AbstractSets for lvalue expressions while checking statements.
@@ -2595,6 +2601,9 @@ namespace {
       Context(SemaRef.Context),
       Facts(Facts),
       BoundsAnalyzer(BoundsAnalysis(SemaRef, Cfg)),
+      BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, Cfg,
+                                                    Info.BoundsVarsLower,
+                                                    Info.BoundsVarsUpper)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       IncludeNullTerminator(false) {}
 
@@ -2608,6 +2617,9 @@ namespace {
       Context(SemaRef.Context),
       Facts(Facts),
       BoundsAnalyzer(BoundsAnalysis(SemaRef, nullptr)),
+      BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, nullptr,
+                                                    Info.BoundsVarsLower,
+                                                    Info.BoundsVarsUpper)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       IncludeNullTerminator(false) {}
 
@@ -2799,6 +2811,9 @@ namespace {
      StmtSet MemoryCheckedStmts;
      StmtSet BoundsCheckedStmts;
      IdentifyChecked(Body, MemoryCheckedStmts, BoundsCheckedStmts, CheckedScopeSpecifier::CSS_Unchecked);
+
+     // Run the bounds widening analysis on this function.
+     BoundsWideningAnalyzer.WidenBounds(FD, NestedElements);
 
      // Run the bounds widening analysis on this function.
      BoundsAnalysis &BA = getBoundsAnalyzer();
@@ -4400,6 +4415,9 @@ namespace {
     }
 
     BoundsAnalysis &getBoundsAnalyzer() { return BoundsAnalyzer; }
+    BoundsWideningAnalysis &getBoundsWideningAnalyzer() {
+      return BoundsWideningAnalyzer;
+    }
 
   private:
     // Sets the bounds expressions based on whether e is an lvalue or an

--- a/clang/test/CheckedC/inferred-bounds/bounds-vars.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-vars.c
@@ -36,7 +36,19 @@ void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
   }
 
 // CHECK-LABEL: In function: f1
-// CHECK: BoundsVars:
+// CHECK: BoundsVars Lower:
+// CHECK: a: { a }
+// CHECK: m: { m }
+// CHECK: p: { p }
+// CHECK: p: { p q }
+// CHECK: param1: { param1 param2 }
+// CHECK: param2: { param2 }
+// CHECK: q: { q }
+// CHECK: q: { m q }
+// CHECK: x: { p }
+
+// CHECK-LABEL: In function: f1
+// CHECK: BoundsVars Upper:
 // CHECK: a: { a }
 // CHECK: m: { m }
 // CHECK: p: { p }
@@ -46,7 +58,7 @@ void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
 // CHECK: q: { q }
 // CHECK: q: { m q }
 // CHECK: w: { a param2 }
-// CHECK: x: { a p param1 q }
+// CHECK: x: { a param1 q }
 // CHECK: y: { a p param1 param2 }
 // CHECK: z: { m p q }
 }


### PR DESCRIPTION
We separate out BoundsVars into BoundsVarsLower and BoundsVarsUpper that track
the variables occurring in the lower and upper bounds expressions,
respectively. This is needed for the bounds widenening analysis where we want
to determine the variables that can potentially be widened in a given
dereference expression.