### PR TITLE
[BoundsWidening] Implement the bounds widening dataflow analysis

### DIFF
--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -314,9 +314,7 @@ namespace clang {
 
     // Run the dataflow analysis to widen bounds for null-terminated arrays.
     // @param[in] FD is the current function.
-    // @param[in] NestedStmts is a set of top-level statements that are
-    // nested in another top-level statement.
-    void WidenBounds(FunctionDecl *FD, StmtSetTy NestedStmts);
+    void WidenBounds(FunctionDecl *FD);
 
     // Pretty print the widened bounds for all null-terminated arrays in the
     // current function.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -321,6 +321,22 @@ namespace clang {
     // @param[in] FD is the current function.
     void DumpWidenedBounds(FunctionDecl *FD);
 
+    // Get the Out set for the statement. This set represents the bounds
+    // widened after the statement.
+    // Note: This method can be called from outside this class to get the
+    // widened bounds after a statement.
+    // @param[in] B is the current block.
+    // @param[in] CurrStmt is the current statement.
+    BoundsMapTy GetStmtOut(const CFGBlock *B, const Stmt *CurrStmt) const;
+
+    // Get the In set for the statement. This set represents the bounds
+    // widened before the statement.
+    // Note: This method can be called from outside this class to get the
+    // widened bounds before a statement.
+    // @param[in] B is the current block.
+    // @param[in] CurrStmt is the current statement.
+    BoundsMapTy GetStmtIn(const CFGBlock *B, const Stmt *CurrStmt) const;
+
   private:
     // Compute Gen and Kill sets for the block and statements in the block.
     // @param[in] EB is the current ElevatedCFGBlock.
@@ -420,18 +436,6 @@ namespace clang {
     // @param[in] CurrStmt is the current statement.
     void AddModifiedVarsToStmtKillSet(ElevatedCFGBlock *EB,
                                       const Stmt *CurrStmt);
-
-    // Get the Out set for the statement. This set represents the bounds
-    // widened after the statement.
-    // @param[in] EB is the current ElevatedCFGBlock.
-    // @param[in] CurrStmt is the current statement.
-    BoundsMapTy GetStmtOut(ElevatedCFGBlock *EB, const Stmt *CurrStmt) const;
-
-    // Get the In set for the statement. This set represents the bounds
-    // widened before the statement.
-    // @param[in] EB is the current ElevatedCFGBlock.
-    // @param[in] CurrStmt is the current statement.
-    BoundsMapTy GetStmtIn(ElevatedCFGBlock *EB, const Stmt *CurrStmt) const;
 
     // Order the blocks by block number to get a deterministic iteration order
     // for the blocks.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -15,23 +15,43 @@
 #define LLVM_CLANG_BOUNDS_WIDENING_ANALYSIS_H
 
 #include "clang/AST/CanonBounds.h"
+#include "clang/AST/ExprUtils.h"
+#include "clang/AST/PrettyPrinter.h"
 #include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Sema/CheckedCAnalysesPrepass.h"
 #include "clang/Sema/Sema.h"
 
 namespace clang {
-  // BoundsMapTy maps a null-terminated array variable to its bounds
-  // expression.
-  using BoundsMapTy = llvm::DenseMap<const VarDecl *, BoundsExpr *>;
+  // BoundsMapTy maps a variable that is a pointer to a null-terminated array
+  // to its bounds expression.
+  using BoundsMapTy = llvm::DenseMap<const VarDecl *, RangeBoundsExpr *>;
 
-  // StmtBoundsMapTy maps each null-terminated array variable that occurs in a
-  // statement to its bounds expression.
+  // StmtBoundsMapTy maps each variable that is a pointer to a null-terminated
+  // array that occurs in a statement to its bounds expression.
   using StmtBoundsMapTy = llvm::DenseMap<const Stmt *, BoundsMapTy>;
 
-  // StmtVarSetTy denotes a set of null-terminated array variables that are
-  // associated with a statement. The set of variables whose bounds are killed
-  // by a statement has the type StmtVarSetTy.
+  // StmtVarSetTy denotes a set of variables that are pointers to
+  // null-terminated arrays and that are associated with a statement. The set
+  // of variables whose bounds are killed by a statement has the type
+  // StmtVarSetTy.
   using StmtVarSetTy = llvm::DenseMap<const Stmt *, VarSetTy>;
+
+  // StmtSetTy denotes a set of statements.
+  using StmtSetTy = llvm::SmallPtrSet<const Stmt *, 16>;
+
+  // StmtMapTy denotes a map of a statement to another statement. This is used
+  // to store the mapping of a statement to its previous statement in a block.
+  using StmtMapTy = llvm::DenseMap<const Stmt *, const Stmt *>;
+
+  // ExprVarsTy maps an expression to a set of variables. If E is an expression
+  // dereferencing a null-terminated array, then ExprVarsTy maps the expression
+  // (E + 1) to a set of null-terminated arrays whose bounds may potentially be
+  // widened to (E + 1).
+  using ExprVarsTy = llvm::DenseMap<Expr *, const VarDecl *>;
+
+  // OrderedBlocksTy denotes blocks ordered by block numbers. This is useful
+  // for printing the blocks in a deterministic order.
+  using OrderedBlocksTy = std::vector<const CFGBlock *>;
 
   // The BoundsWideningAnalysis class represents the dataflow analysis for
   // bounds widening. The sets In, Out, Gen and Kill that are used by the
@@ -39,31 +59,343 @@ namespace clang {
   // these sets to perform the dataflow analysis.
   class BoundsWideningAnalysis {
   private:
-    Sema &S;
+    Sema &SemaRef;
     CFG *Cfg;
     ASTContext &Ctx;
+    BoundsVarsTy &BoundsVarsLower;
+    BoundsVarsTy &BoundsVarsUpper;
     Lexicographic Lex;
     llvm::raw_ostream &OS;
 
     class ElevatedCFGBlock {
     public:
       const CFGBlock *Block;
-      // The In and Out sets for a block.
-      BoundsMapTy In, Out;
-      // The Gen set for each statement in a block.
-      StmtBoundsMapTy Gen;
-      // The Kill set for each statement in a block.
-      StmtVarSetTy Kill;
+      // The In, Out and Gen sets for a block.
+      BoundsMapTy In, Out, Gen;
+      // The Kill set for a block.
+      VarSetTy Kill;
+      // The StmtGen and UnionGen sets for each statement in a block.
+      StmtBoundsMapTy StmtGen, UnionGen;
+      // The StmtKill and UnionKill sets for each statement in a block.
+      StmtVarSetTy StmtKill, UnionKill;
+
+      // A mapping from a statement to its previous statement in a block.
+      StmtMapTy PrevStmtMap;
+      // The last statement of the block. This is nullptr if the block is empty.
+      const Stmt *LastStmt = nullptr;
+      // The terminating condition that dereferences a pointer. This is nullptr
+      // if the terminating condition does not dereference a pointer.
+      Expr *TermCondDerefExpr = nullptr;
 
       ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
-    };
+    }; // end class ElevatedCFGBlock
+
+  private:
+    // BlockMapTy denotes the mapping from CFGBlocks to ElevatedCFGBlocks.
+    using BlockMapTy = llvm::DenseMap<const CFGBlock *, ElevatedCFGBlock *>;
+
+    // A queue of unique ElevatedCFGBlocks involved in the fixpoint of the
+    // dataflow analysis.
+    using WorkListTy = QueueSet<ElevatedCFGBlock>;
+
+    // BlockMap maps a CFGBlock to an ElevatedCFGBlock. Given a CFGBlock it is
+    // used to lookup an ElevatedCFGBlock.
+    BlockMapTy BlockMap;
+
+    // AllNtPtrsInFunc denotes all variables in the function that are pointers
+    // to null-terminated arrays.
+    VarSetTy AllNtPtrsInFunc;
+
+    // Top is a special bounds expression that denotes the super set of all
+    // bounds expressions.
+    RangeBoundsExpr *Top;
   
   public:
-    BoundsWideningAnalysis(Sema &S, CFG *Cfg) :
-      S(S), Cfg(Cfg), Ctx(S.Context),
-      Lex(Lexicographic(Ctx, nullptr)),
-      OS(llvm::outs()) {}
-  };
+    BoundsWideningAnalysis(Sema &SemaRef, CFG *Cfg,
+                           BoundsVarsTy &BoundsVarsLower,
+                           BoundsVarsTy &BoundsVarsUpper) :
+      SemaRef(SemaRef), Cfg(Cfg), Ctx(SemaRef.Context),
+      BoundsVarsLower(BoundsVarsLower), BoundsVarsUpper(BoundsVarsUpper),
+      Lex(Lexicographic(Ctx, nullptr)), OS(llvm::outs()), Top(nullptr) {}
+
+    // Run the dataflow analysis to widen bounds for null-terminated arrays.
+    // @param[in] FD is the current function.
+    // @param[in] NestedStmts is a set of top-level statements that are
+    // nested in another top-level statement.
+    void WidenBounds(FunctionDecl *FD, StmtSetTy NestedStmts);
+
+    // Pretty print the widened bounds for all null-terminated arrays in the
+    // current function.
+    // @param[in] FD is the current function.
+    void DumpWidenedBounds(FunctionDecl *FD);
+
+  private:
+    // Compute Gen and Kill sets for the block and statements in the block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    void ComputeGenKillSets(ElevatedCFGBlock *EB);
+
+    // Compute the StmtGen and StmtKill sets for a statement in a block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    void ComputeStmtGenKillSets(ElevatedCFGBlock *EB, const Stmt *CurrStmt);
+
+    // Compute the union of Gen and Kill sets of all statements up to (and
+    // including) the current statement in the block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    // @param[in] PrevStmt is the previous statement of CurrStmt in the linear
+    // ordering of statements in the block.
+    void ComputeUnionGenKillSets(ElevatedCFGBlock *EB, const Stmt *CurrStmt,
+                                 const Stmt *PrevStmt);
+
+    // Compute the Gen and Kill sets for the block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    void ComputeBlockGenKillSets(ElevatedCFGBlock *EB);
+
+    // Compute the In set for the block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    void ComputeInSet(ElevatedCFGBlock *EB);
+
+    // Compute the Out set for the block.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[out] EB is added to WorkList if the Out set of EB changes.
+    void ComputeOutSet(ElevatedCFGBlock *EB, WorkListTy &WorkList);
+
+    // Initialize the In and Out sets for the block.
+    // @param[in] FD is the current function.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    void InitBlockInOutSets(FunctionDecl *FD, ElevatedCFGBlock *EB);
+
+    // Prune the Out set of the pred block according to various conditions.
+    // @param[in] PredEB is a predecessor block of the current block.
+    // @param[in] CurrEB is the current block.
+    // @return The pruned Out set for PredEB.
+    BoundsMapTy PruneOutSet(ElevatedCFGBlock *PredEB,
+                            ElevatedCFGBlock *CurrEB) const;
+
+    // Determine if the switch-case has a case label (other than default) that
+    // tests for null.
+    // @param[in] CurrBlock is the current block.
+    // @return Returns true if the switch-case has a label that tests for null.
+    bool ExistsNullCaseLabel(const CFGBlock *CurrBlock) const;
+
+    // Determine if the current block begins a case of a switch-case.
+    // @param[in] CurrBlock is the current block.
+    // @return Returns true if the current block begins a case.
+    bool IsSwitchCaseBlock(const CFGBlock *CurrBlock) const;
+
+    // Determine if the switch-case label on the current block tests for null.
+    // @param[in] CurrBlock is the current block.
+    // @return Returns true if the case label on the current block tests for
+    // null.
+    bool CaseLabelTestsForNull(const CFGBlock *CurrBlock) const;
+
+    // Determine if the edge from PredBlock to CurrBlock is a fallthrough.
+    // @param[in] PredBlock is a predecessor block of the current block.
+    // @param[in] CurrBlock is the current block.
+    // @return Returns true if the edge is a fallthrough, false otherwise.
+    bool IsFallthroughEdge(const CFGBlock *PredBlock,
+                           const CFGBlock *CurrBlock) const;
+
+    // Determine if the edge from PredBlock to CurrBlock is a true edge.
+    // @param[in] PredBlock is a predecessor block of the current block.
+    // @param[in] CurrBlock is the current block.
+    // @return Returns true if the edge is a true edge, false otherwise.
+    bool IsTrueEdge(const CFGBlock *PredBlock,
+                    const CFGBlock *CurrBlock) const;
+
+    // Initialize the list of variables that are pointers to null-terminated
+    // arrays to the null-terminated arrays that are passed as parameters to
+    // the function. This function updates the AllNtPtrsInFunc set.
+    // @param[in] FD is the current function.
+    void InitNtPtrsInFunc(FunctionDecl *FD);
+
+    // Update the list of variables that are pointers to null-terminated arrays
+    // with the variables that are in StmtGen for the current statement in the
+    // block. This function updates the AllNtPtrsInFunc set.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    void UpdateNtPtrsInFunc(ElevatedCFGBlock *EB, const Stmt *CurrStmt);
+
+    // Fill the Gen and Kill sets for a statement using the variable and bounds
+    // expressions in VarsAndBounds.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    // @param[in] VarsAndBounds is a map of variables to their bounds
+    // expressions.
+    void FillStmtGenKillSets(ElevatedCFGBlock *EB, const Stmt *CurrStmt,
+                             BoundsMapTy &VarsAndBounds);
+
+    // Get the mapping of variables to their bounds expressions in the bounds
+    // declaration of a null-terminated array.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] V is a variable that is a pointer to a null-terminated array.
+    // @param[out] VarsAndBounds is a map of variables to their bounds
+    // expressions. This field is updated by this function.
+    void GetVarsAndBoundsInDecl(ElevatedCFGBlock *EB, const VarDecl *V,
+                                BoundsMapTy &VarsAndBounds);
+
+    // Get the mapping of variables to their bounds expressions in a where
+    // clause.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] WC is the where clause that annotates CurrStmt.
+    // @param[out] VarsAndBounds is a map of variables to their bounds
+    // expressions. This field is updated by this function.
+    void GetVarsAndBoundsInWhereClause(ElevatedCFGBlock *EB,
+                                       WhereClause *WC,
+                                       BoundsMapTy &VarsAndBounds);
+
+    // Get the mapping of variables to their bounds expressions from an
+    // expression that dereferences a null-terminated array.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[out] VarsAndBounds is a map of variables to their bounds
+    // expressions. This field is updated by this function.
+    void GetVarsAndBoundsInPtrDeref(ElevatedCFGBlock *EB,
+                                    BoundsMapTy &VarsAndBounds);
+
+    // Add to the StmtKill set the variables occurring in the bounds expression
+    // of a null-terminated array that are modified.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    void AddModifiedVarsToStmtKillSet(ElevatedCFGBlock *EB,
+                                      const Stmt *CurrStmt);
+
+    // Get the set of variables that can be potentially widened in an
+    // expression E.
+    // @param[in] E is the given expression.
+    // @param[out] VarsToWiden is a set of variables that can be potentially
+    // widened in expression E.
+    void GetVarsToWiden(Expr *E, VarSetTy &VarsToWiden) const;
+
+    // Get all variables modified by CurrStmt or statements nested in CurrStmt.
+    // @param[in] CurrStmt is a given statement.
+    // @param[out] ModifiedVars is a set of variables modified by CurrStmt or
+    // statements nested in CurrStmt.
+    void GetModifiedVars(const Stmt *CurrStmt, VarSetTy &ModifiedVars) const;
+
+    // Add an offset to a given expression to get the widened expression.
+    // @param[in] E is the given expression.
+    // @param[in] Offset is the given offset.
+    // @return Returns the expression E + Offset.
+    Expr *GetWidenedExpr(Expr *E, unsigned Offset) const;
+
+    // From a given terminating condition extract the terminating condition for
+    // the current block. Given an expression like "if (e1 && e2)" this
+    // function returns e2 which is the terminating condition for the current
+    // block.
+    // @param[in] E is given terminating condition.
+    // @return The terminating condition for the block.
+    Expr *GetTerminatorCondition(const Expr *E) const;
+
+    // Use the last statement in a block to get the terminating condition for
+    // the block. This could be an expression of the form "if (e1 && e2)".
+    // @param[in] B is the block for which we need the terminating condition.
+    // @return Expression for the terminating condition of block B.
+    Expr *GetTerminatorCondition(const CFGBlock *B) const;
+
+    // From the given expression get the dereference expression. A dereference
+    // expression can be of the form "*(p + 1)" or "p[1]".
+    // @param[in] E is the given expression.
+    // @return Returns the dereference expression, if it exists.
+    Expr *GetDerefExpr(Expr *E) const;
+
+    // Get the variables occurring in an expression.
+    // @param[in] E is the given expression.
+    // @param[out] VarsInExpr is a set of variables that occur in E.
+    void GetVarsInExpr(Expr *E, VarSetTy &VarsInExpr) const;
+
+    // Invoke IgnoreValuePreservingOperations to strip off casts.
+    // @param[in] E is the expression whose casts must be stripped.
+    // @return E with casts stripped off.
+    Expr *IgnoreCasts(const Expr *E) const;
+
+    // We do not want to run dataflow analysis on null blocks or the exit
+    // block. So we skip them.
+    // @param[in] B is the block which may need to be skipped from dataflow
+    // analysis.
+    // @return Whether B should be skipped.
+    bool SkipBlock(const CFGBlock *B) const;
+
+    // Check if V is an _Nt_array_ptr or an _Nt_checked array.
+    // @param[in] V is a VarDecl.
+    // @return Whether V is an _Nt_array_ptr or an _Nt_checked array.
+    bool IsNtArrayType(const VarDecl *V) const;
+
+    // Get the Out set for the statement. This set represents the bounds
+    // widened after the statement.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    BoundsMapTy GetStmtOut(ElevatedCFGBlock *EB, const Stmt *CurrStmt) const;
+
+    // Get the In set for the statement. This set represents the bounds
+    // widened before the statement.
+    // @param[in] EB is the current ElevatedCFGBlock.
+    // @param[in] CurrStmt is the current statement.
+    BoundsMapTy GetStmtIn(ElevatedCFGBlock *EB, const Stmt *CurrStmt) const;
+
+    // Check if B2 is a subrange of B1.
+    // @param[in] B1 is the first range.
+    // @param[in] B2 is the second range.
+    // @return Returns true if B2 is a subrange of B1, false otherwise.
+    bool IsSubRange(RangeBoundsExpr *B1, RangeBoundsExpr *B2) const;
+
+    // Order the blocks by block number to get a deterministic iteration order
+    // for the blocks.
+    // @return Blocks ordered by block number from higher to lower since block
+    // numbers decrease from entry to exit.
+    OrderedBlocksTy GetOrderedBlocks() const;
+
+    // Compute the set difference of sets A and B.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return The set difference of sets A and B.
+    template<class T, class U> T Difference(T &A, U &B) const;
+
+    // Compute the intersection of sets A and B.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return The intersection of sets A and B.
+    template<class T> T Intersect(T &A, T &B) const;
+
+    // Compute the union of sets A and B.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return The union of sets A and B.
+    template<class T> T Union(T &A, T &B) const;
+
+    // Determine whether sets A and B are equal. Equality is determined by
+    // comparing each element in the two input sets.
+    // @param[in] A is a set.
+    // @param[in] B is a set.
+    // @return Whether sets A and B are equal.
+    template<class T> bool IsEqual(T &A, T &B) const;
+
+  }; // end class BoundsWideningAnalysis
+
+  // Note: Template specializations of a class member must be present at the
+  // same namespace level as the class. So we need to declare template
+  // specializations outside the class declaration.
+
+  // Template specialization for computing the difference between BoundsMapTy
+  // and VarSetTy.
+  template<>
+  BoundsMapTy BoundsWideningAnalysis::Difference<BoundsMapTy, VarSetTy>(
+    BoundsMapTy &A, VarSetTy &B) const;
+
+  // Template specialization for computing the union of BoundsMapTy.
+  template<>
+  BoundsMapTy BoundsWideningAnalysis::Union<BoundsMapTy>(
+    BoundsMapTy &A, BoundsMapTy &B) const;
+
+  // Template specialization for computing the intersection of BoundsMapTy.
+  template<>
+  BoundsMapTy BoundsWideningAnalysis::Intersect<BoundsMapTy>(
+    BoundsMapTy &A, BoundsMapTy &B) const;
+
+  // Template specialization for determining the equality of BoundsMapTy.
+  template<>
+  bool BoundsWideningAnalysis::IsEqual<BoundsMapTy>(
+    BoundsMapTy &A, BoundsMapTy &B) const;
 
 } // end namespace clang
 #endif

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -119,27 +119,29 @@ namespace clang {
     bool IsTrueEdge(const CFGBlock *PredBlock,
                     const CFGBlock *CurrBlock) const;
 
-    // Get the set of variables that can be potentially widened in an
-    // expression E.
-    // @param[in] E is the given expression.
-    // @param[out] VarsToWiden is a set of variables that can be potentially
-    // widened in expression E.
-    void GetVarsToWiden(Expr *E, VarSetTy &VarsToWiden) const;
-
     // Get all variables modified by CurrStmt or statements nested in CurrStmt.
     // @param[in] CurrStmt is a given statement.
     // @param[out] ModifiedVars is a set of variables modified by CurrStmt or
     // statements nested in CurrStmt.
     void GetModifiedVars(const Stmt *CurrStmt, VarSetTy &ModifiedVars) const;
 
-    // Get the set of variables that are pointers to null-terminated arrays in
-    // whose bounds expressions the variables in Vars occur.
+    // Get the set of variables that are pointers to null-terminated arrays and
+    // in whose lower bounds expressions the variables in Vars occur.
     // @param[in] Vars is a set of variables.
-    // @param[out] PtrsWithVarsInBounds is a set of variables that are pointers
-    // to null-terminated arrays in whose bounds expressions the variables in
-    // Vars occur.
-    void GetPtrsWithVarsInBounds(VarSetTy &Vars,
-                                 VarSetTy &PtrsWithVarsInBounds) const;
+    // @param[out] NtPtrsWithVarsInLowerBounds is a set of variables that are
+    // pointers to null-terminated arrays and in whose lower bounds expressions
+    // the variables in Vars occur.
+    void GetNtPtrsWithVarsInLowerBounds(
+      VarSetTy &Vars, VarSetTy &NtPtrsWithVarsInLowerBounds) const;
+
+    // Get the set of variables that are pointers to null-terminated arrays and
+    // in whose upper bounds expressions the variables in Vars occur.
+    // @param[in] Vars is a set of variables.
+    // @param[out] NtPtrsWithVarsInLowerBounds is a set of variables that are
+    // pointers to null-terminated arrays and in whose upper bounds expressions
+    // the variables in Vars occur.
+    void GetNtPtrsWithVarsInUpperBounds(
+      VarSetTy &Vars, VarSetTy &NtPtrsWithVarsInUpperBounds) const;
 
     // Add an offset to a given expression.
     // @param[in] E is the given expression.
@@ -153,10 +155,12 @@ namespace clang {
     // @return Returns the dereference expression, if it exists.
     Expr *GetDerefExpr(const Expr *E) const;
 
-    // Get the variables occurring in an expression.
+    // Get all variables in an expression that are pointers to null-terminated
+    // arrays.
     // @param[in] E is the given expression.
-    // @param[out] VarsInExpr is a set of variables that occur in E.
-    void GetVarsInExpr(Expr *E, VarSetTy &VarsInExpr) const;
+    // @param[out] VarsInExpr is a set of all variables in the expression E
+    // that are pointers to null-terminated arrays.
+    void GetNtPtrsInExpr(Expr *E, VarSetTy &NtPtrsInExpr) const;
 
     // Invoke IgnoreValuePreservingOperations to strip off casts.
     // @param[in] E is the expression whose casts must be stripped.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -147,25 +147,11 @@ namespace clang {
     // @return Returns the expression E + Offset.
     Expr *AddOffsetToExpr(Expr *E, unsigned Offset) const;
 
-    // From a given terminating condition extract the terminating condition for
-    // the current block. Given an expression like "if (e1 && e2)" this
-    // function returns e2 which is the terminating condition for the current
-    // block.
-    // @param[in] E is given terminating condition.
-    // @return The terminating condition for the block.
-    Expr *GetTerminatorCondition(const Expr *E) const;
-
-    // Use the last statement in a block to get the terminating condition for
-    // the block. This could be an expression of the form "if (e1 && e2)".
-    // @param[in] B is the block for which we need the terminating condition.
-    // @return Expression for the terminating condition of block B.
-    Expr *GetTerminatorCondition(const CFGBlock *B) const;
-
     // From the given expression get the dereference expression. A dereference
     // expression can be of the form "*(p + 1)" or "p[1]".
     // @param[in] E is the given expression.
     // @return Returns the dereference expression, if it exists.
-    Expr *GetDerefExpr(Expr *E) const;
+    Expr *GetDerefExpr(const Expr *E) const;
 
     // Get the variables occurring in an expression.
     // @param[in] E is the given expression.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -380,7 +380,9 @@ namespace clang {
 
     // Compute the In set for the block.
     // @param[in] EB is the current ElevatedCFGBlock.
-    void ComputeInSet(ElevatedCFGBlock *EB);
+    // @return Return true if the In set of the block has changed, false
+    // otherwise.
+    bool ComputeInSet(ElevatedCFGBlock *EB);
 
     // Compute the Out set for the block.
     // @param[in] EB is the current ElevatedCFGBlock.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -163,6 +163,16 @@ namespace clang {
     // expression.
     const VarDecl *GetNullTermPtrInExpr(Expr *E) const;
 
+    // Get the normalized bounds for V as a range bounds expression.
+    // @param[in] V is variable for which we need the normalized range bounds.
+    // @param[in] Bounds is an optional parameter. If bounds are provided then
+    // they are expanded to range bounds expression. If bounds are not provided
+    // then the declared bounds of V are normalized and converted to range
+    // bounds expression.
+    // @return Returns the bounds for V normalized to range bounds.
+    RangeBoundsExpr *GetNormalizedBounds(const VarDecl *V,
+                                         BoundsExpr *Bounds = nullptr);
+
     // Invoke IgnoreValuePreservingOperations to strip off casts.
     // @param[in] E is the expression whose casts must be stripped.
     // @return E with casts stripped off.
@@ -445,12 +455,16 @@ namespace clang {
     void GetVarsAndBoundsInPtrDeref(ElevatedCFGBlock *EB,
                                     BoundsMapTy &VarsAndBounds);
 
-    // Add to the StmtKill set the variables occurring in the bounds expression
-    // of a null-terminated array that are modified.
+    // Get the mapping of variables to their resetted bounds because of a
+    // modification to a variable that occurs in their lower or upper bounds
+    // expressions.
     // @param[in] EB is the current ElevatedCFGBlock.
     // @param[in] CurrStmt is the current statement.
-    void AddModifiedVarsToStmtKillSet(ElevatedCFGBlock *EB,
-                                      const Stmt *CurrStmt);
+    // @param[out] VarsAndBounds is a map of variables to their bounds
+    // expressions. This field is updated by this function.
+    void GetVarsAndBoundsForModifiedVars(ElevatedCFGBlock *EB,
+                                         const Stmt *CurrStmt,
+                                         BoundsMapTy &VarsAndBounds);
 
     // Order the blocks by block number to get a deterministic iteration order
     // for the blocks.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -314,7 +314,9 @@ namespace clang {
 
     // Run the dataflow analysis to widen bounds for null-terminated arrays.
     // @param[in] FD is the current function.
-    void WidenBounds(FunctionDecl *FD);
+    // @param[in] NestedStmts is a set of top-level statements that are nested
+    // in another top-level statement.
+    void WidenBounds(FunctionDecl *FD, StmtSetTy NestedStmts);
 
     // Pretty print the widened bounds for all null-terminated arrays in the
     // current function.
@@ -340,12 +342,17 @@ namespace clang {
   private:
     // Compute Gen and Kill sets for the block and statements in the block.
     // @param[in] EB is the current ElevatedCFGBlock.
-    void ComputeGenKillSets(ElevatedCFGBlock *EB);
+    // @param[in] NestedStmts is a set of top-level statements that are
+    // nested in another top-level statement.
+    void ComputeGenKillSets(ElevatedCFGBlock *EB, StmtSetTy NestedStmts);
 
     // Compute the StmtGen and StmtKill sets for a statement in a block.
     // @param[in] EB is the current ElevatedCFGBlock.
     // @param[in] CurrStmt is the current statement.
-    void ComputeStmtGenKillSets(ElevatedCFGBlock *EB, const Stmt *CurrStmt);
+    // @param[in] NestedStmts is a set of top-level statements that are
+    // nested in another top-level statement.
+    void ComputeStmtGenKillSets(ElevatedCFGBlock *EB, const Stmt *CurrStmt,
+                                StmtSetTy NestedStmts);
 
     // Compute the union of Gen and Kill sets of all statements up to (and
     // including) the current statement in the block.

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -128,20 +128,20 @@ namespace clang {
     // Get the set of variables that are pointers to null-terminated arrays and
     // in whose lower bounds expressions the variables in Vars occur.
     // @param[in] Vars is a set of variables.
-    // @param[out] NtPtrsWithVarsInLowerBounds is a set of variables that are
-    // pointers to null-terminated arrays and in whose lower bounds expressions
-    // the variables in Vars occur.
-    void GetNtPtrsWithVarsInLowerBounds(
-      VarSetTy &Vars, VarSetTy &NtPtrsWithVarsInLowerBounds) const;
+    // @param[out] NullTermPtrsWithVarsInLowerBounds is a set of variables that
+    // are pointers to null-terminated arrays and in whose lower bounds
+    // expressions the variables in Vars occur.
+    void GetNullTermPtrsWithVarsInLowerBounds(
+      VarSetTy &Vars, VarSetTy &NullTermPtrsWithVarsInLowerBounds) const;
 
     // Get the set of variables that are pointers to null-terminated arrays and
     // in whose upper bounds expressions the variables in Vars occur.
     // @param[in] Vars is a set of variables.
-    // @param[out] NtPtrsWithVarsInLowerBounds is a set of variables that are
-    // pointers to null-terminated arrays and in whose upper bounds expressions
-    // the variables in Vars occur.
-    void GetNtPtrsWithVarsInUpperBounds(
-      VarSetTy &Vars, VarSetTy &NtPtrsWithVarsInUpperBounds) const;
+    // @param[out] NullTermPtrsWithVarsInLowerBounds is a set of variables that
+    // are pointers to null-terminated arrays and in whose upper bounds
+    // expressions the variables in Vars occur.
+    void GetNullTermPtrsWithVarsInUpperBounds(
+      VarSetTy &Vars, VarSetTy &NullTermPtrsWithVarsInUpperBounds) const;
 
     // Add an offset to a given expression.
     // @param[in] E is the given expression.
@@ -155,12 +155,13 @@ namespace clang {
     // @return Returns the dereference expression, if it exists.
     Expr *GetDerefExpr(const Expr *E) const;
 
-    // Get all variables in an expression that are pointers to null-terminated
-    // arrays.
+    // Get the variable in an expression that is a pointer to a null-terminated
+    // array.
     // @param[in] E is the given expression.
-    // @param[out] VarsInExpr is a set of all variables in the expression E
-    // that are pointers to null-terminated arrays.
-    void GetNtPtrsInExpr(Expr *E, VarSetTy &NtPtrsInExpr) const;
+    // @return The variable in the expression that is a pointer to a
+    // null-terminated array; nullptr if no such variable exists in the
+    // expression.
+    const VarDecl *GetNullTermPtrInExpr(Expr *E) const;
 
     // Invoke IgnoreValuePreservingOperations to strip off casts.
     // @param[in] E is the expression whose casts must be stripped.
@@ -295,9 +296,9 @@ namespace clang {
     // used to lookup an ElevatedCFGBlock.
     BlockMapTy BlockMap;
 
-    // AllNtPtrsInFunc denotes all variables in the function that are pointers
-    // to null-terminated arrays.
-    VarSetTy AllNtPtrsInFunc;
+    // AllNullTermPtrsInFunc denotes all variables in the function that are
+    // pointers to null-terminated arrays.
+    VarSetTy AllNullTermPtrsInFunc;
   
   public:
     // Top is a special bounds expression that denotes the super set of all
@@ -373,13 +374,20 @@ namespace clang {
 
     // Compute the Out set for the block.
     // @param[in] EB is the current ElevatedCFGBlock.
-    // @param[out] EB is added to WorkList if the Out set of EB changes.
-    void ComputeOutSet(ElevatedCFGBlock *EB, WorkListTy &WorkList);
+    // @return Return true if the Out set of the block has changed, false
+    // otherwise.
+    bool ComputeOutSet(ElevatedCFGBlock *EB);
 
     // Initialize the In and Out sets for the block.
     // @param[in] FD is the current function.
     // @param[in] EB is the current ElevatedCFGBlock.
     void InitBlockInOutSets(FunctionDecl *FD, ElevatedCFGBlock *EB);
+
+    // Add the successor blocks of the current block to WorkList.
+    // @param[in] CurrBlock is the current block.
+    // @param[in] WorkList stores the blocks remaining to be processed for the
+    // fixpoint computation.
+    void AddSuccsToWorkList(const CFGBlock *CurrBlock, WorkListTy &WorkList);
 
     // Prune the Out set of the pred block according to various conditions.
     // @param[in] PredEB is a predecessor block of the current block.
@@ -390,16 +398,16 @@ namespace clang {
 
     // Initialize the list of variables that are pointers to null-terminated
     // arrays to the null-terminated arrays that are passed as parameters to
-    // the function. This function updates the AllNtPtrsInFunc set.
+    // the function. This function updates the AllNullTermPtrsInFunc set.
     // @param[in] FD is the current function.
-    void InitNtPtrsInFunc(FunctionDecl *FD);
+    void InitNullTermPtrsInFunc(FunctionDecl *FD);
 
     // Update the list of variables that are pointers to null-terminated arrays
     // with the variables that are in StmtGen for the current statement in the
-    // block. This function updates the AllNtPtrsInFunc set.
+    // block. This function updates the AllNullTermPtrsInFunc set.
     // @param[in] EB is the current ElevatedCFGBlock.
     // @param[in] CurrStmt is the current statement.
-    void UpdateNtPtrsInFunc(ElevatedCFGBlock *EB, const Stmt *CurrStmt);
+    void UpdateNullTermPtrsInFunc(ElevatedCFGBlock *EB, const Stmt *CurrStmt);
 
     // Fill the Gen and Kill sets for a statement using the variable and bounds
     // expressions in VarsAndBounds.

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -14,4 +14,1206 @@
 #include "clang/Sema/BoundsWideningAnalysis.h"
 
 namespace clang {
+
+void BoundsWideningAnalysis::WidenBounds(FunctionDecl *FD,
+                                         StmtSetTy NestedStmts) {
+  assert(Cfg && "expected CFG to exist");
+
+  // Initialize the list of variables that are pointers to null-terminated
+  // arrays to the null-terminated arrays that are passed as parameters to the
+  // function.
+  InitNtPtrsInFunc(FD);
+
+  WorkListTy WorkList;
+
+  // Add each block to WorkList and create a mapping from CFGBlock to
+  // ElevatedCFGBlock.
+  // Note: By default, PostOrderCFGView iterates in reverse order. So we always
+  // get a reverse post order when we iterate PostOrderCFGView.
+  for (const CFGBlock *B : PostOrderCFGView(Cfg)) {
+    // SkipBlock will skip all null blocks and the exit block. PostOrderCFGView
+    // does not traverse any unreachable blocks. So at the end of this loop
+    // BlockMap only contains reachable blocks.
+    if (SkipBlock(B))
+      continue;
+
+    auto EB = new ElevatedCFGBlock(B);
+    BlockMap[B] = EB;
+
+    // Note: WorkList is a queue. So we maintain the reverse post order when we
+    // iterate WorkList.
+    WorkList.append(EB);
+
+    // Compute Gen and Kill sets for the block and statements in the block.
+    ComputeGenKillSets(EB);
+
+    // Initialize the In and Out sets for the block.
+    InitBlockInOutSets(FD, EB);
+  }
+
+  // Compute the In and Out sets for blocks.
+  while (!WorkList.empty()) {
+    ElevatedCFGBlock *EB = WorkList.next();
+    WorkList.remove(EB);
+
+    ComputeInSet(EB);
+    ComputeOutSet(EB, WorkList);
+  }
+}
+
+void BoundsWideningAnalysis::ComputeGenKillSets(ElevatedCFGBlock *EB) {
+  const Stmt *PrevStmt = nullptr;
+
+  for (CFGBlock::const_iterator I = EB->Block->begin(),
+                                E = EB->Block->end();
+       I != E; ++I) {
+    CFGElement Elem = *I;
+    if (Elem.getKind() == CFGElement::Statement) {
+      const Stmt *CurrStmt = Elem.castAs<CFGStmt>().getStmt();
+      if (!CurrStmt)
+        continue;
+
+
+      ComputeStmtGenKillSets(EB, CurrStmt);
+      ComputeUnionGenKillSets(EB, CurrStmt, PrevStmt);
+      UpdateNtPtrsInFunc(EB, CurrStmt);
+
+      EB->PrevStmtMap[CurrStmt] = PrevStmt;
+      PrevStmt = CurrStmt;
+
+      // Save the last statement of the block.
+      if (I == E - 1)
+        EB->LastStmt = CurrStmt;
+    }
+  }
+
+  ComputeBlockGenKillSets(EB);
+}
+
+void BoundsWideningAnalysis::ComputeStmtGenKillSets(ElevatedCFGBlock *EB,
+                                                    const Stmt *CurrStmt) {
+  // Initialize the Gen and Kill sets for the statement.
+  EB->StmtGen[CurrStmt] = BoundsMapTy();
+  EB->StmtKill[CurrStmt] = VarSetTy();
+
+  BoundsMapTy VarsAndBounds;
+
+  // Determine whether CurrStmt generates a dataflow fact.
+
+  // A conditional statement that dereferences a variable that is a pointer to
+  // a null-terminated array can generate a dataflow fact. For example: if (*(p
+  // + 1)) The conditional will always be the terminator statement of the block.
+  if (CurrStmt == EB->Block->getTerminatorCondition()) {
+    GetVarsAndBoundsInPtrDeref(EB, VarsAndBounds);
+
+  // A bounds declaration of a null-terminated array generates a dataflow fact.
+  // For example: _Nt_array_ptr<char> p : bounds(p, p + 1);
+  } else if (const auto *DS = dyn_cast<DeclStmt>(CurrStmt)) {
+    for (const Decl *D : DS->decls()) {
+      if (const auto *V = dyn_cast<VarDecl>(D)) {
+        if (!V->isInvalidDecl()) {
+          GetVarsAndBoundsInDecl(EB, V, VarsAndBounds);
+
+          // Additionally, a where clause on a declaration can generate a
+          // dataflow fact.
+          // For example: int x = strlen(p) _Where p : bounds(p, p + x);
+          GetVarsAndBoundsInWhereClause(EB, V->getWhereClause(), VarsAndBounds);
+        }
+      }
+    }
+
+  // A where clause on an expression statement (which is represented in the
+  // AST as a ValueStmt) can generate a dataflow fact.
+  // For example: x = strlen(p) _Where p : bounds(p, p + x);
+  } else if (const auto *VS = dyn_cast<ValueStmt>(CurrStmt)) {
+    GetVarsAndBoundsInWhereClause(EB, VS->getWhereClause(), VarsAndBounds);
+
+  // A where clause on a null statement (meaning a standalone where clause) can
+  // generate a dataflow fact.
+  // For example: _Where p : bounds(p, p + 1);
+  // TODO: Currently, a null statement does not appear in the list of
+  // statements of a block. As a result, there are no Gen and Kill sets for a
+  // null statement. So currently the above example does not generate a
+  // dataflow fact.
+  } else if (const auto *NS = dyn_cast<NullStmt>(CurrStmt)) {
+    GetVarsAndBoundsInWhereClause(EB, NS->getWhereClause(), VarsAndBounds);
+  }
+
+  // Using the mapping of variables to bounds expressions in VarsAndBounds fill
+  // the Gen and Kill sets for the statement.
+  FillStmtGenKillSets(EB, CurrStmt, VarsAndBounds);
+
+  // If a variable modified by CurrStmt occurs in the bounds expression of a
+  // null-terminated array then the bounds of that null-terminated array should
+  // be killed.
+  AddModifiedVarsToStmtKillSet(EB, CurrStmt);
+}
+
+void BoundsWideningAnalysis::ComputeUnionGenKillSets(ElevatedCFGBlock *EB,
+                                                     const Stmt *CurrStmt,
+                                                     const Stmt *PrevStmt) {
+  // If this is the first statement in the block.
+  if (!PrevStmt) {
+    EB->UnionGen[CurrStmt] = EB->StmtGen[CurrStmt];
+    EB->UnionKill[CurrStmt] = EB->StmtKill[CurrStmt];
+    return;
+  }
+
+  EB->UnionKill[CurrStmt] = Union(EB->UnionKill[PrevStmt],
+                                  EB->StmtKill[CurrStmt]);
+
+  auto Diff = Difference(EB->UnionGen[PrevStmt], EB->StmtKill[CurrStmt]);
+  EB->UnionGen[CurrStmt] = Union(Diff, EB->StmtGen[CurrStmt]);
+}
+
+void BoundsWideningAnalysis::ComputeBlockGenKillSets(ElevatedCFGBlock *EB) {
+  if (!EB->LastStmt)
+    return;
+
+  EB->Gen = EB->UnionGen[EB->LastStmt];
+  EB->Kill = EB->UnionKill[EB->LastStmt];
+}
+
+void BoundsWideningAnalysis::ComputeInSet(ElevatedCFGBlock *EB) {
+  const CFGBlock *CurrBlock = EB->Block;
+
+  // Iterate through all the predecessor blocks of EB.
+  for (const CFGBlock *PredBlock : CurrBlock->preds()) {
+    auto BlockIt = BlockMap.find(PredBlock);
+    if (BlockIt == BlockMap.end())
+      continue;
+
+    ElevatedCFGBlock *PredEB = BlockIt->second;
+
+    // If the edge from pred to the current block is a fallthrough edge then
+    // the Out of the pred should simply "flow" through to the current block
+    // (meaning PredOut should simply be intersected with the In of the current
+    // block).
+    // Fallthrough edges are generated in case of loops. For example:
+
+    // _Nt_array_ptr<char> p : bounds(p, p + 1);
+    // while (*(p + 1))
+    //   a = 1;
+
+    // B1: pred: Entry, succ: B2
+    //   _Nt_array_ptr<char> p : bounds(p, p + 1);
+
+    // B2: pred: B1, B4, succ: B3
+
+    // B3: pred: B2, succ: B4
+    //   while (*(p + 1))
+
+    // B4: pred, B3, succ: B2
+    //   a = 1;
+
+    // In the above example, the edges B1->B2, B2->B3 and B4->B2 are
+    // fallthrough edges. So in this case, the Out sets of the pred blocks
+    // should simply flow through to the successor blocks. Meaning we do not
+    // need to prune the Out set of the pred block.
+
+    BoundsMapTy PrunedOutSet = IsFallthroughEdge(PredBlock, CurrBlock) ?
+                               PredEB->Out :
+                               PruneOutSet(PredEB, EB);
+
+    EB->In = Intersect(EB->In, PrunedOutSet);
+  }
+}
+
+BoundsMapTy BoundsWideningAnalysis::PruneOutSet(
+  ElevatedCFGBlock *PredEB, ElevatedCFGBlock *CurrEB) const {
+
+  BoundsMapTy PrunedOutSet = PredEB->Out;
+
+  const CFGBlock *PredBlock = PredEB->Block;
+  const CFGBlock *CurrBlock = CurrEB->Block;
+
+  // Check if the edge from pred to the current block is a true edge.
+  bool IsEdgeTrue = IsTrueEdge(PredBlock, CurrBlock);
+
+  // Get the StmtIn of the last statement in the pred block. If the pred
+  // block does not have any statements then StmtInOfLastStmtOfPred is set to
+  // the In set of the pred block.
+  BoundsMapTy StmtInOfLastStmtOfPred = GetStmtIn(PredEB, PredEB->LastStmt);
+
+  // Check if the current block is a case of a switch-case.
+  bool IsSwitchCase = IsSwitchCaseBlock(CurrBlock);
+
+  // If the current block is a case of a switch-case, check if the case label
+  // tests for null. CaseLabelTestsForNull returns false for the default case.
+  bool IsCaseLabelNull = IsSwitchCase && CaseLabelTestsForNull(CurrBlock);
+
+  // PredEB->Out may contain the widened bounds "E + 1" for some variable V.
+  // Here, we need to determine if "E + 1" should make it to the In set of
+  // the current block. To determine this, we need to check if the
+  // dereference is at the upper bound and if we are on a true edge. Else we
+  // will reset the bounds of V in PrunedOutSet to the bounds of V in
+  // StmtInOfLastStmtOfPred.
+  for (auto VarBoundsPair : PredEB->Out) {
+    const VarDecl *V = VarBoundsPair.first;
+    auto StmtInIt = StmtInOfLastStmtOfPred.find(V);
+
+    // If V is not present in StmtIn of the last statement (maybe as a result
+    // of being killed before the last statement) then V cannot be widened in
+    // this block. So we remove V from the computation of the In set for this
+    // block. For example:
+
+    // B1:
+    //   1: _Nt_array_ptr<char> p : bounds(p, p + i);
+    //   2: i = 0;
+    //   3: if (*(p + i)) {
+    // B2:
+    //   4: a = 1;
+    //   }
+
+    // The bounds of p are killed at statement 2. So StmtIn[3] does not
+    // contain p but Gen[3] will contain "p : bounds(p, p + i + 1)". So we
+    // need to remove p from the In set of successor block.
+
+    // Note: We could have done this as part of the Intersect function but
+    // that would have meant teaching Intersect about StmtIn, etc which would
+    // have complicated the logic for intersection. So to keep the Intersect
+    // method simple we check if V is in StmtIn of the last statement of pred
+    // and accordingly remove it from PrunedOutSet.
+
+    if (StmtInIt == StmtInOfLastStmtOfPred.end()) {
+      PrunedOutSet.erase(V);
+      continue;
+    }
+
+    RangeBoundsExpr *BoundsInStmtIn = StmtInIt->second;
+
+    // If the bounds of V before the last statement in the pred block is Top
+    // then we retain whatever the bounds of V are in PrunedOutSet and they
+    // will be part of the computation of In set of the current block.
+    if (BoundsInStmtIn == Top)
+      continue;
+
+    // If the edge from pred to the current block is not a true edge then we
+    // cannot widen the bounds upon entry to the current block. So we reset
+    // the bounds to those before the last statement in the pred block.
+    // For example:
+
+    // Block B1:
+    //   if (*(p + 1)) {
+    // Block B2:
+    //   } else {
+    // Block B3:
+    //   }
+
+    // The edge B1->B2 is a true edge for the condition "if (*(p + 1))". So
+    // we can widen the bounds upon entry to B2.
+    // The edge B1->B3 is a false edge for the condition "if (*(p + 1))". So
+    // we cannot widen the bounds upon entry to B3.
+
+    // Note: Switch cases are handled separately later in this function.
+
+    if (!IsSwitchCase && !IsEdgeTrue) {
+      PrunedOutSet[V] = BoundsInStmtIn;
+      continue;
+    }
+
+    // If the terminating condition of the pred block does not
+    // dereference V at the current upper bound, then we cannot widen the
+    // bounds upon entry to the current block. So we reset the bounds of V to
+    // those before the last statement in pred. For example:
+
+    // Block 1:
+    //   1: _Nt_array_ptr<char> p : bounds(p, p + 1);
+    //   2: if (*(p)) {
+    // Block 2:
+    //   }
+    //   3: if (*(p + 2)) {
+    // Block 3:
+    //   }
+
+    // In the example above, the conditionals at statements 2 and 3 do not
+    // dereference p at its upper bound. So we cannot widen the bounds of p
+    // upon entry to blocks 2 and 3.
+
+    bool IsDerefAtUpperBound =
+      PredEB->TermCondDerefExpr &&
+      Lex.CompareExprSemantically(PredEB->TermCondDerefExpr,
+                                  BoundsInStmtIn->getUpperExpr());
+
+    if (!IsDerefAtUpperBound) {
+      PrunedOutSet[V] = BoundsInStmtIn;
+      continue;
+    }
+
+    // If we are here then it means that the terminating condition of the
+    // pred block dereferences V at its current upper bound.
+
+    // If we are in a block that is a case of a switch-case.
+    if (IsSwitchCase) {
+      // We cannot widen the bounds in the following scenarios:
+
+      // 1. The case label tests for null. For example:
+
+      // _Nt_array_ptr<char> p : bounds(p, p + 1);
+      // switch(*(p + 1)) {
+      // case '\0': // cannot widen here.
+      // }
+
+      if (IsCaseLabelNull)
+        PrunedOutSet[V] = BoundsInStmtIn;
+
+      // 2. We are in a default case and there is no other case that tests
+      // for null. For example:
+
+      // switch(*(p + 1)) {
+      // default: can widen here.
+      // case '\0': cannot widen here.
+      // case 'a': can widen here.
+      // }
+
+      // switch(*(p + 1)) {
+      // default: cannot widen here.
+      // case 'a': can widen here.
+      // case 'b': can widen here.
+      // }
+
+      else if (isa<DefaultStmt>(CurrBlock->getLabel()) &&
+              !ExistsNullCaseLabel(PredBlock))
+        PrunedOutSet[V] = BoundsInStmtIn;
+    }
+  }
+
+  return PrunedOutSet;
+}
+
+bool BoundsWideningAnalysis::ExistsNullCaseLabel(
+  const CFGBlock *CurrBlock) const {
+
+  for (const CFGBlock *SuccBlock : CurrBlock->succs()) {
+    if (SuccBlock && CaseLabelTestsForNull(SuccBlock))
+      return true;
+  }
+  return false;
+}
+
+bool BoundsWideningAnalysis::IsSwitchCaseBlock(
+  const CFGBlock *CurrBlock) const {
+
+  const Stmt *BlockLabel = CurrBlock->getLabel();
+  return BlockLabel &&
+        (isa<CaseStmt>(BlockLabel) ||
+         isa<DefaultStmt>(BlockLabel));
+}
+
+bool BoundsWideningAnalysis::CaseLabelTestsForNull(
+  const CFGBlock *CurrBlock) const {
+
+  const Stmt *BlockLabel = CurrBlock->getLabel();
+  assert(BlockLabel && "invalid switch case");
+
+  if (isa<DefaultStmt>(BlockLabel))
+    return false;
+
+  const auto *CS = dyn_cast<CaseStmt>(BlockLabel);
+
+  // We mimic how clang (in SemaStmt.cpp) gets the value of a switch case. It
+  // invokes EvaluateKnownConstInt and we do the same here. SemaStmt has
+  // already extended/truncated the case value to fit the integer range and
+  // EvaluateKnownConstInt gives us that value.
+  const Expr *LHS = CS->getLHS();
+  if (!LHS)
+    return true;
+
+  llvm::APSInt LHSVal = LHS->EvaluateKnownConstInt(Ctx);
+  llvm::APSInt LHSZero (LHSVal.getBitWidth(), LHSVal.isUnsigned());
+  if (llvm::APSInt::compareValues(LHSVal, LHSZero) == 0)
+    return true;
+
+  // If the case statement is not of the form "case LHS ... RHS" (a GNU
+  // extension) then we are done. We only needed to check the LHS value which
+  // is the case label for the current case. We return false because we have
+  // determined that the current case label is non-null.
+  if (!CS->caseStmtIsGNURange())
+    return false;
+
+  // If we reach are here it means we are in a range-base case statement of the
+  // form "case LHS ... RHS" (a GNU extension).
+  const Expr *RHS = CS->getRHS();
+  if (!RHS)
+    return true;
+
+  llvm::APSInt RHSVal = RHS->EvaluateKnownConstInt(Ctx);
+  llvm::APSInt RHSZero (RHSVal.getBitWidth(), RHSVal.isUnsigned());
+  if (llvm::APSInt::compareValues(RHSVal, RHSZero) == 0)
+    return true;
+
+  // Return true if 0 is contained within the range [LHS, RHS].
+  return (LHSVal <= LHSZero && RHSZero <= RHSVal) ||
+         (LHSVal >= LHSZero && RHSZero >= RHSVal);
+}
+
+bool BoundsWideningAnalysis::IsFallthroughEdge(
+  const CFGBlock *PredBlock, const CFGBlock *CurrBlock) const {
+
+  // A fallthrough edge between two blocks is always a true edge. If PredBlock
+  // has only one successor and CurrBlock is that successor then it means the
+  // edge between PredBlock and CurrBlock is a fallthrough edge.
+  return PredBlock->succ_size() == 1 &&
+         CurrBlock == *(PredBlock->succs().begin());
+}
+
+bool BoundsWideningAnalysis::IsTrueEdge(const CFGBlock *PredBlock,
+                                             const CFGBlock *CurrBlock) const {
+  // Return false if PredBlock does not have any successors.
+  if (PredBlock->succ_empty())
+    return false;
+
+  // A fallthrough edge is always a true edge.
+  if (IsFallthroughEdge(PredBlock, CurrBlock))
+    return true;
+
+  // Get the last successor in the list of successors of PredBlock.
+  const CFGBlock *LastSucc = *(PredBlock->succs().end() - 1);
+
+  // If PredBlock has multiple successors, then a successor on a false edge
+  // would always be last in the list of successors of PredBlock.
+  if (CurrBlock == LastSucc)
+    return PredBlock->succ_size() == 1;
+
+  // Check if CurrBlock is a successor of PredBlock. If CurrBlock is not a
+  // successor of PredBlock then there is no edge between PredBlock and
+  // CurrBlock. So return false.
+  for (const CFGBlock *SuccBlock : PredBlock->succs()) {
+    if (CurrBlock == SuccBlock)
+      return true;
+  }
+
+  return false;
+}
+
+void BoundsWideningAnalysis::ComputeOutSet(ElevatedCFGBlock *EB,
+                                           WorkListTy &WorkList) {
+  auto OrigOut = EB->Out;
+
+  auto Diff = Difference(EB->In, EB->Kill);
+  EB->Out = Union(Diff, EB->Gen);
+
+  if (!IsEqual(EB->Out, OrigOut))
+    WorkList.append(EB);
+}
+
+void BoundsWideningAnalysis::InitBlockInOutSets(FunctionDecl *FD,
+                                                ElevatedCFGBlock *EB) {
+  // Initialize the In and Out sets for the entry block.
+  if (EB->Block == &Cfg->getEntry()) {
+    EB->In = BoundsMapTy();
+    EB->Out = BoundsMapTy();
+
+    // If the function has parameters that generate dataflow facts then add
+    // those to the In and Out sets of the entry block.
+    BoundsMapTy VarsAndBounds;
+    for (const ParmVarDecl *PD : FD->parameters()) {
+      // Bounds declarations on a function parameter can generate a dataflow
+      // fact.
+      // For example: void foo(_Nt_array_ptr<char> p : bounds(p, p + 1)) {}
+      GetVarsAndBoundsInDecl(EB, PD, VarsAndBounds);
+
+      // Additionally, a where clause on a function parameter can generate a
+      // dataflow fact.
+      // For example: void foo(int x _Where p : bounds(p, p + 1)) {}
+      GetVarsAndBoundsInWhereClause(EB, PD->getWhereClause(), VarsAndBounds);
+    }
+
+    for (auto VarBoundsPair : VarsAndBounds) {
+      const VarDecl *V = VarBoundsPair.first;
+      RangeBoundsExpr *R = VarBoundsPair.second;
+
+      EB->In[V] = R;
+      EB->Out[V] = R;
+    }
+
+  } else {
+    // Initialize the In and Out sets for the rest of the blocks to Top.
+    for (const VarDecl *V : AllNtPtrsInFunc) {
+      EB->In[V] = Top;
+      EB->Out[V] = Top;
+    }
+  }
+}
+
+BoundsMapTy BoundsWideningAnalysis::GetStmtOut(ElevatedCFGBlock *EB,
+                                               const Stmt *CurrStmt) const {
+  if (CurrStmt) {
+    auto Diff = Difference(EB->In, EB->UnionKill[CurrStmt]);
+    return Union(Diff, EB->UnionGen[CurrStmt]);
+  }
+  return EB->In;
+}
+
+BoundsMapTy BoundsWideningAnalysis::GetStmtIn(ElevatedCFGBlock *EB,
+                                              const Stmt *CurrStmt) const {
+  // StmtIn of a statement is equal to the StmtOut of its previous statement.
+  return GetStmtOut(EB, EB->PrevStmtMap[CurrStmt]);
+}
+
+void BoundsWideningAnalysis::InitNtPtrsInFunc(FunctionDecl *FD) {
+  // Initialize the list of variables that are pointers to null-terminated
+  // arrays to the null-terminated arrays that are passed as parameters to the
+  // function.
+  for (const ParmVarDecl *PD : FD->parameters()) {
+    if (IsNtArrayType(PD))
+      AllNtPtrsInFunc.insert(PD);
+  }
+}
+
+void BoundsWideningAnalysis::UpdateNtPtrsInFunc(ElevatedCFGBlock *EB,
+                                                const Stmt *CurrStmt) {
+  // Add variables occurring in StmtGen for the current statement to the list
+  // of variables that are pointers to null-terminated arrays.
+  for (auto VarBoundsPair : EB->StmtGen[CurrStmt])
+    AllNtPtrsInFunc.insert(VarBoundsPair.first);
+}
+
+void BoundsWideningAnalysis::FillStmtGenKillSets(ElevatedCFGBlock *EB,
+                                                 const Stmt *CurrStmt,
+                                                 BoundsMapTy &VarsAndBounds) {
+  for (auto VarBoundsPair : VarsAndBounds) {
+    const VarDecl *V = VarBoundsPair.first;
+    RangeBoundsExpr *R = VarBoundsPair.second;
+
+    EB->StmtGen[CurrStmt][V] = R;
+    EB->StmtKill[CurrStmt].insert(V);
+  }
+}
+
+void BoundsWideningAnalysis::GetVarsAndBoundsInDecl(
+  ElevatedCFGBlock *EB, const VarDecl *V, BoundsMapTy &VarsAndBounds) {
+
+  if (IsNtArrayType(V)) {
+    BoundsExpr *NormalizedBounds = SemaRef.NormalizeBounds(V);
+    VarsAndBounds[V] = dyn_cast<RangeBoundsExpr>(NormalizedBounds);
+  }
+}
+
+void BoundsWideningAnalysis::GetVarsAndBoundsInWhereClause(
+  ElevatedCFGBlock *EB, WhereClause *WC, BoundsMapTy &VarsAndBounds) {
+
+  if (!WC)
+    return;
+
+  for (const auto *Fact : WC->getFacts()) {
+    auto *BF = dyn_cast<BoundsDeclFact>(Fact);
+    if (!BF)
+      continue;
+
+    VarDecl *V = BF->Var;
+    if (IsNtArrayType(V)) {
+      BoundsExpr *NormalizedBounds = SemaRef.ExpandBoundsToRange(V, BF->Bounds);
+      VarsAndBounds[V] = dyn_cast<RangeBoundsExpr>(NormalizedBounds);
+    }
+  }
+}
+
+void BoundsWideningAnalysis::GetVarsAndBoundsInPtrDeref(
+  ElevatedCFGBlock *EB, BoundsMapTy &VarsAndBounds) {
+
+  // Get the terminating condition of the block.
+  Expr *TermCond = GetTerminatorCondition(EB->Block);
+  if (!TermCond)
+    return;
+
+  // If the terminating condition is a dereference expression get that
+  // expression.
+  Expr *DerefExpr = GetDerefExpr(TermCond);
+  if (!DerefExpr)
+    return;
+
+  EB->TermCondDerefExpr = DerefExpr;
+
+  // Get the set of null-terminated arrays that the dereference expression
+  // potentially widens. A dereference expression can only widen the bounds of
+  // those null-terminated arrays whose upper bounds expression contains all
+  // variables that occur in the dereference expression. For example: *(p + i +
+  // j) can widen p iff p, i and j all occur in upper_bound(p).
+  VarSetTy VarsToWiden;
+  GetVarsToWiden(DerefExpr, VarsToWiden);
+
+  RangeBoundsExpr *R = nullptr;
+  for (const VarDecl *V : VarsToWiden) {
+    if (!IsNtArrayType(V))
+      continue;
+
+    if (!R) {
+      BoundsExpr *NormalizedBounds = SemaRef.NormalizeBounds(V);
+      RangeBoundsExpr *RBE = dyn_cast<RangeBoundsExpr>(NormalizedBounds);
+
+      // DerefExpr potentially widens V. So we add
+      // "V:bounds(lower, DerefExpr + 1)" to the Gen set.
+
+      // TODO: Here, we always consider the lower bound from the declared
+      // bounds. But this may be incorrect in case a where clause redeclares
+      // the lower bound. This needs to be handled.
+      R = new (Ctx) RangeBoundsExpr(RBE->getLowerExpr(),
+                                    GetWidenedExpr(DerefExpr, 1),
+                                    SourceLocation(), SourceLocation());
+    }
+
+    VarsAndBounds[V] = R;
+  }
+}
+
+void BoundsWideningAnalysis::AddModifiedVarsToStmtKillSet(
+  ElevatedCFGBlock *EB, const Stmt *CurrStmt) {
+
+  // Get variables modified by CurrStmt or statements nested in CurrStmt.
+  VarSetTy ModifiedVars;
+  GetModifiedVars(CurrStmt, ModifiedVars);
+
+  // If a modified variable occurs in the lower or upper bounds expression of a
+  // null-terminated array then the bounds of that null-terminated array should
+  // be killed.
+  for (const VarDecl *ModifiedVar : ModifiedVars) {
+    auto PtrVarIt = BoundsVarsLower.find(ModifiedVar);
+    if (PtrVarIt != BoundsVarsLower.end()) {
+      for (const VarDecl *V : PtrVarIt->second)
+        EB->StmtKill[CurrStmt].insert(V);
+    }
+
+    PtrVarIt = BoundsVarsUpper.find(ModifiedVar);
+    if (PtrVarIt != BoundsVarsUpper.end()) {
+      for (const VarDecl *V : PtrVarIt->second)
+        EB->StmtKill[CurrStmt].insert(V);
+    }
+  }
+}
+
+
+void BoundsWideningAnalysis::GetVarsToWiden(Expr *E,
+                                            VarSetTy &VarsToWiden) const {
+  // Determine the set of variables that can be widened in an expression.
+  if (!E)
+    return;
+
+  // Get all variables that occur in the expression.
+  VarSetTy VarsInExpr;
+  GetVarsInExpr(E, VarsInExpr);
+
+  // If we have the following declarations:
+  // _Nt_array_ptr<T> p : bounds(p + i, p + x + y);
+  // _Nt_array_ptr<T> q : bounds(q + j, q + x + z);
+  // Then BoundsVarsUpper contains the following entries:
+  // p : {p}
+  // q : {q}
+  // x : {p, q}
+  // y : {p}
+  // z : {q}
+  VarSetTy PtrsWithVarInUpperBounds;
+  for (const VarDecl *V : VarsInExpr) {
+    // Get the set of null-terminated arrays in whose upper bounds expressions
+    // V occurs.
+    auto PtrVarIt = BoundsVarsUpper.find(V);
+
+    // If V does not appear in the upper bounds expression of any
+    // null-terminated array then expression E cannot potentially widen the
+    // bounds of any null-terminated array.
+    if (PtrVarIt == BoundsVarsUpper.end())
+      return;
+
+    if (PtrsWithVarInUpperBounds.empty())
+      PtrsWithVarInUpperBounds = PtrVarIt->second;
+    else
+      PtrsWithVarInUpperBounds = Intersect(PtrsWithVarInUpperBounds,
+                                           PtrVarIt->second);
+
+    // If the intersection of PtrsWithVarInUpperBounds is empty then expression
+    // E cannot potentially widen the bounds of any null-terminated array.
+    if (PtrsWithVarInUpperBounds.empty())
+      return;
+  }
+
+  // Gather the set of variables occurring in the upper bounds expression of
+  // each pointer.
+  // If we have the following declarations:
+  // _Nt_array_ptr<T> p : bounds(p + i, p + x + y);
+  // _Nt_array_ptr<T> q : bounds(q + j, q + x + z);
+  // Then VarsInBounds would contain the following entries:
+  // p : {p, x, y}
+  // q : {q, x, z}
+  BoundsVarsTy VarsInBounds;
+  for (auto Pair : BoundsVarsUpper) {
+    const VarDecl *V = Pair.first;
+    for (const VarDecl *Ptr : Pair.second) {
+      if (PtrsWithVarInUpperBounds.count(Ptr))
+        VarsInBounds[Ptr].insert(V);
+    }
+  }
+
+  // If the number of variables occurring in the upper bounds expression of
+  // each pointer in PtrsWithVarInUpperBounds is equal to the number of
+  // variables occurring in the dereference expression then that pointer can
+  // potentially be widened.
+  for (const VarDecl *Ptr : PtrsWithVarInUpperBounds) {
+    if (VarsInExpr.size() == VarsInBounds[Ptr].size())
+      VarsToWiden.insert(Ptr);
+  }
+}
+
+void BoundsWideningAnalysis::GetModifiedVars(const Stmt *CurrStmt,
+                                             VarSetTy &ModifiedVars) const {
+  // Get all variables modified by CurrStmt or statements nested in CurrStmt.
+  if (!CurrStmt)
+    return;
+
+  Expr *E = nullptr;
+
+  // If the variable is modified using a unary operator, like ++I or I++.
+  if (const auto *UO = dyn_cast<const UnaryOperator>(CurrStmt)) {
+    if (UO->isIncrementDecrementOp()) {
+      assert(UO->getSubExpr() && "invalid UnaryOperator expression");
+      E = IgnoreCasts(UO->getSubExpr());
+    }
+
+  // Else if the variable is being assigned to, like I = ...
+  } else if (const auto *BO = dyn_cast<const BinaryOperator>(CurrStmt)) {
+    if (BO->isAssignmentOp())
+      E = IgnoreCasts(BO->getLHS());
+  }
+
+  if (const auto *D = dyn_cast_or_null<DeclRefExpr>(E))
+    if (const auto *V = dyn_cast_or_null<VarDecl>(D->getDecl()))
+      ModifiedVars.insert(V);
+
+  for (const Stmt *NestedStmt : CurrStmt->children())
+    GetModifiedVars(NestedStmt, ModifiedVars);
+}
+
+Expr *BoundsWideningAnalysis::GetWidenedExpr(Expr *E, unsigned Offset) const {
+  // Returns the expression E + Offset.
+  // Note: This function only returns the expression E + Offset and does not
+  // actually evaluate the expression. So if E does not overflow then E +
+  // Offset does not overflow here. However, E + Offset may later overflow when
+  // the preorder AST performs constant folding, for example in case E is e +
+  // MAX_INT and Offset is 1.
+
+  const llvm::APInt
+    APIntOff(Ctx.getTargetInfo().getPointerWidth(0), Offset);
+
+  IntegerLiteral *WidenedOffset =
+    ExprCreatorUtil::CreateIntegerLiteral(Ctx, APIntOff);
+
+  return ExprCreatorUtil::CreateBinaryOperator(SemaRef, E, WidenedOffset,
+                                               BinaryOperatorKind::BO_Add);
+}
+
+Expr *BoundsWideningAnalysis::GetTerminatorCondition(const Expr *E) const {
+  if (!E)
+    return nullptr;
+
+  if (const auto *BO = dyn_cast<BinaryOperator>(E->IgnoreParens()))
+    return GetTerminatorCondition(BO->getRHS());
+
+  // According to C11 standard section 6.5.13, the logical AND Operator shall
+  // yield 1 if both of its operands compare unequal to 0; otherwise, it yields
+  // 0. The result has type int.  An IntegralCast is generated for "if (*p &&
+  // *(p + 1))", where p is _Nt_array_ptr<T>.  Here we strip off the
+  // IntegralCast.
+  if (auto *CE = dyn_cast<CastExpr>(E))
+    if (CE->getCastKind() == CastKind::CK_IntegralCast)
+      return const_cast<Expr *>(CE->getSubExpr());
+  return const_cast<Expr *>(E);
+}
+
+Expr *BoundsWideningAnalysis::GetTerminatorCondition(const CFGBlock *B) const {
+  if (!B)
+    return nullptr;
+
+  if (const Stmt *S = B->getTerminatorStmt()) {
+    if (const auto *BO = dyn_cast<BinaryOperator>(S))
+      return GetTerminatorCondition(BO->getLHS());
+
+    if (const auto *IfS = dyn_cast<IfStmt>(S))
+      return GetTerminatorCondition(IfS->getCond());
+
+    if (const auto *WhileS = dyn_cast<WhileStmt>(S))
+      return const_cast<Expr *>(WhileS->getCond());
+
+    if (const auto *ForS = dyn_cast<ForStmt>(S))
+      return const_cast<Expr *>(ForS->getCond());
+
+    if (const auto *SwitchS = dyn_cast<SwitchStmt>(S)) {
+      // According to C11 standard section 6.8.4.2, the controlling
+      // expression of a switch shall have integer type. If we have switch(*p)
+      // where p is _Nt_array_ptr<char> then it is casted to integer type and
+      // an IntegralCast is generated. GetTerminatorCondition() will strip off
+      // the IntegralCast.
+      return GetTerminatorCondition(SwitchS->getCond());
+    }
+  }
+  return nullptr;
+}
+
+Expr *BoundsWideningAnalysis::GetDerefExpr(Expr *E) const {
+  // A dereference expression can contain an array subscript or a pointer
+  // dereference.
+  if (!E)
+    return nullptr;
+
+  if (auto *CE = dyn_cast<CastExpr>(E))
+    if (CE->getCastKind() == CastKind::CK_LValueToRValue)
+      E = CE->getSubExpr();
+
+  E = IgnoreCasts(E);
+
+  // If a dereference expression is of the form "*(p + i)".
+  if (auto *UO = dyn_cast<UnaryOperator>(E)) {
+    if (UO->getOpcode() == UO_Deref)
+      return IgnoreCasts(UO->getSubExpr());
+
+  // Else if a dereference expression is an array access. An array access can
+  // be written A[i] or i[A] (both are equivalent).  getBase() and getIdx()
+  // always present the normalized view: A[i]. In this case getBase() returns
+  // "A" and getIdx() returns "i".
+
+  // TODO: Currently we normalize A[i] to "A + i" and return that as the
+  // dereference expression because we need to extract the variables that occur
+  // in the deref expression in the function GetVarsInExpr. But once we change
+  // this analysis to use AbstractSets we no longer need to normalize the
+  // expression here and can simply return the ArraySubscriptExpr from this
+  // function.
+  } else if (auto *AE = dyn_cast<ArraySubscriptExpr>(E)) {
+    return ExprCreatorUtil::CreateBinaryOperator(SemaRef, AE->getBase(),
+                                                 AE->getIdx(),
+                                                 BinaryOperatorKind::BO_Add);
+  }
+  return nullptr;
+}
+
+void BoundsWideningAnalysis::GetVarsInExpr(Expr *E,
+                                           VarSetTy &VarsInExpr) const {
+  // Get the VarDecls of all variables occurring in an expression.
+
+  // TODO: Currently this function returns a subset of all variables that occur
+  // in an expression. It returns only the top-level variables that appear in
+  // an expression. For example, in the expression "a + b - c" it returns {a,
+  // b, c}. It does not return variables that are members of a struct or
+  // arguments of a function call, etc.
+  // In future, when we change this analysis to use AbstractSets, this function
+  // can handle an expression like "s->f + func(x)" and return {s, f, x} as the
+  // set of variables that occur in the expression.
+
+  if (!E)
+    return;
+
+  if (auto *CE = dyn_cast<CastExpr>(E))
+    if (CE->getCastKind() == CastKind::CK_LValueToRValue)
+      E = CE->getSubExpr();
+
+  E = IgnoreCasts(E);
+
+  // Get variables in an expression like *e.
+  if (const auto *UO = dyn_cast<const UnaryOperator>(E)) {
+      GetVarsInExpr(UO->getSubExpr(), VarsInExpr);
+
+  // Get variables in an expression like e1 + e2.
+  } else if (const auto *BO = dyn_cast<BinaryOperator>(E)) {
+    GetVarsInExpr(BO->getLHS(), VarsInExpr);
+    GetVarsInExpr(BO->getRHS(), VarsInExpr);
+  }
+
+  if (const auto *D = dyn_cast<DeclRefExpr>(E)) {
+    if (const auto *V = dyn_cast<VarDecl>(D->getDecl()))
+      if (!V->isInvalidDecl())
+        VarsInExpr.insert(V);
+  }
+}
+
+Expr *BoundsWideningAnalysis::IgnoreCasts(const Expr *E) const {
+  return Lex.IgnoreValuePreservingOperations(Ctx, const_cast<Expr *>(E));
+}
+
+bool BoundsWideningAnalysis::SkipBlock(const CFGBlock *B) const {
+  return !B || B == &Cfg->getExit();
+}
+
+bool BoundsWideningAnalysis::IsNtArrayType(const VarDecl *V) const {
+  return V && (V->getType()->isCheckedPointerNtArrayType() ||
+               V->getType()->isNtCheckedArrayType());
+}
+
+bool BoundsWideningAnalysis::IsSubRange(RangeBoundsExpr *B1,
+                                        RangeBoundsExpr *B2) const {
+  // If B2 is a subrange of B1, then
+  // B2.Lower >= B1.Lower and B2.Upper <= B1.Upper
+
+  // Examples:
+  // B1 = bounds(p, p + 5) and B2 = bounds(p + 1, p + 3) ==> True
+  // B1 = bounds(p, p + 5) and B2 = bounds(p, p + 5) ==> True
+  // B1 = bounds(p, p + 5) and B2 = bounds(p, p + 2) ==> True
+  // B1 = bounds(p, p + 5) and B2 = bounds(p + 4, p + 5) ==> True
+  // B1 = bounds(p, p + 5) and B2 = bounds(p, p) ==> True
+  // B1 = bounds(p, p + 5) and B2 = bounds(p + 5, p + 5) ==> True
+  // B1 = bounds(p, p + 5) and B2 = bounds(p, p + 6) ==> False
+  // B1 = bounds(p, p + 5) and B2 = bounds(p - 1, p + 1) ==> False
+  // B1 = bounds(p, p + 5) and B2 = bounds(p + 6, p + 10) ==> False
+  // B1 = bounds(p + 5, p + 6) and B2 = bounds(p, p + 5) ==> False
+  // B1 = bounds(p, p + 5) and B2 = bounds(p, p + x) ==> False
+  // B1 = bounds(p, p + x) and B2 = bounds(p, p + x + y) ==> False
+
+  // To determine if B2 is a subrange of B1 we check if:
+  // B2.Lower - B1.Lower >= 0 and B1.Upper - B2.Upper >= 0
+
+  Expr *Lower1 = B1->getLowerExpr();
+  Expr *Upper1 = B1->getUpperExpr();
+
+  Expr *Lower2 = B2->getLowerExpr();
+  Expr *Upper2 = B2->getUpperExpr();
+
+  llvm::APSInt Zero(Ctx.getTargetInfo().getIntWidth(), 0);
+  llvm::APSInt Offset;
+
+  // Lex.GetExprIntDiff returns false if the two input expressions are not
+  // comparable. This may happen if either of the expressions contains a
+  // variable that is not present in the other.
+  if (!Lex.GetExprIntDiff(Lower2, Lower1, Offset))
+    return false;
+
+  if (llvm::APSInt::compareValues(Offset, Zero) < 0)
+    return false;
+
+  if (!Lex.GetExprIntDiff(Upper1, Upper2, Offset))
+    return false;
+
+  return llvm::APSInt::compareValues(Offset, Zero) >= 0;
+}
+
+void BoundsWideningAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
+  OS << "\n--------------------------------------";
+  // Print the function name.
+  OS << "\nFunction: " << FD->getName();
+
+  for (const CFGBlock *CurrBlock : GetOrderedBlocks()) {
+    // Print the current block number.
+    OS << "\nBlock: B" << CurrBlock->getBlockID();
+
+    // Print the predecessor blocks of the current block.
+    OS << ", Pred: ";
+    for (const CFGBlock *PredBlock : CurrBlock->preds()) {
+      if (PredBlock)
+        OS << "B" << PredBlock->getBlockID() << ", ";
+    }
+
+    // Print the successor blocks of the current block.
+    OS << "Succ: ";
+    for (const CFGBlock *SuccBlock : CurrBlock->succs()) {
+      if (SuccBlock) {
+        OS << "B" << SuccBlock->getBlockID();
+
+        if (SuccBlock != *(CurrBlock->succs().end() - 1))
+          OS << ", ";
+        }
+    }
+
+    ElevatedCFGBlock *EB = BlockMap[CurrBlock];
+
+    bool IsBlockEmpty = true;
+    for (CFGElement Elem : *CurrBlock) {
+      if (Elem.getKind() == CFGElement::Statement) {
+        const Stmt *CurrStmt = Elem.castAs<CFGStmt>().getStmt();
+        if (!CurrStmt)
+          continue;
+
+        BoundsMapTy WidenedBounds = GetStmtIn(EB, CurrStmt);
+
+        std::vector<const VarDecl *> Vars;
+        for (auto VarBoundsPair : WidenedBounds)
+          Vars.push_back(VarBoundsPair.first);
+
+        llvm::sort(Vars.begin(), Vars.end(),
+          [](const VarDecl *A, const VarDecl *B) {
+             return A->getQualifiedNameAsString().compare(
+                    B->getQualifiedNameAsString()) < 0;
+          });
+
+        std::string Str;
+        llvm::raw_string_ostream SS(Str);
+        CurrStmt->printPretty(SS, nullptr, Ctx.getPrintingPolicy());
+
+        // Print the current statement.
+        OS << "\n  Widened bounds before stmt: " << SS.str();
+        if (SS.str().back() != '\n')
+          OS << "\n";
+
+        IsBlockEmpty = false;
+
+        if (Vars.size() == 0)
+          OS << "    <none>\n";
+
+        for (const VarDecl *V : Vars) {
+          RangeBoundsExpr *Bounds = WidenedBounds[V];
+          if (Bounds == Top) {
+            // If this is the only variable and its bounds are Top, we need to
+            // print <none>.
+            if (Vars.size() == 1)
+              OS << "    <none>\n";
+            continue;
+          }
+
+          Expr *Lower = Bounds->getLowerExpr();
+          Expr *Upper = Bounds->getUpperExpr();
+
+          OS << "    " << V->getQualifiedNameAsString() << ": bounds(";
+          Lower->printPretty(OS, nullptr, Ctx.getPrintingPolicy());
+          OS << ", ";
+          Upper->printPretty(OS, nullptr, Ctx.getPrintingPolicy());
+          OS << ")\n";
+        }
+      }
+    }
+
+    if (IsBlockEmpty)
+      OS << "\n";
+  }
+}
+
+OrderedBlocksTy BoundsWideningAnalysis::GetOrderedBlocks() const {
+  // We order the CFG blocks based on block ID. Block IDs decrease from entry
+  // to exit. So we sort in the reverse order.
+  OrderedBlocksTy OrderedBlocks;
+  for (auto BlockEBPair : BlockMap) {
+    const CFGBlock *B = BlockEBPair.first;
+    OrderedBlocks.push_back(B);
+  }
+
+  llvm::sort(OrderedBlocks.begin(), OrderedBlocks.end(),
+    [] (const CFGBlock *A, const CFGBlock *B) {
+        return A->getBlockID() > B->getBlockID();
+    });
+  return OrderedBlocks;
+}
+
+// TODO: Move the templated (not specialized) set operation functions to a
+// common header.
+
+// Common templated set operation functions.
+template<class T, class U>
+T BoundsWideningAnalysis::Difference(T &A, U &B) const {
+  if (!A.size() || !B.size())
+    return A;
+
+  auto CopyA = A;
+  for (auto Item : A) {
+    if (B.count(Item))
+      CopyA.erase(Item);
+  }
+  return CopyA;
+}
+
+template<class T>
+T BoundsWideningAnalysis::Union(T &A, T &B) const {
+  auto CopyA = A;
+  for (auto Item : B)
+    CopyA.insert(Item);
+
+  return CopyA;
+}
+
+template<class T>
+T BoundsWideningAnalysis::Intersect(T &A, T &B) const {
+  if (!A.size() || !B.size())
+    return T();
+
+  auto CopyA = A;
+  for (auto Item : A) {
+    if (!B.count(Item))
+      CopyA.erase(Item);
+  }
+  return CopyA;
+}
+
+template<class T>
+bool BoundsWideningAnalysis::IsEqual(T &A, T &B) const {
+  return A.size() == B.size() &&
+         A.size() == Intersect(A, B).size();
+}
+
+// Template specializations of common set operation functions.
+template<>
+BoundsMapTy BoundsWideningAnalysis::Difference<BoundsMapTy, VarSetTy>(
+  BoundsMapTy &A, VarSetTy &B) const {
+
+  if (!A.size() || !B.size())
+    return A;
+
+  auto CopyA = A;
+  for (auto VarBoundsPair : A) {
+    if (B.count(VarBoundsPair.first))
+      CopyA.erase(VarBoundsPair.first);
+  }
+  return CopyA;
+}
+
+template<>
+BoundsMapTy BoundsWideningAnalysis::Intersect<BoundsMapTy>(
+  BoundsMapTy &A, BoundsMapTy &B) const {
+
+  if (!A.size() || !B.size())
+    return BoundsMapTy();
+
+  auto CopyA = A;
+  for (auto VarBoundsPair : B) {
+    const VarDecl *V = VarBoundsPair.first;
+    auto VarBoundsIt = CopyA.find(V);
+    if (VarBoundsIt == CopyA.end()) {
+      CopyA.erase(V);
+      continue;
+    }
+
+    RangeBoundsExpr *BoundsA = VarBoundsIt->second;
+    RangeBoundsExpr *BoundsB = VarBoundsPair.second;
+
+    // Currently, CopyA[V] is BoundsA. Set CopyA[V] to BoundsB if:
+    // 1. BoundsA is Top, or
+    // 2. BoundsB is not Top and BoundsB is a subrange of BoundsA.
+    if (BoundsA == Top)
+      CopyA[V] = BoundsB;
+    else if (BoundsB != Top && IsSubRange(BoundsA, BoundsB))
+      CopyA[V] = BoundsB;
+  }
+  return CopyA;
+}
+
+template<>
+BoundsMapTy BoundsWideningAnalysis::Union<BoundsMapTy>(
+  BoundsMapTy &A, BoundsMapTy &B) const {
+
+  auto CopyA = A;
+  for (auto VarBoundsPair : B)
+    CopyA[VarBoundsPair.first] = VarBoundsPair.second;
+
+  return CopyA;
+}
+
+template<>
+bool BoundsWideningAnalysis::IsEqual<BoundsMapTy>(
+  BoundsMapTy &A, BoundsMapTy &B) const {
+
+  if (A.size() != B.size())
+    return false;
+
+  auto CopyA = A;
+  for (auto VarBoundsPair : B) {
+    const VarDecl *V = VarBoundsPair.first;
+
+    auto VarBoundsIt = CopyA.find(V);
+    if (VarBoundsIt == CopyA.end())
+      return false;
+
+    RangeBoundsExpr *BoundsA = VarBoundsIt->second;
+    RangeBoundsExpr *BoundsB = VarBoundsPair.second;
+
+    if (BoundsA == Top || BoundsB == Top)
+      return BoundsA == BoundsB;
+
+    if (!Lex.CompareExprSemantically(BoundsA->getUpperExpr(),
+                                     BoundsB->getUpperExpr()))
+      return false;
+  }
+  return true;
+}
+
 } // end namespace clang

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -22,8 +22,7 @@ namespace clang {
 // BoundsWideningUtil class that are defined later in this file.
 //===---------------------------------------------------------------------===//
 
-void BoundsWideningAnalysis::WidenBounds(FunctionDecl *FD,
-                                         StmtSetTy NestedStmts) {
+void BoundsWideningAnalysis::WidenBounds(FunctionDecl *FD) {
   assert(Cfg && "expected CFG to exist");
 
   // Initialize the list of variables that are pointers to null-terminated

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -664,8 +664,12 @@ void BoundsWideningAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
   OS << "\nFunction: " << FD->getName();
 
   for (const CFGBlock *CurrBlock : GetOrderedBlocks()) {
+    unsigned BlockID = CurrBlock->getBlockID();
+
     // Print the current block number.
-    OS << "\nBlock: B" << CurrBlock->getBlockID();
+    OS << "\nBlock: B" << BlockID;
+    if (CurrBlock == &Cfg->getEntry())
+      OS << " (Entry)";
 
     // Print the predecessor blocks of the current block.
     OS << ", Pred: ";

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -155,7 +155,8 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
       // If V has a bounds expression, traverse it so we visit the
       // DeclRefExprs within the bounds.
-      if (V->hasBoundsExpr()) {
+      if (V->getType()->isCheckedPointerArrayType() ||
+          V->getType()->isCheckedArrayType()) {
         if (BoundsExpr *B = SemaRef.NormalizeBounds(V)) {
           VarWithBounds = V;
           TraverseStmt(B);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2817,7 +2817,7 @@ namespace {
      IdentifyChecked(Body, MemoryCheckedStmts, BoundsCheckedStmts, CheckedScopeSpecifier::CSS_Unchecked);
 
      // Run the bounds widening analysis on this function.
-     BoundsWideningAnalyzer.WidenBounds(FD, NestedElements);
+     BoundsWideningAnalyzer.WidenBounds(FD);
      if (S.getLangOpts().DumpWidenedBounds)
        BoundsWideningAnalyzer.DumpWidenedBounds(FD);
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2817,7 +2817,7 @@ namespace {
      IdentifyChecked(Body, MemoryCheckedStmts, BoundsCheckedStmts, CheckedScopeSpecifier::CSS_Unchecked);
 
      // Run the bounds widening analysis on this function.
-     BoundsWideningAnalyzer.WidenBounds(FD);
+     BoundsWideningAnalyzer.WidenBounds(FD, NestedElements);
      if (S.getLangOpts().DumpWidenedBounds)
        BoundsWideningAnalyzer.DumpWidenedBounds(FD);
 

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
@@ -1,6 +1,9 @@
-// Tests for datafow analysis for bounds widening of _Nt_array_ptr's.
+// Tests for datafow analysis for bounds widening in case of conditionals with
+// multiple dereferences of null-terminated arrays.
 //
-// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+// RUN: %clang_cc1 -fdump-widened-bounds -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
 
 int a;
 

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
@@ -73,34 +73,14 @@ void f2() {
 }
 
 void f3(_Nt_array_ptr<char> p : count(0)) {
-  if (p[0] && p[1] && 2[p]) {
+  if ((((0[p]))) && (((p[1]))) && ((p[2]))) {
     a = 1;
   }
 
-  if ((((0[p]))) && (((p[1]))) && ((p[2]))) {
-    a = 2;
-  }
-
 // CHECK: Function: f3
-// CHECK: Block: B9, Pred: Succ: B8
+// CHECK: Block: B5, Pred: Succ: B4
 
-// CHECK: Block: B8, Pred: B9, Succ: B7, B4
-// CHECK:   Widened bounds before stmt: p[0]
-// CHECK:     p: bounds(p, p + 0)
-
-// CHECK: Block: B7, Pred: B8, Succ: B6, B4
-// CHECK:   Widened bounds before stmt: p[1]
-// CHECK:     p: bounds(p, p + 0 + 1)
-
-// CHECK: Block: B6, Pred: B7, Succ: B5, B4
-// CHECK:   Widened bounds before stmt: 2[p]
-// CHECK:     p: bounds(p, p + 1 + 1)
-
-// CHECK: Block: B5, Pred: B6, Succ: B4
-// CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     p: bounds(p, p + 2 + 1)
-
-// CHECK: Block: B4, Pred: B5, B6, B7, B8, Succ: B3, B0
+// CHECK: Block: B4, Pred: B5, Succ: B3, B0
 // CHECK:   Widened bounds before stmt: (((0[p])))
 // CHECK:     p: bounds(p, p + 0)
 
@@ -113,7 +93,7 @@ void f3(_Nt_array_ptr<char> p : count(0)) {
 // CHECK:     p: bounds(p, p + 1 + 1)
 
 // CHECK: Block: B1, Pred: B2, Succ: B0
-// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:   Widened bounds before stmt: a = 1
 // CHECK:     p: bounds(p, p + 2 + 1)
 }
 

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
@@ -1,0 +1,1294 @@
+// Tests for datafow analysis for bounds widening of _Nt_array_ptr's.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+
+int a;
+
+void f1() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p && *(p + 1) && *(p + 2)) {
+    a = 1;
+  }
+
+// CHECK: Function: f1
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f2() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+  int a;
+
+  if (*p && *(p + 1)) {
+    p = "b";
+    a = 1;
+  }
+
+// CHECK: Function: f2
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: int a;
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: p = "b"
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f3(_Nt_array_ptr<char> p : count(0)) {
+  if (p[0] && p[1] && 2[p]) {
+    a = 1;
+  }
+
+  if ((((0[p]))) && (((p[1]))) && ((p[2]))) {
+    a = 2;
+  }
+
+// CHECK: Function: f3
+// CHECK: Block: B9, Pred: Succ: B8
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B4
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B4
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: 2[p]
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B4, Pred: B5, B6, B7, B8, Succ: B3, B0
+// CHECK:   Widened bounds before stmt: (((0[p])))
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B0
+// CHECK:   Widened bounds before stmt: (((p[1])))
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: ((p[2]))
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 2 + 1)
+}
+
+void f4() {
+  char p _Nt_checked[] : count(0) = "abc";
+
+  if (p[0] && p[1] && p[2]) {
+    a = 1;
+  }
+
+// CHECK: Function: f4
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: p[2]
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f5(int i) {
+  char p _Nt_checked[] : bounds(p + i, p)  = "abc";
+
+  if (p[0] && p[1]) {
+    i = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (p[2]) {
+      a = 1;
+    }
+    a = 2;
+  }
+  a = 3;
+
+// CHECK: Function: f5
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p + i, p) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p + i, p)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p + i, p + 0 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: i = 0
+// CHECK:     p: bounds(p + i, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: p[2]
+// CHECK:     <none>
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B5, B6, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     <none>
+}
+
+void f6() {
+  _Nt_array_ptr<char> p : count(2) = "abc";
+
+  if (*p && *(p + 1) && *(p + 2) && *(p + 3)) {
+    a = 1;
+  }
+
+// CHECK: Function: f6
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(2) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, Succ: B0
+}
+
+void f7() {
+  _Nt_array_ptr<char> p : count(0) = "abc";
+
+  if (*p && *(p + 2) && *(p + 3) && *(p + 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f7
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, Succ: B0
+}
+
+void f8() {
+  _Nt_array_ptr<char> p : count(0) = "abc";
+
+  if (*p && *(p + 2) && *(p + 1) && *(p + 3) && *(p + 2) && *(p + 3)) {
+    a = 1;
+  }
+
+// CHECK: Function: f8
+// CHECK: Block: B9, Pred: Succ: B8
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, B7, B8, Succ: B0
+}
+
+void f9(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p + i) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*p && *(p + i) && *(p + i + 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f9
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + i + 1)
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f10(int i) {
+  _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
+
+  if (*(i + p + 1 + 2 + 3) && *(3 + p + i + 4) && *(p + i + 9)) {
+    a = 1;
+  }
+
+// CHECK: Function: f10
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(i + p + 1 + 2 + 3)
+// CHECK:     p: bounds(p, 1 + p + i + 5)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(3 + p + i + 4)
+// CHECK:     p: bounds(p, i + p + 1 + 2 + 3 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + i + 9)
+// CHECK:     p: bounds(p, 3 + p + i + 4 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, 3 + p + i + 4 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f11_1(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + j) && *(p + j + 1)) {
+    i = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (*(p + j + 2)) {
+      a = 1;
+    }
+  }
+
+// CHECK: Function: f11_1
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + j)
+// CHECK:     p: bounds(p + i, p + j)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + j + 1)
+// CHECK:     p: bounds(p + i, p + j + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: i = 0
+// CHECK:     p: bounds(p + i, p + j + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + j + 2)
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f11_2(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + j) && *(p + j + 1)) {
+    j = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (*(p + j + 2)) {
+      a = 1;
+    }
+  }
+
+// CHECK: Function: f11_2
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + j)
+// CHECK:     p: bounds(p + i, p + j)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + j + 1)
+// CHECK:     p: bounds(p + i, p + j + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: j = 0
+// CHECK:     p: bounds(p + i, p + j + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + j + 2)
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f12(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+
+  if (*(((p + i + j))) && *((p) + (1) + (i) + (0) + (j)) && *(1 + (p + i + j) + 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f12
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(((p + i + j)))
+// CHECK:     p: bounds(p, p + i + j)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *((p) + (1) + (i) + (0) + (j))
+// CHECK:     p: bounds(p, p + i + j + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(1 + (p + i + j) + 1)
+// CHECK:     p: bounds(p, (p) + (1) + (i) + (0) + (j) + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, 1 + (p + i + j) + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f13() {
+  char p _Nt_checked[] : count(1) = "a";
+
+  if (p[0] && 1[p] && p[2] && 3[p]) {
+    a = 1;
+  }
+
+// CHECK: Function: f13
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(1) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: 1[p]
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: p[2]
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: 3[p]
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, Succ: B0
+}
+
+void f14(int i) {
+  char p _Nt_checked[] : bounds(p, p + i) = "a";
+
+  if ((1 + i)[p] && p[i] && (2 + i + 1 - 1 + -1)[p]) {
+    a = 1;
+  }
+
+// CHECK: Function: f14
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p, p + i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: (1 + i)[p]
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: p[i]
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: (2 + i + 1 - 1 + -1)[p]
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (2 + i + 1 - 1 + -1) + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f15_1(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p - i) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+  if (*(p - i) && *(p - i + 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f15_1
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p - i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p - i)
+// CHECK:     p: bounds(p, p - i)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p - i + 1)
+// CHECK:     p: bounds(p, p - i + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p - i + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f15_2(int i) {
+  _Nt_array_ptr<char> q : count(0) = "a";
+  if (*q && *(q - 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f15_2
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *q
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(q - 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f15_3() {
+  _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
+  if (*(r + +1) && *(r + +2)) {
+    a = 1;
+  }
+
+// CHECK: Function: f15_3
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(r + +1)
+// CHECK:     r: bounds(r, r + +1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(r + +2)
+// CHECK:     r: bounds(r, r + +1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     r: bounds(r, r + +2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f15_4() {
+  _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
+  if (*(s + -1) && *(s) && *(s + +1)) { // expected-error {{out-of-bounds memory access}}
+    a = 1;
+  }
+
+// CHECK: Function: f15_4
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(s + -1)
+// CHECK:     s: bounds(s, s + -1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(s)
+// CHECK:     s: bounds(s, s + -1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(s + +1)
+// CHECK:     s: bounds(s, (s) + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     s: bounds(s, s + +1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
+  _Nt_array_ptr<char> q : bounds(p, p) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'q' imply the declared bounds of 'q' after initialization}}
+  _Nt_array_ptr<char> r : bounds(p, p + 1) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'r' imply the declared bounds of 'r' after initialization}}
+
+  if (*(p) && *(p + 1)) {
+    a = 1;
+  }
+
+  p = "b"; // expected-error {{inferred bounds for 'q' are unknown after assignment}} expected-error {{inferred bounds for 'r' are unknown after assignment}}
+  a = 2;
+
+// CHECK: Function: f16
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p) = "a";
+// CHECK:     p: bounds(p, p)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(p, p + 1) = "a";
+// CHECK:     p: bounds(p, p)
+// CHECK:     q: bounds(p, p)
+
+// CHECK:   Widened bounds before stmt: *(p)
+// CHECK:     p: bounds(p, p)
+// CHECK:     q: bounds(p, p)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, (p) + 1)
+// CHECK:     q: bounds(p, (p) + 1)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(p, p + 1 + 1)
+// CHECK:     r: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+// CHECK:   Widened bounds before stmt: p = "b"
+// CHECK:     p: bounds(p, p)
+// CHECK:     q: bounds(p, p)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+}
+
+void f17(char p _Nt_checked[] : count(1)) {
+  _Nt_array_ptr<char> q : bounds(p, p + 1) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'q' imply the declared bounds of 'q' after initialization}}
+  _Nt_array_ptr<char> r : bounds(p, p) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'r' imply the declared bounds of 'r' after initialization}}
+
+  if (*(p) && *(p + 1)) {
+    a = 1;
+  }
+
+  p = "b"; // expected-error {{inferred bounds for 'q' are unknown after assignment}} expected-error {{inferred bounds for 'r' are unknown after assignment}}
+  a = 2;
+
+// CHECK: Function: f17
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p + 1) = "a";
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(p, p) = "a";
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, p)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, (p) + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(p, p + 1 + 1)
+// CHECK:     r: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+// CHECK:   Widened bounds before stmt: p = "b"
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, p)
+
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+}
+
+void f18() {
+  char p _Nt_checked[] = "a";
+  char q _Nt_checked[] = "ab";
+  char r _Nt_checked[] : count(0) = "ab";
+  char s _Nt_checked[] : count(1) = "ab";
+
+// CHECK: Function: f18
+// CHECK: Block: B15, Pred: Succ: B14
+
+// CHECK: Block: B14, Pred: B15, Succ: B13, B11
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: char q_Nt_checked[] = "ab";
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: char r_Nt_checked[] : count(0) = "ab";
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+
+// CHECK:   Widened bounds before stmt: char s_Nt_checked[] : count(1) = "ab";
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+
+  if (p[0] && p[1]) {
+    a = 1;
+  }
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B13, Pred: B14, Succ: B12, B11
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B12, Pred: B13, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+  if (q[0] && q[1] && q[2]) {
+    a = 2;
+  }
+
+// CHECK: Block: B11, Pred: B12, B13, B14, Succ: B10, B7
+// CHECK:   Widened bounds before stmt: q[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B10, Pred: B11, Succ: B9, B7
+// CHECK:   Widened bounds before stmt: q[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B7
+// CHECK:   Widened bounds before stmt: q[2]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2 + 1)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+  if (r[0] && r[1]) {
+    a = 3;
+  }
+
+// CHECK: Block: B7, Pred: B8, B9, B10, B11, Succ: B6, B4
+// CHECK:   Widened bounds before stmt: r[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: r[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0 + 1)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 1 + 1)
+// CHECK:     s: bounds(s, s + 1)
+
+  if (s[0] && s[1]) {
+    a = 4;
+  }
+
+// CHECK: Block: B4, Pred: B5, B6, B7, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: s[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: s[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f19() {
+  _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
+
+  if (*(((p + 1))) && *(((p + 2)))) {
+    a = 1;
+  }
+
+// CHECK: Function: f19
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(((p + 1)))
+// CHECK:     p: bounds(p, ((((((p + 1)))))))
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(((p + 2)))
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f20(_Nt_array_ptr<char> p : count(i), int i) {
+  if (*(p + i) && *(p + i + 1)) {
+    a == 1 ? i++ : a++;  // expected-error {{inferred bounds for 'p' are unknown after increment}}
+
+    if (*(p + i + 2)) {
+      a = 3;
+    }
+  }
+
+// CHECK: Function: f20
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B0
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B0
+// CHECK:   Widened bounds before stmt: *(p + i + 1)
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B3, B4
+// CHECK:   Widened bounds before stmt: a == 1
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a++
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+
+// CHECK: Block: B3, Pred: B5, Succ: B2
+// CHECK:   Widened bounds before stmt: i++
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: a == 1 ? i++ : a++
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + i + 2)
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     <none>
+}
+
+void f21() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  if (((*p && *(p + 1)) && *(p + 2)) && (*(p + 3) && *(p + 4))) {
+    a = 1;
+  }
+
+// CHECK: Function: f21
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 4)
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 4 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, B7, Succ: B0
+}
+
+void f22() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  _Nt_array_ptr<char> q : count(0) = "";
+
+  if (((*p && *(p + 1))) && *(p + 2) && (*q && *(q + 1)) && (*(p + 3) && *(p + 4))) {
+    a = 1;
+  }
+
+// CHECK: Function: f22
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "";
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: *q
+// CHECK:     p: bounds(p, p + 2 + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(q + 1)
+// CHECK:     p: bounds(p, p + 2 + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 2 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 4)
+// CHECK:     p: bounds(p, p + 3 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 4 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, B7, B8, B9, Succ: B0
+}
+
+void f23() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  _Nt_array_ptr<char> q : count(1) = "a";
+  _Nt_array_ptr<char> r : count(2) = "ab";
+
+  if (*(r + 2) && *(p) && *(1 + q) && *(1 + p) && *(r + 3) && *(q + 2)) {
+    a = 1;
+  }
+
+// CHECK: Function: f23
+// CHECK: Block: B9, Pred: Succ: B8
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(1) = "a";
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : count(2) = "ab";
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK:   Widened bounds before stmt: *(r + 2)
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *(p)
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+// CHECK:     r: bounds(r, r + 2 + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: *(1 + q)
+// CHECK:     p: bounds(p, (p) + 1)
+// CHECK:     q: bounds(q, q + 1)
+// CHECK:     r: bounds(r, r + 2 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(1 + p)
+// CHECK:     p: bounds(p, (p) + 1)
+// CHECK:     q: bounds(q, 1 + q + 1)
+// CHECK:     r: bounds(r, r + 2 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(r + 3)
+// CHECK:     p: bounds(p, 1 + p + 1)
+// CHECK:     q: bounds(q, 1 + q + 1)
+// CHECK:     r: bounds(r, r + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(q + 2)
+// CHECK:     p: bounds(p, 1 + p + 1)
+// CHECK:     q: bounds(q, 1 + q + 1)
+// CHECK:     r: bounds(r, r + 3 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, 1 + p + 1)
+// CHECK:     q: bounds(q, q + 2 + 1)
+// CHECK:     r: bounds(r, r + 3 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, B7, B8, Succ: B0
+}
+
+void f24() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p || *(p + 1)) { // expected-error {{out-of-bounds memory access}}
+    a = 1;
+  }
+
+// CHECK: Function: f24
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B2, B3
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f25() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if ((*p || *(p + 1)) && *p && (*(p + 1) || *p) && *(p + 1)) { // expected-error {{out-of-bounds memory access}}
+    a = 1;
+  }
+
+// CHECK: Function: f25
+// CHECK: Block: B9, Pred: Succ: B8
+
+// CHECK: Block: B8, Pred: B9, Succ: B6, B7
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, B8, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B3, B4
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B6, B7, Succ: B0
+}
+
+void f26() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p && a > 0) {
+    a = 1;
+  }
+
+// CHECK: Function: f26
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a > 0
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f27() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  while (*p && *(p + 1) && *(p + 2)) {
+    a = 1;
+  }
+
+  for (int i = 0; *p && *(p + 1); ++i) {
+    a = 2;
+  }
+
+// CHECK: Function: f27
+// CHECK: Block: B13, Pred: Succ: B12
+
+// CHECK: Block: B12, Pred: B13, Succ: B11
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK: Block: B11, Pred: B7, B12, Succ: B10, B6
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B10, Pred: B11, Succ: B9, B6
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B6
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B7, Pred: B8, Succ: B11
+
+// CHECK: Block: B6, Pred: B9, B10, B11, Succ: B5
+// CHECK:   Widened bounds before stmt: int i = 0;
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B2, B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B5
+// CHECK:   Widened bounds before stmt: ++i
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B4, B5, Succ: B0
+}

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
@@ -940,7 +940,7 @@ void f20(_Nt_array_ptr<char> p : count(i), int i) {
 
 // CHECK: Block: B2, Pred: B3, B4, Succ: B1, B0
 // CHECK:   Widened bounds before stmt: a == 1 ? i++ : a++
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i + 1 + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + i + 2)
 // CHECK:     <none>

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
@@ -19,7 +19,7 @@ void f1() {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -53,7 +53,7 @@ void f2() {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: int a;
 // CHECK:     p: bounds(p, p + 0)
@@ -70,7 +70,7 @@ void f2() {
 // CHECK:     p: bounds(p, p + 1 + 1)
 
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
 }
@@ -112,7 +112,7 @@ void f4() {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[0]
 // CHECK:     p: bounds(p, p + 0)
@@ -149,7 +149,7 @@ void f5(int i) {
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p + i, p) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[0]
 // CHECK:     p: bounds(p + i, p)
@@ -163,19 +163,19 @@ void f5(int i) {
 // CHECK:     p: bounds(p + i, p + 1 + 1)
 
 // CHECK:   Widened bounds before stmt: p[2]
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 
 // CHECK: Block: B3, Pred: B4, Succ: B2
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 
 // CHECK: Block: B2, Pred: B3, B4, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 
 // CHECK: Block: B1, Pred: B2, B5, B6, Succ: B0
 // CHECK:   Widened bounds before stmt: a = 3
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 }
 
 void f6() {
@@ -190,7 +190,7 @@ void f6() {
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(2) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 2)
@@ -226,7 +226,7 @@ void f7() {
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -262,7 +262,7 @@ void f8() {
 
 // CHECK: Block: B8, Pred: B9, Succ: B7, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -306,7 +306,7 @@ void f9(int i) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + i)
@@ -338,7 +338,7 @@ void f10(int i) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(i + p + 1 + 2 + 3)
 // CHECK:     p: bounds(p, 1 + p + i + 5)
@@ -373,7 +373,7 @@ void f11_1(int i, int j) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + j)
 // CHECK:     p: bounds(p + i, p + j)
@@ -387,11 +387,11 @@ void f11_1(int i, int j) {
 // CHECK:     p: bounds(p + i, p + j + 1 + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + j + 2)
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B2, Pred: B3, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
 }
@@ -411,7 +411,7 @@ void f11_2(int i, int j) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + j)
 // CHECK:     p: bounds(p + i, p + j)
@@ -425,11 +425,11 @@ void f11_2(int i, int j) {
 // CHECK:     p: bounds(p + i, p + j + 1 + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + j + 2)
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B2, Pred: B3, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
 }
@@ -446,7 +446,7 @@ void f12(int i, int j) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(((p + i + j)))
 // CHECK:     p: bounds(p, p + i + j)
@@ -478,7 +478,7 @@ void f13() {
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(1) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[0]
 // CHECK:     p: bounds(p, p + 1)
@@ -514,7 +514,7 @@ void f14(int i) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p, p + i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: (1 + i)[p]
 // CHECK:     p: bounds(p, p + i)
@@ -545,7 +545,7 @@ void f15_1(int i) {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p - i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p - i)
 // CHECK:     p: bounds(p, p - i)
@@ -572,7 +572,7 @@ void f15_2(int i) {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *q
 // CHECK:     q: bounds(q, q + 0)
@@ -599,7 +599,7 @@ void f15_3() {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(r + +1)
 // CHECK:     r: bounds(r, r + +1)
@@ -626,7 +626,7 @@ void f15_4() {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(s + -1)
 // CHECK:     s: bounds(s, s + -1)
@@ -692,7 +692,9 @@ void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
 // CHECK:     r: bounds(p, p + 1)
 
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p)
+// CHECK:     q: bounds(p, p)
+// CHECK:     r: bounds(p, p + 1)
 }
 
 void f17(char p _Nt_checked[] : count(1)) {
@@ -741,7 +743,9 @@ void f17(char p _Nt_checked[] : count(1)) {
 // CHECK:     r: bounds(p, p)
 
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, p)
 }
 
 void f18() {
@@ -755,7 +759,7 @@ void f18() {
 
 // CHECK: Block: B14, Pred: B15, Succ: B13, B11
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: char q_Nt_checked[] = "ab";
 // CHECK:     p: bounds(p, p + 1)
@@ -890,7 +894,7 @@ void f19() {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(((p + 1)))
 // CHECK:     p: bounds(p, ((((((p + 1)))))))
@@ -943,11 +947,11 @@ void f20(_Nt_array_ptr<char> p : count(i), int i) {
 // CHECK:     p: bounds(p, p + i + 1 + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + i + 2)
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i)
 
 // CHECK: Block: B1, Pred: B2, Succ: B0
 // CHECK:   Widened bounds before stmt: a = 3
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i)
 }
 
 void f21() {
@@ -962,7 +966,7 @@ void f21() {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -1003,7 +1007,7 @@ void f22() {
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "";
 // CHECK:     p: bounds(p, p + 0)
@@ -1064,7 +1068,7 @@ void f23() {
 
 // CHECK: Block: B8, Pred: B9, Succ: B7, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(1) = "a";
 // CHECK:     p: bounds(p, p + 0)
@@ -1129,7 +1133,7 @@ void f24() {
 
 // CHECK: Block: B4, Pred: B5, Succ: B2, B3
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -1157,7 +1161,7 @@ void f25() {
 
 // CHECK: Block: B8, Pred: B9, Succ: B6, B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -1201,7 +1205,7 @@ void f26() {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -1233,7 +1237,7 @@ void f27() {
 
 // CHECK: Block: B12, Pred: B13, Succ: B11
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B11, Pred: B7, B12, Succ: B10, B6
 // CHECK:   Widened bounds before stmt: *p

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-multiple-derefs.c
@@ -15,7 +15,7 @@ void f1() {
   }
 
 // CHECK: Function: f1
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -49,7 +49,7 @@ void f2() {
   }
 
 // CHECK: Function: f2
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -81,7 +81,7 @@ void f3(_Nt_array_ptr<char> p : count(0)) {
   }
 
 // CHECK: Function: f3
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B0
 // CHECK:   Widened bounds before stmt: (((0[p])))
@@ -108,7 +108,7 @@ void f4() {
   }
 
 // CHECK: Function: f4
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
@@ -145,7 +145,7 @@ void f5(int i) {
   a = 3;
 
 // CHECK: Function: f5
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p + i, p) = "abc";
@@ -186,7 +186,7 @@ void f6() {
   }
 
 // CHECK: Function: f6
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(2) = "abc";
@@ -222,7 +222,7 @@ void f7() {
   }
 
 // CHECK: Function: f7
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "abc";
@@ -258,7 +258,7 @@ void f8() {
   }
 
 // CHECK: Function: f8
-// CHECK: Block: B9, Pred: Succ: B8
+// CHECK: Block: B9 (Entry), Pred: Succ: B8
 
 // CHECK: Block: B8, Pred: B9, Succ: B7, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "abc";
@@ -302,7 +302,7 @@ void f9(int i) {
   }
 
 // CHECK: Function: f9
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
@@ -334,7 +334,7 @@ void f10(int i) {
   }
 
 // CHECK: Function: f10
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
@@ -369,7 +369,7 @@ void f11_1(int i, int j) {
   }
 
 // CHECK: Function: f11_1
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
@@ -407,7 +407,7 @@ void f11_2(int i, int j) {
   }
 
 // CHECK: Function: f11_2
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
@@ -442,7 +442,7 @@ void f12(int i, int j) {
   }
 
 // CHECK: Function: f12
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
@@ -474,7 +474,7 @@ void f13() {
   }
 
 // CHECK: Function: f13
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(1) = "a";
@@ -510,7 +510,7 @@ void f14(int i) {
   }
 
 // CHECK: Function: f14
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p, p + i) = "a";
@@ -541,7 +541,7 @@ void f15_1(int i) {
   }
 
 // CHECK: Function: f15_1
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p - i) = "a";
@@ -568,7 +568,7 @@ void f15_2(int i) {
   }
 
 // CHECK: Function: f15_2
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "a";
@@ -595,7 +595,7 @@ void f15_3() {
   }
 
 // CHECK: Function: f15_3
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
@@ -622,7 +622,7 @@ void f15_4() {
   }
 
 // CHECK: Function: f15_4
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
@@ -658,7 +658,7 @@ void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
   a = 2;
 
 // CHECK: Function: f16
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p) = "a";
@@ -707,7 +707,7 @@ void f17(char p _Nt_checked[] : count(1)) {
   a = 2;
 
 // CHECK: Function: f17
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p + 1) = "a";
@@ -751,7 +751,7 @@ void f18() {
   char s _Nt_checked[] : count(1) = "ab";
 
 // CHECK: Function: f18
-// CHECK: Block: B15, Pred: Succ: B14
+// CHECK: Block: B15 (Entry), Pred: Succ: B14
 
 // CHECK: Block: B14, Pred: B15, Succ: B13, B11
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] = "a";
@@ -886,7 +886,7 @@ void f19() {
   }
 
 // CHECK: Function: f19
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
@@ -916,7 +916,7 @@ void f20(_Nt_array_ptr<char> p : count(i), int i) {
   }
 
 // CHECK: Function: f20
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B0
 // CHECK:   Widened bounds before stmt: *(p + i)
@@ -958,7 +958,7 @@ void f21() {
   }
 
 // CHECK: Function: f21
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -999,7 +999,7 @@ void f22() {
   }
 
 // CHECK: Function: f22
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -1060,7 +1060,7 @@ void f23() {
   }
 
 // CHECK: Function: f23
-// CHECK: Block: B9, Pred: Succ: B8
+// CHECK: Block: B9 (Entry), Pred: Succ: B8
 
 // CHECK: Block: B8, Pred: B9, Succ: B7, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -1125,7 +1125,7 @@ void f24() {
   }
 
 // CHECK: Function: f24
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B2, B3
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -1153,7 +1153,7 @@ void f25() {
   }
 
 // CHECK: Function: f25
-// CHECK: Block: B9, Pred: Succ: B8
+// CHECK: Block: B9 (Entry), Pred: Succ: B8
 
 // CHECK: Block: B8, Pred: B9, Succ: B6, B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -1197,7 +1197,7 @@ void f26() {
   }
 
 // CHECK: Function: f26
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -1229,7 +1229,7 @@ void f27() {
   }
 
 // CHECK: Function: f27
-// CHECK: Block: B13, Pred: Succ: B12
+// CHECK: Block: B13 (Entry), Pred: Succ: B12
 
 // CHECK: Block: B12, Pred: B13, Succ: B11
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-semantic-compare.c
@@ -1,0 +1,431 @@
+// Tests for bounds widening of null-terminated arrays using the preorder AST
+// to semantically compare two expressions.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
+
+int a;
+
+void f1(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p + i) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(i + p)) {
+    a = 1;
+  }
+
+// CHECK: Function: f1
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(i + p)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, i + p + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f2(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + (j + i))) {
+    a = 1;
+  }
+
+// CHECK: Function: f2
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + (j + i))
+// CHECK:     p: bounds(p, p + (i + j))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (j + i) + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f3(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + (j * i))) {
+    a = 1;
+  }
+
+// CHECK: Function: f3
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + (j * i))
+// CHECK:     p: bounds(p, p + (i * j))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (j * i) + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f4(int i, int j, int k, int m, int n) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j + k + m + n) = "a";
+
+  if (*(n + m + k + j + i + p)) {
+    a = 1;
+  }
+
+// CHECK: Function: f4
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + k + m + n) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(n + m + k + j + i + p)
+// CHECK:     p: bounds(p, p + i + j + k + m + n)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, n + m + k + j + i + p + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f5(int i, int j, int k, int m, int n) {
+  _Nt_array_ptr<char> p : bounds(p, (p + i) + (j + k) + (m + n)) = "a";
+
+  if (*((n + m + k) + (j + i + p))) {
+    a = 1;
+  }
+
+// CHECK: Function: f5
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j + k) + (m + n)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *((n + m + k) + (j + i + p))
+// CHECK:     p: bounds(p, (p + i) + (j + k) + (m + n))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, (n + m + k) + (j + i + p) + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f6(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j + i + j) = "a";
+
+  if (*(j + j + p + i + i)) {
+    a = 1;
+  }
+
+// CHECK: Function: f6
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + i + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(j + j + p + i + i)
+// CHECK:     p: bounds(p, p + i + j + i + j)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, j + j + p + i + i + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f7(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + i + j)) {
+    a = 1;
+  }
+
+// CHECK: Function: f7
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + i + j)
+// CHECK:     p: bounds(p, p + i * j)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i * j)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f8(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+
+  if (*(p + i + i)) {
+    a = 1;
+  }
+
+// CHECK: Function: f8
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + i + i)
+// CHECK:     p: bounds(p, p + i + j)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i + j)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f9(int i, int j, int k) {
+  _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
+
+  if (*((p + i) + (j * k))) {
+    a = 1;
+  }
+
+// CHECK: Function: f9
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *((p + i) + (j * k))
+// CHECK:     p: bounds(p, (p + i) + (j * k))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, (p + i) + (j * k) + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f10(int i, int j, int k) {
+  _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
+
+  if (*((p + i) + (j + k))) {
+    a = 1;
+  }
+
+// CHECK: Function: f10
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *((p + i) + (j + k))
+// CHECK:     p: bounds(p, (p + i) + (j * k))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, (p + i) + (j * k))
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f11(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+
+  if (*(j + i + p)) {
+    a = 1;
+    if (*(i + j + p - 1 - -4 + -2)) {
+      a = 2;
+    }
+  }
+
+// CHECK: Function: f11
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(j + i + p)
+// CHECK:     p: bounds(p, p + i + j)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, j + i + p + 1)
+
+// CHECK:   Widened bounds before stmt: *(i + j + p - 1 - -4 + -2)
+// CHECK:     p: bounds(p, j + i + p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, i + j + p - 1 - -4 + -2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f12() {
+  _Nt_array_ptr<char> p : bounds(p, p) = "a";
+
+  if (*(p + 0)) {
+    a = 1;
+    if (*(p + 1 - 1 + -1 - +1 - -3)) {
+      a = 2;
+    }
+  }
+
+// CHECK: Function: f12
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + 0)
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1 - 1 + -1 - +1 - -3)
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 - 1 + -1 - +1 - -3 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f13(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + (i * j * 2 + 2 + 1)) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + (i * j * 2 + 3))) {
+    a = 1;
+    if (*(p + (i * j * 2 + 1 + 1 + 1) + 1)) {
+      a = 2;
+    }
+  }
+
+// CHECK: Function: f13
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * j * 2 + 2 + 1)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + (i * j * 2 + 3))
+// CHECK:     p: bounds(p, p + (i * j * 2 + 2 + 1))
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (i * j * 2 + 3) + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + (i * j * 2 + 1 + 1 + 1) + 1)
+// CHECK:     p: bounds(p, p + (i * j * 2 + 3) + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + (i * j * 2 + 1 + 1 + 1) + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f14(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p + (i * 1)) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + (i * 2))) {
+    a = 1;
+  }
+
+// CHECK: Function: f14
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * 1)) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + (i * 2))
+// CHECK:     p: bounds(p, p + (i * 1))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (i * 1))
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f15(_Nt_array_ptr<char> p : count(6)) {
+  if (*(p + (1 * (2 * 3)))) {
+    a = 1;
+  }
+
+// CHECK: Function: f15
+// CHECK: Block: B3, Pred: Succ: B2
+
+// CHECK: Block: B2, Pred: B3, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: *(p + (1 * (2 * 3)))
+// CHECK:     p: bounds(p, p + 6)
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (1 * (2 * 3)) + 1)
+}
+
+void f16(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j + 8) = "a";
+  if (*(p + (i + 3 * 2 + (j + 2)))) {
+    a = 1;
+  }
+
+// CHECK: Function: f16
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + 8) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + (i + 3 * 2 + (j + 2)))
+// CHECK:     p: bounds(p, p + i + j + 8)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + (i + 3 * 2 + (j + 2)) + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f17(_Nt_array_ptr<char> p : bounds(p - 10, p - 3)) {
+  if (p[-(1 + 2)]) {
+    a = 1;
+  }
+
+// CHECK: Function: f17
+// CHECK: Block: B3, Pred: Succ: B2
+
+// CHECK: Block: B2, Pred: B3, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: p[-(1 + 2)]
+// CHECK:     p: bounds(p - 10, p - 3)
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p - 10, p + -(1 + 2) + 1)
+}

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-semantic-compare.c
@@ -15,7 +15,7 @@ void f1(int i) {
   }
 
 // CHECK: Function: f1
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
@@ -39,7 +39,7 @@ void f2(int i, int j) {
   }
 
 // CHECK: Function: f2
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a";
@@ -63,7 +63,7 @@ void f3(int i, int j) {
   }
 
 // CHECK: Function: f3
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a";
@@ -87,7 +87,7 @@ void f4(int i, int j, int k, int m, int n) {
   }
 
 // CHECK: Function: f4
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + k + m + n) = "a";
@@ -111,7 +111,7 @@ void f5(int i, int j, int k, int m, int n) {
   }
 
 // CHECK: Function: f5
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j + k) + (m + n)) = "a";
@@ -135,7 +135,7 @@ void f6(int i, int j) {
   }
 
 // CHECK: Function: f6
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + i + j) = "a";
@@ -159,7 +159,7 @@ void f7(int i, int j) {
   }
 
 // CHECK: Function: f7
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a";
@@ -183,7 +183,7 @@ void f8(int i, int j) {
   }
 
 // CHECK: Function: f8
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
@@ -207,7 +207,7 @@ void f9(int i, int j, int k) {
   }
 
 // CHECK: Function: f9
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
@@ -231,7 +231,7 @@ void f10(int i, int j, int k) {
   }
 
 // CHECK: Function: f10
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
@@ -258,7 +258,7 @@ void f11(int i, int j) {
   }
 
 // CHECK: Function: f11
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
@@ -292,7 +292,7 @@ void f12() {
   }
 
 // CHECK: Function: f12
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p) = "a";
@@ -326,7 +326,7 @@ void f13(int i, int j) {
   }
 
 // CHECK: Function: f13
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * j * 2 + 2 + 1)) = "a";
@@ -357,7 +357,7 @@ void f14(int i) {
   }
 
 // CHECK: Function: f14
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * 1)) = "a";
@@ -379,7 +379,7 @@ void f15(_Nt_array_ptr<char> p : count(6)) {
   }
 
 // CHECK: Function: f15
-// CHECK: Block: B3, Pred: Succ: B2
+// CHECK: Block: B3 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B2, Pred: B3, Succ: B1, B0
 // CHECK:   Widened bounds before stmt: *(p + (1 * (2 * 3)))
@@ -397,7 +397,7 @@ void f16(int i, int j) {
   }
 
 // CHECK: Function: f16
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + 8) = "a";
@@ -419,7 +419,7 @@ void f17(_Nt_array_ptr<char> p : bounds(p - 10, p - 3)) {
   }
 
 // CHECK: Function: f17
-// CHECK: Block: B3, Pred: Succ: B2
+// CHECK: Block: B3 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B2, Pred: B3, Succ: B1, B0
 // CHECK:   Widened bounds before stmt: p[-(1 + 2)]

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-semantic-compare.c
@@ -19,7 +19,7 @@ void f1(int i) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(i + p)
 // CHECK:     p: bounds(p, p + i)
@@ -43,7 +43,7 @@ void f2(int i, int j) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i + j)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + (j + i))
 // CHECK:     p: bounds(p, p + (i + j))
@@ -67,7 +67,7 @@ void f3(int i, int j) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * j)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + (j * i))
 // CHECK:     p: bounds(p, p + (i * j))
@@ -91,7 +91,7 @@ void f4(int i, int j, int k, int m, int n) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + k + m + n) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(n + m + k + j + i + p)
 // CHECK:     p: bounds(p, p + i + j + k + m + n)
@@ -115,7 +115,7 @@ void f5(int i, int j, int k, int m, int n) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j + k) + (m + n)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *((n + m + k) + (j + i + p))
 // CHECK:     p: bounds(p, (p + i) + (j + k) + (m + n))
@@ -139,7 +139,7 @@ void f6(int i, int j) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + i + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(j + j + p + i + i)
 // CHECK:     p: bounds(p, p + i + j + i + j)
@@ -163,7 +163,7 @@ void f7(int i, int j) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i * j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + i + j)
 // CHECK:     p: bounds(p, p + i * j)
@@ -187,7 +187,7 @@ void f8(int i, int j) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + i + i)
 // CHECK:     p: bounds(p, p + i + j)
@@ -211,7 +211,7 @@ void f9(int i, int j, int k) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *((p + i) + (j * k))
 // CHECK:     p: bounds(p, (p + i) + (j * k))
@@ -235,7 +235,7 @@ void f10(int i, int j, int k) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, (p + i) + (j * k)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *((p + i) + (j + k))
 // CHECK:     p: bounds(p, (p + i) + (j * k))
@@ -262,7 +262,7 @@ void f11(int i, int j) {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(j + i + p)
 // CHECK:     p: bounds(p, p + i + j)
@@ -296,7 +296,7 @@ void f12() {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + 0)
 // CHECK:     p: bounds(p, p)
@@ -330,7 +330,7 @@ void f13(int i, int j) {
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * j * 2 + 2 + 1)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + (i * j * 2 + 3))
 // CHECK:     p: bounds(p, p + (i * j * 2 + 2 + 1))
@@ -361,7 +361,7 @@ void f14(int i) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + (i * 1)) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + (i * 2))
 // CHECK:     p: bounds(p, p + (i * 1))
@@ -401,7 +401,7 @@ void f16(int i, int j) {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j + 8) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + (i + 3 * 2 + (j + 2)))
 // CHECK:     p: bounds(p, p + i + j + 8)

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-where-clauses.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-where-clauses.c
@@ -1,0 +1,414 @@
+// Tests for bounds widening of null-terminated arrays in presence of where
+// clauses.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
+
+int a;
+
+void f1(_Nt_array_ptr<char> p : bounds(p, p + 1)) {
+  if (*(p + 1)) {
+    a = 1;
+  }
+
+  int x = 1 _Where p : bounds(p, p + x);
+
+  if (*(p + 1)) {
+    a = 2;
+  }
+
+  if (*(p + x)) {
+    a = 3;
+    if (*(p + x + 1)) {
+      a = 4;
+      if (*(p + x + 2)) {
+        a = 5;
+      }
+    }
+  }
+
+// CHECK: Function: f1
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B7
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B7, Pred: B8, B9, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: int x = 1;
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B5, Pred: B6, B7, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + x)
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + x + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + x + 1)
+// CHECK:     p: bounds(p, p + x + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + x + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + x + 2)
+// CHECK:     p: bounds(p, p + x + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + x + 2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, Succ: B0
+}
+
+void f2() {
+  _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
+  int x = 1 _Where p : count(x);
+
+  if (*(p + 1)) {
+    a = 1;
+  } else if (*(p + x)) {
+    a = 2;
+  }
+
+// CHECK: Function: f2
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: int x = 1;
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B4, Pred: B5, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B3, Pred: B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + x)
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + x + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f3(_Nt_array_ptr<char> p : bounds(p, p + 1)) {
+  int x = 1 _Where p : bounds(p, p + x);
+
+  if (*(p + x)) {
+    x = 0;
+    if (*(p + x + 1)) {
+      a = 1;
+    }
+  }
+
+// CHECK: Function: f3
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: int x = 1;
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + x)
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: x = 0
+// CHECK:     p: bounds(p, p + x + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + x + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f4(_Nt_array_ptr<char> p : bounds(p, p + i), int i) {
+  if (*(p + i)) {
+    i = 0;  // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (*(p + i + 1)) {
+      a = 1 _Where p : bounds(p, p + i);
+      if (*(p + i)) {
+        a = 2;
+      }
+    }
+  }
+
+// CHECK: Function: f4
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B2
+// CHECK:   Widened bounds before stmt: i = 0
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + i + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + i + 1)
+
+  if (*(p + i)) {
+    a = 3;
+  }
+
+// CHECK: Block: B2, Pred: B3, B4, B5, B6, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     <none>
+}
+
+void f5() {
+  _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
+  _Nt_array_ptr<char> q : bounds(p, p + 1) = p;
+
+  if (*(p + 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f5
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p + 1) = p;
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(p, p + 1 + 1)
+
+  a = 2 _Where q : bounds(q, q + 1);
+
+  if (*(p + 1)) {
+    a = 3;
+  }
+
+// CHECK: Block: B5, Pred: B6, B7, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+  if (*(q + 1)) {
+    a = 4;
+  }
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(q + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, q + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f6() {
+  _Nt_array_ptr<char> p = "a";
+  _Nt_array_ptr<char> q  = "b";
+  _Nt_array_ptr<char> r  = "c";
+
+  int x = 1 _Where p : bounds(p, p + x + 1) _And q : count(x) _And r : bounds(p, p + x);
+
+  if (*(p + x) && *(p + x + 1) && *(q + x) && *(q + x + 1)) {
+    a = 1;
+  }
+
+// CHECK: Function: f6
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "b";
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : count(0) = "c";
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK:   Widened bounds before stmt: int x = 1;
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+// CHECK:     r: bounds(r, r + 0)
+
+// CHECK:   Widened bounds before stmt: *(p + x)
+// CHECK:     p: bounds(p, p + x + 1)
+// CHECK:     q: bounds(q, q + x)
+// CHECK:     r: bounds(p, p + x)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + x + 1)
+// CHECK:     p: bounds(p, p + x + 1)
+// CHECK:     q: bounds(q, q + x)
+// CHECK:     r: bounds(r, p + x + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(q + x)
+// CHECK:     p: bounds(p, p + x + 1 + 1)
+// CHECK:     q: bounds(q, q + x)
+// CHECK:     r: bounds(r, p + x + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(q + x + 1)
+// CHECK:     p: bounds(p, p + x + 1 + 1)
+// CHECK:     q: bounds(q, q + x + 1)
+// CHECK:     r: bounds(r, p + x + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + x + 1 + 1)
+// CHECK:     q: bounds(q, q + x + 1 + 1)
+// CHECK:     r: bounds(r, p + x + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, Succ: B0
+}
+
+void f7() {
+  _Nt_array_ptr<char> p = "a";
+
+  int x = 1 _Where x > 0 _And p : count(x) _And 1 == 1 _And p : count(x + 10);
+
+  if (*(p + x)) {
+    a = 1;
+  }
+
+  if (*(p + x + 10)) {
+    a = 2;
+  }
+
+// CHECK: Function: f7
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: int x = 1;
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: *(p + x)
+// CHECK:     p: bounds(p, p + x + 10)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + x + 10)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + x + 10)
+// CHECK:     p: bounds(p, p + x + 10)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + x + 10 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f8() {
+  _Nt_array_ptr<char> p = "a";
+
+  while (*p) {
+    p = "b" _Where p : count(0);
+  }
+
+// CHECK: Function: f8
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK: Block: B8, Pred: B6, B9, Succ: B7, B5
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: p = "b"
+// CHECK:     p: bounds(p, p + 1)
+
+  int x = 1 _Where p : bounds(p, p + x);
+
+  while (*(p + x)) {
+    x = 0;
+    a = 1 _Where p : bounds(p, p + x);
+  }
+
+// CHECK: Block: B6, Pred: B7, Succ: B8
+
+// CHECK: Block: B5, Pred: B8, Succ: B4
+// CHECK:   Widened bounds before stmt: int x = 1;
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B2, B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + x)
+// CHECK:     p: bounds(p, p + x)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: x = 0
+// CHECK:     p: bounds(p, p + x + 1)
+
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, Succ: B4
+
+// CHECK: Block: B1, Pred: B4, Succ: B0
+}

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-where-clauses.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-where-clauses.c
@@ -29,7 +29,7 @@ void f1(_Nt_array_ptr<char> p : bounds(p, p + 1)) {
   }
 
 // CHECK: Function: f1
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B7
 // CHECK:   Widened bounds before stmt: *(p + 1)
@@ -86,7 +86,7 @@ void f2() {
   }
 
 // CHECK: Function: f2
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B3
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
@@ -124,7 +124,7 @@ void f3(_Nt_array_ptr<char> p : bounds(p, p + 1)) {
   }
 
 // CHECK: Function: f3
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: int x = 1;
@@ -159,7 +159,7 @@ void f4(_Nt_array_ptr<char> p : bounds(p, p + i), int i) {
   }
 
 // CHECK: Function: f4
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B2
 // CHECK:   Widened bounds before stmt: *(p + i)
@@ -205,7 +205,7 @@ void f5() {
   }
 
 // CHECK: Function: f5
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B5
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
@@ -271,7 +271,7 @@ void f6() {
   }
 
 // CHECK: Function: f6
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -335,7 +335,7 @@ void f7() {
   }
 
 // CHECK: Function: f7
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B3
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -370,7 +370,7 @@ void f8() {
   }
 
 // CHECK: Function: f8
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds-where-clauses.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds-where-clauses.c
@@ -90,7 +90,7 @@ void f2() {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B3
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: int x = 1;
 // CHECK:     p: bounds(p, p + 1)
@@ -138,11 +138,11 @@ void f3(_Nt_array_ptr<char> p : bounds(p, p + 1)) {
 // CHECK:     p: bounds(p, p + x + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + x + 1)
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 1)
 
 // CHECK: Block: B2, Pred: B3, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 1)
 
 // CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
 }
@@ -170,11 +170,11 @@ void f4(_Nt_array_ptr<char> p : bounds(p, p + i), int i) {
 // CHECK:     p: bounds(p, p + i + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + i + 1)
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i)
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B2
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i)
 
 // CHECK:   Widened bounds before stmt: *(p + i)
 // CHECK:     p: bounds(p, p + i)
@@ -189,11 +189,11 @@ void f4(_Nt_array_ptr<char> p : bounds(p, p + i), int i) {
 
 // CHECK: Block: B2, Pred: B3, B4, B5, B6, Succ: B1, B0
 // CHECK:   Widened bounds before stmt: *(p + i)
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i)
 
 // CHECK: Block: B1, Pred: B2, Succ: B0
 // CHECK:   Widened bounds before stmt: a = 3
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i + 1)
 }
 
 void f5() {
@@ -209,7 +209,7 @@ void f5() {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B5
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p + 1) = p;
 // CHECK:     p: bounds(p, p + 1)
@@ -275,7 +275,7 @@ void f6() {
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "b";
 // CHECK:     p: bounds(p, p + 0)
@@ -339,7 +339,7 @@ void f7() {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B3
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: int x = 1;
 // CHECK:     p: bounds(p, p + 0)
@@ -374,7 +374,7 @@ void f8() {
 
 // CHECK: Block: B9, Pred: B10, Succ: B8
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B8, Pred: B6, B9, Succ: B7, B5
 // CHECK:   Widened bounds before stmt: *p
@@ -406,7 +406,7 @@ void f8() {
 // CHECK:     p: bounds(p, p + x + 1)
 
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B2, Pred: B3, Succ: B4
 

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -1,0 +1,2619 @@
+// Tests for datafow analysis for bounds widening of _Nt_array_ptr's.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+
+#include <limits.h>
+#include <stdint.h>
+
+int a;
+
+void f1() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p) {
+    a = 1;
+  }
+  a = 2;
+
+// CHECK: Function: f1
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+}
+
+void f2() {
+  _Nt_array_ptr<char> p : count(0) = "ab";
+
+  if (*p) {
+    a = 1;
+    if (*(p + 1)) {
+      a = 2;
+      if (*(p + 2)) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f2
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "ab";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, B6, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B1, Pred: B2, B7, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+}
+
+void f3() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p) {
+    p = "a";
+    if (a) {
+      a = 1;
+    }
+    a = 2;
+  }
+  a = 3;
+
+// CHECK: Function: f3
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: p = "a"
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: a
+// CHECK:     <none>
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B5, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     <none>
+}
+
+void f4(_Nt_array_ptr<char> p : count(0)) {
+  if (p[0]) {
+    a = 1;
+  }
+  a = 2;
+
+  _Nt_array_ptr<char> q : count(0) = "a";
+  if (0[q]) {
+    a = 3;
+  }
+  a = 4;
+
+  if ((((q[0])))) {
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f4
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B5, Pred: B6, B7, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "a";
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: 0[q]
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK:   Widened bounds before stmt: (((q[0])))
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+}
+
+void f5() {
+  char p _Nt_checked[] : count(0) = "abc";
+
+  if (p[0]) {
+    a = 1;
+    if (p[1]) {
+      a = 2;
+      if (p[2]) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f5
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: p[2]
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, B6, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B1, Pred: B2, B7, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+}
+
+void f6(int i) {
+  char p _Nt_checked[] : bounds(p + i, p)  = "abc";
+
+  if (p[0]) {
+    i = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (p[1]) {
+      a = 1;
+    }
+    a = 2;
+  }
+  a = 3;
+
+// CHECK: Function: f6
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p + i, p) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p + i, p)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: i = 0
+// CHECK:     p: bounds(p + i, p + 0 + 1)
+
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     <none>
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+}
+
+void f7(char p _Nt_checked[] : count(0)) {
+  if (p[0]) {
+    a = 1;
+  }
+  a = 2;
+
+  char q _Nt_checked[] : count(0) = "a";
+  if (0[q]) {
+    a = 3;
+  }
+  a = 4;
+
+  if ((((q[0])))) {
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f7
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B5, Pred: B6, B7, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: char q_Nt_checked[] : count(0) = "a";
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: 0[q]
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK:   Widened bounds before stmt: (((q[0])))
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+}
+
+void f8() {
+  _Nt_array_ptr<char> p : count(2) = "abc";
+
+  if (*p) {
+    a = 1;
+    if (*(p + 1)) {
+      a = 2;
+      if (*(p + 2)) {
+        a = 3;
+        if (*(p + 3)) {
+          a = 4;
+        }
+        a = 5;
+      }
+      a = 6;
+    }
+    a = 7;
+  }
+  a = 8;
+
+// CHECK: Function: f8
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(2) = "abc";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B4, Pred: B5, B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, B7, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B2, Pred: B3, B8, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 2)
+
+// CHECK: Block: B1, Pred: B2, B9, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 2)
+}
+
+void f9(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p + i) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*p) {
+    a = 1;
+    if (*(p + i)) {
+      a = 2;
+      if (*(p + i + 1)) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f9
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + i + 1)
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B2, Pred: B3, B6, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B1, Pred: B2, B7, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + i)
+}
+
+void f10(int i) {
+  _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
+
+  if (*(i + p + 1 + 2 + 3)) {
+    a = 1;
+    if (*(3 + p + i + 4)) {
+      a = 2;
+      if (*(p + i + 9)) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f10
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(i + p + 1 + 2 + 3)
+// CHECK:     p: bounds(p, 1 + p + i + 5)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, i + p + 1 + 2 + 3 + 1)
+
+// CHECK:   Widened bounds before stmt: *(3 + p + i + 4)
+// CHECK:     p: bounds(p, i + p + 1 + 2 + 3 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, 3 + p + i + 4 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + i + 9)
+// CHECK:     p: bounds(p, 3 + p + i + 4 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, 3 + p + i + 4 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, 3 + p + i + 4 + 1)
+
+// CHECK: Block: B2, Pred: B3, B6, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, i + p + 1 + 2 + 3 + 1)
+
+// CHECK: Block: B1, Pred: B2, B7, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, 1 + p + i + 5)
+}
+
+void f11(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p + j)) {
+    i = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (*(p + j + 1)) {
+      a = 1;
+    }
+    a = 2;
+  }
+  a = 3;
+
+// CHECK: Function: f11
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B5
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + j)
+// CHECK:     p: bounds(p + i, p + j)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B6
+// CHECK:   Widened bounds before stmt: i = 0
+// CHECK:     p: bounds(p + i, p + j + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + j + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B6, Pred: B7, B8, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+
+// CHECK: Block: B5, Pred: B6, B9, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     <none>
+
+  if (*(p + j)) {
+    j = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
+    if (*(p + j + 1)) {
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK:   Widened bounds before stmt: *(p + j)
+// CHECK:     <none>
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: j = 0
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + j + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     <none>
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, B5, Succ: B0
+// CHECK:     <none>
+}
+
+void f12(int i, int j) {
+  _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+
+  if (*(((p + i + j)))) {
+    a = 1;
+    if (*((p) + (i) + (j) + (1))) {
+      a = 2;
+      if (*((p + i + j) + 2)) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f12
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(((p + i + j)))
+// CHECK:     p: bounds(p, p + i + j)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i + j + 1)
+
+// CHECK:   Widened bounds before stmt: *((p) + (i) + (j) + (1))
+// CHECK:     p: bounds(p, p + i + j + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, (p) + (i) + (j) + (1) + 1)
+
+// CHECK:   Widened bounds before stmt: *((p + i + j) + 2)
+// CHECK:     p: bounds(p, (p) + (i) + (j) + (1) + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, (p + i + j) + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, (p) + (i) + (j) + (1) + 1)
+
+// CHECK: Block: B2, Pred: B3, B6, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + i + j + 1)
+
+// CHECK: Block: B1, Pred: B2, B7, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + i + j)
+}
+
+void f13() {
+  char p _Nt_checked[] : count(1) = "a";
+
+  if (p[0]) {
+    a = 1;
+    if (1[p]) {
+      a = 2;
+      if (p[2]) {
+        a = 3;
+        if (3[p]) {
+          a = 4;
+        }
+        a = 5;
+      }
+      a = 6;
+    }
+    a = 7;
+  }
+  a = 8;
+
+// CHECK: Function: f13
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(1) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: 1[p]
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: p[2]
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK:   Widened bounds before stmt: 3[p]
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B4, Pred: B5, B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B3, Pred: B4, B7, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, B8, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B1, Pred: B2, B9, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1)
+}
+
+void f14(int i) {
+  char p _Nt_checked[] : bounds(p, p + i) = "a";
+
+  if ((1 + i)[p]) {
+    a = 1;
+    if (p[i]) {
+      a = 2;
+      if ((1 + i)[p]) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f14
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p, p + i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: (1 + i)[p]
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK:   Widened bounds before stmt: p[i]
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK:   Widened bounds before stmt: (1 + i)[p]
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + (1 + i) + 1)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B2, Pred: B3, B6, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B1, Pred: B2, B7, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + i)
+}
+
+void f15(int i) {
+  _Nt_array_ptr<char> p : bounds(p, p - i) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after initialization}}
+
+  if (*(p - i)) {
+    a = 1;
+  }
+
+// CHECK: Function: f15
+// CHECK: Block: B11, Pred: Succ: B10
+
+// CHECK: Block: B10, Pred: B11, Succ: B9, B8
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p - i) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p - i)
+// CHECK:     p: bounds(p, p - i)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p - i + 1)
+
+  _Nt_array_ptr<char> q : count(0) = "a";
+  if (*q) {
+    a = 2;
+    if (*(q - 1)) {
+      a = 3;
+    }
+  }
+
+// CHECK: Block: B8, Pred: B9, B10, Succ: B7, B5
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count(0) = "a";
+// CHECK:     p: bounds(p, p - i)
+
+// CHECK:   Widened bounds before stmt: *q
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK:   Widened bounds before stmt: *(q - 1)
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 1)
+
+  _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
+  if (*(r + +1)) {
+    a = 4;
+  }
+
+// CHECK: Block: B5, Pred: B6, B7, B8, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK:   Widened bounds before stmt: *(r + +1)
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+// CHECK:     r: bounds(r, r + +1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+// CHECK:     r: bounds(r, r + +1 + 1)
+
+  _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
+  if (*(s + -1)) { // expected-error {{out-of-bounds memory access}}
+    a = 5;
+  }
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+// CHECK:     r: bounds(r, r + +1)
+
+// CHECK:   Widened bounds before stmt: *(s + -1)
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+// CHECK:     r: bounds(r, r + +1)
+// CHECK:     s: bounds(s, s + -1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p - i)
+// CHECK:     q: bounds(q, q + 0)
+// CHECK:     r: bounds(r, r + +1)
+// CHECK:     s: bounds(s, s + -1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
+  _Nt_array_ptr<char> q : bounds(p, p) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'q' imply the declared bounds of 'q' after initialization}}
+  _Nt_array_ptr<char> r : bounds(p, p + 1) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'r' imply the declared bounds of 'r' after initialization}}
+
+  if (*(p)) {
+    a = 1;
+    if (*(p + 1)) {
+      a = 2;
+    }
+    a = 3;
+  }
+
+// CHECK: Function: f16
+// CHECK: Block: B6, Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p) = "a";
+// CHECK:     p: bounds(p, p)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(p, p + 1) = "a";
+// CHECK:     p: bounds(p, p)
+// CHECK:     q: bounds(p, p)
+
+// CHECK:   Widened bounds before stmt: *(p)
+// CHECK:     p: bounds(p, p)
+// CHECK:     q: bounds(p, p)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, (p) + 1)
+// CHECK:     q: bounds(p, (p) + 1)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, (p) + 1)
+// CHECK:     q: bounds(p, (p) + 1)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(p, p + 1 + 1)
+// CHECK:     r: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, (p) + 1)
+// CHECK:     q: bounds(p, (p) + 1)
+// CHECK:     r: bounds(p, p + 1)
+
+// CHECK: Block: B1, Pred: B2, B5, Succ: B0
+}
+
+void f17(char p _Nt_checked[] : count(1)) {
+  _Nt_array_ptr<char> q : bounds(p, p + 1) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'q' imply the declared bounds of 'q' after initialization}}
+  _Nt_array_ptr<char> r : bounds(p, p) = "a"; // expected-error {{it is not possible to prove that the inferred bounds of 'r' imply the declared bounds of 'r' after initialization}}
+
+  if (*(p)) {
+    a = 1;
+    if (*(p + 1)) {
+      a = 2;
+    }
+  }
+
+// CHECK: Function: f17
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p + 1) = "a";
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : bounds(p, p) = "a";
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, p)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, (p) + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(p, p + 1)
+// CHECK:     r: bounds(p, (p) + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(p, p + 1 + 1)
+// CHECK:     r: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f18() {
+  char p _Nt_checked[] = "a";
+  char q _Nt_checked[] = "ab";
+  char r _Nt_checked[] : count(0) = "ab";
+  char s _Nt_checked[] : count(1) = "ab";
+
+// CHECK: Function: f18
+// CHECK: Block: B14, Pred: Succ: B13
+
+// CHECK: Block: B13, Pred: B14, Succ: B12, B10
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] = "a";
+
+// CHECK:   Widened bounds before stmt: char q_Nt_checked[] = "ab";
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: char r_Nt_checked[] : count(0) = "ab";
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+
+// CHECK:   Widened bounds before stmt: char s_Nt_checked[] : count(1) = "ab";
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+
+  if (p[0]) {
+    a = 1;
+    if (p[1]) {
+      a = 2;
+    }
+  }
+
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B12, Pred: B13, Succ: B11, B10
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B11, Pred: B12, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+  if (q[0]) {
+    a = 3;
+    if (q[1]) {
+      a = 4;
+      if (q[2]) {
+        a = 5;
+      }
+    }
+  }
+
+// CHECK: Block: B10, Pred: B11, B12, B13, Succ: B9, B6
+// CHECK:   Widened bounds before stmt: q[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B6
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK:   Widened bounds before stmt: q[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B6
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK:   Widened bounds before stmt: q[2]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2 + 1)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+  if (r[0]) {
+    a = 6;
+  }
+
+// CHECK: Block: B6, Pred: B7, B8, B9, B10, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: r[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0 + 1)
+// CHECK:     s: bounds(s, s + 1)
+
+  if (s[0]) {
+    a = 7;
+    if (s[1]) {
+      a = 8;
+    }
+  }
+
+// CHECK: Block: B4, Pred: B5, B6, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: s[0]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK:   Widened bounds before stmt: s[1]
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 2)
+// CHECK:     r: bounds(r, r + 0)
+// CHECK:     s: bounds(s, s + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, Succ: B0
+}
+
+void f19() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p) {
+    a = 1;
+    if (*(p + 1)) {
+      a = 2;
+      if (*(p + 3)) {
+        a = 3;
+        if (*(p + 2)) {
+          a = 4;
+        }
+      }
+    }
+  }
+
+// CHECK: Function: f19
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, B4, B5, B6, Succ: B0
+}
+
+void f20_1() {
+  // Pointer dereferenced at the upper bound. Valid bounds widening.
+  _Nt_array_ptr<char> p : count(INT_MAX) = "";  // expected-error {{declared bounds for 'p' are invalid after initialization}}
+  if (*(p + INT_MAX)) {
+    a = 1;
+  }
+
+// CHECK: Function: f20_1
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count({{.*}}) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + {{.*}})
+// CHECK:     p: bounds(p, p + {{.*}})
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + {{.*}} + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f20_2() {
+  // Pointer dereferenced at the upper bound. Valid bounds widening.
+  _Nt_array_ptr<char> q : count(INT_MIN) = "";
+  if (*(q + INT_MIN)) {  // expected-error {{out-of-bounds memory access}}
+    a = 2;
+  }
+
+// CHECK: Function: f20_2
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count({{.*}}) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(q + {{.*}})
+// CHECK:     q: bounds(q, q + {{.*}})
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     q: bounds(q, q + {{.*}} + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+// See issue #780 for a test involving INT_MAX that does not work on an Windows
+// X86 build.
+void f20_3() {
+  _Nt_array_ptr<char> r : count(INT_MIN) = "";
+  if (*(r + INT_MAX - 1)) { // expected-error {{out-of-bounds memory access}}
+    a = 3;
+  }
+
+// CHECK: Function: f20_3
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : count({{.*}}) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(r + {{.*}} - 1)
+// CHECK:     r: bounds(r, r + {{.*}})
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     r: bounds(r, r + {{.*}})
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f20_4() {
+  // Pointer dereferenced at the upper bound but integer overflow occurs. No
+  // bounds widening.
+  _Nt_array_ptr<char> s : count(INT_MAX + 1) = "";
+  if (*(s + INT_MAX + 1)) {  // expected-error {{out-of-bounds memory access}}
+    a = 4;
+  }
+
+// CHECK: Function: f20_4
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : count({{.*}} + 1) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(s + {{.*}} + 1)
+// CHECK:     s: bounds(s, s + {{.*}} + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     s: bounds(s, s + {{.*}} + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f20_5() {
+  // Pointer dereferenced at the upper bound. Valid bounds widening.
+  _Nt_array_ptr<char> t : count(INT_MIN + 1) = "";
+  if (*(t + INT_MIN + 1)) {  // expected-error {{out-of-bounds memory access}}
+    a = 5;
+  }
+
+// CHECK: Function: f20_5
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> t : count({{.*}} + 1) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(t + {{.*}} + 1)
+// CHECK:     t: bounds(t, t + {{.*}} + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     t: bounds(t, t + {{.*}} + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f20_6() {
+  // Pointer dereferenced at the upper bound but integer underflow occurs. No
+  // bounds widening.
+  _Nt_array_ptr<char> u : count(INT_MIN + -1) = ""; // expected-error {{declared bounds for 'u' are invalid after initialization}}
+  if (*(u + INT_MIN + -1)) {
+    a = 6;
+  }
+
+// CHECK: Function: f20_6
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> u : count({{.*}} + -1) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(u + {{.*}} + -1)
+// CHECK:     u: bounds(u, u + {{.*}} + -1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     u: bounds(u, u + {{.*}} + -1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f21() {
+  char p _Nt_checked[] : count(0) = "abc";
+
+  while (p[0]) {
+    a = 1;
+    while (p[1]) {
+      a = 2;
+      while (p[2]) {
+        a = 3;
+      }
+    }
+  }
+
+// CHECK: Function: f21
+// CHECK: Block: B12, Pred: Succ: B11
+
+// CHECK: Block: B11, Pred: B12, Succ: B10
+// CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
+// CHECK:     <none>
+
+// CHECK: Block: B10, Pred: B2, B11, Succ: B9, B1
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B8, Pred: B3, B9, Succ: B7, B2
+// CHECK:   Widened bounds before stmt: p[1]
+// CHECK:     p: bounds(p, p + 0 + 1)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B6, Pred: B4, B7, Succ: B5, B3
+// CHECK:   Widened bounds before stmt: p[2]
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B6
+
+// CHECK: Block: B3, Pred: B6, Succ: B8
+
+// CHECK: Block: B2, Pred: B8, Succ: B10
+
+// CHECK: Block: B1, Pred: B10, Succ: B0
+}
+
+void f22() {
+  _Nt_array_ptr<char> p : count(0) = "a";
+
+  if (*p) {
+    a = 1;
+    while (*(p + 1)) {
+      a = 2;
+      if (*(p + 2)) {
+        a = 3;
+      }
+    }
+  }
+
+// CHECK: Function: f22
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B2, B6, Succ: B4, B1
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B5
+
+// CHECK: Block: B1, Pred: B5, B7, Succ: B0
+}
+
+void f23() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  goto B;
+  while (*p) {
+B:  a = 1;
+    while (*(p + 1)) { // expected-error {{out-of-bounds memory access}}
+      a = 2;
+    }
+  }
+
+// CHECK: Function: f23
+// CHECK: Block: B16, Pred: Succ: B15
+
+// CHECK: Block: B15, Pred: B16, Succ: B13
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK: Block: B14, Pred: B9, Succ: B13, B8
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B13, Pred: B14, B15, Succ: B12
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B12, Pred: B10, B13, Succ: B11, B9
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B11, Pred: B12, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B10, Pred: B11, Succ: B12
+
+// CHECK: Block: B9, Pred: B12, Succ: B14
+
+  while (*p) {
+    a = 3;
+    while (*(p + 1)) {
+C:    a = 4;
+    }
+  }
+  goto C;
+
+// CHECK: Block: B8, Pred: B3, B14, Succ: B7, B2
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B4, B7, Succ: B5, B3
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B6, B2, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B6
+
+// CHECK: Block: B3, Pred: B6, Succ: B8
+
+// CHECK: Block: B2, Pred: B8, Succ: B5
+}
+
+void f24() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  while (*p) {
+    p++;
+    while (*(p + 1)) { // expected-error {{out-of-bounds memory access}}
+      a = 1;
+    }
+  }
+
+// CHECK: Function: f24
+// CHECK: Block: B9, Pred: Succ: B8
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK: Block: B7, Pred: B2, B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     <none>
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: p++
+// CHECK:     <none>
+
+// CHECK: Block: B5, Pred: B3, B6, Succ: B4, B2
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     <none>
+
+// CHECK: Block: B3, Pred: B4, Succ: B5
+
+// CHECK: Block: B2, Pred: B5, Succ: B7
+
+// CHECK: Block: B1, Pred: B7, Succ: B0
+}
+
+void f25_1() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  for (; *p; ) {
+    a = 1;
+    for (; *(p + 1); ) {
+      a = 2;
+      for (; *(p + 2); ) {
+        a = 3;
+      }
+      a = 4;
+    }
+    a = 5;
+  }
+  a = 6;
+
+// CHECK: Function: f25_1
+// CHECK: Block: B21, Pred: Succ: B20
+
+// CHECK: Block: B20, Pred: B21, Succ: B19
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK: Block: B19, Pred: B9, B20, Succ: B18, B8
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B18, Pred: B19, Succ: B17
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B17, Pred: B11, B18, Succ: B16, B10
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B16, Pred: B17, Succ: B15
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B15, Pred: B13, B16, Succ: B14, B12
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B14, Pred: B15, Succ: B13
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B13, Pred: B14, Succ: B15
+
+// CHECK: Block: B12, Pred: B15, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B11, Pred: B12, Succ: B17
+
+// CHECK: Block: B10, Pred: B17, Succ: B9
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B9, Pred: B10, Succ: B19
+
+// CHECK: Block: B8, Pred: B19, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+
+  for (; *p; ) {
+    p++;
+    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+      a = 7;
+    }
+  }
+
+// CHECK: Block: B7, Pred: B2, B8, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     <none>
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: p++
+// CHECK:     <none>
+
+// CHECK: Block: B5, Pred: B3, B6, Succ: B4, B2
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     <none>
+
+// CHECK: Block: B3, Pred: B4, Succ: B5
+
+// CHECK: Block: B2, Pred: B5, Succ: B7
+
+// CHECK: Block: B1, Pred: B7, Succ: B0
+}
+
+void f25_2() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  for (; *p; ) {
+D:  a = 1;
+    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+      a = 2;
+    }
+  }
+  goto D;
+
+// CHECK: Function: f25_2
+// CHECK: Block: B10, Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK: Block: B8, Pred: B3, B9, Succ: B7, B2
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B8, B2, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B4, B7, Succ: B5, B3
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B5, Succ: B6
+
+// CHECK: Block: B3, Pred: B6, Succ: B8
+
+// CHECK: Block: B2, Pred: B8, Succ: B7
+}
+
+void f26() {
+  _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
+
+  if (*(((p + 1)))) {
+    a = 1;
+  }
+
+// CHECK: Function: f26
+// CHECK: Block: B4, Pred: Succ: B3
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(((p + 1)))
+// CHECK:     p: bounds(p, ((((((p + 1)))))))
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+}
+
+void f27(_Nt_array_ptr<char> p : count(i), int i) {
+  if (*(p + i)) {
+    a == 1 ? i++ : i;  // expected-error {{inferred bounds for 'p' are unknown after increment}}
+
+    if (*(p + i + 1)) {
+      a = 2;
+    }
+  }
+
+// CHECK: Function: f27
+// CHECK: Block: B7, Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B0
+// CHECK:   Widened bounds before stmt: *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B5, Pred: B6, Succ: B3, B4
+// CHECK:   Widened bounds before stmt: a == 1
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B2
+// CHECK:   Widened bounds before stmt: i
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B3, Pred: B5, Succ: B2
+// CHECK:   Widened bounds before stmt: i++
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: a == 1 ? i++ : i
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *(p + i + 1)
+// CHECK:     <none>
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     <none>
+}
+
+void f28() {
+  int i, j;
+  for (;;) {
+    i = 1;
+    j = 2;
+    _Nt_array_ptr<char> p : count(i + j) = 0;
+    if (p[i + j]) {
+      return;
+    }
+  }
+
+// CHECK: Function: f28
+// CHECK: Block: B8, Pred: Succ: B7
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: int i;
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: int j;
+// CHECK:     <none>
+
+// CHECK: Block: B6, Pred: B2, B7, Succ: B5,
+
+// CHECK: Block: B5, Pred: B6, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: i = 1
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: j = 2
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(i + j) = 0;
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: p[i + j]
+// CHECK:     p: bounds(p, p + i + j)
+
+// CHECK: Block: B4, Pred: B5, Succ: B0
+// CHECK:   Widened bounds before stmt: return;
+// CHECK:     p: bounds(p, p + i + j + 1)
+
+// CHECK: Block: B3, Pred: B5, Succ: B2
+
+// CHECK: Block: B2, Pred: B3, Succ: B6
+}
+
+void f29() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch (*p) {
+  default: a = 0; break;
+  case 'a': a = 1; break;
+  case 'b': a = 2; break;
+  }
+
+// CHECK: Function: f29
+// CHECK: Block: B22, Pred: Succ: B18
+
+// CHECK: Block: B21, Pred: B18, Succ: B14
+// CHECK:   Widened bounds before stmt: a = 0
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B20, Pred: B18, Succ: B14
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B19, Pred: B18, Succ: B14
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1)
+
+  switch (*p) {
+  case 'a': a = 3;
+  default: a = 4;
+  case 'b': a = 5; break;
+  }
+
+// CHECK: Block: B18, Pred: B22, Succ: B19, B20, B21
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B17, Pred: B14, Succ: B16
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B16, Pred: B17, B14, Succ: B15
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B15, Pred: B14, B16, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  case 'a': a = 6; break;
+  default: a = 7;
+  case 'b': a = 8; break;
+  }
+
+// CHECK: Block: B14, Pred: B19, B20, B21, Succ: B15, B17, B16
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B13, Pred: B10, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B12, Pred: B10, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B11, Pred: B10, B12, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  default: a = 9; break;
+  case '\0': a = 10; break;
+  case 'a': a = 11; break;
+  }
+
+// CHECK: Block: B10, Pred: B15, Succ: B11, B13, B12
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B9, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 9
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B8, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 10
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 11
+// CHECK:     p: bounds(p, p + 1)
+
+  switch (*p) {
+  case '\0': a = 12;
+  case 'a': a = 13; break;
+  default: a = 14; break;
+  }
+
+// CHECK: Block: B6, Pred: B11, B13, Succ: B7, B8, B9
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B2, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 12
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B2, B5, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 13
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 14
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B7, B8, B9, Succ: B4, B5, B3
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B4, Succ: B0
+}
+
+void f30() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  const char c1 = '\0';
+  const int c2 = '0';
+  const char c3 = '1';
+  const int c4 = '2';
+
+  switch (*p) {
+  default: a = 1; break;
+
+  case c1: a = 2; break;
+
+  case c2: a = 3; break;
+
+  case c3: a = 4; break;
+
+  case c4: a = 5; break;
+  }
+
+// CHECK: Function: f30
+// CHECK: Block: B12, Pred: Succ: B6
+// CHECK: Block: B11, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B10, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B9, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B8, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B7, Pred: B6, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+  enum {e1, e2};
+  switch (*p) {
+  case e1: a = 6; break;
+
+  case e2: a = 7; break;
+
+  default: a = 8; break;
+  }
+
+// CHECK: Block: B5, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B7, B8, B9, B10, B11, Succ: B4, B5, B3
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B4, B5, Succ: B0
+}
+
+void f31() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch (*p) {
+  default: a = 1; break;
+
+  case 0: a = 2;
+    switch (*p) {
+      default: a = 3; break;
+      case 1: a = 4; break;
+    }
+  }
+
+// CHECK: Function: f31
+// CHECK: Block: B15, Pred: Succ: B10
+
+// CHECK: Block: B14, Pred: B10, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B13, Pred: B11, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B12, Pred: B11, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B11, Pred: B10, Succ: B12, B13
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B10, Pred: B15, Succ: B11, B14
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  case 1: a = 5;
+    switch (*(p + 1)) {
+      case 2: a = 6; break;
+    }
+  }
+
+// CHECK: Block: B9, Pred: B8, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B8, Pred: B7, Succ: B9, B2
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B7, Pred: B12, B13, B14, Succ: B8, B2
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  case 1: a = 7; do { a = 8;
+                 } while (a > 0);
+  }
+
+// CHECK: Block: B6, Pred: B2, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B3, Succ: B4
+
+// CHECK: Block: B4, Pred: B5, B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B5, B1
+// CHECK:   Widened bounds before stmt: a > 0
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B9, B8, B7, Succ: B6, B1
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B2, Succ: B0
+}
+
+void f32() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch (*p) {
+  case 'a':
+    a = 1;
+
+    if (*(p + 1)) {
+      a = 2;
+
+      for (;*(p + 2);) {
+        a = 3;
+
+        while (*(p + 3)) {
+          a = 4;
+        }
+        a = 5;
+      }
+      a = 6;
+    }
+    a = 7;
+
+    break;
+  }
+  a = 8;
+
+// CHECK: Function: f32
+// CHECK: Block: B14, Pred: Succ: B2
+
+// CHECK: Block: B13, Pred: B2, Succ: B12, B3
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B12, Pred: B13, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B11, Pred: B5, B12, Succ: B10, B4
+// CHECK:   Widened bounds before stmt: *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B10, Pred: B11, Succ: B9
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B9, Pred: B7, B10, Succ: B8, B6
+// CHECK:   Widened bounds before stmt: *(p + 3)
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 3 + 1)
+
+// CHECK: Block: B7, Pred: B8, Succ: B9
+
+// CHECK: Block: B6, Pred: B9, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 2 + 1)
+
+// CHECK: Block: B5, Pred: B6, Succ: B11
+
+// CHECK: Block: B4, Pred: B11, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B3, Pred: B4, B13, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B14, Succ: B13, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 0)
+}
+
+void f33() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  const int i = -1;
+  const int j = 1;
+
+  switch (*p) {
+  case i ... j: a = 1; break;
+  }
+
+// CHECK: Function: f33
+// CHECK: Block: B14, Pred: Succ: B12
+
+// CHECK: Block: B13, Pred: B12, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  case 1 ... -1: a = 2; break;
+
+  case 1 ... 0: a = 3; break;
+
+  case -2 ... -1: a = 4; break;
+  }
+
+// CHECK: Block: B11, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B10, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B9, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+
+  switch (*p) {
+  case -1 ... 1: a = 5; break;
+  }
+
+// CHECK: Block: B7, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  case 0 ... 1: a = 6; break;
+  }
+
+// CHECK: Block: B5, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+
+  switch (*p) {
+  case 1 ... 2: a = 7; break;
+  }
+
+// CHECK: Block: B3, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+}
+
+void f34() {
+  _Nt_array_ptr<char> p : count(0) = "";
+  const int i = 'abc';
+  const char c = 'xyz';
+  const unsigned u = UINT_MAX;
+
+  switch (*p) {
+  case 999999999999999999999999999: a = 1; break; // expected-error {{integer literal is too large to be represented in any integer type}}
+
+  case 00000000000000000000000000000000000: a = 2; break;
+  case 00000000000000000000000000000000001: a = 3; break;
+  case '00000000000000000000000000000000000': a = 4; break;
+
+  case i: a = 5; break;
+  case c: a = 6; break;
+  case u: a = 7; break;
+  }
+
+// CHECK: Function: f34
+// CHECK: Block: B25, Pred: Succ: B17
+// CHECK: Block: B24, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B23, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B22, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B21, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B20, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B19, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B18, Pred: B17, Succ: B11
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+  switch (*p) {
+  case INT_MAX: a = 8; break;
+  case INT_MIN: a = 9; break;
+  case INT_MAX + INT_MAX: a = 10; break;
+  case INT_MAX - INT_MAX: a = 11; break;
+  case INT_MAX + INT_MIN: a = 12; break;
+  }
+
+// CHECK: Block: B16, Pred: B11, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B15, Pred: B11, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 9
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B14, Pred: B11, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 10
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B13, Pred: B11, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 11
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B12, Pred: B11, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 12
+// CHECK:     p: bounds(p, p + 1)
+
+  switch (*p) {
+  case INT_MIN - INT_MIN: a = 13; break;
+  case INT_MAX - INT_MIN: a = 14; break;
+  }
+
+// CHECK: Block: B10, Pred: B8, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 13
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B9, Pred: B8, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 14
+// CHECK:     p: bounds(p, p + 1)
+
+  switch (*p) {
+  // Note: This does not widen the bounds as the value of the expression is
+  // computed to 0 and we have the warning: overflow in expression; result is 0
+  // with type 'int'.
+  case INT_MIN + INT_MIN: a = 15; break;
+
+  case UINT_MAX: a = 16; break;
+  }
+
+// CHECK: Block: B7, Pred: B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 15
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B5, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 16
+// CHECK:     p: bounds(p, p + 1)
+
+  _Nt_array_ptr<uint64_t> q : count(0) = 0;
+  const uint64_t x = 0x0000444400004444LL;
+
+  switch (*p) {
+    case ULLONG_MAX: a = 17; break;
+    case x: a = 18; break;
+  }
+
+// CHECK: Block: B4, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 17
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B3, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 18
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+}
+
+void f35_1() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch(*p) {
+    default: f1(); break;
+    case 0: {
+      a = 1;
+
+      switch(*p) {
+        default: f2(); break;
+        case 'a': a = 2; break;
+      }
+      break;
+    }
+  }
+
+// CHECK: Function: f35_1
+// CHECK: Block: B8, Pred: Succ: B2
+
+// CHECK: Block: B7, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: f1()
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: f2()
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B2, Succ: B5, B6
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B5, B6, Succ: B1
+
+// CHECK: Block: B2, Pred: B8, Succ: B4, B7
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B7, Succ: B0
+}
+
+void f35_2() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch(*p) {
+    default: f1(); break;
+    case 0: {
+      a = 3;
+
+      switch(*p) {
+        default: f2(); break;
+        case '\0': a = 4; break;
+      }
+      break;
+    }
+  }
+
+// CHECK: Function: f35_2
+// CHECK: Block: B8, Pred: Succ: B2
+
+// CHECK: Block: B7, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: f1()
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: f2()
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B4, Pred: B2, Succ: B5, B6
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B5, B6, Succ: B1
+
+// CHECK: Block: B2, Pred: B8, Succ: B4, B7
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B7, Succ: B0
+}
+
+void f35_3() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch(*p) {
+    default: f1(); break;
+    case 'b': {
+      a = 5;
+
+      switch(*(p + 1)) {
+        default: f2(); break;
+        case 'a': a = 6; break;
+      }
+      break;
+    }
+  }
+
+// CHECK: Function: f35_3
+// CHECK: Block: B8, Pred: Succ: B2
+
+// CHECK: Block: B7, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: f1()
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: f2()
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B4, Pred: B2, Succ: B5, B6
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B5, B6, Succ: B1
+
+// CHECK: Block: B2, Pred: B8, Succ: B4, B7
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B7, Succ: B0
+}
+
+void f35_4() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch(*p) {
+    default: f1(); break;
+    case 'b': {
+      a = 7;
+
+      switch(*(p + 1)) {
+        default: f2(); break;
+        case '\0': a = 8; break;
+      }
+      break;
+    }
+  }
+
+// CHECK: Function: f35_4
+// CHECK: Block: B8, Pred: Succ: B2
+
+// CHECK: Block: B7, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: f1()
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: f2()
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B5, Pred: B4, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B2, Succ: B5, B6
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B3, Pred: B5, B6, Succ: B1
+
+// CHECK: Block: B2, Pred: B8, Succ: B4, B7
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B7, Succ: B0
+}
+
+void f35_5() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  switch(*p) {
+    default: {
+      a = 9;
+
+      switch(*(p + 1)) {
+        default: f2(); break;
+        case '\0': a = 10; break;
+      }
+      break;
+    }
+    case 0: a = 11; break;
+  }
+
+// CHECK: Function: f35_5
+// CHECK: Block: B8, Pred: Succ: B2
+
+// CHECK: Block: B7, Pred: B5, Succ: B4
+// CHECK:   Widened bounds before stmt: f2()
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B6, Pred: B5, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 10
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B5, Pred: B2, Succ: B6, B7
+// CHECK:   Widened bounds before stmt: a = 9
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B6, B7, Succ: B1
+
+// CHECK: Block: B3, Pred: B2, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 11
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B2, Pred: B8, Succ: B3, B5
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, B4, Succ: B0
+}

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -2617,3 +2617,124 @@ void f35_5() {
 
 // CHECK: Block: B1, Pred: B3, B4, Succ: B0
 }
+
+void f36() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  if (*p) {
+    a = 1;
+A:  a = 2;
+    a = 3;
+  }
+
+// CHECK: Function: f36
+// CHECK: Block: B5, Pred: Succ: B4
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B1, Pred: B2, B4, Succ: B0
+}
+
+void f37() {
+  _Nt_array_ptr<char> p : count(0) = "";
+
+  if (a > 0) {
+    a = 1;
+A:  a = 2;
+    a = 3;
+
+  } else if (a == 0) {
+    a = 4;
+
+    while (a != 0) {
+      ++a;
+
+      switch(a) {
+      default: a = 5; break;
+      case 1: a = 6; break;
+      }
+    }
+  }
+
+  if (*p) {
+    a = 7;
+  }
+
+  goto A;
+
+// CHECK: Function: f37
+// CHECK: Block: B15, Pred: Succ: B14
+
+// CHECK: Block: B14, Pred: B15, Succ: B13, B11
+// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
+// CHECK:     <none>
+
+// CHECK:   Widened bounds before stmt: a > 0
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B13, Pred: B14, Succ: B12
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B12, Pred: B13, B2, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B11, Pred: B14, Succ: B10, B4
+// CHECK:   Widened bounds before stmt: a == 0
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B10, Pred: B11, Succ: B9
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B9, Pred: B5, B10, Succ: B6, B4
+// CHECK:   Widened bounds before stmt: a != 0
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B8, Pred: B6, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B7, Pred: B6, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B6, Pred: B9, Succ: B7, B8
+// CHECK:   Widened bounds before stmt: ++a
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK:   Widened bounds before stmt: a
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B7, B8, Succ: B9
+
+// CHECK: Block: B4, Pred: B9, B11, B12, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B12
+}

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -1,6 +1,8 @@
-// Tests for datafow analysis for bounds widening of _Nt_array_ptr's.
+// Tests for datafow analysis for bounds widening of null-terminated arrays.
 //
-// RUN: %clang_cc1 -fdump-widened-bounds -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+// RUN: %clang_cc1 -fdump-widened-bounds -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
 
 #include <limits.h>
 #include <stdint.h>

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -1762,11 +1762,11 @@ void f27(_Nt_array_ptr<char> p : count(i), int i) {
 // CHECK:     p: bounds(p, p + i + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + i + 1)
-// CHECK:     <no widening>
+// CHECK:     p: bounds(p, p + i)
 
 // CHECK: Block: B1, Pred: B2, Succ: B0
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <no widening>
+// CHECK:     p: bounds(p, p + i)
 }
 
 void f28() {

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -18,7 +18,7 @@ void f1() {
   a = 2;
 
 // CHECK: Function: f1
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -53,7 +53,7 @@ void f2() {
   a = 6;
 
 // CHECK: Function: f2
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "ab";
@@ -106,7 +106,7 @@ void f3() {
   a = 3;
 
 // CHECK: Function: f3
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -153,7 +153,7 @@ void f4(_Nt_array_ptr<char> p : count(0)) {
   a = 6;
 
 // CHECK: Function: f4
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B5
 // CHECK:   Widened bounds before stmt: p[0]
@@ -216,7 +216,7 @@ void f5() {
   a = 6;
 
 // CHECK: Function: f5
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
@@ -269,7 +269,7 @@ void f6(int i) {
   a = 3;
 
 // CHECK: Function: f6
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p + i, p) = "abc";
@@ -312,7 +312,7 @@ void f7(char p _Nt_checked[] : count(0)) {
   a = 6;
 
 // CHECK: Function: f7
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B5
 // CHECK:   Widened bounds before stmt: p[0]
@@ -379,7 +379,7 @@ void f8() {
   a = 8;
 
 // CHECK: Function: f8
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(2) = "abc";
@@ -447,7 +447,7 @@ void f9(int i) {
   a = 6;
 
 // CHECK: Function: f9
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
@@ -504,7 +504,7 @@ void f10(int i) {
   a = 6;
 
 // CHECK: Function: f10
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
@@ -557,7 +557,7 @@ void f11(int i, int j) {
   a = 3;
 
 // CHECK: Function: f11
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B5
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
@@ -633,7 +633,7 @@ void f12(int i, int j) {
   a = 6;
 
 // CHECK: Function: f12
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
@@ -694,7 +694,7 @@ void f13() {
   a = 8;
 
 // CHECK: Function: f13
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(1) = "a";
@@ -762,7 +762,7 @@ void f14(int i) {
   a = 6;
 
 // CHECK: Function: f14
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p, p + i) = "a";
@@ -810,7 +810,7 @@ void f15(int i) {
   }
 
 // CHECK: Function: f15
-// CHECK: Block: B11, Pred: Succ: B10
+// CHECK: Block: B11 (Entry), Pred: Succ: B10
 
 // CHECK: Block: B10, Pred: B11, Succ: B9, B8
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p - i) = "a";
@@ -914,7 +914,7 @@ void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
   }
 
 // CHECK: Function: f16
-// CHECK: Block: B6, Pred: Succ: B5
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p) = "a";
@@ -967,7 +967,7 @@ void f17(char p _Nt_checked[] : count(1)) {
   }
 
 // CHECK: Function: f17
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : bounds(p, p + 1) = "a";
@@ -1009,7 +1009,7 @@ void f18() {
   char s _Nt_checked[] : count(1) = "ab";
 
 // CHECK: Function: f18
-// CHECK: Block: B14, Pred: Succ: B13
+// CHECK: Block: B14 (Entry), Pred: Succ: B13
 
 // CHECK: Block: B13, Pred: B14, Succ: B12, B10
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] = "a";
@@ -1181,7 +1181,7 @@ void f19() {
   }
 
 // CHECK: Function: f19
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -1226,7 +1226,7 @@ void f20_1() {
   }
 
 // CHECK: Function: f20_1
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count({{.*}}) = "";
@@ -1250,7 +1250,7 @@ void f20_2() {
   }
 
 // CHECK: Function: f20_2
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count({{.*}}) = "";
@@ -1275,7 +1275,7 @@ void f20_3() {
   }
 
 // CHECK: Function: f20_3
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : count({{.*}}) = "";
@@ -1300,7 +1300,7 @@ void f20_4() {
   }
 
 // CHECK: Function: f20_4
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : count({{.*}} + 1) = "";
@@ -1324,7 +1324,7 @@ void f20_5() {
   }
 
 // CHECK: Function: f20_5
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> t : count({{.*}} + 1) = "";
@@ -1349,7 +1349,7 @@ void f20_6() {
   }
 
 // CHECK: Function: f20_6
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> u : count({{.*}} + -1) = "";
@@ -1379,7 +1379,7 @@ void f21() {
   }
 
 // CHECK: Function: f21
-// CHECK: Block: B12, Pred: Succ: B11
+// CHECK: Block: B12 (Entry), Pred: Succ: B11
 
 // CHECK: Block: B11, Pred: B12, Succ: B10
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
@@ -1432,7 +1432,7 @@ void f22() {
   }
 
 // CHECK: Function: f22
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
@@ -1477,7 +1477,7 @@ B:  a = 1;
   }
 
 // CHECK: Function: f23
-// CHECK: Block: B16, Pred: Succ: B15
+// CHECK: Block: B16 (Entry), Pred: Succ: B15
 
 // CHECK: Block: B15, Pred: B16, Succ: B13
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -1545,7 +1545,7 @@ void f24() {
   }
 
 // CHECK: Function: f24
-// CHECK: Block: B9, Pred: Succ: B8
+// CHECK: Block: B9 (Entry), Pred: Succ: B8
 
 // CHECK: Block: B8, Pred: B9, Succ: B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -1591,7 +1591,7 @@ void f25_1() {
   a = 6;
 
 // CHECK: Function: f25_1
-// CHECK: Block: B21, Pred: Succ: B20
+// CHECK: Block: B21 (Entry), Pred: Succ: B20
 
 // CHECK: Block: B20, Pred: B21, Succ: B19
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -1681,7 +1681,7 @@ D:  a = 1;
   goto D;
 
 // CHECK: Function: f25_2
-// CHECK: Block: B10, Pred: Succ: B9
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
 
 // CHECK: Block: B9, Pred: B10, Succ: B8
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -1718,7 +1718,7 @@ void f26() {
   }
 
 // CHECK: Function: f26
-// CHECK: Block: B4, Pred: Succ: B3
+// CHECK: Block: B4 (Entry), Pred: Succ: B3
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
@@ -1744,7 +1744,7 @@ void f27(_Nt_array_ptr<char> p : count(i), int i) {
   }
 
 // CHECK: Function: f27
-// CHECK: Block: B7, Pred: Succ: B6
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B0
 // CHECK:   Widened bounds before stmt: *(p + i)
@@ -1786,7 +1786,7 @@ void f28() {
   }
 
 // CHECK: Function: f28
-// CHECK: Block: B8, Pred: Succ: B7
+// CHECK: Block: B8 (Entry), Pred: Succ: B7
 
 // CHECK: Block: B7, Pred: B8, Succ: B6
 // CHECK:   Widened bounds before stmt: int i;
@@ -1829,7 +1829,7 @@ void f29() {
   }
 
 // CHECK: Function: f29
-// CHECK: Block: B22, Pred: Succ: B18
+// CHECK: Block: B22 (Entry), Pred: Succ: B18
 
 // CHECK: Block: B21, Pred: B18, Succ: B14
 // CHECK:   Widened bounds before stmt: a = 0
@@ -1961,7 +1961,7 @@ void f30() {
   }
 
 // CHECK: Function: f30
-// CHECK: Block: B12, Pred: Succ: B6
+// CHECK: Block: B12 (Entry), Pred: Succ: B6
 // CHECK: Block: B11, Pred: B6, Succ: B2
 // CHECK:   Widened bounds before stmt: a = 1
 // CHECK:     p: bounds(p, p + 1)
@@ -2024,7 +2024,7 @@ void f31() {
   }
 
 // CHECK: Function: f31
-// CHECK: Block: B15, Pred: Succ: B10
+// CHECK: Block: B15 (Entry), Pred: Succ: B10
 
 // CHECK: Block: B14, Pred: B10, Succ: B7
 // CHECK:   Widened bounds before stmt: a = 1
@@ -2127,7 +2127,7 @@ void f32() {
   a = 8;
 
 // CHECK: Function: f32
-// CHECK: Block: B14, Pred: Succ: B2
+// CHECK: Block: B14 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B13, Pred: B2, Succ: B12, B3
 // CHECK:   Widened bounds before stmt: a = 1
@@ -2194,7 +2194,7 @@ void f33() {
   }
 
 // CHECK: Function: f33
-// CHECK: Block: B14, Pred: Succ: B12
+// CHECK: Block: B14 (Entry), Pred: Succ: B12
 
 // CHECK: Block: B13, Pred: B12, Succ: B8
 // CHECK:   Widened bounds before stmt: a = 1
@@ -2264,7 +2264,7 @@ void f34() {
   }
 
 // CHECK: Function: f34
-// CHECK: Block: B25, Pred: Succ: B17
+// CHECK: Block: B25 (Entry), Pred: Succ: B17
 // CHECK: Block: B24, Pred: B17, Succ: B11
 // CHECK:   Widened bounds before stmt: a = 1
 // CHECK:     p: bounds(p, p + 1)
@@ -2387,7 +2387,7 @@ void f35_1() {
   }
 
 // CHECK: Function: f35_1
-// CHECK: Block: B8, Pred: Succ: B2
+// CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
 // CHECK:   Widened bounds before stmt: f1()
@@ -2437,7 +2437,7 @@ void f35_2() {
   }
 
 // CHECK: Function: f35_2
-// CHECK: Block: B8, Pred: Succ: B2
+// CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
 // CHECK:   Widened bounds before stmt: f1()
@@ -2487,7 +2487,7 @@ void f35_3() {
   }
 
 // CHECK: Function: f35_3
-// CHECK: Block: B8, Pred: Succ: B2
+// CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
 // CHECK:   Widened bounds before stmt: f1()
@@ -2537,7 +2537,7 @@ void f35_4() {
   }
 
 // CHECK: Function: f35_4
-// CHECK: Block: B8, Pred: Succ: B2
+// CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
 // CHECK:   Widened bounds before stmt: f1()
@@ -2587,7 +2587,7 @@ void f35_5() {
   }
 
 // CHECK: Function: f35_5
-// CHECK: Block: B8, Pred: Succ: B2
+// CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B5, Succ: B4
 // CHECK:   Widened bounds before stmt: f2()
@@ -2630,7 +2630,7 @@ A:  a = 2;
   }
 
 // CHECK: Function: f36
-// CHECK: Block: B5, Pred: Succ: B4
+// CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
@@ -2681,7 +2681,7 @@ A:  a = 2;
   goto A;
 
 // CHECK: Function: f37
-// CHECK: Block: B15, Pred: Succ: B14
+// CHECK: Block: B15 (Entry), Pred: Succ: B14
 
 // CHECK: Block: B14, Pred: B15, Succ: B13, B11
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -22,7 +22,7 @@ void f1() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -57,7 +57,7 @@ void f2() {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "ab";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -110,7 +110,7 @@ void f3() {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -120,19 +120,19 @@ void f3() {
 // CHECK:     p: bounds(p, p + 1)
 
 // CHECK:   Widened bounds before stmt: a
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B3, Pred: B4, Succ: B2
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B2, Pred: B3, B4, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B1, Pred: B2, B5, Succ: B0
 // CHECK:   Widened bounds before stmt: a = 3
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 }
 
 void f4(_Nt_array_ptr<char> p : count(0)) {
@@ -220,7 +220,7 @@ void f5() {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[0]
 // CHECK:     p: bounds(p, p + 0)
@@ -273,7 +273,7 @@ void f6(int i) {
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p + i, p) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[0]
 // CHECK:     p: bounds(p + i, p)
@@ -283,15 +283,15 @@ void f6(int i) {
 // CHECK:     p: bounds(p + i, p + 0 + 1)
 
 // CHECK:   Widened bounds before stmt: p[1]
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 
 // CHECK: Block: B3, Pred: B4, Succ: B2
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 
 // CHECK: Block: B2, Pred: B3, B4, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p)
 }
 
 void f7(char p _Nt_checked[] : count(0)) {
@@ -383,7 +383,7 @@ void f8() {
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(2) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 2)
@@ -451,7 +451,7 @@ void f9(int i) {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + i)
@@ -508,7 +508,7 @@ void f10(int i) {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, 1 + p + i + 5) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(i + p + 1 + 2 + 3)
 // CHECK:     p: bounds(p, 1 + p + i + 5)
@@ -561,7 +561,7 @@ void f11(int i, int j) {
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B5
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p + i, p + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + j)
 // CHECK:     p: bounds(p + i, p + j)
@@ -571,19 +571,19 @@ void f11(int i, int j) {
 // CHECK:     p: bounds(p + i, p + j + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + j + 1)
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B7, Pred: B8, Succ: B6
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B6, Pred: B7, B8, Succ: B5
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B5, Pred: B6, B9, Succ: B4, B1
 // CHECK:   Widened bounds before stmt: a = 3
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
   if (*(p + j)) {
     j = 0; // expected-error {{inferred bounds for 'p' are unknown after assignment}}
@@ -595,25 +595,26 @@ void f11(int i, int j) {
   a = 6;
 
 // CHECK:   Widened bounds before stmt: *(p + j)
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B2
 // CHECK:   Widened bounds before stmt: j = 0
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + j + 1)
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B3, Pred: B4, Succ: B2
 // CHECK:   Widened bounds before stmt: a = 4
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B2, Pred: B3, B4, Succ: B1
 // CHECK:   Widened bounds before stmt: a = 5
-// CHECK:     <none>
+// CHECK:     p: bounds(p + i, p + j)
 
 // CHECK: Block: B1, Pred: B2, B5, Succ: B0
-// CHECK:     <none>
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p + i, p + j)
 }
 
 void f12(int i, int j) {
@@ -637,7 +638,7 @@ void f12(int i, int j) {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(((p + i + j)))
 // CHECK:     p: bounds(p, p + i + j)
@@ -698,7 +699,7 @@ void f13() {
 
 // CHECK: Block: B9, Pred: B10, Succ: B8, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(1) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[0]
 // CHECK:     p: bounds(p, p + 1)
@@ -766,7 +767,7 @@ void f14(int i) {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : bounds(p, p + i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: (1 + i)[p]
 // CHECK:     p: bounds(p, p + i)
@@ -814,7 +815,7 @@ void f15(int i) {
 
 // CHECK: Block: B10, Pred: B11, Succ: B9, B8
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, p - i) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p - i)
 // CHECK:     p: bounds(p, p - i)
@@ -1185,7 +1186,7 @@ void f19() {
 
 // CHECK: Block: B6, Pred: B7, Succ: B5, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -1230,7 +1231,7 @@ void f20_1() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count({{.*}}) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(p + {{.*}})
 // CHECK:     p: bounds(p, p + {{.*}})
@@ -1254,7 +1255,7 @@ void f20_2() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> q : count({{.*}}) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(q + {{.*}})
 // CHECK:     q: bounds(q, q + {{.*}})
@@ -1279,7 +1280,7 @@ void f20_3() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> r : count({{.*}}) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(r + {{.*}} - 1)
 // CHECK:     r: bounds(r, r + {{.*}})
@@ -1304,7 +1305,7 @@ void f20_4() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> s : count({{.*}} + 1) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(s + {{.*}} + 1)
 // CHECK:     s: bounds(s, s + {{.*}} + 1)
@@ -1328,7 +1329,7 @@ void f20_5() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> t : count({{.*}} + 1) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(t + {{.*}} + 1)
 // CHECK:     t: bounds(t, t + {{.*}} + 1)
@@ -1353,7 +1354,7 @@ void f20_6() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> u : count({{.*}} + -1) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(u + {{.*}} + -1)
 // CHECK:     u: bounds(u, u + {{.*}} + -1)
@@ -1383,7 +1384,7 @@ void f21() {
 
 // CHECK: Block: B11, Pred: B12, Succ: B10
 // CHECK:   Widened bounds before stmt: char p_Nt_checked[] : count(0) = "abc";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B10, Pred: B2, B11, Succ: B9, B1
 // CHECK:   Widened bounds before stmt: p[0]
@@ -1436,7 +1437,7 @@ void f22() {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -1481,7 +1482,7 @@ B:  a = 1;
 
 // CHECK: Block: B15, Pred: B16, Succ: B13
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B14, Pred: B9, Succ: B13, B8
 // CHECK:   Widened bounds before stmt: *p
@@ -1549,23 +1550,23 @@ void f24() {
 
 // CHECK: Block: B8, Pred: B9, Succ: B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B7, Pred: B2, B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: *p
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B6, Pred: B7, Succ: B5
 // CHECK:   Widened bounds before stmt: p++
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 1)
 
 // CHECK: Block: B5, Pred: B3, B6, Succ: B4, B2
 // CHECK:   Widened bounds before stmt: *(p + 1)
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B4, Pred: B5, Succ: B3
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B3, Pred: B4, Succ: B5
 
@@ -1595,7 +1596,7 @@ void f25_1() {
 
 // CHECK: Block: B20, Pred: B21, Succ: B19
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B19, Pred: B9, B20, Succ: B18, B8
 // CHECK:   Widened bounds before stmt: *p
@@ -1648,19 +1649,19 @@ void f25_1() {
 
 // CHECK: Block: B7, Pred: B2, B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: *p
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B6, Pred: B7, Succ: B5
 // CHECK:   Widened bounds before stmt: p++
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 1)
 
 // CHECK: Block: B5, Pred: B3, B6, Succ: B4, B2
 // CHECK:   Widened bounds before stmt: *(p + 1)
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B4, Pred: B5, Succ: B3
 // CHECK:   Widened bounds before stmt: a = 7
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + 0)
 
 // CHECK: Block: B3, Pred: B4, Succ: B5
 
@@ -1685,7 +1686,7 @@ D:  a = 1;
 
 // CHECK: Block: B9, Pred: B10, Succ: B8
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B8, Pred: B3, B9, Succ: B7, B2
 // CHECK:   Widened bounds before stmt: *p
@@ -1702,12 +1703,6 @@ D:  a = 1;
 // CHECK: Block: B5, Pred: B6, Succ: B4
 // CHECK:   Widened bounds before stmt: a = 2
 // CHECK:     p: bounds(p, p + 0)
-
-// CHECK: Block: B4, Pred: B5, Succ: B6
-
-// CHECK: Block: B3, Pred: B6, Succ: B8
-
-// CHECK: Block: B2, Pred: B8, Succ: B7
 }
 
 void f26() {
@@ -1722,7 +1717,7 @@ void f26() {
 
 // CHECK: Block: B3, Pred: B4, Succ: B2, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : bounds(p, ((((((p + 1))))))) = "a";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *(((p + 1)))
 // CHECK:     p: bounds(p, ((((((p + 1)))))))
@@ -1767,11 +1762,11 @@ void f27(_Nt_array_ptr<char> p : count(i), int i) {
 // CHECK:     p: bounds(p, p + i + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + i + 1)
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B1, Pred: B2, Succ: B0
 // CHECK:   Widened bounds before stmt: a = 2
-// CHECK:     <none>
+// CHECK:     <no widening>
 }
 
 void f28() {
@@ -1790,22 +1785,22 @@ void f28() {
 
 // CHECK: Block: B7, Pred: B8, Succ: B6
 // CHECK:   Widened bounds before stmt: int i;
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: int j;
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK: Block: B6, Pred: B2, B7, Succ: B5,
 
 // CHECK: Block: B5, Pred: B6, Succ: B4, B3
 // CHECK:   Widened bounds before stmt: i = 1
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: j = 2
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(i + j) = 0;
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: p[i + j]
 // CHECK:     p: bounds(p, p + i + j)
@@ -1851,7 +1846,7 @@ void f29() {
 
 // CHECK: Block: B18, Pred: B22, Succ: B19, B20, B21
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2047,7 +2042,7 @@ void f31() {
 
 // CHECK: Block: B10, Pred: B15, Succ: B11, B14
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2174,7 +2169,7 @@ void f32() {
 
 // CHECK: Block: B2, Pred: B14, Succ: B13, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2412,7 +2407,7 @@ void f35_1() {
 
 // CHECK: Block: B2, Pred: B8, Succ: B4, B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2462,7 +2457,7 @@ void f35_2() {
 
 // CHECK: Block: B2, Pred: B8, Succ: B4, B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2512,7 +2507,7 @@ void f35_3() {
 
 // CHECK: Block: B2, Pred: B8, Succ: B4, B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2562,7 +2557,7 @@ void f35_4() {
 
 // CHECK: Block: B2, Pred: B8, Succ: B4, B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2612,7 +2607,7 @@ void f35_5() {
 
 // CHECK: Block: B2, Pred: B8, Succ: B3, B5
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2634,7 +2629,7 @@ A:  a = 2;
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: *p
 // CHECK:     p: bounds(p, p + 0)
@@ -2685,7 +2680,7 @@ A:  a = 2;
 
 // CHECK: Block: B14, Pred: B15, Succ: B13, B11
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <none>
+// CHECK:     <no widening>
 
 // CHECK:   Widened bounds before stmt: a > 0
 // CHECK:     p: bounds(p, p + 0)

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -1770,51 +1770,6 @@ void f27(_Nt_array_ptr<char> p : count(i), int i) {
 }
 
 void f28() {
-  int i, j;
-  for (;;) {
-    i = 1;
-    j = 2;
-    _Nt_array_ptr<char> p : count(i + j) = 0;
-    if (p[i + j]) {
-      return;
-    }
-  }
-
-// CHECK: Function: f28
-// CHECK: Block: B8 (Entry), Pred: Succ: B7
-
-// CHECK: Block: B7, Pred: B8, Succ: B6
-// CHECK:   Widened bounds before stmt: int i;
-// CHECK:     <no widening>
-
-// CHECK:   Widened bounds before stmt: int j;
-// CHECK:     <no widening>
-
-// CHECK: Block: B6, Pred: B2, B7, Succ: B5,
-
-// CHECK: Block: B5, Pred: B6, Succ: B4, B3
-// CHECK:   Widened bounds before stmt: i = 1
-// CHECK:     <no widening>
-
-// CHECK:   Widened bounds before stmt: j = 2
-// CHECK:     <no widening>
-
-// CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(i + j) = 0;
-// CHECK:     <no widening>
-
-// CHECK:   Widened bounds before stmt: p[i + j]
-// CHECK:     p: bounds(p, p + i + j)
-
-// CHECK: Block: B4, Pred: B5, Succ: B0
-// CHECK:   Widened bounds before stmt: return;
-// CHECK:     p: bounds(p, p + i + j + 1)
-
-// CHECK: Block: B3, Pred: B5, Succ: B2
-
-// CHECK: Block: B2, Pred: B3, Succ: B6
-}
-
-void f29() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch (*p) {
@@ -1823,7 +1778,7 @@ void f29() {
   case 'b': a = 2; break;
   }
 
-// CHECK: Function: f29
+// CHECK: Function: f28
 // CHECK: Block: B22 (Entry), Pred: Succ: B18
 
 // CHECK: Block: B21, Pred: B18, Succ: B14
@@ -1936,7 +1891,7 @@ void f29() {
 // CHECK: Block: B1, Pred: B3, B4, Succ: B0
 }
 
-void f30() {
+void f29() {
   _Nt_array_ptr<char> p : count(0) = "";
   const char c1 = '\0';
   const int c2 = '0';
@@ -1955,7 +1910,7 @@ void f30() {
   case c4: a = 5; break;
   }
 
-// CHECK: Function: f30
+// CHECK: Function: f29
 // CHECK: Block: B12 (Entry), Pred: Succ: B6
 // CHECK: Block: B11, Pred: B6, Succ: B2
 // CHECK:   Widened bounds before stmt: a = 1
@@ -2005,7 +1960,7 @@ void f30() {
 // CHECK: Block: B1, Pred: B3, B4, B5, Succ: B0
 }
 
-void f31() {
+void f30() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch (*p) {
@@ -2018,7 +1973,7 @@ void f31() {
     }
   }
 
-// CHECK: Function: f31
+// CHECK: Function: f30
 // CHECK: Block: B15 (Entry), Pred: Succ: B10
 
 // CHECK: Block: B14, Pred: B10, Succ: B7
@@ -2095,7 +2050,7 @@ void f31() {
 // CHECK: Block: B1, Pred: B3, B2, Succ: B0
 }
 
-void f32() {
+void f31() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch (*p) {
@@ -2121,7 +2076,7 @@ void f32() {
   }
   a = 8;
 
-// CHECK: Function: f32
+// CHECK: Function: f31
 // CHECK: Block: B14 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B13, Pred: B2, Succ: B12, B3
@@ -2179,7 +2134,7 @@ void f32() {
 // CHECK:     p: bounds(p, p + 0)
 }
 
-void f33() {
+void f32() {
   _Nt_array_ptr<char> p : count(0) = "";
   const int i = -1;
   const int j = 1;
@@ -2188,7 +2143,7 @@ void f33() {
   case i ... j: a = 1; break;
   }
 
-// CHECK: Function: f33
+// CHECK: Function: f32
 // CHECK: Block: B14 (Entry), Pred: Succ: B12
 
 // CHECK: Block: B13, Pred: B12, Succ: B8
@@ -2365,7 +2320,7 @@ void f34() {
 // CHECK:     q: bounds(q, q + 0)
 }
 
-void f35_1() {
+void f34_1() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch(*p) {
@@ -2381,7 +2336,7 @@ void f35_1() {
     }
   }
 
-// CHECK: Function: f35_1
+// CHECK: Function: f34_1
 // CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
@@ -2415,7 +2370,7 @@ void f35_1() {
 // CHECK: Block: B1, Pred: B3, B7, Succ: B0
 }
 
-void f35_2() {
+void f34_2() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch(*p) {
@@ -2431,7 +2386,7 @@ void f35_2() {
     }
   }
 
-// CHECK: Function: f35_2
+// CHECK: Function: f34_2
 // CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
@@ -2465,7 +2420,7 @@ void f35_2() {
 // CHECK: Block: B1, Pred: B3, B7, Succ: B0
 }
 
-void f35_3() {
+void f34_3() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch(*p) {
@@ -2481,7 +2436,7 @@ void f35_3() {
     }
   }
 
-// CHECK: Function: f35_3
+// CHECK: Function: f34_3
 // CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
@@ -2515,7 +2470,7 @@ void f35_3() {
 // CHECK: Block: B1, Pred: B3, B7, Succ: B0
 }
 
-void f35_4() {
+void f34_4() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch(*p) {
@@ -2531,7 +2486,7 @@ void f35_4() {
     }
   }
 
-// CHECK: Function: f35_4
+// CHECK: Function: f34_4
 // CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B2, Succ: B1
@@ -2565,7 +2520,7 @@ void f35_4() {
 // CHECK: Block: B1, Pred: B3, B7, Succ: B0
 }
 
-void f35_5() {
+void f34_5() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   switch(*p) {
@@ -2581,7 +2536,7 @@ void f35_5() {
     case 0: a = 11; break;
   }
 
-// CHECK: Function: f35_5
+// CHECK: Function: f34_5
 // CHECK: Block: B8 (Entry), Pred: Succ: B2
 
 // CHECK: Block: B7, Pred: B5, Succ: B4
@@ -2615,7 +2570,7 @@ void f35_5() {
 // CHECK: Block: B1, Pred: B3, B4, Succ: B0
 }
 
-void f36() {
+void f35() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   if (*p) {
@@ -2624,7 +2579,7 @@ A:  a = 2;
     a = 3;
   }
 
-// CHECK: Function: f36
+// CHECK: Function: f35
 // CHECK: Block: B5 (Entry), Pred: Succ: B4
 
 // CHECK: Block: B4, Pred: B5, Succ: B3, B1
@@ -2648,7 +2603,7 @@ A:  a = 2;
 // CHECK: Block: B1, Pred: B2, B4, Succ: B0
 }
 
-void f37() {
+void f36() {
   _Nt_array_ptr<char> p : count(0) = "";
 
   if (a > 0) {
@@ -2675,7 +2630,7 @@ A:  a = 2;
 
   goto A;
 
-// CHECK: Function: f37
+// CHECK: Function: f36
 // CHECK: Block: B15 (Entry), Pred: Succ: B14
 
 // CHECK: Block: B14, Pred: B15, Succ: B13, B11

--- a/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/new-widened-bounds.c
@@ -1764,7 +1764,7 @@ void f27(_Nt_array_ptr<char> p : count(i), int i) {
 
 // CHECK: Block: B2, Pred: B3, B4, Succ: B1, B0
 // CHECK:   Widened bounds before stmt: a == 1 ? i++ : i
-// CHECK:     <none>
+// CHECK:     p: bounds(p, p + i + 1)
 
 // CHECK:   Widened bounds before stmt: *(p + i + 1)
 // CHECK:     <none>


### PR DESCRIPTION
This is an updated implementation of the dataflow analysis for bounds widening.
In addition to the existing support for bounds widening on a conditional
dereferencing a null-terminated array at its upper bound this implementation
also supports bounds widening in presence of _Where clauses. For example:
```
  _Nt_array_ptr<char> p : bounds(p, p + 1);
  int x = strlen(p) _Where p : bounds(p, p + x); // Bounds of p widened to bounds(p, p + x).
```