### PR TITLE
Normalize bounds for BoundsDeclFacts

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -7159,13 +7159,38 @@ class BoundsDeclFact : public WhereClauseFact {
 public:
   VarDecl *Var;
   BoundsExpr *Bounds;
+  BoundsExpr *NormalizedBounds;
 
   BoundsDeclFact(VarDecl *Var, BoundsExpr *Bounds, SourceLocation Loc)
     : WhereClauseFact(FactKind::BoundsDeclFact, Loc),
-      Var(Var), Bounds(Bounds) {}
+      Var(Var), Bounds(Bounds), NormalizedBounds(nullptr) {}
 
   static bool classof(const WhereClauseFact *Fact) {
     return Fact->Kind == FactKind::BoundsDeclFact;
+  }
+
+  // \brief The bounds expression for this bounds fact, expanded to a
+  // range bounds expression.
+  BoundsExpr *getNormalizedBounds() const {
+    return const_cast<BoundsDeclFact *>(this)->getNormalizedBounds();
+  }
+
+  // \brief The bounds expression for this bounds fact, expanded to a
+  // range bounds expression.
+  BoundsExpr *getNormalizedBounds() {
+    return NormalizedBounds;
+  }
+
+  // \brief Set the bounds expression for this bounds fact, expanded to a
+  // range bounds expression.
+  void setNormalizedBounds(BoundsExpr *E) const {
+    const_cast<BoundsDeclFact *>(this)->setNormalizedBounds(E);
+  }
+
+  // \brief Set the bounds expression for this bounds fact, expanded to a
+  // range bounds expression.
+  void setNormalizedBounds(BoundsExpr *E) {
+    NormalizedBounds = E;
   }
 };
 

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -7169,6 +7169,26 @@ public:
     return Fact->Kind == FactKind::BoundsDeclFact;
   }
 
+  // \brief The variable declaration associated with this bounds fact.
+  VarDecl *getVarDecl() const {
+    return const_cast<BoundsDeclFact *>(this)->getVarDecl();
+  }
+
+  // \brief The variable declaration associated with this bounds fact.
+  VarDecl *getVarDecl() {
+    return Var;
+  }
+
+  // \brief The bounds expression associated with this bounds fact.
+  BoundsExpr *getBoundsExpr() const {
+    return const_cast<BoundsDeclFact *>(this)->getBoundsExpr();
+  }
+
+  // \brief The bounds expression associated with this bounds fact.
+  BoundsExpr *getBoundsExpr() {
+    return Bounds;
+  }
+
   // \brief The bounds expression for this bounds fact, expanded to a
   // range bounds expression.
   BoundsExpr *getNormalizedBounds() const {

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -7156,11 +7156,12 @@ public:
 
 /// \brief Represents a Checked C where clause bounds decl fact.
 class BoundsDeclFact : public WhereClauseFact {
-public:
+private:
   VarDecl *Var;
   BoundsExpr *Bounds;
   BoundsExpr *NormalizedBounds;
 
+public:
   BoundsDeclFact(VarDecl *Var, BoundsExpr *Bounds, SourceLocation Loc)
     : WhereClauseFact(FactKind::BoundsDeclFact, Loc),
       Var(Var), Bounds(Bounds), NormalizedBounds(nullptr) {}

--- a/clang/include/clang/Sema/BoundsUtils.h
+++ b/clang/include/clang/Sema/BoundsUtils.h
@@ -53,6 +53,11 @@ public:
 
   // Given a byte_count or count bounds expression for the VarDecl D,
   // ExpandBoundsToRange will expand it to a range bounds expression.
+  //
+  // ExpandBoundsToRange creates a DeclRefExpr for D. Clients should not
+  // call ExpandBoundsToRange directly. Instead, clients should call
+  // Sema::NormalizeBounds, which computes the expanded bounds for D once
+  // and attaches the expanded bounds to D.
   static BoundsExpr *ExpandBoundsToRange(Sema &S, VarDecl *D, BoundsExpr *B);
 
   // Given a byte_count or count bounds expression for the expression Base,
@@ -61,10 +66,6 @@ public:
   //  E : ByteCount(C)  expands to Bounds((array_ptr<char>) E,
   //                                      (array_ptr<char>) E + C)
   static BoundsExpr *ExpandToRange(Sema &S, Expr *Base, BoundsExpr *B);
-
-  // ExpandToRange expands the bounds expression for a variable declaration
-  // to a range bounds expression.
-  static BoundsExpr *ExpandToRange(Sema &S, VarDecl *D, BoundsExpr *B);
 
   // If Bounds uses the value of LValue and an original value is provided,
   // ReplaceLValueInBounds will return a bounds expression where the uses
@@ -82,6 +83,11 @@ public:
   static Expr *ReplaceLValue(Sema &S, Expr *E, Expr *LValue,
                              Expr *OriginalValue,
                              CheckedScopeSpecifier CSS);
+
+private:
+  // ExpandToRange expands the bounds expression for a variable declaration
+  // to a range bounds expression.
+  static BoundsExpr *ExpandToRange(Sema &S, VarDecl *D, BoundsExpr *B);
 };
 
 } // end namespace clang

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5732,6 +5732,12 @@ public:
   // normalized bounds for D.
   BoundsExpr *NormalizeBounds(const VarDecl *D);
 
+  // If the BoundsDeclFact F has a byte_count or count bounds expression,
+  // NormalizeBounds expands it to a range bounds expression.  The expanded
+  // range bounds are attached to the BoundsDeclFact F to avoid recomputing
+  // the normalized bounds for F.
+  BoundsExpr *NormalizeBounds(const BoundsDeclFact *F);
+
   // Returns the declared bounds for the lvalue expression E. Assignments
   // to E must satisfy these bounds. After checking a top-level statement,
   // the inferred bounds of E must imply these declared bounds.

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -216,8 +216,8 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
 
       for (WhereClauseFact *Fact : WC->getFacts()) {
         if (BoundsDeclFact *BDF = dyn_cast<BoundsDeclFact>(Fact)) {
-          VarDecl *V = BDF->Var;
-          BoundsExpr *B = BDF->Bounds;
+          VarDecl *V = BDF->getVarDecl();
+          BoundsExpr *B = BDF->getBoundsExpr();
 
           VarDecl *OrigVarWithBounds = VarWithBounds;
           VarWithBounds = V;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -6391,12 +6391,17 @@ BoundsExpr *Sema::NormalizeBounds(const VarDecl *D) {
 // range bounds are attached to the BoundsDeclFact F to avoid recomputing
 // the normalized bounds for F.
 BoundsExpr *Sema::NormalizeBounds(const BoundsDeclFact *F) {
+  // Do not attempt to normalize bounds for bounds facts that are
+  // associated with invalid declarations.
+  const VarDecl *D = F->getVarDecl();
+  if (D->isInvalidDecl())
+    return nullptr;
+
   // If F already has a normalized bounds expression, do not recompute it.
   if (BoundsExpr *NormalizedBounds = F->getNormalizedBounds())
     return NormalizedBounds;
 
   // Expand the bounds expression of F to a RangeBoundsExpr if possible.
-  const VarDecl *D = F->getVarDecl();
   const BoundsExpr *B = F->getBoundsExpr();
   BoundsExpr *ExpandedBounds = BoundsUtil::ExpandBoundsToRange(*this,
                                              const_cast<VarDecl *>(D),

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3941,8 +3941,7 @@ namespace {
                 << Init->getSourceRange();
           InitBounds = S.CreateInvalidBoundsExpr();
         } else if (CheckBounds) {
-          BoundsExpr *NormalizedDeclaredBounds =
-            BoundsUtil::ExpandToRange(S, D, DeclaredBounds);
+          BoundsExpr *NormalizedDeclaredBounds = S.NormalizeBounds(D);
           CheckBoundsDeclAtInitializer(D->getLocation(), D, NormalizedDeclaredBounds,
             Init, InitBounds, State.EquivExprs, CSS);
         }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -4533,7 +4533,9 @@ BoundsDeclFact
     return nullptr;
   }
 
-  return new (Context) BoundsDeclFact(VD, Bounds, IdLoc);
+  BoundsDeclFact *F = new (Context) BoundsDeclFact(VD, Bounds, IdLoc);
+  NormalizeBounds(F);
+  return F;
 }
 
 EqualityOpFact *Sema::ActOnEqualityOpFact(Expr *E, SourceLocation ExprLoc) {


### PR DESCRIPTION
This PR adds a `NormalizedBounds` member to `BoundsDeclFact` and adds a `Sema::NormalizeBounds` method that takes a `BoundsDeclFacts *`. `Sema::NormalizeBounds` expands the bounds expression of a `BoundsDeclFact` once and saves it in the `NormalizedBounds` member of the `BoundsDeclFact`. 