### PR TITLE
Parser: Mark deferred bounds annotation tokens as reinjected.

### DIFF
--- a/clang-tools-extra/clangd/test/checkedc-deferred-bound.test
+++ b/clang-tools-extra/clangd/test/checkedc-deferred-bound.test
@@ -1,0 +1,13 @@
+# Regression test for a crash caused by Checked C deferred bounds annotations
+# not being marked as reinjected (the first sub-issue of
+# https://github.com/microsoft/checkedc-clang/issues/1066).
+
+# We only care that this doesn't crash.
+# RUN: clangd -lit-test < %s
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"clangd","capabilities":{},"trace":"off"}}
+---
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"test:///main.c","languageId":"c","version":1,"text":"_Array_ptr<int> foo(void) : count(2);"}}}
+---
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+---
+{"jsonrpc":"2.0","method":"exit"}

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -4126,7 +4126,7 @@ Parser::DeferredParseBoundsAnnotations(std::unique_ptr<CachedTokens> Toks,
 
   Toks->push_back(Tok); // Save the current token at the end of the new tokens
                        // so it isn't lost.
-  PP.EnterTokenStream(*Toks, true, /*IsReinject=*/false);
+  PP.EnterTokenStream(*Toks, true, /*IsReinject=*/true);
   ConsumeAnyToken();   // Skip past the current token to the new tokens.
   bool Error = ParseBoundsAnnotations(D, SourceLocation(), Result,
                                       nullptr, false, ThisDecl);


### PR DESCRIPTION
This is needed to avoid crashing clangd.

Modeled on a similar fix in upstream Clang:

https://github.com/llvm/llvm-project/commit/f43ff34ae67a6557fe9fd1ba0e992da18bd102f7

Fixes part of #1066.  That issue includes a manual test case; I'm not yet familiar with how to write an automated test for this and would appreciate any suggestions before I research it myself.  I performed some simple manual tests of the Checked C compiler with this change and didn't notice any problems, but I haven't yet tried to run the full test suite or anything like that.