### PR TITLE
An nt_checked array with an empty initializer list should be an error

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -2260,7 +2260,7 @@ bool InitListExpr::isNullTerminated(ASTContext &C, unsigned DeclArraySize) const
                              "sub-objects are made explicit");
 
   if (getNumInits() == 0) {
-    return true;
+    return false;
   }
 
   if (getNumInits() == 1 && getInit(0))

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13023,10 +13023,17 @@ bool Sema::ValidateNTCheckedType(ASTContext &Ctx, QualType VDeclType,
         }
       } else if (InitListExpr *E = dyn_cast<InitListExpr>(Init)) {
         if (!E->isNullTerminated(Ctx, *DeclaredArraySize)) {
-          const Expr *LastItem = E->getInit(E->getNumInits() - 1);
-          Diag(LastItem->getBeginLoc(),
-               diag::err_initializer_not_null_terminated_for_nt_checked)
-              << LastItem->getSourceRange();
+          if (E->getNumInits() == 0) {
+            Diag(Init->getBeginLoc(),
+                 diag::err_initializer_not_null_terminated_for_nt_checked)
+                 << Init->getSourceRange();
+
+          } else {
+            const Expr *LastItem = E->getInit(E->getNumInits() - 1);
+            Diag(LastItem->getBeginLoc(),
+                 diag::err_initializer_not_null_terminated_for_nt_checked)
+                 << LastItem->getSourceRange();
+          }
           return false;
         }
       }


### PR DESCRIPTION
Consider the following declaration of an nt_checked array:
char p nt_checked[] = {}

According to the Checked C spec section 2.4:

1. nt_checked declares an array whose last element is a null terminator. The size
   of the array includes the null terminator element.

2. An nt_checked array with size d converts to an nt_array_ptr with a count of d -
   1 elements.

So it should be illegal to declare an nt_checked array with an empty initializer list.

This fixes issue #1120.