### PR TITLE
Make ReplaceLValue methods available outside CheckBoundsDeclarations

### DIFF
--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -113,6 +113,12 @@ public:
   // referent type of Ty in chars.
   static bool getReferentSizeInChars(ASTContext &Ctx, QualType Ty,
                                      llvm::APSInt &Size);
+
+  // ConvertToSignedPointerWidth converts I to a signed integer with
+  // Ctx.PointerWidth.
+  static llvm::APSInt ConvertToSignedPointerWidth(ASTContext &Ctx,
+                                                  llvm::APSInt I,
+                                                  bool &Overflow);
 };
 
 } // end namespace clang

--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -108,6 +108,11 @@ public:
 
   // IgnoreRedundantCast strips redundant casts off of E.
   static Expr *IgnoreRedundantCast(ASTContext &Ctx, CastKind NewCK, Expr *E);
+
+  // getReferentSizeInChars sets the out parameter Size to the size of the
+  // referent type of Ty in chars.
+  static bool getReferentSizeInChars(ASTContext &Ctx, QualType Ty,
+                                     llvm::APSInt &Size);
 };
 
 } // end namespace clang

--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -119,6 +119,9 @@ public:
   static llvm::APSInt ConvertToSignedPointerWidth(ASTContext &Ctx,
                                                   llvm::APSInt I,
                                                   bool &Overflow);
+
+  // FindLValue returns true if the given lvalue expression occurs in E.
+  static bool FindLValue(Sema &S, Expr *LValue, Expr *E);
 };
 
 } // end namespace clang

--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -105,6 +105,9 @@ public:
   // GetRValueCastChild returns the child of a possibly parenthesized
   // rvalue cast.
   static Expr *GetRValueCastChild(Sema &S, Expr *E);
+
+  // IgnoreRedundantCast strips redundant casts off of E.
+  static Expr *IgnoreRedundantCast(ASTContext &Ctx, CastKind NewCK, Expr *E);
 };
 
 } // end namespace clang

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -32,6 +32,15 @@ public:
 
   // CreateBoundsUnknown returns bounds(unknown).
   static BoundsExpr *CreateBoundsUnknown(Sema &S);
+
+private:
+  // If an original value is provided, ReplaceLValue returns an expression
+  // that replaces all uses of the lvalue expression LValue in E with the
+  // original value.  If no original value is provided and E uses LValue,
+  // ReplaceLValue returns nullptr.
+  static Expr *ReplaceLValue(Sema &S, Expr *E, Expr *LValue,
+                             Expr *OriginalValue,
+                             CheckedScopeSpecifier CSS);
 };
 
 } // end namespace clang

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -1,0 +1,36 @@
+//===----------- BoundsUtils.h: Utility functions for bounds ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+//
+//  This file defines the utility functions for bounds expressions.
+//
+//===------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_BOUNDSUTILS_H
+#define LLVM_CLANG_BOUNDSUTILS_H
+
+#include "clang/AST/Expr.h"
+#include "clang/Sema/Sema.h"
+
+namespace clang {
+
+class BoundsUtil {
+public:
+  // IsStandardForm returns true if the bounds expression BE is:
+  // 1. bounds(any), or:
+  // 2. bounds(unknown), or:
+  // 3. bounds(e1, e2), or:
+  // 4. Invalid bounds.
+  // It returns false if BE is of the form count(e) or byte_count(e).
+  static bool IsStandardForm(const BoundsExpr *BE);
+};
+
+} // end namespace clang
+
+#endif

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -33,7 +33,15 @@ public:
   // CreateBoundsUnknown returns bounds(unknown).
   static BoundsExpr *CreateBoundsUnknown(Sema &S);
 
-private:
+  // If Bounds uses the value of LValue and an original value is provided,
+  // ReplaceLValueInBounds will return a bounds expression where the uses
+  // of LValue are replaced with the original value.
+  // If Bounds uses the value of LValue and no original value is provided,
+  // ReplaceLValueInBounds will return bounds(unknown).
+  static BoundsExpr *ReplaceLValueInBounds(Sema &S, BoundsExpr *Bounds,
+                                           Expr *LValue, Expr *OriginalValue,
+                                           CheckedScopeSpecifier CSS);
+
   // If an original value is provided, ReplaceLValue returns an expression
   // that replaces all uses of the lvalue expression LValue in E with the
   // original value.  If no original value is provided and E uses LValue,

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -29,6 +29,9 @@ public:
   // 4. Invalid bounds.
   // It returns false if BE is of the form count(e) or byte_count(e).
   static bool IsStandardForm(const BoundsExpr *BE);
+
+  // CreateBoundsUnknown returns bounds(unknown).
+  static BoundsExpr *CreateBoundsUnknown(Sema &S);
 };
 
 } // end namespace clang

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -207,9 +207,9 @@ bool ExprUtil::getReferentSizeInChars(ASTContext &Ctx, QualType Ty,
   return true;
 }
 
-llvm::APSInt EpxrUtil::ConvertToSignedPointerWidth(ASTContext &Ctx,
+llvm::APSInt ExprUtil::ConvertToSignedPointerWidth(ASTContext &Ctx,
                                                    llvm::APSInt I,
-                                                  bool &Overflow) {
+                                                   bool &Overflow) {
   uint64_t PointerWidth = Ctx.getTargetInfo().getPointerWidth(0);
   Overflow = false;
   if (I.getBitWidth() > PointerWidth) {

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -181,3 +181,16 @@ Expr *ExprUtil::GetRValueCastChild(Sema &S, Expr *E) {
   }
   return nullptr;
 }
+
+Expr *ExprUtil::IgnoreRedundantCast(ASTContext &Ctx, CastKind NewCK, Expr *E) {
+  CastExpr *P = dyn_cast<CastExpr>(E);
+  if (!P)
+    return E;
+
+  CastKind ExistingCK = P->getCastKind();
+  Expr *SE = P->getSubExpr();
+  if (NewCK == CK_BitCast && ExistingCK == CK_BitCast)
+    return SE;
+
+  return E;
+}

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -206,3 +206,25 @@ bool ExprUtil::getReferentSizeInChars(ASTContext &Ctx, QualType Ty,
   Size = llvm::APSInt(llvm::APInt(Ctx.getTargetInfo().getPointerWidth(0), ElemSize), false);
   return true;
 }
+
+llvm::APSInt EpxrUtil::ConvertToSignedPointerWidth(ASTContext &Ctx,
+                                                   llvm::APSInt I,
+                                                  bool &Overflow) {
+  uint64_t PointerWidth = Ctx.getTargetInfo().getPointerWidth(0);
+  Overflow = false;
+  if (I.getBitWidth() > PointerWidth) {
+    Overflow = true;
+    goto exit;
+  }
+  if (I.getBitWidth() < PointerWidth)
+    I = I.extend(PointerWidth);
+  if (I.isUnsigned()) {
+    if (I > llvm::APSInt(I.getSignedMaxValue(PointerWidth))) {
+      Overflow = true;
+      goto exit;
+    }
+    I = llvm::APSInt(I, false);
+  }
+  exit:
+    return I;
+}

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -194,3 +194,15 @@ Expr *ExprUtil::IgnoreRedundantCast(ASTContext &Ctx, CastKind NewCK, Expr *E) {
 
   return E;
 }
+
+bool ExprUtil::getReferentSizeInChars(ASTContext &Ctx, QualType Ty,
+                                      llvm::APSInt &Size) {
+  assert(Ty->isPointerType());
+  const Type *Pointee = Ty->getPointeeOrArrayElementType();
+  if (Pointee->isIncompleteType())
+    return false;
+  uint64_t ElemBitSize = Ctx.getTypeSize(Pointee);
+  uint64_t ElemSize = Ctx.toCharUnitsFromBits(ElemBitSize).getQuantity();
+  Size = llvm::APSInt(llvm::APInt(Ctx.getTargetInfo().getPointerWidth(0), ElemSize), false);
+  return true;
+}

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -12,7 +12,9 @@
 //
 //===--------------------------------------------------------------------===//
 
+#include "clang/AST/ExprUtils.h"
 #include "clang/Sema/BoundsUtils.h"
+#include "TreeTransform.h"
 
 using namespace clang;
 
@@ -24,4 +26,100 @@ bool BoundsUtil::IsStandardForm(const BoundsExpr *BE) {
 
 BoundsExpr *BoundsUtil::CreateBoundsUnknown(Sema &S) {
   return S.Context.getPrebuiltBoundsUnknown();
+}
+
+namespace {
+  class ReplaceLValueHelper : public TreeTransform<ReplaceLValueHelper> {
+    typedef TreeTransform<ReplaceLValueHelper> BaseTransform;
+    private:
+      Lexicographic Lex;
+
+      // The lvalue expression whose uses should be replaced in an expression.
+      Expr *LValue;
+
+      // The original value (if any) to replace uses of the lvalue with.
+      // If no original value is provided, an expression using the lvalue
+      // will be transformed into an invalid result.
+      Expr *OriginalValue;
+
+    public:
+      ReplaceLValueHelper(Sema &SemaRef, Expr *LValue, Expr *OriginalValue) :
+        BaseTransform(SemaRef),
+        Lex(Lexicographic(SemaRef.Context, nullptr)),
+        LValue(LValue),
+        OriginalValue(OriginalValue) { }
+
+      ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
+        DeclRefExpr *V = dyn_cast_or_null<DeclRefExpr>(LValue);
+        if (!V)
+          return E;
+        if (Lex.CompareExpr(V, E) == Lexicographic::Result::Equal) {
+          if (OriginalValue)
+            return OriginalValue;
+          else
+            return ExprError();
+        } else
+          return E;
+      }
+
+      ExprResult TransformMemberExpr(MemberExpr *E) {
+        MemberExpr *M = dyn_cast_or_null<MemberExpr>(LValue);
+        if (!M)
+          return E;
+        if (Lex.CompareExprSemantically(M, E)) {
+          if (OriginalValue)
+            return OriginalValue;
+          else
+            return ExprError();
+        } else
+          return E;
+      }
+
+      // Overriding TransformImplicitCastExpr is necessary since TreeTransform
+      // does not preserve implicit casts.
+      ExprResult TransformImplicitCastExpr(ImplicitCastExpr *E) {
+        // Replace V with OV (if applicable) in the subexpression of E.
+        ExprResult ChildResult = TransformExpr(E->getSubExpr());
+        if (ChildResult.isInvalid())
+          return ChildResult;
+
+        Expr *Child = ChildResult.get();
+        CastKind CK = E->getCastKind();
+
+        if (CK == CastKind::CK_LValueToRValue ||
+            CK == CastKind::CK_ArrayToPointerDecay)
+          // Only cast children of lvalue to rvalue casts to an rvalue if
+          // necessary.  The transformed child expression may no longer be
+          // an lvalue, depending on the original value.  For example, if x
+          // is transformed to the original value x + 1, it does not need to
+          // be cast to an rvalue.
+          return ExprCreatorUtil::EnsureRValue(SemaRef, Child);
+        else
+          return ExprCreatorUtil::CreateImplicitCast(SemaRef, Child,
+                                                     CK, E->getType());
+      }
+  };
+}
+
+Expr *BoundsUtil::ReplaceLValue(Sema &S, Expr *E, Expr *LValue,
+                              Expr *OriginalValue,
+                              CheckedScopeSpecifier CSS) {
+  // Don't transform E if it does not use the value of LValue.
+  if (!ExprUtil::FindLValue(S, LValue, E))
+    return E;
+
+  // If E uses the value of LValue, but no original value is provided,
+  // we know the result is null without needing to transform E.
+  if (!OriginalValue)
+    return nullptr;
+
+  // Account for checked scope information when transforming the expression.
+  Sema::CheckedScopeRAII CheckedScope(S, CSS);
+
+  Sema::ExprSubstitutionScope Scope(S); // suppress diagnostics
+  ExprResult R = ReplaceLValueHelper(S, LValue, OriginalValue).TransformExpr(E);
+  if (R.isInvalid())
+    return nullptr;
+  else
+    return R.get();
 }

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -1,0 +1,23 @@
+//===----------- BoundsUtils.cpp: Utility functions for bounds ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===--------------------------------------------------------------------===//
+//
+//  This file implements utility functions for bounds expressions.
+//
+//===--------------------------------------------------------------------===//
+
+#include "clang/Sema/BoundsUtils.h"
+
+using namespace clang;
+
+bool BoundsUtil::IsStandardForm(const BoundsExpr *BE) {
+  BoundsExpr::Kind K = BE->getKind();
+  return (K == BoundsExpr::Kind::Any || K == BoundsExpr::Kind::Unknown ||
+    K == BoundsExpr::Kind::Range || K == BoundsExpr::Kind::Invalid);
+}

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -21,3 +21,7 @@ bool BoundsUtil::IsStandardForm(const BoundsExpr *BE) {
   return (K == BoundsExpr::Kind::Any || K == BoundsExpr::Kind::Unknown ||
     K == BoundsExpr::Kind::Range || K == BoundsExpr::Kind::Invalid);
 }
+
+BoundsExpr *BoundsUtil::CreateBoundsUnknown(Sema &S) {
+  return S.Context.getPrebuiltBoundsUnknown();
+}

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -28,6 +28,18 @@ BoundsExpr *BoundsUtil::CreateBoundsUnknown(Sema &S) {
   return S.Context.getPrebuiltBoundsUnknown();
 }
 
+BoundsExpr *BoundsUtil::ReplaceLValueInBounds(Sema &S, BoundsExpr *Bounds,
+                                              Expr *LValue, Expr *OriginalValue,
+                                              CheckedScopeSpecifier CSS) {
+  Expr *Replaced = ReplaceLValue(S, Bounds, LValue, OriginalValue, CSS);
+  if (!Replaced)
+    return CreateBoundsUnknown(S);
+  else if (BoundsExpr *AdjustedBounds = dyn_cast<BoundsExpr>(Replaced))
+    return AdjustedBounds;
+  else
+    return CreateBoundsUnknown(S);
+}
+
 namespace {
   class ReplaceLValueHelper : public TreeTransform<ReplaceLValueHelper> {
     typedef TreeTransform<ReplaceLValueHelper> BaseTransform;

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -24,6 +24,7 @@ add_clang_library(clangSema
   AnalysisBasedWarnings.cpp
   AvailableFactsAnalysis.cpp
   BoundsAnalysis.cpp
+  BoundsUtils.cpp
   BoundsWideningAnalysis.cpp
   CheckedCAlias.cpp
   CheckedCAnalysesPrepass.cpp

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -68,19 +68,6 @@ public:
       K == BoundsExpr::Kind::Range || K == BoundsExpr::Kind::Invalid);
   }
 
-  static Expr *IgnoreRedundantCast(ASTContext &Ctx, CastKind NewCK, Expr *E) {
-    CastExpr *P = dyn_cast<CastExpr>(E);
-    if (!P)
-      return E;
-
-    CastKind ExistingCK = P->getCastKind();
-    Expr *SE = P->getSubExpr();
-    if (NewCK == CK_BitCast && ExistingCK == CK_BitCast)
-      return SE;
-
-    return E;
-  }
-
   static bool getReferentSizeInChars(ASTContext &Ctx, QualType Ty, llvm::APSInt &Size) {
     assert(Ty->isPointerType());
     const Type *Pointee = Ty->getPointeeOrArrayElementType();
@@ -4635,7 +4622,7 @@ namespace {
     Expr *CreateExplicitCast(QualType Target, CastKind CK, Expr *E,
                                bool isBoundsSafeInterface) {
       // Avoid building up nested chains of no-op casts.
-      E = BoundsUtil::IgnoreRedundantCast(Context, CK, E);
+      E = ExprUtil::IgnoreRedundantCast(Context, CK, E);
 
       // Synthesize some dummy type source source information.
       TypeSourceInfo *DI = Context.getTrivialTypeSourceInfo(Target);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -46,6 +46,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Sema/AvailableFactsAnalysis.h"
 #include "clang/Sema/BoundsAnalysis.h"
+#include "clang/Sema/BoundsUtils.h"
 #include "clang/Sema/CheckedCAnalysesPrepass.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -58,17 +59,6 @@
 
 using namespace clang;
 using namespace sema;
-
-namespace {
-class BoundsUtil {
-public:
-  static bool IsStandardForm(const BoundsExpr *BE) {
-    BoundsExpr::Kind K = BE->getKind();
-    return (K == BoundsExpr::Kind::Any || K == BoundsExpr::Kind::Unknown ||
-      K == BoundsExpr::Kind::Range || K == BoundsExpr::Kind::Invalid);
-  }
-};
-}
 
 namespace {
   class AbstractBoundsExpr : public TreeTransform<AbstractBoundsExpr> {


### PR DESCRIPTION
This PR makes `ReplaceLValueInBounds` and `ReplaceLValue` available via a `BoundsUtil` class.

This involves moving several methods into utility classes:
* ExprUtil:
   * getReferentSizeInChars
   * ConvertToSignedPointerWidth
   * FindLValue
* BoundsUtil:
   * IsStandardForm
   * CreateBoundsUnknown
   * ReplaceLValue
   * ReplaceLValueInBounds