### PR TITLE
[PreorderAST] Add method to compute integer diff between two expressions

### DIFF
--- a/clang/include/clang/AST/CanonBounds.h
+++ b/clang/include/clang/AST/CanonBounds.h
@@ -131,6 +131,12 @@ namespace clang {
     bool GetDerefOffset(const Expr *UpperExpr, const Expr *DerefExpr,
                         llvm::APSInt &Offset) const;
 
+    /// \brief Get the integer difference between two expressions.
+    /// The boolean return value indicates whether the two expressions are
+    /// comparable.
+    bool GetExprIntDiff(const Expr *E1, const Expr *E2,
+                        llvm::APSInt &Offset) const;
+
     /// \brief Compare declarations that may be used by expressions or
     /// or types.
     Result CompareDecl(const NamedDecl *D1, const NamedDecl *D2) const;

--- a/clang/include/clang/AST/PreorderAST.h
+++ b/clang/include/clang/AST/PreorderAST.h
@@ -302,6 +302,16 @@ namespace clang {
     bool GetDerefOffset(Node *UpperExpr, Node *DerefExpr,
                         llvm::APSInt &Offset);
 
+    // Get the integer difference between expressions.
+    // @param[in] E1 is the first expression.
+    // @param[in] E2 is the second expression.
+    // @param[out] Offset is the integer difference between E1 and E2.
+    // @return Returns a boolean indicating whether the expressions are
+    // comparable. True means the expressions are comparable and their integer
+    // difference is present in the "Offset" parameter.  False means the
+    // expressions are not comparable.
+    bool GetExprIntDiff(Node *E1, Node *E2, llvm::APSInt &Offset);
+
     // Set Error in case an error occurs during transformation of the AST.
     void SetError() { Error = true; }
 
@@ -326,6 +336,18 @@ namespace clang {
     // exists.
     bool GetDerefOffset(PreorderAST &P, llvm::APSInt &Offset) {
       return GetDerefOffset(/*UpperExpr*/ Root, /*DerefExpr*/ P.Root, Offset);
+    }
+
+    // Get the integer difference between two expressions represented as
+    // preorder ASTs. This function is intended to be called from outside this
+    // class.
+    // @param[in] this is the first AST.
+    // @param[in] P is the second AST.
+    // @param[out] Offset is the integer difference.
+    // @return Returns a bool indicating whether the two expressions are
+    // comparable.
+    bool GetExprIntDiff(PreorderAST &P, llvm::APSInt &Offset) {
+      return GetExprIntDiff(Root, P.Root, Offset);
     }
 
     // Lexicographically compare the two ASTs. This is intended to be called

--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -320,6 +320,31 @@ bool Lexicographic::GetDerefOffset(const Expr *UpperExpr,
   return Res;
 }
 
+bool Lexicographic::GetExprIntDiff(const Expr *Arg1, const Expr *Arg2,
+                                   llvm::APSInt &Offset) const {
+  Expr *E1 = const_cast<Expr *>(Arg1);
+  Expr *E2 = const_cast<Expr *>(Arg2);
+
+  PreorderAST P1(Context, E1);
+  P1.Normalize();
+  if (P1.GetError()) {
+    P1.Cleanup();
+    return false;
+  }
+
+  PreorderAST P2(Context, E2);
+  P2.Normalize();
+  if (P2.GetError()) {
+    P2.Cleanup();
+    return false;
+  }
+
+  bool Res = P1.GetExprIntDiff(P2, Offset);
+  P1.Cleanup();
+  P2.Cleanup();
+  return Res;
+}
+
 Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) const {
    if (Trace) {
      raw_ostream &OS = llvm::outs();

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -514,6 +514,9 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   if (B1->Children.size() != B2->Children.size())
     return false;
 
+  llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
+  Offset = Zero;
+
   // Check if the children are equivalent.
   for (size_t I = 0; I != B1->Children.size(); ++I) {
     auto *Child1 = B1->Children[I];
@@ -549,7 +552,6 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
     // This guards us from a case where the constants were not folded for
     // some reason. In theory this should never happen. But we are adding this
     // check just in case.
-    llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
     if (llvm::APSInt::compareValues(Offset, Zero) != 0)
       return false;
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -542,7 +542,7 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
     // Offset should always be of the form (ptr + offset). So we check for
     // addition.
     // Note: We have already converted (ptr - offset) to (ptr + -offset). So
-    // its okay to only check for addition.
+    // it is okay to only check for addition.
     if (B1->Opc != BO_Add)
       return false;
 
@@ -617,7 +617,7 @@ bool PreorderAST::GetExprIntDiff(Node *E1, Node *E2, llvm::APSInt &Offset) {
     // Offset should always be of the form (ptr + offset). So we check for
     // addition.
     // Note: We have already converted (ptr - offset) to (ptr + -offset). So
-    // its okay to only check for addition.
+    // it is okay to only check for addition.
     if (B1->Opc != BO_Add)
       return false;
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -514,9 +514,6 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   if (B1->Children.size() != B2->Children.size())
     return false;
 
-  llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
-  Offset = Zero;
-
   // Check if the children are equivalent.
   for (size_t I = 0; I != B1->Children.size(); ++I) {
     auto *Child1 = B1->Children[I];
@@ -552,6 +549,7 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
     // This guards us from a case where the constants were not folded for
     // some reason. In theory this should never happen. But we are adding this
     // check just in case.
+    llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
     if (llvm::APSInt::compareValues(Offset, Zero) != 0)
       return false;
 
@@ -598,6 +596,10 @@ bool PreorderAST::GetExprIntDiff(Node *E1, Node *E2, llvm::APSInt &Offset) {
   if (B1->Children.size() != B2->Children.size())
       return false;
 
+  llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
+  // Initialize Offset to 0.
+  Offset = Zero;
+
   // Check if the children are equivalent.
   for (size_t I = 0; I != B1->Children.size(); ++I) {
     auto *Child1 = B1->Children[I];
@@ -626,7 +628,6 @@ bool PreorderAST::GetExprIntDiff(Node *E1, Node *E2, llvm::APSInt &Offset) {
     // This guards us from a case where the constants were not folded for
     // some reason. In theory this should never happen. But we are adding this
     // check just in case.
-    llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
     if (llvm::APSInt::compareValues(Offset, Zero) != 0)
       return false;
 

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -509,13 +509,6 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   if (B1->Opc != B2->Opc)
     return false;
 
-  // Offset should always be of the form (ptr + offset). So we check for
-  // addition.
-  // Note: We have already converted (ptr - offset) to (ptr + -offset). So
-  // it is okay to only check for addition.
-  if (B1->Opc != BO_Add)
-    return false;
-
   // We have already constant folded the constants. So return false if the
   // number of children mismatch.
   if (B1->Children.size() != B2->Children.size())
@@ -544,6 +537,13 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
 
     llvm::APSInt DerefOffset;
     if (!L2->E->isIntegerConstantExpr(DerefOffset, Ctx))
+      return false;
+
+    // Offset should always be of the form (ptr + offset). So we check for
+    // addition.
+    // Note: We have already converted (ptr - offset) to (ptr + -offset). So
+    // it is okay to only check for addition.
+    if (B1->Opc != BO_Add)
       return false;
 
     // This guards us from a case where the constants were not folded for
@@ -584,6 +584,13 @@ bool PreorderAST::GetExprIntDiff(Node *E1, Node *E2, llvm::APSInt &Offset) {
   if (B1->Opc != B2->Opc)
     return false;
 
+  // Offset should always be of the form (ptr + offset). So we check for
+  // addition.
+  // Note: We have already converted (ptr - offset) to (ptr + -offset). So
+  // it is okay to only check for addition.
+  if (B1->Opc != BO_Add)
+    return false;
+
   // We have already constant folded the constants. So return false if the
   // number of children mismatch.
   if (B1->Children.size() != B2->Children.size())
@@ -612,13 +619,6 @@ bool PreorderAST::GetExprIntDiff(Node *E1, Node *E2, llvm::APSInt &Offset) {
 
     llvm::APSInt IntegerPart2;
     if (!L2->E->isIntegerConstantExpr(IntegerPart2, Ctx))
-      return false;
-
-    // Offset should always be of the form (ptr + offset). So we check for
-    // addition.
-    // Note: We have already converted (ptr - offset) to (ptr + -offset). So
-    // it is okay to only check for addition.
-    if (B1->Opc != BO_Add)
       return false;
 
     // This guards us from a case where the constants were not folded for

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -509,6 +509,13 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
   if (B1->Opc != B2->Opc)
     return false;
 
+  // Offset should always be of the form (ptr + offset). So we check for
+  // addition.
+  // Note: We have already converted (ptr - offset) to (ptr + -offset). So
+  // it is okay to only check for addition.
+  if (B1->Opc != BO_Add)
+    return false;
+
   // We have already constant folded the constants. So return false if the
   // number of children mismatch.
   if (B1->Children.size() != B2->Children.size())
@@ -537,13 +544,6 @@ bool PreorderAST::GetDerefOffset(Node *UpperNode, Node *DerefNode,
 
     llvm::APSInt DerefOffset;
     if (!L2->E->isIntegerConstantExpr(DerefOffset, Ctx))
-      return false;
-
-    // Offset should always be of the form (ptr + offset). So we check for
-    // addition.
-    // Note: We have already converted (ptr - offset) to (ptr + -offset). So
-    // it is okay to only check for addition.
-    if (B1->Opc != BO_Add)
       return false;
 
     // This guards us from a case where the constants were not folded for


### PR DESCRIPTION
Added a method called PreorderAST::GetExprIntDiff that computes the integer
difference between two input expressions and returns true if the expressions
are comparable. If the expressions are not comparable then it returns false.

This method will be used in the updated bounds widening analysis. This method
is meant to replace PreorderAST::GetDerefOffset after the updated bounds
widening analysis merges.

See https://github.com/microsoft/checkedc-clang/issues/1078