### PR TITLE
Add null statements to the CFG

### DIFF
--- a/clang/include/clang/Analysis/CFG.h
+++ b/clang/include/clang/Analysis/CFG.h
@@ -1252,6 +1252,7 @@ public:
     bool MarkElidedCXXConstructors = false;
     bool AddVirtualBaseBranches = false;
     bool OmitImplicitValueInitializers = false;
+    bool AddNullStmt = false;
 
     BuildOptions() = default;
 

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -540,6 +540,7 @@ public:
 
 private:
   // Visitors to walk an AST and construct the CFG.
+  CFGBlock *VisitNullStmt(Stmt *S);
   CFGBlock *VisitInitListExpr(InitListExpr *ILE, AddStmtChoice asc);
   CFGBlock *VisitAddrLabelExpr(AddrLabelExpr *A, AddStmtChoice asc);
   CFGBlock *VisitBinaryOperator(BinaryOperator *B, AddStmtChoice asc);
@@ -2284,7 +2285,7 @@ CFGBlock *CFGBuilder::Visit(Stmt * S, AddStmtChoice asc,
       return VisitMemberExpr(cast<MemberExpr>(S), asc);
 
     case Stmt::NullStmtClass:
-      return Block;
+      return VisitNullStmt(cast<NullStmt>(S));
 
     case Stmt::ObjCAtCatchStmtClass:
       return VisitObjCAtCatchStmt(cast<ObjCAtCatchStmt>(S));
@@ -2392,6 +2393,14 @@ CFGBlock *CFGBuilder::VisitInitListExpr(InitListExpr *ILE, AddStmtChoice asc) {
     }
   }
   return B;
+}
+
+CFGBlock *CFGBuilder::VisitNullStmt(Stmt *S) {
+  if (BuildOpts.AddNullStmt) {
+    autoCreateBlock();
+    appendStmt(Block, S);
+  }
+  return Block;
 }
 
 CFGBlock *CFGBuilder::VisitAddrLabelExpr(AddrLabelExpr *A,

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -6828,6 +6828,7 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   std::pair<ComparisonSet, ComparisonSet> EmptyFacts;
   CFG::BuildOptions BO;
   BO.AddLifetime = true;
+  BO.AddNullStmt = true;
   std::unique_ptr<CFG> Cfg = CFG::buildCFG(nullptr, Body, &getASTContext(), BO);
   CheckBoundsDeclarations Checker(*this, Info, Body, Cfg.get(), FD->getBoundsExpr(), EmptyFacts);
   if (Cfg != nullptr) {


### PR DESCRIPTION
 `_Where` clauses, which are processed in a dataflow analysis like `BoundsWideningAnalysis` (and will soon be processed in `AvailableFactsAnalysis`) could be attached to null statements. Therefore, it is necessary for the null statements to be present among the statements of a basic block.

Null statements are added to the CFG on a flag, and this flag is set to true only for the CFG built in `SemaBounds.cpp`. These null statements are currently not being dumped during an AST dump or a CFG dump.