### PR TITLE
Revert "[BoundsWidening] Determine checked scope specifier per statement (#1139)"

### DIFF
--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -82,17 +82,14 @@ namespace clang {
     Lexicographic Lex;
     BoundsVarsTy &BoundsVarsLower;
     BoundsVarsTy &BoundsVarsUpper;
-    CheckedScopeMapTy &CheckedScopeMap;
 
   public:
     BoundsWideningUtil(Sema &SemaRef, CFG *Cfg,
                        ASTContext &Ctx, Lexicographic Lex,
                        BoundsVarsTy &BoundsVarsLower,
-                       BoundsVarsTy &BoundsVarsUpper,
-                       CheckedScopeMapTy &CheckedScopeMap) :
+                       BoundsVarsTy &BoundsVarsUpper) :
       SemaRef(SemaRef), Cfg(Cfg), Ctx(Ctx), Lex(Lex),
-      BoundsVarsLower(BoundsVarsLower), BoundsVarsUpper(BoundsVarsUpper),
-      CheckedScopeMap(CheckedScopeMap) {}
+      BoundsVarsLower(BoundsVarsLower), BoundsVarsUpper(BoundsVarsUpper) {}
 
     // Check if B2 is a subrange of B1.
     // @param[in] B1 is the first range.
@@ -174,14 +171,6 @@ namespace clang {
     // null-terminated array; nullptr if no such variable exists in the
     // expression.
     const VarDecl *GetNullTermPtrInExpr(Expr *E) const;
-
-    // Update the checked scope specifier for the current statement if it has
-    // changed from that of the previous statement.
-    // @param[in] CurrStmt is the current statement.
-    // @param[out] CSS is updated with the checked scope specifier for the
-    // current statement if it has changed from that of the previous statement.
-    void UpdateCheckedScopeSpecifier(const Stmt *CurrStmt,
-                                     CheckedScopeSpecifier &CSS) const;
 
     // Invoke IgnoreValuePreservingOperations to strip off casts.
     // @param[in] E is the expression whose casts must be stripped.
@@ -343,13 +332,11 @@ namespace clang {
 
     BoundsWideningAnalysis(Sema &SemaRef, CFG *Cfg,
                            BoundsVarsTy &BoundsVarsLower,
-                           BoundsVarsTy &BoundsVarsUpper,
-                           CheckedScopeMapTy &CheckedScopeMap) :
+                           BoundsVarsTy &BoundsVarsUpper) :
       SemaRef(SemaRef), Cfg(Cfg), Ctx(SemaRef.Context),
       Lex(Lexicographic(Ctx, nullptr)), OS(llvm::outs()),
       BWUtil(BoundsWideningUtil(SemaRef, Cfg, Ctx, Lex,
-                                BoundsVarsLower, BoundsVarsUpper,
-                                CheckedScopeMap)) {}
+                                BoundsVarsLower, BoundsVarsUpper)) {}
 
     // Run the dataflow analysis to widen bounds for null-terminated arrays.
     // @param[in] FD is the current function.

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -38,9 +38,6 @@ namespace clang {
   // of F in whose declared bounds expressions F occurs.
   using BoundsSiblingFieldsTy = llvm::DenseMap<const FieldDecl *, FieldSetTy>;
 
-  // CheckedScopeMapTy maps a statement to its checked scope specifier.
-  using CheckedScopeMapTy = llvm::DenseMap<const Stmt *, CheckedScopeSpecifier>;
-
   struct PrepassInfo {
     // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)
     // that is the first use of V, if V fulfills the following conditions:
@@ -85,10 +82,6 @@ namespace clang {
     // a deterministic iteration order we must remember to sort the keys as
     // well as the values.
     BoundsSiblingFieldsTy BoundsSiblingFields;
-
-    // A map of statements to their checked scope specifiers. An entry in this
-    // map is made only when the checked scope specifier changes.
-    CheckedScopeMapTy CheckedScopeMap;
   };
 } // end namespace clang
 #endif

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -82,7 +82,6 @@ BoundsMapTy BoundsWideningAnalysis::GetOutOfLastStmt(
   // statement and return the StmtOut for the last statement of the block.
 
   BoundsMapTy StmtOut = EB->In;
-  CheckedScopeSpecifier CSS = CheckedScopeSpecifier::CSS_None;
 
   for (CFGBlock::const_iterator I = EB->Block->begin(),
                                 E = EB->Block->end();
@@ -93,9 +92,6 @@ BoundsMapTy BoundsWideningAnalysis::GetOutOfLastStmt(
     const Stmt *CurrStmt = Elem.castAs<CFGStmt>().getStmt();
     if (!CurrStmt)
       continue;
-
-    // Update the checked scope specifier for the current statement.
-    BWUtil.UpdateCheckedScopeSpecifier(CurrStmt, CSS);
 
     // The In of the current statement is the value of StmtOut computed so far.
     BoundsMapTy InOfCurrStmt = StmtOut;
@@ -124,6 +120,9 @@ BoundsMapTy BoundsWideningAnalysis::GetOutOfLastStmt(
     Expr *ModifiedLValue = std::get<0>(ValuesToReplaceInBounds);
     Expr *OriginalLValue = std::get<1>(ValuesToReplaceInBounds);
     VarSetTy PtrsWithAffectedBounds = std::get<2>(ValuesToReplaceInBounds);
+
+    // TODO: Determine the Checked scope for each statement.
+    CheckedScopeSpecifier CSS = CheckedScopeSpecifier::CSS_None;
 
     for (const VarDecl *V : PtrsWithAffectedBounds) {
       auto StmtInIt = InOfCurrStmt.find(V);
@@ -1418,14 +1417,6 @@ const VarDecl *BoundsWideningUtil::GetNullTermPtrInExpr(Expr *E) const {
         return V;
   }
   return nullptr;
-}
-
-void BoundsWideningUtil::UpdateCheckedScopeSpecifier(
-  const Stmt *CurrStmt, CheckedScopeSpecifier &CSS) const {
-
-  auto ScopeIt = CheckedScopeMap.find(CurrStmt);
-  if (ScopeIt != CheckedScopeMap.end())
-    CSS = ScopeIt->second;
 }
 
 Expr *BoundsWideningUtil::IgnoreCasts(const Expr *E) const {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -2576,8 +2576,7 @@ namespace {
       Facts(Facts),
       BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, Cfg,
                                                     Info.BoundsVarsLower,
-                                                    Info.BoundsVarsUpper,
-                                                    Info.CheckedScopeMap)),
+                                                    Info.BoundsVarsUpper)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       BoundsSiblingFields(Info.BoundsSiblingFields),
       IncludeNullTerminator(false) {}
@@ -2594,8 +2593,7 @@ namespace {
       Facts(Facts),
       BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, nullptr,
                                                     Info.BoundsVarsLower,
-                                                    Info.BoundsVarsUpper,
-                                                    Info.CheckedScopeMap)),
+                                                    Info.BoundsVarsUpper)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       BoundsSiblingFields(Info.BoundsSiblingFields),
       IncludeNullTerminator(false) {}


### PR DESCRIPTION
This reverts commit 980321d2378918268e23dc758ca55efc76a5018b.

We are working on a cleaner solution to determining checked scopes per statement.