### PR TITLE
Call ExprUtil::EqualValue in CompareUpperOffsetsWithConstantFolding

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1431,7 +1431,7 @@ namespace {
         if (!Variable || !RVariable)
           return false;
 
-        if (!EqualValue(S.Context, Variable, RVariable, EquivExprs))
+        if (!ExprUtil::EqualValue(S.Context, Variable, RVariable, EquivExprs))
           return false;
 
         EnsureEqualBitWidths(Constant, RConstant);


### PR DESCRIPTION
This PR updates the `CompareUpperOffsetsWithConstantFolding` method since `EqualValue` was moved into the `ExprUtil` class.