### PR TITLE
Move ExpandToRange methods into BoundsUtil

### DIFF
--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -37,6 +37,11 @@ public:
   // be able to infer bounds for.
   static BoundsExpr *CreateBoundsAlwaysUnknown(Sema &S);
 
+  // Given an array type with constant dimension size, CreateBoundsForArrayType
+  // returns a count expression with that size.
+  static BoundsExpr *CreateBoundsForArrayType(Sema &S, QualType T,
+                                              bool IncludeNullTerminator = false);
+
   // If Bounds uses the value of LValue and an original value is provided,
   // ReplaceLValueInBounds will return a bounds expression where the uses
   // of LValue are replaced with the original value.

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -33,6 +33,10 @@ public:
   // CreateBoundsUnknown returns bounds(unknown).
   static BoundsExpr *CreateBoundsUnknown(Sema &S);
 
+  // This describes that this is an expression we will never
+  // be able to infer bounds for.
+  static BoundsExpr *CreateBoundsAlwaysUnknown(Sema &S);
+
   // If Bounds uses the value of LValue and an original value is provided,
   // ReplaceLValueInBounds will return a bounds expression where the uses
   // of LValue are replaced with the original value.

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -53,6 +53,10 @@ public:
   //                                      (array_ptr<char>) E + C)
   static BoundsExpr *ExpandToRange(Sema &S, Expr *Base, BoundsExpr *B);
 
+  // ExpandToRange expands the bounds expression for a variable declaration
+  // to a range bounds expression.
+  static BoundsExpr *ExpandToRange(Sema &S, VarDecl *D, BoundsExpr *B);
+
   // If Bounds uses the value of LValue and an original value is provided,
   // ReplaceLValueInBounds will return a bounds expression where the uses
   // of LValue are replaced with the original value.

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -37,6 +37,10 @@ public:
   // be able to infer bounds for.
   static BoundsExpr *CreateBoundsAlwaysUnknown(Sema &S);
 
+  // If we have an error in our bounds inference that we can't
+  // recover from, bounds(unknown) is our error value.
+  static BoundsExpr *CreateBoundsInferenceError(Sema &S);
+
   // Given an array type with constant dimension size, CreateBoundsForArrayType
   // returns a count expression with that size.
   static BoundsExpr *CreateBoundsForArrayType(Sema &S, QualType T,

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -46,6 +46,13 @@ public:
   static BoundsExpr *CreateBoundsForArrayType(Sema &S, QualType T,
                                               bool IncludeNullTerminator = false);
 
+  // Given a byte_count or count bounds expression for the expression Base,
+  // expand it to a range bounds expression:
+  //  E : Count(C) expands to Bounds(E, E + C)
+  //  E : ByteCount(C)  expands to Bounds((array_ptr<char>) E,
+  //                                      (array_ptr<char>) E + C)
+  static BoundsExpr *ExpandToRange(Sema &S, Expr *Base, BoundsExpr *B);
+
   // If Bounds uses the value of LValue and an original value is provided,
   // ReplaceLValueInBounds will return a bounds expression where the uses
   // of LValue are replaced with the original value.

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -51,6 +51,10 @@ public:
   static BoundsExpr *ArrayExprBounds(Sema &S, Expr *E,
                                      bool IncludeNullTerminator = false);
 
+  // Given a byte_count or count bounds expression for the VarDecl D,
+  // ExpandBoundsToRange will expand it to a range bounds expression.
+  static BoundsExpr *ExpandBoundsToRange(Sema &S, VarDecl *D, BoundsExpr *B);
+
   // Given a byte_count or count bounds expression for the expression Base,
   // expand it to a range bounds expression:
   //  E : Count(C) expands to Bounds(E, E + C)

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -46,6 +46,11 @@ public:
   static BoundsExpr *CreateBoundsForArrayType(Sema &S, QualType T,
                                               bool IncludeNullTerminator = false);
 
+  // Compute bounds for a variable expression or member reference expression
+  // with an array type.
+  static BoundsExpr *ArrayExprBounds(Sema &S, Expr *E,
+                                     bool IncludeNullTerminator = false);
+
   // Given a byte_count or count bounds expression for the expression Base,
   // expand it to a range bounds expression:
   //  E : Count(C) expands to Bounds(E, E + C)

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5543,7 +5543,6 @@ public:
   /// of a bounds expression.  Ty is the original unchecked type.  Returns null
   /// if none exists.
   InteropTypeExpr *SynthesizeInteropTypeExpr(QualType Ty, bool IsParam);
-  BoundsExpr *CreateCountForArrayType(QualType QT);
 
   // _Return_value in Checked C bounds expressions.
   ExprResult ActOnReturnValueExpr(SourceLocation Loc);

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -32,6 +32,10 @@ BoundsExpr *BoundsUtil::CreateBoundsAlwaysUnknown(Sema &S) {
   return CreateBoundsUnknown(S);
 }
 
+BoundsExpr *BoundsUtil::CreateBoundsInferenceError(Sema &S) {
+  return CreateBoundsUnknown(S);
+}
+
 BoundsExpr *BoundsUtil::CreateBoundsForArrayType(Sema &S, QualType T,
                                                  bool IncludeNullTerminator) {
   const IncompleteArrayType *IAT = S.Context.getAsIncompleteArrayType(T);

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -129,6 +129,20 @@ BoundsExpr *BoundsUtil::ExpandToRange(Sema &S, Expr *Base, BoundsExpr *B) {
   }
 }
 
+BoundsExpr *BoundsUtil::ExpandToRange(Sema &S, VarDecl *D, BoundsExpr *B) {
+  if (!B)
+    return B;
+  QualType QT = D->getType();
+  ExprResult ER = S.BuildDeclRefExpr(D, QT,
+                                     clang::ExprValueKind::VK_LValue, SourceLocation());
+  if (ER.isInvalid())
+    return nullptr;
+  Expr *Base = ER.get();
+  if (!QT->isArrayType())
+    Base = ExprCreatorUtil::CreateImplicitCast(S, Base, CastKind::CK_LValueToRValue, QT);
+  return ExpandToRange(S, Base, B);
+}
+
 BoundsExpr *BoundsUtil::ReplaceLValueInBounds(Sema &S, BoundsExpr *Bounds,
                                               Expr *LValue, Expr *OriginalValue,
                                               CheckedScopeSpecifier CSS) {

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -28,6 +28,10 @@ BoundsExpr *BoundsUtil::CreateBoundsUnknown(Sema &S) {
   return S.Context.getPrebuiltBoundsUnknown();
 }
 
+BoundsExpr *BoundsUtil::CreateBoundsAlwaysUnknown(Sema &S) {
+  return CreateBoundsUnknown(S);
+}
+
 BoundsExpr *BoundsUtil::ReplaceLValueInBounds(Sema &S, BoundsExpr *Bounds,
                                               Expr *LValue, Expr *OriginalValue,
                                               CheckedScopeSpecifier CSS) {

--- a/clang/lib/Sema/CheckedCInterop.cpp
+++ b/clang/lib/Sema/CheckedCInterop.cpp
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Sema/BoundsUtils.h"
 #include "TreeTransform.h"
 
 using namespace clang;
@@ -184,8 +185,9 @@ public:
           CurrentParamTypes[i] = ParamType;
           // Remove the interop type annotation.
           BoundsExpr *Bounds = IndividualAnnots.getBoundsExpr();
-          if (IT->getType()->isCheckedArrayType() && !Bounds)    
-            Bounds = SemaRef.CreateCountForArrayType(IT->getType());
+          if (IT->getType()->isCheckedArrayType() && !Bounds)
+            Bounds = BoundsUtil::CreateBoundsForArrayType(SemaRef,
+                                                          IT->getType());
           if (Bounds) {
             hasParamAnnots = true;
             CurrentParamAnnots[i] = BoundsAnnotations(Bounds, nullptr);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -6206,10 +6206,6 @@ BoundsExpr *Sema::CheckNonModifyingBounds(BoundsExpr *B, Expr *E) {
     return B;
 }
 
-BoundsExpr *Sema::CreateCountForArrayType(QualType QT) {
-  return BoundsUtil::CreateBoundsForArrayType(*this, QT);
-}
-
 Expr *Sema::MakeAssignmentImplicitCastExplicit(Expr *E) {
   if (!E->isRValue())
     return E;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -33,6 +33,7 @@
 #include "clang/Lex/Lexer.h" // TODO: Extract static functions to fix layering.
 #include "clang/Lex/ModuleLoader.h" // TODO: Sema shouldn't depend on Lex
 #include "clang/Lex/Preprocessor.h" // Included for isCodeCompletionEnabled()
+#include "clang/Sema/BoundsUtils.h"
 #include "clang/Sema/CXXFieldCollector.h"
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/DelayedDiagnostic.h"
@@ -14874,10 +14875,12 @@ void Sema::InferBoundsAnnots(QualType Ty, BoundsAnnotations &Annots, bool IsPara
       // Handle parameters that originally had a checked array type.
     if (const DecayedType *DType = Ty->getAs<DecayedType>())
       if (DType->getOriginalType()->isCheckedArrayType())
-        BoundsExpr = CreateCountForArrayType(DType->getOriginalType());
+        BoundsExpr =
+          BoundsUtil::CreateBoundsForArrayType(*this, DType->getOriginalType());
 
     if (!BoundsExpr && IType && IType->getType()->isCheckedArrayType())
-        BoundsExpr = CreateCountForArrayType(IType->getType());
+        BoundsExpr =
+          BoundsUtil::CreateBoundsForArrayType(*this, IType->getType());
 
     if (!BoundsExpr)
       if (Ty->isCheckedPointerNtArrayType() || (IType &&


### PR DESCRIPTION
This PR moves methods to expand bounds to a range bounds expression into the `BoundsUtil` class.