### PR TITLE
Do not normalize bounds for invalid decls

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5733,12 +5733,6 @@ public:
   // normalized bounds for D.
   BoundsExpr *NormalizeBounds(const VarDecl *D);
 
-  // This is wrapper around CheckBoundsDeclaration::ExpandToRange. This
-  // provides an easy way to invoke this function from outside the class. Given
-  // a byte_count or count bounds expression for the VarDecl D, ExpandToRange
-  // will expand it to a range bounds expression.
-  BoundsExpr *ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B);
-
   // Returns the declared bounds for the lvalue expression E. Assignments
   // to E must satisfy these bounds. After checking a top-level statement,
   // the inferred bounds of E must imply these declared bounds.

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -6998,6 +6998,10 @@ void Sema::WarnDynamicCheckAlwaysFails(const Expr *Condition) {
 // range bounds are attached to the VarDecl D to avoid recomputing the
 // normalized bounds for D.
 BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
+  // Do not attempt to normalize bounds for invalid declarations.
+  if (D->isInvalidDecl())
+    return nullptr;
+
   // If D already has a normalized bounds expression, do not recompute it.
   if (BoundsExpr *NormalizedBounds = D->getNormalizedBounds())
     return NormalizedBounds;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -7006,44 +7006,44 @@ BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
   if (BoundsExpr *NormalizedBounds = D->getNormalizedBounds())
     return NormalizedBounds;
 
-  // Normalize the bounds of D to a RangeBoundsExpr and attach the normalized
-  // bounds to D to avoid recomputing them.
-  BoundsExpr *Bounds = ExpandBoundsToRange(D, D->getBoundsExpr());
-  D->setNormalizedBounds(Bounds);
-  return Bounds;
-}
+  // Expand the bounds expression of D to a RangeBoundsExpr if possible.
+  const BoundsExpr *B = D->getBoundsExpr();
+  BoundsExpr *ExpandedBounds = nullptr;
 
-// This is wrapper around CheckBoundsDeclaration::ExpandToRange. This provides
-// an easy way to invoke this function from outside the class. Given a
-// byte_count or count bounds expression for the VarDecl D, ExpandToRange will
-// expand it to a range bounds expression.
-BoundsExpr *Sema::ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B) {
-  // If the bounds expr is already a RangeBoundsExpr, simply return it.
+  // If the bounds expr of D is already a RangeBoundsExpr, there is
+  // no need to expand it.
   if (B && isa<RangeBoundsExpr>(B))
-    return const_cast<BoundsExpr *>(B);
+    ExpandedBounds = const_cast<BoundsExpr *>(B);
+  else {
+    PrepassInfo Info;
+    std::pair<ComparisonSet, ComparisonSet> EmptyFacts;
+    CheckBoundsDeclarations CBD = CheckBoundsDeclarations(*this, Info, EmptyFacts);
 
-  PrepassInfo Info;
-  std::pair<ComparisonSet, ComparisonSet> EmptyFacts;
-  CheckBoundsDeclarations CBD = CheckBoundsDeclarations(*this, Info, EmptyFacts);
+    if (D->getType()->isArrayType()) {
+      ExprResult ER = BuildDeclRefExpr(const_cast<VarDecl *>(D), D->getType(),
+                                       clang::ExprValueKind::VK_LValue,
+                                       SourceLocation());
+      if (ER.isInvalid())
+        return nullptr;
+      Expr *Base = ER.get();
 
-  if (D->getType()->isArrayType()) {
-    ExprResult ER = BuildDeclRefExpr(const_cast<VarDecl *>(D), D->getType(),
-                                     clang::ExprValueKind::VK_LValue,
-                                     SourceLocation());
-    if (ER.isInvalid())
-      return nullptr;
-    Expr *Base = ER.get();
-
-    // Declared bounds override the bounds based on the array type.
-    if (!B)
-      return CBD.ArrayExprBounds(Base);
-    Base = CBD.CreateImplicitCast(Context.getDecayedType(Base->getType()),
-                                  CastKind::CK_ArrayToPointerDecay,
-                                  Base);
-    return CBD.ExpandToRange(Base, const_cast<BoundsExpr *>(B));
+      // Declared bounds override the bounds based on the array type.
+      if (!B)
+        ExpandedBounds = CBD.ArrayExprBounds(Base);
+      else {
+        Base = CBD.CreateImplicitCast(Context.getDecayedType(Base->getType()),
+                                      CastKind::CK_ArrayToPointerDecay,
+                                      Base);
+        ExpandedBounds = CBD.ExpandToRange(Base, const_cast<BoundsExpr *>(B));
+      }
+    } else
+      ExpandedBounds = CBD.ExpandToRange(const_cast<VarDecl *>(D),
+                                         const_cast<BoundsExpr *>(B));
   }
-  return CBD.ExpandToRange(const_cast<VarDecl *>(D),
-                           const_cast<BoundsExpr *>(B));
+
+  // Attach the normalized bounds to D to avoid recomputing them.
+  D->setNormalizedBounds(ExpandedBounds);
+  return ExpandedBounds;
 }
 
 // Returns the declared bounds for the lvalue expression E. Assignments

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -2766,3 +2766,51 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }  
 }
+
+//////////////////////////////////////////////////////////////////////////
+// Invalid variable declarations are not included in the bounds context //
+//////////////////////////////////////////////////////////////////////////
+
+// Parameter with an invalid declaration
+_Checked void invalid_decl1(int **p : count(i), int i) { // expected-error {{parameter in a checked scope must have a bounds-safe interface type that uses only checked types or parameter/return types with bounds-safe interfaces}} \
+                                                         // expected-note {{'int *' is not allowed in a checked scope}}
+  // Even though i is used in the declared bounds of p, since p is an invalid
+  // declaration, we do not include p in the observed bounds context, so this
+  // statement does not invalidate any bounds.
+  // Observed bounds context: { }
+  i = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: { }
+}
+
+// Local variable with an invalid declaration
+_Checked void invalid_decl2(int i) {
+  // p is an invalid declaration, so we do not include p in the bounds context.
+  // Observed bounds context: { }
+  _Array_ptr<char *> p : count(i) = 0; // expected-error {{local variable in a checked scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}} \
+                                       // expected-note {{'char *' is not allowed in a checked scope}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT:   VarDecl {{.*}} invalid p
+  // CHECK-NEXT:     CountBoundsExpr {{.*}} Element
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: { }
+
+  // Even though i is used in the declared bounds of p, since p is an invalid
+  // declaration, we do not include p in the observed bounds context, so this
+  // statement does not invalidate any bounds.
+  // Observed bounds context: { }
+  i = 0;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: Observed bounds context after checking S:
+  // CHECK-NEXT: { }
+}


### PR DESCRIPTION
Fixes #1084 

This PR fixes a crash that would occur in `Sema::NormalizeBounds` for certain kinds of (invalid) `VarDecls`. When expanding bounds to a range, `Sema` needs to create a `DeclRefExpr` for a `VarDecl`. In order to do so, it may call `Sema::ConvertToFullyCheckedType`, which asserts that the type of the `VarDecl` is not an unchecked type and does not contain an unchecked type.

Consider the following example:

```
_Checked void f(int **p : count(i), int i) {
  i = 0;
}
```

In a checked scope, this produces the error "parameter in a checked scope must have a bounds-safe interface type that uses only checked types or parameter/return types with bounds-safe interfaces". `p` is an invalid declaration.

Accounting for the bounds-safe interface, the type of `p` is `_Array_ptr<int *>`. If we attempt to normalize the declared bounds `count(i)` for `p`, the assertion in `ConvertToFullyCheckedType` fails since `_Array_ptr<int *>` contains the unchecked type `int *`. Therefore, we should not attempt to normalize the declared bounds for `p`. We do not include `p` in the observed bounds context, and we do not attempt to validate the bounds of `p` after each statement. The statement `i = 0` results in no bounds validation errors.