### PR TITLE
Add missing initialization of TypeVariableTypeLoc's SourceLocation.

### DIFF
--- a/clang-tools-extra/clangd/test/Inputs/checkedc-typevariabletypeloc-uninit.h
+++ b/clang-tools-extra/clangd/test/Inputs/checkedc-typevariabletypeloc-uninit.h
@@ -1,0 +1,1 @@
+_For_any(T) void my_free(_Ptr<T> p);

--- a/clang-tools-extra/clangd/test/checkedc-typevariabletypeloc-uninit.test
+++ b/clang-tools-extra/clangd/test/checkedc-typevariabletypeloc-uninit.test
@@ -1,0 +1,57 @@
+# Regression test for a bug where Parser::ParseForanySpecifierHelper left the
+# memory representing the SourceLocation of the TypeVariableTypeLoc
+# uninitialized (the second sub-issue of
+# https://github.com/microsoft/checkedc-clang/issues/1066).
+
+# The original symptom was that when a C file includes a header containing a
+# _For_any or _Itype_for_any construct, clangd writes out a precompiled header
+# with a garbage value for the SourceLocation, and when clangd reads the
+# precompiled header back in, the bad SourceLocation causes an "offset overflow"
+# assertion failure with TypeLocReader::VisitTypeVariableTypeLoc on the call
+# stack. However, this is nondeterministic depending on the content of the
+# uninitialized memory. To write a test that consistently catches the problem,
+# we run clangd under valgrind memcheck and check for an uninitialized memory
+# error. Alternatively, there might be a way to query the SourceLocation from
+# clangd so we can check that it is actually correct, although conceivably this
+# could falsely pass if the uninitialized memory coincidentally contained the
+# correct value.
+
+# Note that lit has a --vg command-line option to run test(s) under `valgrind
+# --error-exitcode`, but there doesn't seem to be a way that we can force that
+# option to be enabled just for this test, so we hard-code the valgrind command
+# here. If valgrind isn't available on the system, the test will fail;
+# effectively, we're requiring the user to install valgrind in order to run the
+# clangd test suite. We consider this a lesser evil than automatically skipping
+# the test if valgrind is unavailable, in which case users might not pay
+# attention to the fact that they should run it at all.
+
+# This test won't work correctly when run under a second level of valgrind via
+# `lit --vg`, so treat it as unsupported in that case. Hopefully users don't run
+# the test suite _only_ with --vg and forget to run this test.
+# UNSUPPORTED: valgrind
+
+# No good drop-in replacement for valgrind is currently available for Windows.
+# UNSUPPORTED: system-windows
+
+# Notes about command-line arguments:
+#
+# - Without --compile_args_from=lsp, clangd seems to automatically take
+#   undesired compiler options from the LLVM monorepo's own compilation
+#   database.
+#
+# - --path-mappings seems to be the easiest way to get the `#include` to resolve
+#   to our desired header file in the Inputs directory, since lit expands %S
+#   there but not in the uri in the actual LSP message. This is modeled on
+#   path-mappings.test, although the purpose of path-mappings.test is actually
+#   to test the path mapping, while here, we just use it to facilitate the
+#   TypeVariableTypeLoc test.
+
+# RUN: valgrind --error-exitcode=1 clangd --compile_args_from=lsp --path-mappings '/test-workspace=%S/Inputs' -lit-test < %s
+
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"clangd","capabilities":{},"trace":"off"}}
+---
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test-workspace/checkedc-typevariabletypeloc-uninit.c","languageId":"c","version":1,"text":"#include \"checkedc-typevariabletypeloc-uninit.h\""}}}
+---
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+---
+{"jsonrpc":"2.0","method":"exit"}

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7999,6 +7999,7 @@ bool Parser::ParseForanySpecifierHelper(DeclSpec &DS,
       // TypeVariableType.
       QualType R = Actions.Context.getTypeVariableType(Depth, typeVariableIndex, S == Scope::ItypeforanyScope);
       TypeSourceInfo *TInfo = Actions.Context.CreateTypeSourceInfo(R);
+      TInfo->getTypeLoc().castAs<TypeVariableTypeLoc>().setNameLoc(Tok.getLocation());
       TypedefDecl *NewTD = TypedefDecl::Create(Actions.Context, Actions.CurContext,
         Loc,
         Tok.getLocation(),


### PR DESCRIPTION
If the SourceLocation was allowed to contain a garbage value from uninitialized memory, that could crash clangd.

Fixes part of #1066.

I ran `ninja check-checkedc` on Linux and it passed.  I still plan to try to [run the rest of the existing tests](https://github.com/microsoft/checkedc-clang/pull/1067#issuecomment-853097748) [UPDATE: done, see below], but please go ahead and let me know if you see any problem with the code.