### PR TITLE
Return nullptr from ExpandToRange and GetOriginalValue if arguments are null

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5046,6 +5046,11 @@ namespace {
     // construct the inverse expression of the source with respect to V.
     Expr *GetOriginalValue(DeclRefExpr *V, Expr *Target, Expr *Src,
                            const EquivExprSets EQ, bool &OriginalValueUsesV) {
+      if (!V) {
+        OriginalValueUsesV = false;
+        return nullptr;
+      }
+
       // Check if Src has an inverse expression with respect to v.
       Expr *IV = nullptr;
       if (IsInvertible(V, Src))

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4393,6 +4393,8 @@ namespace {
     //                                      (array_ptr<char>) E + C)
     BoundsExpr *ExpandToRange(Expr *Base, BoundsExpr *B) {
       assert(Base->isRValue() && "expected rvalue expression");
+      if (!B)
+        return B;
       BoundsExpr::Kind K = B->getKind();
       switch (K) {
         case BoundsExpr::Kind::ByteCount:
@@ -4449,6 +4451,8 @@ namespace {
     }
 
     BoundsExpr *ExpandToRange(VarDecl *D, BoundsExpr *B) {
+      if (!B)
+        return B;
       QualType QT = D->getType();
       ExprResult ER = S.BuildDeclRefExpr(D, QT,
                                        clang::ExprValueKind::VK_LValue, SourceLocation());


### PR DESCRIPTION
This PR is one of several small changes to support #1058.