### PR TITLE
Update observed bounds with widened bounds

### DIFF
--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -337,6 +337,15 @@ namespace clang {
     // @param[in] CurrStmt is the current statement.
     BoundsMapTy GetStmtIn(const CFGBlock *B, const Stmt *CurrStmt) const;
 
+    // Get the bounds that are widened in the current block before the current
+    // statement and that are not killed by the current statement.
+    // Note: This method can be called from outside this class and can be used
+    // to control diagnostics for observed bounds.
+    // @param[in] B is the current block.
+    // @param[in] CurrStmt is the current statement.
+    BoundsMapTy GetBoundsWidenedAndNotKilled(const CFGBlock *B,
+                                             const Stmt *CurrStmt) const;
+
   private:
     // Compute Gen and Kill sets for the block and statements in the block.
     // @param[in] EB is the current ElevatedCFGBlock.

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -502,6 +502,20 @@ BoundsMapTy BoundsWideningAnalysis::GetStmtIn(const CFGBlock *B,
   return GetStmtOut(B, EB->PrevStmtMap[CurrStmt]);
 }
 
+BoundsMapTy BoundsWideningAnalysis::GetBoundsWidenedAndNotKilled(
+  const CFGBlock *B, const Stmt *CurrStmt) const {
+
+  auto BlockIt = BlockMap.find(B);
+  if (BlockIt == BlockMap.end())
+    return BoundsMapTy();
+
+  ElevatedCFGBlock *EB = BlockIt->second;
+
+  BoundsMapTy StmtInOfCurrStmt = GetStmtIn(B, CurrStmt);
+  return BWUtil.Difference(StmtInOfCurrStmt,
+                           EB->StmtKill[CurrStmt]);
+}
+
 void BoundsWideningAnalysis::InitNtPtrsInFunc(FunctionDecl *FD) {
   // Initialize the list of variables that are pointers to null-terminated
   // arrays to the null-terminated arrays that are passed as parameters to the

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2720,14 +2720,16 @@ namespace {
 
      // If a variable does not exist in WidenedBounds but exists in
      // State.ObservedBounds it means that the bounds of the variable got
-     // killed before the current statement. So we set the bounds of the
-     // variable in State.ObservedBounds to bounds(unknown).
+     // killed before the current statement. So we reset the bounds of the
+     // variable in State.ObservedBounds to its declared bounds.
      for (auto I = State.ObservedBounds.begin(),
                E = State.ObservedBounds.end(); I != E; ++I) {
        const AbstractSet *A = I->first;
        const VarDecl *V = A->GetVarDecl();
-       if (V && WidenedBounds.find(V) == WidenedBounds.end())
-         I->second = CreateBoundsUnknown();
+       if (V) {
+         if (WidenedBounds.find(V) == WidenedBounds.end())
+           I->second = S.NormalizeBounds(V);
+       }
      }
 
      // Update State.ObservedBounds with the WidenedBounds before the current
@@ -2843,7 +2845,7 @@ namespace {
            if (NestedElements.find(S) != NestedElements.end())
              continue;
 
-           // Update the observed bounds with the widened bounds calculated
+           // Update the observed bounds with the widened bounds computed
            // above.
            UpdateWidenedBounds(BoundsWideningAnalyzer, Block, S, BlockState);
 


### PR DESCRIPTION
For each statement update the observed bounds in the BlockState with the
widened bounds as computed by the updated bounds widening analysis. This PR
also updates the method GetBoundsWidenedAndNotKilled that returns the bounds
widened in a block before a given statement and not killed by that statement.