### PR TITLE
Move GetLValueVariable, GetRValueVariable, and IsRValueCastOfVariable into VariableUtil

### DIFF
--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -72,6 +72,33 @@ public:
 } // end namespace clang
 
 namespace clang {
+
+class VariableUtil {
+public:
+  // If E is a possibly parenthesized lvalue variable V,
+  // GetLValueVariable returns V. Otherwise, it returns nullptr.
+  //
+  // V may have value-preserving operations applied to it, such as
+  // LValueBitCasts.  For example, if E is (LValueBitCast(V)), where V
+  // is a variable, GetLValueVariable will return V.
+  static DeclRefExpr *GetLValueVariable(Sema &S, Expr *E);
+
+  // If E is a possibly parenthesized rvalue cast of a variable V,
+  // GetRValueVariable returns V. Otherwise, it returns nullptr.
+  //
+  // V may have value-preserving operations applied to it.  For example,
+  // if E is (LValueToRValue(LValueBitCast(V))), where V is a variable,
+  // GetRValueVariable will return V.
+  static DeclRefExpr *GetRValueVariable(Sema &S, Expr *E);
+
+  // IsRValueCastOfVariable returns true if the expression e is a possibly
+  // parenthesized lvalue-to-rvalue cast of the lvalue variable v.
+  static bool IsRValueCastOfVariable(Sema &S, Expr *E, DeclRefExpr *V);
+};
+
+} // end namespace clang
+
+namespace clang {
   // QueueSet is a queue backed by a set. The queue is useful for processing
   // the items in a Topological sort order which means that if item1 is a
   // predecessor of item2 then item1 is processed before item2. The set is

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4752,7 +4752,7 @@ namespace {
 
       // Update the checking state and result bounds if LValue is a
       // variable V.
-      DeclRefExpr *V = GetLValueVariable(LValue);
+      DeclRefExpr *V = VariableUtil::GetLValueVariable(S, LValue);
       if (!V)
         return SrcBounds;
 


### PR DESCRIPTION
This PR moves several utility methods from `CheckBoundsDeclarations` into a new `VariableUtil` class in ExprUtils.

This is one of several small changes to support #1058.