### PR TITLE
PreorderAST: ensure that ConstFoldedVal and CurrConstVal have the same bit width

### DIFF
--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -407,7 +407,7 @@ bool BinaryOperatorNode::ConstantFold(bool &Error, ASTContext &Ctx) {
       // Ensure that ConstFoldedVal and CurrConstVal have the same bit width.
       if (ConstFoldedVal.getBitWidth() < CurrConstVal.getBitWidth())
         ConstFoldedVal = ConstFoldedVal.extOrTrunc(CurrConstVal.getBitWidth());
-      if (CurrConstVal.getBitWidth() < ConstFoldedVal.getBitWidth())
+      else if (CurrConstVal.getBitWidth() < ConstFoldedVal.getBitWidth())
         CurrConstVal = CurrConstVal.extOrTrunc(ConstFoldedVal.getBitWidth());
 
       // Constant fold based on the operator.

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -404,6 +404,12 @@ bool BinaryOperatorNode::ConstantFold(bool &Error, ASTContext &Ctx) {
       ConstFoldedVal = CurrConstVal;
 
     } else {
+      // Ensure that ConstFoldedVal and CurrConstVal have the same bit width.
+      if (ConstFoldedVal.getBitWidth() < CurrConstVal.getBitWidth())
+        ConstFoldedVal = ConstFoldedVal.extOrTrunc(CurrConstVal.getBitWidth());
+      if (CurrConstVal.getBitWidth() < ConstFoldedVal.getBitWidth())
+        CurrConstVal = CurrConstVal.extOrTrunc(ConstFoldedVal.getBitWidth());
+
       // Constant fold based on the operator.
       bool Overflow;
       switch(Opc) {


### PR DESCRIPTION
This PR fixes an assert that would happen in `APInt::+=` in `sadd_ov` and `smul_ov` when arguments had different bit widths. When we expand the set of expressions that we canonicalize (create PreorderASTs for), we can encounter binary operators with subexpressions with different bit widths, so we can hit this assert unless we ensure that the arguments have the same bit width.

This is one of several small changes to support #1058.