### PR TITLE
[LValue Generalization] Validate bounds context for member expressions [11/n]

### DIFF
--- a/clang/include/clang/AST/AbstractSet.h
+++ b/clang/include/clang/AST/AbstractSet.h
@@ -59,17 +59,16 @@ namespace clang {
       return Representative;
     }
 
-    // Returns the VarDecl, if any, associated with the Representative
+    // Returns the NamedDecl, if any, associated with the Representative
     // expression for this AbstractSet.
-    // This VarDecl is used by bounds declaration checking to emit
+    // This NamedDecl is used by bounds declaration checking to emit
     // diagnostics for statements that invalidate the inferred bounds of
     // the lvalue expressions in the AbstractSet.
-    const VarDecl *GetVarDecl() const {
-      if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(Representative)) {
-        if (const VarDecl *V = dyn_cast<VarDecl>(DRE->getDecl()))
-          return V;
-        return nullptr;
-      }
+    const NamedDecl *GetDecl() const {
+      if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(Representative))
+        return DRE->getDecl();
+      if (MemberExpr *ME = dyn_cast<MemberExpr>(Representative))
+        return ME->getMemberDecl();
       return nullptr;
     }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11290,18 +11290,18 @@ def err_bounds_type_annotation_lost_checking : Error<
     "expected _Array_ptr type">;
 
   def warn_bounds_declaration_invalid : Warning<
-    "cannot prove declared bounds for %1 are valid after "
+    "cannot prove declared bounds for '%1' are valid after "
     "%select{assignment|decrement|increment|initialization|statement}0">,
     InGroup<CheckBoundsDeclsUnchecked>;
 
   def warn_checked_scope_bounds_declaration_invalid : Warning<
-    "cannot prove declared bounds for %1 are valid after "
+    "cannot prove declared bounds for '%1' are valid after "
     "%select{assignment|decrement|increment|initialization|statement}0">,
     InGroup<CheckBoundsDeclsChecked>;
 
   def error_bounds_declaration_unprovable : Error<
-    "it is not possible to prove that the inferred bounds of %1 "
-    "imply the declared bounds of %1 after "
+    "it is not possible to prove that the inferred bounds of '%1' "
+    "imply the declared bounds of '%1' after "
     "%select{assignment|decrement|increment|initialization|statement}0">;
 
   def note_free_variable_decl_or_inferred : Note<
@@ -11317,11 +11317,11 @@ def err_bounds_type_annotation_lost_checking : Error<
     "%select{lower |upper |}1bounds">;
 
   def error_bounds_declaration_invalid : Error<
-    "declared bounds for %1 are invalid after "
+    "declared bounds for '%1' are invalid after "
     "%select{assignment|decrement|increment|initialization|statement}0">;
 
   def err_unknown_inferred_bounds : Error<
-    "inferred bounds for %1 are unknown after "
+    "inferred bounds for '%1' are unknown after "
     "%select{assignment|decrement|increment|initialization|statement}0">;
 
   def note_declared_bounds : Note<
@@ -11341,7 +11341,7 @@ def err_bounds_type_annotation_lost_checking : Error<
     "which is used in the (expanded) inferred bounds '%1' of '%2'">;
 
   def note_unknown_source_bounds : Note<
-    "assigned expression '%0' with unknown bounds to %1">;
+    "assigned expression '%0' with unknown bounds to '%1'">;
 
   def err_modifying_expr_not_supported : Error<
    "argument must be a non-modifying expression because %ordinal0 parameter "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11336,9 +11336,9 @@ def err_bounds_type_annotation_lost_checking : Error<
   def note_required_bounds : Note<
     "(expanded) required bounds are '%0'">;
 
-  def note_lost_variable : Note<
-    "lost the value of the variable '%0' "
-    "which is used in the (expanded) inferred bounds '%1' of %2">;
+  def note_lost_expression : Note<
+    "lost the value of the expression '%0' "
+    "which is used in the (expanded) inferred bounds '%1' of '%2'">;
 
   def note_unknown_source_bounds : Note<
     "assigned expression '%0' with unknown bounds to %1">;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2590,10 +2590,10 @@ namespace {
       // 2. Otherwise, if Src is a non-modifying expression, record
       //    equivalence between V and Src.
       CHKCBindTemporaryExpr *Temp = GetTempBinding(Src);
+      // TODO: make sure variable being initialized isn't read by Src.
+      DeclRefExpr *TargetDeclRef = ExprCreatorUtil::CreateVarUse(S, D);
       if (Temp ||  S.CheckIsNonModifying(Src, Sema::NonModifyingContext::NMC_Unknown,
                                          Sema::NonModifyingMessage::NMM_None)) {
-        // TODO: make sure variable being initialized isn't read by Src.
-        DeclRefExpr *TargetDeclRef = ExprCreatorUtil::CreateVarUse(S, D);
         CastKind Kind;
         QualType TargetTy;
         if (D->getType()->isArrayType()) {
@@ -2633,7 +2633,7 @@ namespace {
                        : diag::warn_bounds_declaration_invalid);
 
         S.Diag(ExprLoc, DiagId)
-          << Sema::BoundsDeclarationCheck::BDC_Initialization << D
+          << Sema::BoundsDeclarationCheck::BDC_Initialization << TargetDeclRef
           << D->getLocation() << Src->getSourceRange();
         if (Result == ProofResult::False)
           ExplainProofFailure(ExprLoc, Cause, ProofStmtKind::BoundsDeclaration);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3436,8 +3436,6 @@ namespace {
         }
       }
 
-      // Determine whether the assignment is to a variable.
-      DeclRefExpr *LHSVar = VariableUtil::GetLValueVariable(S, LHS);
       // Determine whether the checking state is updated for an assignment.
       bool StateUpdated = false;
 
@@ -3467,7 +3465,7 @@ namespace {
         // SameValue is empty for assignments to a non-variable. This
         // conservative approach avoids recording false equality facts for
         // assignments where the LHS appears on the RHS, e.g. *p = *p + 1.
-        if (!LHSVar)
+        if (!VariableUtil::GetLValueVariable(S, LHS))
           State.SameValue.clear();
       } else if (BinaryOperator::isLogicalOp(Op)) {
         // TODO: update State for logical operators `e1 && e2` and `e1 || e2`.
@@ -3507,11 +3505,11 @@ namespace {
               RightBounds = S.CheckNonModifyingBounds(ResultBounds, RHS);
 
             // If RightBounds are invalid bounds, it is because the bounds for
-            // the RHS contained a modifying expression. Update the variable's
-            // observed bounds to be InvalidBounds to avoid extraneous errors
+            // the RHS contained a modifying expression. Update the observed
+            // bounds of the LHS to be InvalidBounds to avoid extraneous errors
             // during bounds declaration validation.
-            if (LHSVar && RightBounds->isInvalid()) {
-              const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(LHSVar);
+            if (StateUpdated && RightBounds->isInvalid()) {
+              const AbstractSet *A = AbstractSetMgr.GetOrCreateAbstractSet(LHS);
               State.ObservedBounds[A] = RightBounds;
             }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4661,13 +4661,9 @@ namespace {
         std::pair<BoundsExpr *, Expr *> Lost = LostLValueIt->second;
         BoundsExpr *InitialObservedBounds = Lost.first;
         Expr *LostLValue = Lost.second;
-        // TODO: currently, we only validate bounds for an AbstractSet A in
-        // ObservedBounds if the representative of A is a DeclRefExpr, so
-        // we can still emit the note_lost_variable diagnostic message.
-        // In the future, we should change this message so that it applies
-        // to all kinds of lvalue expressions.
-        S.Diag(LostLValue->getBeginLoc(), diag::note_lost_variable)
-          << LostLValue << InitialObservedBounds << V << LostLValue->getSourceRange();
+        S.Diag(LostLValue->getBeginLoc(), diag::note_lost_expression)
+          << LostLValue << InitialObservedBounds
+          << A->GetRepresentative() << LostLValue->getSourceRange();
       }
 
       // The observed bounds of A are unknown because at least one expression

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4674,7 +4674,7 @@ namespace {
         for (auto I = UnknownSources.begin(); I != UnknownSources.end(); ++I) {
           Expr *Src = *I;
           S.Diag(Src->getBeginLoc(), diag::note_unknown_source_bounds)
-            << Src << V << Src->getSourceRange();
+            << Src << A->GetRepresentative() << Src->getSourceRange();
         }
       }
     }
@@ -4761,7 +4761,8 @@ namespace {
       if (isa<DeclStmt>(St)) {
         Loc = V->getLocation();
         BDCType = Sema::BoundsDeclarationCheck::BDC_Initialization;
-        S.Diag(Loc, DiagId) << BDCType << V << SrcRange << SrcRange;
+        S.Diag(Loc, DiagId) << BDCType << A->GetRepresentative()
+          << SrcRange << SrcRange;
         return Loc;
       }
 
@@ -4788,7 +4789,8 @@ namespace {
           BDCType = Sema::BoundsDeclarationCheck::BDC_Assignment;
         }
       }
-      S.Diag(Loc, DiagId) << BDCType << V << SrcRange << SrcRange;
+      S.Diag(Loc, DiagId) << BDCType << A->GetRepresentative()
+        << SrcRange << SrcRange;
       return Loc;
     }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4683,8 +4683,8 @@ namespace {
       }
     }
 
-    // CheckObservedBounds checks that the observed bounds for a variable v
-    // imply that the declared bounds for v are provably true after checking
+    // CheckObservedBounds checks that the observed bounds for the AbstractSet
+    // A imply that the declared bounds for A are provably true after checking
     // the top-level CFG statement St.
     //
     // EquivExprs contains all equality facts contained in State.EquivExprs,
@@ -4743,10 +4743,11 @@ namespace {
     }
 
     // BlameAssignmentWithinStmt prints a diagnostic message that highlights the
-    // assignment expression in St that causes V's observed bounds to be unknown
-    // or not provably valid.  If St is a DeclStmt, St itself and V are
-    // highlighted.  BlameAssignmentWithinStmt returns the source location of
-    // the blamed assignment.
+    // assignment expression in St that causes A's observed bounds to be unknown
+    // or not provably valid.  If St is a DeclStmt, St itself and the
+    // representative lvalue expression of A are highlighted.
+    // BlameAssignmentWithinStmt returns the source location of the blamed
+    // assignment.
     SourceLocation BlameAssignmentWithinStmt(Stmt *St, const AbstractSet *A,
                                              CheckingState State,
                                              unsigned DiagId) const {

--- a/clang/test/3C/arrboundsbasic.c
+++ b/clang/test/3C/arrboundsbasic.c
@@ -36,8 +36,7 @@ int foo(int *arr, unsigned len) {
   for (i = 0; i < len; i++) {
     arr[i] = 0;
   }
-  a.a_len = 4;
-  a.a = malloc(a.a_len * sizeof(char));
+  a.a_len = 4, a.a = malloc(a.a_len * sizeof(char));
   a.a[0] = 0;
   return 0;
 }

--- a/clang/test/3C/contextsensitivebounds.c
+++ b/clang/test/3C/contextsensitivebounds.c
@@ -36,8 +36,7 @@ int foo() {
   unsigned i;
   struct hash_node *n = somefunc(sizeof(struct hash_node));
   i = 5 * sizeof(int);
-  n->pqlen = i;
-  n->p_key = somefunc(i);
+  n->pqlen = i, n->p_key = somefunc(i), n->q_key = 0;
   n->r_key = somefunc(n->r_len);
   n->p_key[0] = 1;
   n->r_key[0] = 1;

--- a/clang/test/3C/contextsensitivebounds1.c
+++ b/clang/test/3C/contextsensitivebounds1.c
@@ -53,8 +53,7 @@ int foo() {
   unsigned i, j;
   struct hash_node *n = somefunc(sizeof(struct hash_node));
   i = 5 * sizeof(int);
-  n->pqlen = i;
-  n->p_key = somefunc(i);
+  n->pqlen = i, n->p_key = somefunc(i), n->q_key = 0;
   n->r_key = somefunc(n->r_len);
   ctxsensfunc(n->w_key, n->xo);
   n->p_key[0] = 1;

--- a/clang/test/CheckedC/dump-dataflow-facts.c
+++ b/clang/test/CheckedC/dump-dataflow-facts.c
@@ -850,8 +850,7 @@ struct st_80_arr {
 void fn_16(_Ptr<struct st_80_arr> arr, int b) {
   _Array_ptr<_Ptr<struct st_80>> a : count(b) = 0;
   if (arr->c <= b) {
-    arr->c = b * b;
-    arr->e = a;
+    arr->c = b * b, arr->e = a;
   }
 // CHECK-LABEL: fn_16
 // CHECK-NEXT: Block #4: {

--- a/clang/test/CheckedC/dump-profiling-stats.c
+++ b/clang/test/CheckedC/dump-profiling-stats.c
@@ -2,8 +2,6 @@
 //
 // RUN: %clang_cc1 -print-stats -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | grep '' %s | FileCheck %s --dump-input=always
 
-// expected-no-diagnostics
-
 struct B {
   int len;
 };
@@ -21,7 +19,7 @@ void synthesize_members(struct A *a) {
   // While synthesizing members for the following assignment, MemberExprs
   // will be created for a->f and a->g. An AbstractSet will be created
   // for a->f.
-  a->b->len = 0;
+  a->b->len = 0; // expected-error {{inferred bounds for 'a->f' are unknown after assignment}}
 }
 
 // CHECK: *** Checked C Stats:

--- a/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
@@ -8,12 +8,13 @@
 
 struct S {
   int len;
-  array_ptr<int> p : count(len);
+  array_ptr<int> p : count(len); // expected-note 4 {{(expanded) declared bounds are 'bounds(s->p, s->p + s->len)'}}
   int i;
-  array_ptr<int> q : count(i);
-  array_ptr<int> r : count(i);
-  array_ptr<int> f : count(3);
-  array_ptr<int> g : bounds(f, f + 3);
+  array_ptr<int> q : count(i); // expected-note 2 {{(expanded) declared bounds are 'bounds(s[3].q, s[3].q + s[3].i)'}} \
+                               // expected-note {{(expanded) declared bounds are 'bounds(s[4].q, s[4].q + s[4].i)'}}
+  array_ptr<int> r : count(i); // expected-note 2 {{(expanded) declared bounds are 'bounds(s[3].r, s[3].r + s[3].i)'}}
+  array_ptr<int> f : count(3); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}}
+  array_ptr<int> g : bounds(f, f + 3); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}}
   array_ptr<int> a : count(2);
   array_ptr<int> b : count(2);
 };
@@ -21,7 +22,8 @@ struct S {
 // Assignment to a struct member that kills the bounds of another struct member
 void kill_bounds1(struct S *s) {
   // Observed bounds context after assignment: { s->p => bounds(unknown) }
-  s->len = 0;
+  s->len = 0; // expected-error {{inferred bounds for 's->p' are unknown after assignment}} \
+              // expected-note {{lost the value of the expression 's->len' which is used in the (expanded) inferred bounds 'bounds(s->p, s->p + s->len)' of 's->p'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:
@@ -35,7 +37,8 @@ void kill_bounds1(struct S *s) {
   // CHECK-NEXT: }
 
   // Observed bounds context after assignment: { s->p => bounds(unknown) }
-  (*s).len = 0;
+  (*s).len = 0; // expected-error {{inferred bounds for 's->p' are unknown after assignment}} \
+                // expected-note {{lost the value of the expression '(*s).len' which is used in the (expanded) inferred bounds 'bounds(s->p, s->p + s->len)' of 's->p'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:
@@ -49,7 +52,8 @@ void kill_bounds1(struct S *s) {
   // CHECK-NEXT: }
 
   // Observed bounds context after assignment: { s->p => bounds(unknown) }
-  s[0].len = 0;
+  s[0].len = 0; // expected-error {{inferred bounds for 's->p' are unknown after assignment}} \
+                // expected-note {{lost the value of the expression 's[0].len' which is used in the (expanded) inferred bounds 'bounds(s->p, s->p + s->len)' of 's->p'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:
@@ -66,7 +70,10 @@ void kill_bounds1(struct S *s) {
 // Assignment to a struct member that kills the bounds of multiple struct members
 void kill_bounds2(struct S *s) {
   // Observed bounds context after assignment: { s[3].q => bounds(unknown), s[3].r => bounds(unknown) }
-  s[3].i = 0;
+  s[3].i = 0; // expected-error {{inferred bounds for 's[3].q' are unknown after assignment}} \
+              // expected-note {{lost the value of the expression 's[3].i' which is used in the (expanded) inferred bounds 'bounds(s[3].q, s[3].q + s[3].i)' of 's[3].q'}} \
+              // expected-error {{inferred bounds for 's[3].r' are unknown after assignment}} \
+              // expected-note {{lost the value of the expression 's[3].i' which is used in the (expanded) inferred bounds 'bounds(s[3].r, s[3].r + s[3].i)' of 's[3].r'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:
@@ -90,7 +97,10 @@ void kill_bounds2(struct S *s) {
   // CHECK-NEXT: }
 
   // Observed bounds context after assignment: { s[3].q => bounds(unknown), s[3].r => bounds(unknown) }
-  (1 + 2)[s].i = 0;
+  (1 + 2)[s].i = 0; // expected-error {{inferred bounds for 's[3].q' are unknown after assignment}} \
+                    // expected-note {{lost the value of the expression '(1 + 2)[s].i' which is used in the (expanded) inferred bounds 'bounds(s[3].q, s[3].q + s[3].i)' of 's[3].q'}} \
+                    // expected-error {{inferred bounds for 's[3].r' are unknown after assignment}} \
+                    // expected-note {{lost the value of the expression '(1 + 2)[s].i' which is used in the (expanded) inferred bounds 'bounds(s[3].r, s[3].r + s[3].i)' of 's[3].r'}} \
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:
@@ -118,7 +128,8 @@ void kill_bounds2(struct S *s) {
 void kill_bounds3(struct S *s) {
   // Original value of s->p after increment: s->p - 1
   // Observed bounds context after increment: { s->p => bounds(s->p - 1, s->p - 1 + s->len) }
-  s->p++;
+  s->p++; // expected-warning {{cannot prove declared bounds for 's->p' are valid after increment}} \
+          // expected-note {{(expanded) inferred bounds are 'bounds(s->p - 1, s->p - 1 + s->len)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} '++'
   // CHECK: Observed bounds context after checking S:
@@ -205,8 +216,7 @@ void updated_source_bounds2(struct S *s) {
   // Observed bounds context after assignment: { s[4].q => bounds(s[3].r, s[3].r + s[3].i) }
   // s[4].q and s[3].r are (temporarily) equivalent, but s[4].i and s[3].i
   // are not equivalent, so we get a warning.
-  s[4].q = s[3].r; // expected-warning {{cannot prove declared bounds for s[4].q are valid after assignment}} \
-                   // expected-note {{(expanded) declared bounds are 'bounds(s[4].q, s[4].q + s[4].i)'}} \
+  s[4].q = s[3].r; // expected-warning {{cannot prove declared bounds for 's[4].q' are valid after assignment}} \
                    // expected-note {{(expanded) inferred bounds are 'bounds(s[3].r, s[3].r + s[3].i)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -275,8 +285,9 @@ void updated_source_bounds2(struct S *s) {
 void updated_source_bounds3(struct S *s) {
   // Original value of s->f: s->f - 1
   // Observed bounds context after assignment: { s->f => bounds(s->f + 2, s->f + 2 + 3), s->g => bounds(s->f + 2, s->f + 2 + 3) }
-  s->f = s->f - 2; // expected-warning {{cannot prove declared bounds for s->f are valid after assignment}} \
-                   // expected-note {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}} \
+  s->f = s->f - 2; // expected-warning {{cannot prove declared bounds for 's->f' are valid after assignment}} \
+                   // expected-note {{(expanded) inferred bounds are 'bounds(s->f + 2, s->f + 2 + 3)'}} \
+                   // expected-warning {{cannot prove declared bounds for 's->g' are valid after assignment}} \
                    // expected-note {{(expanded) inferred bounds are 'bounds(s->f + 2, s->f + 2 + 3)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -326,7 +337,10 @@ void updated_source_bounds3(struct S *s) {
 
   // Observed bounds context after assignment: { s->f => bounds(unknown), s->g => bounds(unknown) }
   // This is not an invertible assignment, so s->f has no original value.
-  s->f = s->g; // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds because the left-hand side has bounds}}
+  s->f = s->g; // expected-error {{inferred bounds for 's->f' are unknown after assignment}} \
+               // expected-note {{lost the value of the expression 's->f' which is used in the (expanded) inferred bounds 'bounds(s->f, s->f + 3)' of 's->f'}} \
+               // expected-error {{inferred bounds for 's->g' are unknown after assignment}} \
+               // expected-note {{lost the value of the expression 's->f' which is used in the (expanded) inferred bounds 'bounds(s->f, s->f + 3)' of 's->g'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:
@@ -348,23 +362,28 @@ void updated_source_bounds3(struct S *s) {
 
 struct C {
   int len;
-  array_ptr<int> r : count(len);
+  array_ptr<int> r : count(len); // expected-note {{(expanded) declared bounds are 'bounds(a.b.c.r, a.b.c.r + a.b.c.len)'}}
 };
 
 struct B {
   struct C c;
-  array_ptr<int> q : count(c.len);
+  array_ptr<int> q : count(c.len); // expected-note {{(expanded) declared bounds are 'bounds(a.b.q, a.b.q + a.b.c.len)'}}
 };
 
 struct A {
   struct B b;
-  array_ptr<int> p : count(b.c.len);
+  array_ptr<int> p : count(b.c.len); // expected-note {{(expanded) declared bounds are 'bounds(a.p, a.p + a.b.c.len)'}}
 };
 
 // Assigning to a nested member expression
 void nested1(struct A a) {
   // Observed bounds context after assignment: { a.p => bounds(unknown), a.b.q => bounds(unknown), a.b.c.r => bounds(unknown) }
-  a.b.c.len = 0;
+  a.b.c.len = 0; // expected-error {{inferred bounds for 'a.p' are unknown after assignment}} \
+                 // expected-note {{lost the value of the expression 'a.b.c.len' which is used in the (expanded) inferred bounds 'bounds(a.p, a.p + a.b.c.len)' of 'a.p'}} \
+                 // expected-error {{inferred bounds for 'a.b.q' are unknown after assignment}} \
+                 // expected-note {{lost the value of the expression 'a.b.c.len' which is used in the (expanded) inferred bounds 'bounds(a.b.q, a.b.q + a.b.c.len)' of 'a.b.q'}} \
+                 // expected-error {{inferred bounds for 'a.b.c.r' are unknown after assignment}} \
+                 // expected-note {{lost the value of the expression 'a.b.c.len' which is used in the (expanded) inferred bounds 'bounds(a.b.c.r, a.b.c.r + a.b.c.len)' of 'a.b.c.r'}}
   // CHECK: Statement S:
   // CHECK: BinaryOperator {{.*}} '='
   // CHECK: Observed bounds context after checking S:

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -476,7 +476,7 @@ void assign6(array_ptr<int> a : count(len), int len) { // expected-note {{(expan
   // Original value of len: null
   // Observed bounds context after assignment:  { a => bounds(unknown) }
   len = len * 2; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
-                 // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}}
+                 // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'len'
@@ -503,11 +503,11 @@ void assign7(
   // Original value of a: null
   // Observed bounds context after assignment:  { a => bounds(unknown), b => bounds(unknown), c => bounds(unknown) }
   a = b; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
-         // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'a'}} \
+         // expected-note {{lost the value of the expression 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'a'}} \
          // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
-         // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'b'}} \
+         // expected-note {{lost the value of the expression 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'b'}} \
          // expected-error {{inferred bounds for 'c' are unknown after assignment}} \
-         // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'c'}}
+         // expected-note {{lost the value of the expression 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + 1)' of 'c'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
@@ -1139,10 +1139,10 @@ void multiple_assign1(
   // Observed bounds of b at assignment a = b: bounds(unknown)
   // Observed bounds context after assignments: { a => bounds(unknown), b => bounds(unknown) }
   len = 0, a = b; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
-                  // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
+                  // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
                   // expected-note {{assigned expression 'b' with unknown bounds to 'a'}} \
                   // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
-                  // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(b, b + len)' of 'b'}}
+                  // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(b, b + len)' of 'b'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
   // CHECK-NEXT:   BinaryOperator {{.*}} '='
@@ -1232,9 +1232,9 @@ void multiple_assign2(
   // Observed bounds context after statement: { a => bounds(unknown), b => bounds(unknown) }
   len = 0, a[0]; // expected-error {{expression has unknown bounds}} \
                  // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
-                 // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
+                 // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
                  // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
-                 // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'b'}}
+                 // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'b'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
   // CHECK-NEXT:   BinaryOperator {{.*}} '='
@@ -1264,9 +1264,9 @@ void multiple_assign2(
   // Observed bounds context after statement: { a => bounds(unknown), b => bounds(unknown) }
   a = b, *b; // expected-error {{expression has unknown bounds}} \
              // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
-             // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
+             // expected-note {{lost the value of the expression 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
              // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
-             // expected-note {{lost the value of the variable 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'b'}}
+             // expected-note {{lost the value of the expression 'a' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'b'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
   // CHECK-NEXT:   BinaryOperator {{.*}} '='
@@ -1351,7 +1351,7 @@ void multiple_assign4(array_ptr<int> a : count(len), int len) { // expected-note
   // Original value of len: null
   // Observed bounds context after assignment:  { a => bounds(unknown) }
   len = 0; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
-           // expected-note {{lost the value of the variable 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}}
+           // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'len'
@@ -1955,7 +1955,7 @@ void killed_widened_bounds1(
     // This statement kills the widened bounds of p since it modifies i
     // Observed bounds context: { p => bounds(unknown) }
     i++, --other; // expected-error {{inferred bounds for 'p' are unknown after increment}} \
-                  // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}}
+                  // expected-note {{lost the value of the expression 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}}
     // CHECK: Statement S:
     // CHECK-NEXT: BinaryOperator {{.*}} ','
     // CHECK-NEXT:   UnaryOperator {{.*}} postfix '++'
@@ -2167,7 +2167,7 @@ void killed_widened_bounds3(
       // This statement kills the widened bounds of p and q
       // Observed bounds context: { p => bounds(unknown), q => bounds(q - 1, q - 1 + 1 + 1) }
       i = 0, q++; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
-                  // expected-note {{lost the value of the variable 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}} \
+                  // expected-note {{lost the value of the expression 'i' which is used in the (expanded) inferred bounds 'bounds(p, p + i + 1)' of 'p'}} \
                   // expected-warning {{cannot prove declared bounds for 'q' are valid after increment}} \
                   // expected-note {{(expanded) inferred bounds are 'bounds(q - 1, q - 1 + 1 + 1)'}}
       // CHECK: Statement S:

--- a/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-sibling-fields.c
@@ -3,8 +3,6 @@
 //
 // RUN: %clang_cc1 -fdump-boundssiblingfields -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
 
-// expected-no-diagnostics
-
 struct C {
   int len;
   _Array_ptr<int> r : count(len);
@@ -101,7 +99,7 @@ void f4(_Ptr<struct S> s[3][4]) {
 }
 
 void f5(void) {
-  ((struct A){ 0 }).i = 0;
+  ((struct A){ 0 }).i = 0; // expected-error {{inferred bounds for '((struct A){0}).r' are unknown after assignment}}
   // CHECK-LABEL: In function: f5
   // CHECK: BoundsSiblingFields:
   // CHECK: A::b: { A::p }

--- a/clang/test/CheckedC/inferred-bounds/member-arrow-reference.c
+++ b/clang/test/CheckedC/inferred-bounds/member-arrow-reference.c
@@ -96,7 +96,7 @@ void f1(struct S1 *a1, struct S2 *b2) {
 void f2(struct S1 *a3) {
   int local_arr1[5];
   // TODO: need bundled block.
-  a3->p = local_arr1;  // expected-warning {{cannot prove declared bounds for a3->p are valid after assignment}} \
+  a3->p = local_arr1;  // expected-warning {{cannot prove declared bounds for 'a3->p' are valid after assignment}} \
                        // expected-note {{(expanded) inferred bounds are 'bounds(local_arr1, local_arr1 + 5)'}}
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '='

--- a/clang/test/CheckedC/inferred-bounds/member-arrow-reference.c
+++ b/clang/test/CheckedC/inferred-bounds/member-arrow-reference.c
@@ -12,7 +12,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -verify -fdump-inferred-bounds %s | FileCheck %s
 
 struct S1 {
-  _Array_ptr<int> p : count(len);
+  _Array_ptr<int> p : count(len); // expected-note 3 {{(expanded) declared bounds are 'bounds(a3->p, a3->p + a3->len)'}}
   int len;
 };
 
@@ -97,7 +97,6 @@ void f2(struct S1 *a3) {
   int local_arr1[5];
   // TODO: need bundled block.
   a3->p = local_arr1;  // expected-warning {{cannot prove declared bounds for a3->p are valid after assignment}} \
-                       // expected-note {{(expanded) declared bounds are 'bounds(a3->p, a3->p + a3->len)'}} \
                        // expected-note {{(expanded) inferred bounds are 'bounds(local_arr1, local_arr1 + 5)'}}
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '='
@@ -131,12 +130,14 @@ void f2(struct S1 *a3) {
 // CHECK:   | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} 'int [5]' lvalue Var {{0x[0-9a-f]+}} 'local_arr1' 'int [5]'
 // CHECK:   `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 5
 
-  a3->len = 5;
+  a3->len = 5; // expected-error {{inferred bounds for 'a3->p' are unknown after assignment}} \
+               // expected-note {{lost the value of the expression 'a3->len' which is used in the (expanded) inferred bounds 'bounds(a3->p, a3->p + a3->len)' of 'a3->p'}}
 
   // Ignore the bounds on this assignment, which is here to avoid having a program
   // with undefined behavior.
   a3->p = 0;
-  a3->len = 0;
+  a3->len = 0; // expected-error {{inferred bounds for 'a3->p' are unknown after assignment}} \
+               // expected-note {{lost the value of the expression 'a3->len' which is used in the (expanded) inferred bounds 'bounds(a3->p, a3->p + a3->len)' of 'a3->p'}}
 }
 
 //-------------------------------------------------------------------------//

--- a/clang/test/CheckedC/inferred-bounds/member-reference.c
+++ b/clang/test/CheckedC/inferred-bounds/member-reference.c
@@ -10,7 +10,6 @@
 //
 // This line is for the clang test infrastructure:
 // RUN: %clang_cc1 -fcheckedc-extension -fdump-inferred-bounds -verify -verify-ignore-unexpected=warning -verify-ignore-unexpected=note -fdump-inferred-bounds %s | FileCheck %s
-// expected-no-diagnostics
 
 struct S1 {
   _Array_ptr<int> p : count(len);
@@ -102,7 +101,7 @@ int global_arr1[5];
 void f2(struct S1 a3) {
   // TODO: need bundled block.
   a3.p = global_arr1;
-  a3.len = 5;
+  a3.len = 5; // expected-error {{inferred bounds for 'a3.p' are unknown after assignment}}
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '='
 // CHECK: |-MemberExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue .p {{0x[0-9a-f]+}}
@@ -349,7 +348,7 @@ int global_arr2 _Checked[5];
 void f12(struct Interop_S1 a1) {
   // TODO: need bundled block.
   a1.p = global_arr2;
-  a1.len = 5;
+  a1.len = 5; // expected-error {{inferred bounds for 'a1.p' are unknown after assignment}}
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' '='
@@ -382,7 +381,7 @@ void f12(struct Interop_S1 a1) {
 _Checked void f13(struct Interop_S1 a1) {
   // TODO: need bundled block.
   a1.p = global_arr2;
-  a1.len = 5;
+  a1.len = 5; // expected-error {{inferred bounds for 'a1.p' are unknown after assignment}}
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '='

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -666,7 +666,7 @@ void f83(_Ptr<int> d, size_t a) {
 
 struct st_80;
 struct st_80_arr {
-  struct st_80 **e : itype(_Array_ptr<_Ptr<struct st_80>>) count(c);
+  struct st_80 **e : itype(_Array_ptr<_Ptr<struct st_80>>) count(c); // expected-note 4 {{declared bounds are 'bounds(arr->e, arr->e + arr->c)'}}
   int d;
   int c;
 };
@@ -674,9 +674,9 @@ struct st_80_arr {
 void f84(_Ptr<struct st_80_arr> arr, int b) {
   _Array_ptr<_Ptr<struct st_80>> a : count(b) = 0;
   if (arr->c <= b) {
-    arr->c = b * b;
     arr->e = a; // expected-warning {{cannot prove declared bounds for arr->e are valid after assignment}} \
-                // expected-note {{declared bounds are 'bounds(arr->e, arr->e + arr->c)'}} \
+    arr->c = b * b; // expected-error {{inferred bounds for 'arr->e' are unknown after assignment}} \
+                    // expected-note {{lost the value of the expression 'arr->c' which is used in the (expanded) inferred bounds 'bounds(arr->e, arr->e + arr->c)' of 'arr->e'}}
                 // expected-note {{inferred bounds are 'bounds(a, a + b)'}}
   }
 }
@@ -685,9 +685,9 @@ void f85(_Ptr<struct st_80_arr> arr, int b) {
   _Array_ptr<_Ptr<struct st_80>> a : count(b) = 0;
   if (arr->c <= b) {
     arr->e = a; // expected-warning {{cannot prove declared bounds for arr->e are valid after assignment}} \
-                // expected-note {{declared bounds are 'bounds(arr->e, arr->e + arr->c)'}} \
                 // expected-note {{inferred bounds are 'bounds(a, a + b)'}}
-    arr->c = b * b;
+    arr->c = b * b; // expected-error {{inferred bounds for 'arr->e' are unknown after assignment}} \
+                    // expected-note {{lost the value of the expression 'arr->c' which is used in the (expanded) inferred bounds 'bounds(arr->e, arr->e + arr->c)' of 'arr->e'}}
   }
 }
 

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -674,9 +674,9 @@ struct st_80_arr {
 void f84(_Ptr<struct st_80_arr> arr, int b) {
   _Array_ptr<_Ptr<struct st_80>> a : count(b) = 0;
   if (arr->c <= b) {
-    arr->e = a; // expected-warning {{cannot prove declared bounds for arr->e are valid after assignment}} \
     arr->c = b * b; // expected-error {{inferred bounds for 'arr->e' are unknown after assignment}} \
                     // expected-note {{lost the value of the expression 'arr->c' which is used in the (expanded) inferred bounds 'bounds(arr->e, arr->e + arr->c)' of 'arr->e'}}
+    arr->e = a; // expected-warning {{cannot prove declared bounds for 'arr->e' are valid after assignment}} \
                 // expected-note {{inferred bounds are 'bounds(a, a + b)'}}
   }
 }
@@ -684,7 +684,7 @@ void f84(_Ptr<struct st_80_arr> arr, int b) {
 void f85(_Ptr<struct st_80_arr> arr, int b) {
   _Array_ptr<_Ptr<struct st_80>> a : count(b) = 0;
   if (arr->c <= b) {
-    arr->e = a; // expected-warning {{cannot prove declared bounds for arr->e are valid after assignment}} \
+    arr->e = a; // expected-warning {{cannot prove declared bounds for 'arr->e' are valid after assignment}} \
                 // expected-note {{inferred bounds are 'bounds(a, a + b)'}}
     arr->c = b * b; // expected-error {{inferred bounds for 'arr->e' are unknown after assignment}} \
                     // expected-note {{lost the value of the expression 'arr->c' which is used in the (expanded) inferred bounds 'bounds(arr->e, arr->e + arr->c)' of 'arr->e'}}

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -104,14 +104,14 @@ struct S1 {
 void f1(struct S1 *s) {
   // We currently do not detect free variables for indirect accesses.
   array_ptr<int> p : count(5) = 0;
-  s->p = p; // expected-warning {{cannot prove declared bounds for s->p are valid after assignment}} \
+  s->p = p; // expected-warning {{cannot prove declared bounds for 's->p' are valid after assignment}} \
             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
 
   int a[] = { 1, 2 };
   array_ptr<int> q : bounds(q, &a[0]) = p; // expected-warning {{cannot prove declared bounds for 'q' are valid after initialization}} \
-  s->p = &a[1]; // expected-warning {{cannot prove declared bounds for s->p are valid after assignment}} \
                                            // expected-note {{(expanded) declared bounds are 'bounds(q, &a[0])'}} \
                                            // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
+  s->p = &a[1]; // expected-warning {{cannot prove declared bounds for 's->p' are valid after assignment}} \
                 // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 2)'}}
 }
 
@@ -126,7 +126,7 @@ void f3(struct S1 a3) {
   array_ptr<int> p : count(5) = 0;
 
   // We current do not detect free variables for member accesses.
-  a3.p = p; // expected-warning {{cannot prove declared bounds for a3.p are valid after assignment}} \
+  a3.p = p; // expected-warning {{cannot prove declared bounds for 'a3.p' are valid after assignment}} \
             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
 }
 

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -96,24 +96,23 @@ void f13() {
 }
 
 struct S1 {
-	_Array_ptr<int> p : count(len2);
-	int len2;
+  _Array_ptr<int> p : count(len2); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->p, s->p + s->len2)'}} \
+                                   // expected-note {{(expanded) declared bounds are 'bounds(a3.p, a3.p + a3.len2)'}}
+  int len2;
 };
 
 void f1(struct S1 *s) {
   // We currently do not detect free variables for indirect accesses.
   array_ptr<int> p : count(5) = 0;
   s->p = p; // expected-warning {{cannot prove declared bounds for s->p are valid after assignment}} \
-            // expected-note {{declared bounds are}} \
-            // expected-note {{inferred bounds are}}
+            // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
 
   int a[] = { 1, 2 };
   array_ptr<int> q : bounds(q, &a[0]) = p; // expected-warning {{cannot prove declared bounds for 'q' are valid after initialization}} \
-                                           // expected-note {{declared bounds are}} \
-                                           // expected-note {{inferred bounds are}}
   s->p = &a[1]; // expected-warning {{cannot prove declared bounds for s->p are valid after assignment}} \
-                // expected-note {{declared bounds are}} \
-                // expected-note {{inferred bounds are}}
+                                           // expected-note {{(expanded) declared bounds are 'bounds(q, &a[0])'}} \
+                                           // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
+                // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 2)'}}
 }
 
 void f2(struct S1 a3) {
@@ -128,7 +127,6 @@ void f3(struct S1 a3) {
 
   // We current do not detect free variables for member accesses.
   a3.p = p; // expected-warning {{cannot prove declared bounds for a3.p are valid after assignment}} \
-            // expected-note {{(expanded) declared bounds are 'bounds(a3.p, a3.p + a3.len2)'}} \
             // expected-note {{(expanded) inferred bounds are 'bounds(p, p + 5)'}}
 }
 


### PR DESCRIPTION
This PR validates the observed bounds of each `AbstractSet` `M` recorded in the `ObservedBounds` context where `M` represents a set of `MemberExprs`.

This means that the compiler will issue errors and warnings for cases such as:

```
struct S {
  int len;
  _Array_ptr<int> p : count(len);
};

void f(struct S *s) {
  // error: inferred bounds of 's->p' are unknown after assignment
  // Lost the value of 's->len', and 's->len' is used in the declared bounds of 's->p'
  s->len = 0;

  // warning: cannot prove declared bounds of 's->p' are valid after increment
  // s->p has the original value s->p - 1
  // The inferred bounds of s->p are bounds(s->p - 1, s->p - 1 + s->len)
  s->p++;
}
```