### PR TITLE
Fix for issue #1085

### DIFF
--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3552,7 +3552,7 @@ bool Parser::StartsRelativeBoundsClause(Token &T) {
 }
 
 bool Parser::StartsWhereClause(const Token &T) {
-  return getLangOpts().CheckedC && Tok.is(tok::kw__Where);
+  return getLangOpts().CheckedC && T.is(tok::kw__Where);
 }
 
 ExprResult Parser::ParseInteropTypeAnnotation(const Declarator &D, bool IsReturn) {

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -84,3 +84,13 @@ L1: a = 0 _Where a > 1;
 
   for (int i = 0 _Where i != 0; i > 0; i ++) {}
 }
+
+_Checked
+void iface(unsigned long n _Where n > 0) {
+    return;
+}
+
+_Checked
+void iface_test(void) {
+  iface(50);
+}


### PR DESCRIPTION
The fix is to correct a slip in the function `StartsWhereClause`.

Because of the bug in this function, the code in `ParseParameterDeclarationClause` associated a `BoundsAnnotations` object with the first parameter of the function `iface` in the test case of issue #1085. This `BoundsAnnotations` object set the `Bounds` field to a (non-null) `NullaryBoundsExpr` and the `InteropType` field to null. The non-null `Bounds` field in the `BoundsAnnotations` associated with the first parameter caused the `CheckCallExpr` function to expect the first argument to function `iface` to have bounds.