### PR TITLE
checkedc-supported test: Add --no-cuda-version-check.

### DIFF
--- a/clang/test/Driver/checkedc-supported.c
+++ b/clang/test/Driver/checkedc-supported.c
@@ -15,7 +15,7 @@
 // RUN:  | FileCheck %s -check-prefix=clcheck-cpp
 // clcheck-cpp: warning: Checked C extension not supported with 'C++'; ignoring '-fcheckedc-extension'
 //
-// RUN: not %clang -c -fcheckedc-extension -x cuda -nocudalib -nocudainc %s -o %t 2>&1 \
+// RUN: not %clang -c -fcheckedc-extension -x cuda -nocudalib -nocudainc --no-cuda-version-check %s -o %t 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=check-cuda
 // check-cuda: warning: Checked C extension not supported with 'CUDA'; ignoring '-fcheckedc-extension'
 //


### PR DESCRIPTION
This was needed for the test to pass on CCI's Linux machine and seems consistent with the intent of the other options to skip actually checking for a CUDA installation.

**Testing:** Since this PR changes only a test, it should only be necessary to run that one test, and in this case, the most convenient way to do so is `ninja check-clang-driver`.  Our results:

- Linux: Before the PR, the test fails with [this log](https://github.com/microsoft/checkedc-clang/files/6593109/Driver-checkedc-supported-cuda-failure.txt).  After the PR, it passes.
- Windows: The test passes both before and after the PR.