### PR TITLE
[BoundsVars] Store separate lower and upper bounds variables

### DIFF
--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -25,10 +25,10 @@ namespace clang {
   // Note: We use the shorthand "ntptr" to denote _Nt_array_ptr. We extract the
   // declaration of an ntptr as a VarDecl from a DeclRefExpr.
 
-  // BoundsMapTy denotes the unsigned integer offset I by which the bounds of
+  // BoundsOffsetMapTy denotes the unsigned integer offset I by which the bounds of
   // an ntptr should be widened. Given VarDecl V with declared bounds as bounds
   // (low, high), the bounds of V should be widened to bounds (low, high + I).
-  using BoundsMapTy = llvm::MapVector<const VarDecl *, unsigned>;
+  using BoundsOffsetMapTy = llvm::MapVector<const VarDecl *, unsigned>;
 
   // BoundsExprMapTy denotes the widened bounds expression of an ntptr. Given
   // VarDecl V with declared bounds (low, high), and an unsigned integer offset
@@ -37,7 +37,7 @@ namespace clang {
   using BoundsExprMapTy = llvm::MapVector<const VarDecl *, BoundsExpr *>;
 
   // For each edge B1->B2, EdgeBoundsTy denotes the Gen and Out sets.
-  using EdgeBoundsTy = llvm::DenseMap<const CFGBlock *, BoundsMapTy>;
+  using EdgeBoundsTy = llvm::DenseMap<const CFGBlock *, BoundsOffsetMapTy>;
 
   // DeclSetTy denotes a set of VarDecls.
   using DeclSetTy = llvm::DenseSet<const VarDecl *>;
@@ -83,7 +83,7 @@ namespace clang {
     public:
       const CFGBlock *Block;
       // The In set for the block.
-      BoundsMapTy In;
+      BoundsOffsetMapTy In;
       // The Gen and Out sets for the block.
       EdgeBoundsTy Gen, Out;
       // The Kill set for the block.
@@ -148,7 +148,7 @@ namespace clang {
 
     // So we initialize the In and Out sets of all blocks, except the Entry
     // block, as "Top".
-    BoundsMapTy Top;
+    BoundsOffsetMapTy Top;
 
   public:
     BoundsAnalysis(Sema &S, CFG *Cfg) :
@@ -167,7 +167,7 @@ namespace clang {
     // needed.
     // @return A mapping of variables to the offsets by which their bounds
     // should be widened in block B.
-    BoundsMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
+    BoundsOffsetMapTy GetWidenedBoundsOffsets(const CFGBlock *B);
 
     // Get the set of variables whose bounds are widened but not killed in
     // block B. This function is invoked from SemaBounds.cpp and is used to

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -45,17 +45,19 @@ namespace clang {
     // 2. V has a declared bounds expression.
     VarUsageTy VarUses;
 
-    // BoundsVars maps each variable Z in a function to the set of all
-    // variables in whose bounds expressions Z occurs. A variable Z can occur
-    // in the bounds expression of a variable V if
-    // 1. Z occurs in the declared bounds expression of V, or
-    // 2. A where clause declares bounds B of V and Z occurs in B.
+    // BoundsVarsLower maps each variable Z in a function to the set of all
+    // variables in whose lower bounds expressions Z occurs. A variable Z can
+    // occur in the lower bounds expression of a variable V if
+    // 1. Z occurs in the declared lower bounds expression of V, or
+    // 2. A where clause declares lower bounds B of V and Z occurs in B.
+    BoundsVarsTy BoundsVarsLower;
 
-    // Note: BoundsVarsTy is a map of keys to values which are sets. As a
-    // result, there is no defined iteration order for either its keys or its
-    // values. So in case we want to iterate BoundsVars and need a determinstic
-    // iteration order we must remember to sort the keys as well as the values.
-    BoundsVarsTy BoundsVars;
+    // BoundsVarsUpper maps each variable Z in a function to the set of all
+    // variables in whose upper bounds expressions Z occurs. A variable Z can
+    // occur in the upper bounds expression of a variable V if
+    // 1. Z occurs in the declared upper bounds expression of V, or
+    // 2. A where clause declares upper bounds B of V and Z occurs in B.
+    BoundsVarsTy BoundsVarsUpper;
 
     // BoundsSiblingFields maps each FieldDecl F in a record declaration S to
     // a set of fields in S in whose declared bounds F occurs. More precisely,

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -489,7 +489,7 @@ void BoundsAnalysis::FillKillSet(ElevatedCFGBlock *EB,
 void BoundsAnalysis::ComputeInSets(ElevatedCFGBlock *EB) {
   // In[B1] = n Out[B*->B1], where B* are all preds of B1.
 
-  BoundsMapTy Intersections;
+  BoundsOffsetMapTy Intersections;
   bool FirstIntersection = true;
 
   for (const CFGBlock *pred : EB->Block->preds()) {
@@ -520,13 +520,13 @@ void BoundsAnalysis::ComputeOutSets(ElevatedCFGBlock *EB,
     KilledVars.insert(Vars.begin(), Vars.end());
   }
 
-  BoundsMapTy InMinusKill = Difference(EB->In, KilledVars);
+  BoundsOffsetMapTy InMinusKill = Difference(EB->In, KilledVars);
 
   for (const CFGBlock *succ : EB->Block->succs()) {
     if (SkipBlock(succ))
       continue;
 
-    BoundsMapTy OldOut = EB->Out[succ];
+    BoundsOffsetMapTy OldOut = EB->Out[succ];
 
     // Here's how we compute (In - Kill) u Gen:
 
@@ -569,10 +569,10 @@ DeclSetTy BoundsAnalysis::GetKilledBounds(const CFGBlock *B, const Stmt *St) {
   return J->second;
 }
 
-BoundsMapTy BoundsAnalysis::GetWidenedBoundsOffsets(const CFGBlock *B) {
+BoundsOffsetMapTy BoundsAnalysis::GetWidenedBoundsOffsets(const CFGBlock *B) {
   auto I = BlockMap.find(B);
   if (I == BlockMap.end())
-    return BoundsMapTy();
+    return BoundsOffsetMapTy();
 
   ElevatedCFGBlock *EB = I->second;
   return EB->In;
@@ -617,7 +617,7 @@ BoundsExprMapTy BoundsAnalysis::GetWidenedBounds(const CFGBlock *B) {
 
 DeclSetTy BoundsAnalysis::GetBoundsWidenedAndNotKilled(const CFGBlock *B,
                                                        const Stmt *St) {
-  BoundsMapTy WidenedBounds = GetWidenedBoundsOffsets(B);
+  BoundsOffsetMapTy WidenedBounds = GetWidenedBoundsOffsets(B);
   if (!WidenedBounds.size())
     return DeclSetTy();
 
@@ -779,7 +779,7 @@ void BoundsAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
     OS << "--------------------------------------";
     B->print(OS, Cfg, S.getLangOpts(), /* ShowColors */ true);
 
-    BoundsMapTy Vars = GetWidenedBoundsOffsets(B);
+    BoundsOffsetMapTy Vars = GetWidenedBoundsOffsets(B);
     using VarPairTy = std::pair<const VarDecl *, unsigned>;
 
     llvm::sort(Vars.begin(), Vars.end(),

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -82,17 +82,17 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
       return T->getAsRecordDecl();
     }
 
-    // AddPtrWithBounds adds PtrWithBounds to the set of variables in whose
-    // bounds Var occurs.
-    template<class M, class P, class V>
-    void AddPtrWithBounds(M &Map, const P *PtrWithBounds, const V *Var) {
-      auto It = Map.find(Var);
+    // AddPtrWithBounds adds PtrWithBounds to the set of variables or fields in
+    // whose bounds VarOrField occurs.
+    template<class T, class U>
+    void AddPtrWithBounds(T &Map, const U *PtrWithBounds, const U *VarOrField) {
+      auto It = Map.find(VarOrField);
       if (It != Map.end())
         It->second.insert(PtrWithBounds);
       else {
-        typename M::mapped_type Ptrs;
+        typename T::mapped_type Ptrs;
         Ptrs.insert(PtrWithBounds);
-        Map[Var] = Ptrs;
+        Map[VarOrField] = Ptrs;
       }
     }
 

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -50,6 +50,18 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     // };
     FieldDecl *FieldWithBounds = nullptr;
 
+    // InBoundsExprLower indicates that we are currently processing the lower
+    // bounds expression of a BoundsExpr that has been expanded to a
+    // RangeBoundsExpr. This flag is used to determine whether a variable
+    // occurs in the lower bounds expression of a VarWithBounds.
+    bool InBoundsExprLower = false;
+
+    // InBoundsExprUpper indicates that we are currently processing the upper
+    // bounds expression of a BoundsExpr that has been expanded to a
+    // RangeBoundsExpr. This flag is used to determine whether a variable
+    // occurs in the upper bounds expression of a VarWithBounds.
+    bool InBoundsExprUpper = false;
+
     // ProcessedRecords keeps tracks of the record declarations whose fields
     // have been traversed by the FillBoundsSiblingFields method. This avoids
     // unnecessary duplicate traversals of record fields.
@@ -70,16 +82,17 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
       return T->getAsRecordDecl();
     }
 
-    // AddBoundsSiblingField adds FieldWithBounds to the set of fields in
-    // whose declared bounds F occurs.
-    void AddBoundsSiblingField(const FieldDecl *F) {
-      auto It = Info.BoundsSiblingFields.find(F);
-      if (It != Info.BoundsSiblingFields.end())
-        It->second.insert(FieldWithBounds);
+    // AddPtrWithBounds adds PtrWithBounds to the set of variables in whose
+    // bounds Var occurs.
+    template<class M, class P, class V>
+    void AddPtrWithBounds(M &Map, const P *PtrWithBounds, const V *Var) {
+      auto It = Map.find(Var);
+      if (It != Map.end())
+        It->second.insert(PtrWithBounds);
       else {
-        FieldSetTy Fields;
-        Fields.insert(FieldWithBounds);
-        Info.BoundsSiblingFields[F] = Fields;
+        typename M::mapped_type Ptrs;
+        Ptrs.insert(PtrWithBounds);
+        Map[Var] = Ptrs;
       }
     }
 
@@ -115,7 +128,7 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
           // bounds. For example, if a field p has declared bounds count(1),
           // then p occurs in the declared bounds of p.
           if (isa<CountBoundsExpr>(FieldBounds))
-            AddBoundsSiblingField(Field);
+            AddPtrWithBounds(Info.BoundsSiblingFields, FieldWithBounds, Field);
 
           // Traverse the declared bounds to visit the DeclRefExprs that
           // explicitly occur in the declared bounds. These DeclRefExprs
@@ -165,7 +178,7 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
       if (FieldWithBounds) {
         const FieldDecl *F = dyn_cast_or_null<FieldDecl>(E->getDecl());
         if (F && !F->isInvalidDecl())
-          AddBoundsSiblingField(F);
+          AddPtrWithBounds(Info.BoundsSiblingFields, FieldWithBounds, F);
         return true;
       }
 
@@ -180,17 +193,13 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
           Info.VarUses[V] = E;
       }
 
-      // We add VarWithBounds to the set of all variables in whose bounds
-      // expressions V occurs.
       if (VarWithBounds) {
-        auto It = Info.BoundsVars.find(V);
-        if (It != Info.BoundsVars.end())
-          It->second.insert(VarWithBounds);
-        else {
-          VarSetTy Vars;
-          Vars.insert(VarWithBounds);
-          Info.BoundsVars[V] = Vars;
-        }
+        // We add VarWithBounds to the set of all variables in whose lower and
+        // upper bounds expressions V occurs.
+        if (InBoundsExprLower)
+          AddPtrWithBounds(Info.BoundsVarsLower, VarWithBounds, V);
+        else if (InBoundsExprUpper)
+          AddPtrWithBounds(Info.BoundsVarsUpper, VarWithBounds, V);
       }
 
       return true;
@@ -207,6 +216,24 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     // type), fill in the bounds sibling fields for the record declaration.
     bool VisitCallExpr(CallExpr *E) {
       FillBoundsSiblingFields(E->getType());
+      return true;
+    }
+
+    bool VisitBoundsExpr(BoundsExpr *B) {
+      if (!VarWithBounds)
+        return true;
+
+      BoundsExpr *Bounds = SemaRef.ExpandBoundsToRange(VarWithBounds, B);
+      if (auto *RBE = dyn_cast<RangeBoundsExpr>(Bounds)) {
+        InBoundsExprLower = true;
+        TraverseStmt(RBE->getLowerExpr());
+        InBoundsExprLower = false;
+
+        InBoundsExprUpper = true;
+        TraverseStmt(RBE->getUpperExpr());
+        InBoundsExprUpper = false;
+      }
+
       return true;
     }
 
@@ -242,7 +269,10 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
     }
 
     void DumpBoundsVars(FunctionDecl *FD) {
-      PrintDeclMap<const VarDecl *>(FD, "BoundsVars", Info.BoundsVars);
+      PrintDeclMap<const VarDecl *>(FD, "BoundsVars Lower",
+                                    Info.BoundsVarsLower);
+      PrintDeclMap<const VarDecl *>(FD, "BoundsVars Upper",
+                                    Info.BoundsVarsUpper);
     }
 
     void DumpBoundsSiblingFields(FunctionDecl *FD) {
@@ -252,8 +282,8 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
     // Print a map from a key of type T to a set of elements of type T,
     // where T should inherit from NamedDecl.
-    // This method can be used to print the BoundsVars and
-    // BoundsSiblingFields maps.
+    // This method can be used to print the BoundsVarsLower, BoundsVarsUpper
+    // and BoundsSiblingFields maps.
     template<class T>
     void PrintDeclMap(FunctionDecl *FD, const char *Message,
                       llvm::DenseMap<T, llvm::SmallPtrSet<T, 2>> Map) {

--- a/clang/test/CheckedC/inferred-bounds/bounds-vars.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-vars.c
@@ -36,7 +36,19 @@ void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
   }
 
 // CHECK-LABEL: In function: f1
-// CHECK: BoundsVars:
+// CHECK: BoundsVars Lower:
+// CHECK: a: { a }
+// CHECK: m: { m }
+// CHECK: p: { p }
+// CHECK: p: { p q }
+// CHECK: param1: { param1 param2 }
+// CHECK: param2: { param2 }
+// CHECK: q: { q }
+// CHECK: q: { m q }
+// CHECK: x: { p }
+
+// CHECK-LABEL: In function: f1
+// CHECK: BoundsVars Upper:
 // CHECK: a: { a }
 // CHECK: m: { m }
 // CHECK: p: { p }
@@ -46,7 +58,7 @@ void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
 // CHECK: q: { q }
 // CHECK: q: { m q }
 // CHECK: w: { a param2 }
-// CHECK: x: { a p param1 q }
+// CHECK: x: { a param1 q }
 // CHECK: y: { a p param1 param2 }
 // CHECK: z: { m p q }
 }


### PR DESCRIPTION
We separate out BoundsVars into BoundsVarsLower and BoundsVarsUpper that track
the variables occurring in the lower and upper bounds expressions,
respectively. This is needed for the bounds widenening analysis where we want
to determine the variables that can potentially be widened in a given
dereference expression.