### PR TITLE
[BoundsWidening] Dump dataflow sets computed by bounds widening analysis

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -264,6 +264,7 @@ BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables
 BENIGN_LANGOPT(DumpInferredBounds, 1, 0, "dump inferred Checked C bounds for assignments and declarations")
 BENIGN_LANGOPT(DumpExtractedComparisonFacts, 1, 0, "dump extracted comparison facts")
 BENIGN_LANGOPT(DumpWidenedBounds, 1, 0, "dump widened bounds")
+BENIGN_LANGOPT(DumpWidenedBoundsDataflowSets, 1, 0, "dump widened bounds dataflow sets")
 BENIGN_LANGOPT(DumpBoundsVars, 1, 0, "dump bounds vars")
 BENIGN_LANGOPT(DumpBoundsSiblingFields, 1, 0, "dump bounds sibling fields")
 BENIGN_LANGOPT(DumpPreorderAST, 1, 0, "dump the preorder AST")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -854,6 +854,8 @@ def fdump_extracted_comparison_facts : Flag<["-"], "fdump-extracted-comparison-f
   HelpText<"Dump extracted comparison facts">;
 def fdump_widened_bounds : Flag<["-"], "fdump-widened-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump widened bounds">;
+def fdump_widened_bounds_dataflow_sets : Flag<["-"], "fdump-widened-bounds-dataflow-sets">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Dump dataflow sets computed by the bounds widening analysis">;
 def fdump_boundsvars : Flag<["-"], "fdump-boundsvars">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump bounds vars">;
 def fdump_boundssiblingfields : Flag<["-"], "fdump-boundssiblingfields">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -322,7 +322,31 @@ namespace clang {
     // Pretty print the widened bounds for all null-terminated arrays in the
     // current function.
     // @param[in] FD is the current function.
-    void DumpWidenedBounds(FunctionDecl *FD);
+    // @param[in] PrintOption == 0: Dump widened bounds
+    //            PrintOption == 1: Dump dataflow sets for bounds widening
+    void DumpWidenedBounds(FunctionDecl *FD, int PrintOption);
+
+    // Pretty print a container that maps variables to their bounds
+    // expressions.
+    // @param[in] BoundsMap is a map that maps variables to their bounds
+    // expressions.
+    // @param[in] EmptyMessage is the message displayed if the container is
+    // empty.
+    // @param[in] PrintOption == 0: Dump widened bounds
+    //            PrintOption == 1: Dump dataflow sets for bounds widening
+    void PrintBoundsMap(BoundsMapTy BoundsMap, int PrintOption) const;
+
+    // Pretty print a set of variables.
+    // @param[in] VarSet is a set of variables.
+    // @param[in] EmptyMessage is the message displayed if the container is
+    // empty.
+    // @param[in] PrintOption == 0: Dump widened bounds
+    //            PrintOption == 1: Dump dataflow sets for bounds widening
+    void PrintVarSet(VarSetTy VarSet, int PrintOption) const;
+
+    // Pretty print a statement.
+    // @param[in] CurrStmt is the statement to be printed.
+    void PrintStmt(const Stmt *CurrStmt) const;
 
     // Get the Out set for the statement. This set represents the bounds
     // widened after the statement.

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2846,6 +2846,9 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   if (Args.hasArg(OPT_fdump_widened_bounds))
     Opts.DumpWidenedBounds = true;
 
+  if (Args.hasArg(OPT_fdump_widened_bounds_dataflow_sets))
+    Opts.DumpWidenedBoundsDataflowSets = true;
+
   if (Args.hasArg(OPT_fdump_boundsvars))
     Opts.DumpBoundsVars = true;
 

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -711,7 +711,84 @@ void BoundsWideningAnalysis::GetVarsAndBoundsForModifiedVars(
   }
 }
 
-void BoundsWideningAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
+void BoundsWideningAnalysis::PrintVarSet(VarSetTy VarSet,
+                                         int PrintOption) const {
+  if (VarSet.size() == 0) {
+    if (PrintOption == 0)
+      OS << "<no widening>\n";
+    else
+      OS << "    {}\n";
+    return;
+  }
+
+  // A VarSetTy has const iterator. So we cannot simply sort a VarSetTy and
+  // need to copy the elements to a vector to sort.
+  std::vector<const VarDecl *> Vars(VarSet.begin(), VarSet.end());
+
+  llvm::sort(Vars.begin(), Vars.end(),
+    [](const VarDecl *A, const VarDecl *B) {
+       return A->getQualifiedNameAsString().compare(
+              B->getQualifiedNameAsString()) < 0;
+    });
+
+  for (const VarDecl *V : Vars)
+    OS << "    " << V->getQualifiedNameAsString() << "\n";
+}
+
+void BoundsWideningAnalysis::PrintBoundsMap(BoundsMapTy BoundsMap,
+                                            int PrintOption) const {
+  if (BoundsMap.size() == 0) {
+    if (PrintOption == 0)
+      OS << "<no widening>\n";
+    else
+      OS << "    {}\n";
+    return;
+  }
+
+  std::vector<const VarDecl *> Vars;
+  for (auto VarBoundsPair : BoundsMap)
+    Vars.push_back(VarBoundsPair.first);
+
+  llvm::sort(Vars.begin(), Vars.end(),
+    [](const VarDecl *A, const VarDecl *B) {
+       return A->getQualifiedNameAsString().compare(
+              B->getQualifiedNameAsString()) < 0;
+    });
+
+  for (const VarDecl *V : Vars) {
+    OS << "    " << V->getQualifiedNameAsString() << ": ";
+
+    RangeBoundsExpr *Bounds = BoundsMap[V];
+
+    if (Bounds == Top) {
+      OS << "Top\n";
+      continue;
+    }
+
+    Expr *Lower = Bounds->getLowerExpr();
+    Expr *Upper = Bounds->getUpperExpr();
+
+    OS << "bounds(";
+    Lower->printPretty(OS, nullptr, Ctx.getPrintingPolicy());
+    OS << ", ";
+    Upper->printPretty(OS, nullptr, Ctx.getPrintingPolicy());
+    OS << ")\n";
+  }
+}
+
+void BoundsWideningAnalysis::PrintStmt(const Stmt *CurrStmt) const {
+  std::string Str;
+  llvm::raw_string_ostream SS(Str);
+  CurrStmt->printPretty(SS, nullptr, Ctx.getPrintingPolicy());
+
+  OS << SS.str();
+  if (SS.str().back() != '\n')
+    OS << "\n";
+}
+
+void BoundsWideningAnalysis::DumpWidenedBounds(FunctionDecl *FD,
+                                               int PrintOption) {
+
   OS << "\n--------------------------------------";
   // Print the function name.
   OS << "\nFunction: " << FD->getName();
@@ -742,64 +819,64 @@ void BoundsWideningAnalysis::DumpWidenedBounds(FunctionDecl *FD) {
         }
     }
 
-    bool IsBlockEmpty = true;
+    ElevatedCFGBlock *EB = BlockMap[CurrBlock];
+
+    if (PrintOption == 1) {
+      // Print the In set for the block.
+      OS << "\n  In:\n";
+      PrintBoundsMap(EB->In, PrintOption);
+
+      // Print the Gen set for the block.
+      OS << "  Gen:\n";
+      PrintBoundsMap(EB->Gen, PrintOption);
+
+      // Print the Kill set for the block.
+      OS << "  Kill:\n";
+      PrintVarSet(EB->Kill, PrintOption);
+
+      // Print the Out set for the block.
+      OS << "  Out:\n";
+      PrintBoundsMap(EB->Out, PrintOption);
+    }
+
     for (CFGElement Elem : *CurrBlock) {
       if (Elem.getKind() != CFGElement::Statement)
         continue;
-
       const Stmt *CurrStmt = Elem.castAs<CFGStmt>().getStmt();
       if (!CurrStmt)
         continue;
-
-      BoundsMapTy WidenedBounds = GetStmtIn(CurrBlock, CurrStmt);
-
-      std::vector<const VarDecl *> Vars;
-      for (auto VarBoundsPair : WidenedBounds)
-        Vars.push_back(VarBoundsPair.first);
-
-      llvm::sort(Vars.begin(), Vars.end(),
-        [](const VarDecl *A, const VarDecl *B) {
-           return A->getQualifiedNameAsString().compare(
-                  B->getQualifiedNameAsString()) < 0;
-        });
-
-      std::string Str;
-      llvm::raw_string_ostream SS(Str);
-      CurrStmt->printPretty(SS, nullptr, Ctx.getPrintingPolicy());
-
+   
+      if (PrintOption == 0) {
+        OS << "\n  Widened bounds before stmt: ";
+      } else if (PrintOption == 1) {
+        OS << "\n  Stmt: ";
+      }
+  
       // Print the current statement.
-      OS << "\n  Widened bounds before stmt: " << SS.str();
-      if (SS.str().back() != '\n')
-        OS << "\n";
+      PrintStmt(CurrStmt);
 
-      IsBlockEmpty = false;
+      if (PrintOption == 0) {
+        // Print widened bounds before the statement.
+        PrintBoundsMap(GetStmtIn(CurrBlock, CurrStmt), PrintOption);
 
-      if (Vars.size() == 0)
-        OS << "    <no widening>\n";
+      } else if (PrintOption == 1) {
+        // Print the In set for the statement.
+        OS << "  In:\n";
+        PrintBoundsMap(GetStmtIn(CurrBlock, CurrStmt), PrintOption);
 
-      for (const VarDecl *V : Vars) {
-        RangeBoundsExpr *Bounds = WidenedBounds[V];
-        if (Bounds == Top) {
-          // If this is the only variable and its bounds are Top, we need to
-          // print <no widening>.
-          if (Vars.size() == 1)
-            OS << "    <no widening>\n";
-          continue;
-        }
+        // Print the Gen set for the statement.
+        OS << "  Gen:\n";
+        PrintBoundsMap(EB->StmtGen[CurrStmt], PrintOption);
 
-        Expr *Lower = Bounds->getLowerExpr();
-        Expr *Upper = Bounds->getUpperExpr();
+        // Print the Kill set for the statement.
+        OS << "  Kill:\n";
+        PrintVarSet(EB->StmtKill[CurrStmt], PrintOption);
 
-        OS << "    " << V->getQualifiedNameAsString() << ": bounds(";
-        Lower->printPretty(OS, nullptr, Ctx.getPrintingPolicy());
-        OS << ", ";
-        Upper->printPretty(OS, nullptr, Ctx.getPrintingPolicy());
-        OS << ")\n";
+        // Print the Out set for the statement.
+        OS << "  Out:\n";
+        PrintBoundsMap(GetStmtOut(CurrBlock, CurrStmt), PrintOption);
       }
     }
-
-    if (IsBlockEmpty)
-      OS << "\n";
   }
 }
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2847,7 +2847,9 @@ namespace {
      // Run the bounds widening analysis on this function.
      BoundsWideningAnalyzer.WidenBounds(FD, NestedElements);
      if (S.getLangOpts().DumpWidenedBounds)
-       BoundsWideningAnalyzer.DumpWidenedBounds(FD);
+       BoundsWideningAnalyzer.DumpWidenedBounds(FD, 0);
+     if (S.getLangOpts().DumpWidenedBoundsDataflowSets)
+       BoundsWideningAnalyzer.DumpWidenedBounds(FD, 1);
 
      PostOrderCFGView POView = PostOrderCFGView(Cfg);
      ResetFacts();

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-dataflow-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-dataflow-sets.c
@@ -1,0 +1,299 @@
+// Tests for dumping the various datafow sets computed by the bounds widening
+// analysis.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds-dataflow-sets -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
+
+int a;
+
+void f1(_Nt_array_ptr<char> p : bounds(p, p + i), int i,
+        _Nt_array_ptr<char> q : bounds(q, q + j), int j) {
+  char r _Nt_checked[3] = "ab";
+
+  if (*(p + i)) {
+    if (*(p + i + 1)) {
+      a = 1;
+    }
+  }
+
+  if (*(q + j)) {
+    a = 2;
+  }
+
+  a = 3 _Where r : bounds(r, r + 1);
+
+  i++; // expected-error {{inferred bounds for 'p' are unknown after increment}}
+  if (*(p + i)) {
+    a = 4;
+  }
+
+// CHECK: Function: f1
+// CHECK: Block: B9 (Entry), Pred: Succ: B8
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B5
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: Top
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:     r
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK:   Stmt: char r_Nt_checked[3] = "ab";
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: Top
+// CHECK:   Gen:
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Kill:
+// CHECK:     r
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK:   Stmt: *(p + i)
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B5
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK:   Stmt: *(p + i + 1)
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK:   Stmt: a = 1
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1 + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK: Block: B5, Pred: B6, B7, B8, Succ: B4, B3
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:   Kill:
+// CHECK:     q
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK:   Stmt: *(q + j)
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:   Kill:
+// CHECK:     q
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK:   Stmt: a = 2
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j + 1)
+// CHECK:     r: bounds(r, r + 2)
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:     r
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+
+// CHECK:   Stmt: a = 3
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 2)
+// CHECK:   Gen:
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Kill:
+// CHECK:     r
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+
+// CHECK:   Stmt: i++
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+
+// CHECK:   Stmt: *(p + i)
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Gen:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:   Kill:
+// CHECK:     p
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+
+// CHECK:   Stmt: a = 4
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i + 1)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+
+// CHECK: Block: B1, Pred: B2, B3, Succ: B0
+// CHECK:   In:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+// CHECK:   Gen:
+// CHECK:     {}
+// CHECK:   Kill:
+// CHECK:     {}
+// CHECK:   Out:
+// CHECK:     p: bounds(p, p + i)
+// CHECK:     q: bounds(q, q + j)
+// CHECK:     r: bounds(r, r + 1)
+}


### PR DESCRIPTION
This PR dumps dataflow sets In, Out, Gen and Kill for blocks and statements as
computed by the bounds widening analysis. The flag
-fdump-widened-bounds-dataflow-sets controls the dumping of these sets. The
dumping of the dataflow sets are useful for quick and efficient debugging as well
as for validation of the implementation.