### PR TITLE
[BoundsWidening] Use invertibility to support bounds widening in loops

### DIFF
--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -121,8 +121,8 @@ BoundsMapTy BoundsWideningAnalysis::GetOutOfLastStmt(
     Expr *OriginalLValue = std::get<1>(ValuesToReplaceInBounds);
     VarSetTy PtrsWithAffectedBounds = std::get<2>(ValuesToReplaceInBounds);
 
-    // TODO: 
-    CheckedScopeSpecifier CSS = CheckedScopeSpecifier::CSS_Unchecked;
+    // TODO: Determine the Checked scope for each statement.
+    CheckedScopeSpecifier CSS = CheckedScopeSpecifier::CSS_None;
 
     for (const VarDecl *V : PtrsWithAffectedBounds) {
       auto StmtInIt = InOfCurrStmt.find(V);
@@ -592,6 +592,8 @@ BoundsMapTy BoundsWideningAnalysis::GetStmtOut(const CFGBlock *B,
   auto Diff = BWUtil.Difference(EB->OutOfPrevStmt, EB->StmtKill[CurrStmt]);
   auto StmtOut = BWUtil.Union(Diff, EB->StmtGen[CurrStmt]);
 
+  // Account for bounds which are killed by the current statement but which may
+  // have been adjusted using invertibility of the statement.
   UpdateAdjustedBounds(EB, CurrStmt, StmtOut);
 
   EB->OutOfPrevStmt = StmtOut;
@@ -628,6 +630,8 @@ BoundsMapTy BoundsWideningAnalysis::GetBoundsWidenedAndNotKilled(
   auto BoundsWidenedAndNotKilled = BWUtil.Difference(InOfCurrStmt,
                                                      EB->StmtKill[CurrStmt]);
 
+  // Account for bounds which are killed by the current statement but which may
+  // have been adjusted using invertibility of the statement.
   UpdateAdjustedBounds(EB, CurrStmt, BoundsWidenedAndNotKilled);
   return BoundsWidenedAndNotKilled;
 }

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -300,7 +300,7 @@ void assign1(array_ptr<int> arr : count(1)) { // expected-note {{(expanded) decl
 // Assignment to a variable used in other variables' bounds
 void assign2(
   array_ptr<int> a : count(len - 1), // expected-note {{(expanded) declared bounds are 'bounds(a, a + len - 1)'}}
-  char b nt_checked[0] : count(len), // expected-note {{(expanded) declared bounds are 'bounds(b, b + len)'}}
+  char b nt_checked[0] : count(len),
   unsigned len
 ) {
   // Observed bounds context before assignment: { a => bounds(a, a + len - 1), b => bounds(b, b + len) }
@@ -308,8 +308,6 @@ void assign2(
   // Observed bounds context after assignment : { a => bounds(a, a + ((len + 3) - 1)), b => bounds(b, b + (len + 3)) }
   len = len - 3; // expected-warning {{cannot prove declared bounds for 'a' are valid after assignment}} \
                  // expected-note {{(expanded) inferred bounds are 'bounds(a, a + len + 3 - 1)'}} \
-                 // expected-warning {{cannot prove declared bounds for 'b' are valid after assignment}} \
-                 // expected-note {{(expanded) inferred bounds are 'bounds(b, b + len + 3)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'len'

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-invertibility.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-invertibility.c
@@ -1,0 +1,209 @@
+// Tests for invertibility of statements in the datafow analysis for bounds
+// widening of null-terminated arrays.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
+
+// expected-no-diagnostics
+
+#include <limits.h>
+#include <stdint.h>
+
+int a;
+
+void f1(_Nt_array_ptr<char> p : count(len), unsigned len) {
+
+  while (*(p + len)) {
+    len++;
+    a = 1;
+  }
+
+// CHECK: Function: f1
+// CHECK: Block: B25 (Entry), Pred: Succ: B24
+
+// CHECK: Block: B24, Pred: B22, B25, Succ: B23, B21
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B23, Pred: B24, Succ: B22
+// CHECK:   Widened bounds before stmt: len++
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + len - 1U + 1)
+
+  while (*(p + len)) {
+    ++len;
+    a = 2;
+  }
+
+// CHECK: Block: B22, Pred: B23, Succ: B24
+
+// CHECK: Block: B21, Pred: B19, B24, Succ: B20, B18
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B20, Pred: B21, Succ: B19
+// CHECK:   Widened bounds before stmt: ++len
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + len - 1U + 1)
+
+  while (*(p + len)) {
+    len--;
+    a = 3;
+  }
+
+// CHECK: Block: B19, Pred: B20, Succ: B21
+
+// CHECK: Block: B18, Pred: B16, B21, Succ: B17, B15
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B17, Pred: B18, Succ: B16
+// CHECK:   Widened bounds before stmt: len--
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + len + 1U + 1)
+
+  while (*(p + len)) {
+    --len;
+    a = 4;
+  }
+
+// CHECK: Block: B16, Pred: B17, Succ: B18
+
+// CHECK: Block: B15, Pred: B13, B18, Succ: B14, B12
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B14, Pred: B15, Succ: B13
+// CHECK:   Widened bounds before stmt: --len
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + len + 1U + 1)
+
+  while (*(p + len)) {
+    len = len + 1;
+    a = 5;
+  }
+
+// CHECK: Block: B13, Pred: B14, Succ: B15
+
+// CHECK: Block: B12, Pred: B10, B15, Succ: B11, B9
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B11, Pred: B12, Succ: B10
+// CHECK:   Widened bounds before stmt: len = len + 1
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + len - 1 + 1)
+
+  while (*(p + len)) {
+    len = len - 1;
+    a = 6;
+  }
+
+// CHECK: Block: B10, Pred: B11, Succ: B12
+
+// CHECK: Block: B9, Pred: B7, B12, Succ: B8, B6
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: len = len - 1
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + len + 1 + 1)
+
+  while (*(p + len)) {
+    len += 1;
+    a = 7;
+  }
+
+// CHECK: Block: B7, Pred: B8, Succ: B9
+
+// CHECK: Block: B6, Pred: B4, B9, Succ: B5, B3
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: len += 1
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + len - 1 + 1)
+
+  while (*(p + len)) {
+    len -= 1;
+    a = 8;
+  }
+
+// CHECK: Block: B4, Pred: B5, Succ: B6
+
+// CHECK: Block: B3, Pred: B1, B6, Succ: B2, B0
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: len -= 1
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + len + 1 + 1)
+}
+
+void f2(_Nt_array_ptr<char> p : count(len), unsigned len) {
+  while (*(p + len)) {
+    if (*(p + len + 1)) {
+      if (*(p + len + 2)) {
+        len = len + 1;    
+        a = *(p + len + 1);
+      }
+    }
+  }
+
+// CHECK: Function: f2
+// CHECK: Block: B6 (Entry), Pred: Succ: B5
+
+// CHECK: Block: B5, Pred: B1, B6, Succ: B4, B0
+// CHECK:   Widened bounds before stmt: *(p + len)
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: *(p + len + 1)
+// CHECK:     p: bounds(p, p + len + 1)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + len + 2)
+// CHECK:     p: bounds(p, p + len + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: len = len + 1
+// CHECK:     p: bounds(p, p + len + 2 + 1)
+
+// CHECK:   Widened bounds before stmt: a = *(p + len + 1)
+// CHECK:     p: bounds(p, p + len - 1 + 2 + 1)
+}
+
+void f3(_Nt_array_ptr<char> p : count(len), unsigned len) {
+  len--;
+  a = 1;
+
+// CHECK: Function: f3
+// CHECK: Block: B2 (Entry), Pred: Succ: B1
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: len--
+// CHECK:     p: bounds(p, p + len)
+
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + len + 1U)
+}

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -1540,7 +1540,7 @@ void f24() {
 
   while (*p) {
     p++;
-    while (*(p + 1)) { // expected-error {{out-of-bounds memory access}}
+    while (*(p + 1)) {
       a = 1;
     }
   }
@@ -1550,7 +1550,7 @@ void f24() {
 
 // CHECK: Block: B8, Pred: B9, Succ: B7
 // CHECK:   Widened bounds before stmt: _Nt_array_ptr<char> p : count(0) = "";
-// CHECK:     <no widening>
+// CHECK: <no widening>
 
 // CHECK: Block: B7, Pred: B2, B8, Succ: B6, B1
 // CHECK:   Widened bounds before stmt: *p
@@ -1562,11 +1562,11 @@ void f24() {
 
 // CHECK: Block: B5, Pred: B3, B6, Succ: B4, B2
 // CHECK:   Widened bounds before stmt: *(p + 1)
-// CHECK:     p: bounds(p, p + 0)
+// CHECK:     p: bounds(p - 1, p - 1 + 1)
 
 // CHECK: Block: B4, Pred: B5, Succ: B3
 // CHECK:   Widened bounds before stmt: a = 1
-// CHECK:     p: bounds(p, p + 0)
+// CHECK:     p: bounds(p - 1, p - 1 + 1)
 
 // CHECK: Block: B3, Pred: B4, Succ: B5
 
@@ -1642,7 +1642,7 @@ void f25_1() {
 
   for (; *p; ) {
     p++;
-    for (; *(p + 1); ) { // expected-error {{out-of-bounds memory access}}
+    for (; *(p + 1); ) {
       a = 7;
     }
   }
@@ -1657,11 +1657,11 @@ void f25_1() {
 
 // CHECK: Block: B5, Pred: B3, B6, Succ: B4, B2
 // CHECK:   Widened bounds before stmt: *(p + 1)
-// CHECK:     p: bounds(p, p + 0)
+// CHECK:     p: bounds(p - 1, p - 1 + 1)
 
 // CHECK: Block: B4, Pred: B5, Succ: B3
 // CHECK:   Widened bounds before stmt: a = 7
-// CHECK:     p: bounds(p, p + 0)
+// CHECK:     p: bounds(p - 1, p - 1 + 1)
 
 // CHECK: Block: B3, Pred: B4, Succ: B5
 


### PR DESCRIPTION
An expression that modifies an LValue is said to be invertible w.r.t. the
LValue if we can write an expression in terms of the original value of the
LValue before the modification. For example, the expression x + 1 is invertible
w.r.t x because we can write this expression in terms of the original value of
x which is (x - 1) + 1.

In this PR, we use invertibility of statements to support bounds widening in
loops. More specifically, if a statement modifies a variable that occurs in the
bounds expression of a null-terminated array then instead of killing its bounds
at that statement we use invertibility of the statement to try to write the
widened bounds in terms of the original value of the variable.