### PR TITLE
PreorderAST: fold one constant

### DIFF
--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -251,11 +251,11 @@ namespace clang {
     // @param[in] Parent is the parent of the new node.
     void CreateUnaryOperator(UnaryOperator *E, Node *Parent);
 
-    // Create a UnaryOperatorNode with the sub expression Child and the
-    // Deref unary operator.
-    // @param[in] Child is the expression that is the child of a new node.
+    // Create a UnaryOperatorNode with the dereference operator and the
+    // subexpression e1 + e2, given an array subscript expression e1[e2].
+    // @param[in] E is the expression that is used to create a new node.
     // @param[in] Parent is the parent of the new node.
-    void CreateDereference(Expr *Child, Node *Parent);
+    void CreateArraySubscript(ArraySubscriptExpr *E, Node *Parent);
 
     // Create a MemberNode for the expression E.
     // @param[in] E is the expression whose Base and Field will be added to

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -83,7 +83,9 @@ void PreorderAST::Create(Expr *E, Node *Parent) {
                                              BinaryOperatorKind::BO_Add, AE->getType(),
                                              AE->getValueKind(), AE->getObjectKind(),
                                              AE->getExprLoc(), FPOptionsOverride());
-    CreateDereference(DerefExpr, Parent);
+    auto *N = new UnaryOperatorNode(UnaryOperatorKind::UO_Deref, Parent);
+    AttachNode(N, Parent);
+    Create(DerefExpr, N);
 
   } else if (auto *ME = dyn_cast<MemberExpr>(E)) {
     CreateMember(ME, Parent);

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -422,8 +422,10 @@ bool BinaryOperatorNode::ConstantFold(bool &Error, ASTContext &Ctx) {
     }
   }
 
-  // To fold constants we need at least 2 constants.
-  if (NumConsts <= 1)
+  // To fold constants we need at least 1 constant. If we have only 1 constant
+  // it can trivially be folded. Folding 1 constant allows us to constant
+  // fold expressions such as *(p + -(1 + 2)) to *(p + -3).
+  if (NumConsts < 1)
     return false;
 
   // Delete the folded constants and reclaim memory.

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -191,3 +191,13 @@ void f16(int i, int j) {
 //  [B1]
 // upper_bound(p) = 1
 }
+
+void f17(_Nt_array_ptr<char> p : bounds(p - 10, p - 3)) {
+  if (p[-(1 + 2)]) {}
+
+// CHECK: In function: f17
+//  [B2]
+//    1: p[-(1 + 2)]
+//  [B1]
+// upper_bounds(p) = 1
+}


### PR DESCRIPTION
This PR addresses the following point from issue #1043:

**5. Minimum number of constants needed to constant fold**
It is not true that we need at least two constants to fold constants - a single constant can be trivially "folded". The presence of this check may cause redundant calls to AddZero just to ensure that constant folding happens - this issue had come up in one of the earlier offline review discussions.