### PR TITLE
CreateStandardForm: check for multiplication operators

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1951,6 +1951,8 @@ namespace {
         return false;
       if (Base->getType()->getPointeeOrArrayElementType()->isCharType()) {
         if (BinaryOperator *BO = dyn_cast<BinaryOperator>(Offset->IgnoreParens())) {
+          // Check to see if Offset is already of the form e * i or i * e. In this case,
+          // ConstantPart = i, VariablePart = e.
           if (BinaryOperator::isMultiplicativeOp(BO->getOpcode())) {
             if (BO->getRHS()->isIntegerConstantExpr(ConstantPart, Ctx))
               VariablePart = BO->getLHS();

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1959,18 +1959,18 @@ namespace {
             else if (BO->getLHS()->isIntegerConstantExpr(ConstantPart, Ctx))
               VariablePart = BO->getRHS();
             else
-              goto exit;
+              goto fallback_std_form;
             IsOpSigned = VariablePart->getType()->isSignedIntegerType();
             ConstantPart = BoundsUtil::ConvertToSignedPointerWidth(Ctx, ConstantPart, Overflow);
             if (Overflow)
-              goto exit;
+              goto fallback_std_form;
           } else
-            goto exit;
+            goto fallback_std_form;
         } else
-          goto exit;
+          goto fallback_std_form;
         return true;
 
-      exit:
+      fallback_std_form:
         VariablePart = Offset;
         ConstantPart = llvm::APSInt(llvm::APInt(PointerWidth, 1), false);
         IsOpSigned = VariablePart->getType()->isSignedIntegerType();

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1950,7 +1950,7 @@ namespace {
       if (!Base->getType()->isPointerType())
         return false;
       if (Base->getType()->getPointeeOrArrayElementType()->isCharType()) {
-        if (BinaryOperator *BO = dyn_cast<BinaryOperator>(Offset)) {
+        if (BinaryOperator *BO = dyn_cast<BinaryOperator>(Offset->IgnoreParens())) {
           if (BinaryOperator::isMultiplicativeOp(BO->getOpcode())) {
             if (BO->getRHS()->isIntegerConstantExpr(ConstantPart, Ctx))
               VariablePart = BO->getLHS();

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -1893,6 +1893,57 @@ void inc_dec_bounds5(nt_array_ptr<int> *p, array_ptr<int> a) {
   // CHECK-NEXT: { }
 }
 
+// Increment/decrement operators on variables used in a _Nt_array_ptr<char>
+void inc_dec_bounds6(nt_array_ptr<char> p : count(i), unsigned int i) { // expected-note 2 {{(expanded) declared bounds are 'bounds(p, p + i)'}}
+  // Observed bounds context after increment: { p => bounds(p, p + i - 1) }
+  i++; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
+       // expected-note {{(expanded) inferred bounds are 'bounds(p, p + i - 1U)'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i' 'unsigned int'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'i' 'unsigned int'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: }
+
+  // Observed bounds context after decrement: { p => bounds(p + 1, p + 1 + i) }
+  --p; // expected-warning {{cannot prove declared bounds for 'p' are valid after decrement}} \
+       // expected-note {{(expanded) inferred bounds are 'bounds(p + 1, p + 1 + i)'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} prefix '--'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 'int' 1
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 'int' 1
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'i' 'unsigned int'
+  // CHECK-NEXT: }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Expressions that contain multiple assignments can kill widened bounds //
 ///////////////////////////////////////////////////////////////////////////

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -1944,6 +1944,36 @@ void inc_dec_bounds6(nt_array_ptr<char> p : count(i), unsigned int i) { // expec
   // CHECK-NEXT: }
 }
 
+// Increment/decrement operators on variables used in a _Nt_array_ptr<char>
+void inc_dec_bounds7(nt_array_ptr<char> p : count((3 * i)), unsigned int i) { // expected-note {{(expanded) declared bounds are 'bounds(p, p + (3 * i))'}}
+  // Observed bounds context after increment: { p => bounds(p, p + 3 * (i - 1)) }
+  i++; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
+       // expected-note {{(expanded) inferred bounds are 'bounds(p, p + (3 * i - 1U))'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i' 'unsigned int'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+  // CHECK-NEXT:     ParenExpr
+  // CHECK-NEXT:       BinaryOperator {{.*}} '*'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 3
+  // CHECK-NEXT:         BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'i' 'unsigned int'
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 'unsigned int' 1
+  // CHECK-NEXT: }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Expressions that contain multiple assignments can kill widened bounds //
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR addresses an issue with the `CreateStandardForm` method.

Consider an expression of the form `p + (v OP c)`, where:
* `p` is a pointer to a `char`
* `v` is an integer-typed variable expression
* `c` is an integer constant

The out parameter `ConstantPart` should be set to `c` if and only if `OP` is multiplication. Otherwise, `ConstantPart` should be set to 1. For example, for the expression `p + v * sizeof(int)`, `ConstantPart` should be set to `sizeof(int)`. For `p + v + 2`, `ConstantPart` should not be set to 1, not 2.

This change fixes an issue that would occur with bounds checking for `char` pointers: with the previous behavior, `bounds(p, p + i - 1` imply `bounds(p, p + i)` for an `_Array_ptr<char>` or `_Nt_array_ptr<char>` `p`. `CreateStandardForm` set `VariablePart` to `i` and `ConstantPart` to 1 for both `p + i` and `p + i - 1`. With this change, `CreateStandardForm` sets `ConstantPart` to 1 for both `p + i` and `p + i - 1`, but it sets `VariablePart` to `i` and `i - 1` for `p + i` and `p + i - 1`, respectively.