### PR TITLE
[BoundsWidening] Determine checked scope specifier per statement

### DIFF
--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -82,14 +82,17 @@ namespace clang {
     Lexicographic Lex;
     BoundsVarsTy &BoundsVarsLower;
     BoundsVarsTy &BoundsVarsUpper;
+    CheckedScopeMapTy &CheckedScopeMap;
 
   public:
     BoundsWideningUtil(Sema &SemaRef, CFG *Cfg,
                        ASTContext &Ctx, Lexicographic Lex,
                        BoundsVarsTy &BoundsVarsLower,
-                       BoundsVarsTy &BoundsVarsUpper) :
+                       BoundsVarsTy &BoundsVarsUpper,
+                       CheckedScopeMapTy &CheckedScopeMap) :
       SemaRef(SemaRef), Cfg(Cfg), Ctx(Ctx), Lex(Lex),
-      BoundsVarsLower(BoundsVarsLower), BoundsVarsUpper(BoundsVarsUpper) {}
+      BoundsVarsLower(BoundsVarsLower), BoundsVarsUpper(BoundsVarsUpper),
+      CheckedScopeMap(CheckedScopeMap) {}
 
     // Check if B2 is a subrange of B1.
     // @param[in] B1 is the first range.
@@ -171,6 +174,14 @@ namespace clang {
     // null-terminated array; nullptr if no such variable exists in the
     // expression.
     const VarDecl *GetNullTermPtrInExpr(Expr *E) const;
+
+    // Update the checked scope specifier for the current statement if it has
+    // changed from that of the previous statement.
+    // @param[in] CurrStmt is the current statement.
+    // @param[out] CSS is updated with the checked scope specifier for the
+    // current statement if it has changed from that of the previous statement.
+    void UpdateCheckedScopeSpecifier(const Stmt *CurrStmt,
+                                     CheckedScopeSpecifier &CSS) const;
 
     // Invoke IgnoreValuePreservingOperations to strip off casts.
     // @param[in] E is the expression whose casts must be stripped.
@@ -332,11 +343,13 @@ namespace clang {
 
     BoundsWideningAnalysis(Sema &SemaRef, CFG *Cfg,
                            BoundsVarsTy &BoundsVarsLower,
-                           BoundsVarsTy &BoundsVarsUpper) :
+                           BoundsVarsTy &BoundsVarsUpper,
+                           CheckedScopeMapTy &CheckedScopeMap) :
       SemaRef(SemaRef), Cfg(Cfg), Ctx(SemaRef.Context),
       Lex(Lexicographic(Ctx, nullptr)), OS(llvm::outs()),
       BWUtil(BoundsWideningUtil(SemaRef, Cfg, Ctx, Lex,
-                                BoundsVarsLower, BoundsVarsUpper)) {}
+                                BoundsVarsLower, BoundsVarsUpper,
+                                CheckedScopeMap)) {}
 
     // Run the dataflow analysis to widen bounds for null-terminated arrays.
     // @param[in] FD is the current function.

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -38,6 +38,9 @@ namespace clang {
   // of F in whose declared bounds expressions F occurs.
   using BoundsSiblingFieldsTy = llvm::DenseMap<const FieldDecl *, FieldSetTy>;
 
+  // CheckedScopeMapTy maps a statement to its checked scope specifier.
+  using CheckedScopeMapTy = llvm::DenseMap<const Stmt *, CheckedScopeSpecifier>;
+
   struct PrepassInfo {
     // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)
     // that is the first use of V, if V fulfills the following conditions:
@@ -82,6 +85,10 @@ namespace clang {
     // a deterministic iteration order we must remember to sort the keys as
     // well as the values.
     BoundsSiblingFieldsTy BoundsSiblingFields;
+
+    // A map of statements to their checked scope specifiers. An entry in this
+    // map is made only when the checked scope specifier changes.
+    CheckedScopeMapTy CheckedScopeMap;
   };
 } // end namespace clang
 #endif

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -307,7 +307,7 @@ class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
         // the beginning of a basic block as we are assured of ordered lookup
         // only within a basic block (i.e. the first statement of a basic block
         // may be accessed out of statement-order).
-        else if (isa<LabelStmt>(S)) {
+        } else if (isa<LabelStmt>(CurrStmt)) {
           Info.CheckedScopeMap[CurrStmt] = CSS;
 
         // Else if the previous statement was a compound statement store the

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2576,7 +2576,8 @@ namespace {
       Facts(Facts),
       BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, Cfg,
                                                     Info.BoundsVarsLower,
-                                                    Info.BoundsVarsUpper)),
+                                                    Info.BoundsVarsUpper,
+                                                    Info.CheckedScopeMap)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       BoundsSiblingFields(Info.BoundsSiblingFields),
       IncludeNullTerminator(false) {}
@@ -2593,7 +2594,8 @@ namespace {
       Facts(Facts),
       BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, nullptr,
                                                     Info.BoundsVarsLower,
-                                                    Info.BoundsVarsUpper)),
+                                                    Info.BoundsVarsUpper,
+                                                    Info.CheckedScopeMap)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       BoundsSiblingFields(Info.BoundsSiblingFields),
       IncludeNullTerminator(false) {}


### PR DESCRIPTION
We use the CheckedCAnalysesPrepass.cpp to gather the checked scopes for
statements. We store a map of statements to their checked scope specifiers. An
entry in this map is only made for the following statements:
1. For the first non-compound statement of a compound statement.
2. For the first statement that follows a compound statement.

We then use this info in the bounds widening analysis to determine the checked
scope specifiers for each statement.