### PR TITLE
Simple constant folding for bounds upper offsets

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1444,22 +1444,30 @@ namespace {
 
         llvm::APSInt LHSConst;
         llvm::APSInt RHSConst;
+        BinaryOperator *LHSBinOp = nullptr;
 
-        BinaryOperator *RootBinOp = dyn_cast<BinaryOperator>(UpperOffsetVariable->IgnoreParens());
+        // UpperOffsetVariable must be of the form LHS +/- RHS.
+        BinaryOperator *RootBinOp =
+          dyn_cast<BinaryOperator>(UpperOffsetVariable->IgnoreParens());
         if (!RootBinOp)
           goto exit;
         if (!RootBinOp->isAdditiveOp())
           goto exit;
 
-        BinaryOperator *LHSBinOp = dyn_cast<BinaryOperator>(RootBinOp->getLHS()->IgnoreParens());
+        // UpperOffsetVariable must be of the form (e1 +/- e2) +/- RHS.
+        LHSBinOp = dyn_cast<BinaryOperator>(RootBinOp->getLHS()->IgnoreParens());
         if (!LHSBinOp)
           goto exit;
         if (!LHSBinOp->isAdditiveOp())
           goto exit;
 
+        // UpperOffsetVariable must be of the form (e1 +/- e2) +/- b,
+        // where b is a constant.
         if (!GetRHSConstant(RootBinOp, RHSConst))
           goto exit;
 
+        // UpperOffsetVariable must be of the form (e1 +/- a) +/- b,
+        // where a is a constant.
         if (!GetRHSConstant(LHSBinOp, LHSConst))
           goto exit;
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1410,7 +1410,7 @@ namespace {
         }
         llvm::APSInt ElemSize;
         if (!BoundsUtil::getReferentSizeInChars(S.Context, Base->getType(), ElemSize))
-          return false;;
+          return false;
         Constant = Constant.smul_ov(ElemSize, Overflow);
         if (Overflow)
           return false;

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -701,3 +701,36 @@ void f86(void) {
   }
   len = 4;
 }
+
+//
+// Test comparing bounds expressions using simple constant folding
+//
+
+extern int simulate_snprintf(char * restrict s : itype(restrict _Nt_array_ptr<char>) count(n - 1), size_t n);
+
+void f87(_Nt_array_ptr<char> p : count(len), size_t len) {
+  // No warning when proving that inferred argument bounds (p, p + len) imply
+  // expected argument bounds (p, p + ((len + 1) - 1))
+  simulate_snprintf(p, len + 1);
+}
+
+void f88(int len) {
+  _Array_ptr<int> p : count(len + 2) = 0;
+  _Array_ptr<int> q : count(len + 2 - 1 + 1) = p;
+}
+
+void f89(_Ptr<int> p) {
+  _Nt_array_ptr<char> a : count(*p) = 0;
+  _Nt_array_ptr<char> b : count(*p + 2 - 1) = 0;
+  a = b;
+}
+
+struct S3 {
+  _Array_ptr<char> f : count(len - 2 + 1);
+  _Array_ptr<char> g : count(len);
+  int len;
+};
+
+void f90(struct S3 s) {
+  s.f = s.g;
+}


### PR DESCRIPTION
This PR introduces a temporary solution for an issue with bounds validation: the bounds checker should be able to prove that `bounds(p, p + ((len + 1) - 1))` imply `bounds(p, p + len)`.

The solution involves performing constant folding for a limited set of expressions. If the upper offset of a range is of the form `(e +/- a) +/ b`, where `a` and `b` are integer constants and `e` is an expression, we extract the variable part as `e` and the constant part as `a + b` (or `a + -b`, `-a + b`, or `-a + -b`).

This is intended to be a temporary fix until we can solve issues with constant folding, commutativity, and associativity in bounds expressions in a more general way.

This fix addresses +1/-1 situations that can arise from passing arguments to functions with declared parameter bounds (see [checkedc/450](https://github.com/microsoft/checkedc/issues/450)). However, it does not fix +1/-1 situations that can occur as a result of bounds widening, e.g.

```
void f(_Nt_array_ptr<char> p : count(len), unsigned int len) {
  if (*(p + len)) {
    ++len;
  }
}
```

The bounds checker is unable to create a base range for the inferred bounds `bounds(p, (p + (len - 1)) + 1)`. We need further work to address associativity issues with bounds expressions.