### PR TITLE
Check return value bounds

### DIFF
--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -145,6 +145,10 @@ public:
   // pointer). Returns false if E is nullptr.
   static bool ReadsMemoryViaPointer(Expr *E, bool IncludeAllMemberExprs = false);
 
+  // IsReturnValueExpr return true if the expression E is a _Return_value
+  // expression.
+  static bool IsReturnValueExpr(Expr *E);
+
   // FindLValue returns true if the given lvalue expression occurs in E.
   static bool FindLValue(Sema &S, Expr *LValue, Expr *E);
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11619,6 +11619,12 @@ def err_bounds_type_annotation_lost_checking : Error<
   def error_static_cast_bounds_invalid : Error<
     "cast source bounds are too narrow for %0">;
 
+  def note_declared_return_bounds : Note<
+    "(expanded) declared return bounds are '%0'">;
+
+  def note_inferred_return_bounds : Note<
+    "(expanded) inferred return value bounds are '%0'">;
+
   def error_out_of_bounds_access : Error<
     "out-of-bounds %select{|||memory access|base value}0">;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11620,7 +11620,7 @@ def err_bounds_type_annotation_lost_checking : Error<
     "cast source bounds are too narrow for %0">;
 
   def error_out_of_bounds_access : Error<
-    "out-of-bounds %select{||memory access|base value}0">;
+    "out-of-bounds %select{|||memory access|base value}0">;
 
   def note_source_bounds_empty : Note<"source bounds are an empty range">;
 
@@ -11631,21 +11631,22 @@ def err_bounds_type_annotation_lost_checking : Error<
   def note_destination_bounds_invalid : Note<"destination bounds are an invalid range">;
 
   def note_bounds_too_narrow : Note<
-    "%select{destination bounds are|target bounds are|memory accessed is|"
-    "struct/union pointed to by base is}0 wider than the "
-    "%select{source|source||}0 bounds">;
+    "%select{destination bounds are|target bounds are|declared return bounds are|"
+    "memory accessed is|struct/union pointed to by base is|}0 wider "
+    "than the %select{source|source|return value|source|source}0 bounds">;
 
   def note_lower_out_of_bounds : Note<
-    "%select{destination lower bound is|target lower bound is|accesses memory|"
-    "base value is}0 below %select{source|source|the|its}0 lower bound">;
+    "%select{destination lower bound is|target lower bound is|"
+    "declared return lower bound is|accesses memory|base value is}0 "
+    "below %select{source|source|return value|the|its}0 lower bound">;
 
   def note_upper_out_of_bounds : Note<
     "%select{destination upper bound is|target upper bound is|"
-    "accesses memory at or|base value is}0 "
-    "above %select{source|source|the|its}0 upper bound">;
+    "declared return upper bound is|accesses memory at or|base value is}0 "
+    "above %select{source|source|return value|the|its}0 upper bound">;
 
    def note_bounds_partially_overlap : Note<
-    "%select{||accesses memory that|struct/union pointed to by base value}0 is "
+    "%select{|||accesses memory that|struct/union pointed to by base value}0 is "
     "only partially in bounds">;
 
   def no_prototype_generic_function : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11386,6 +11386,10 @@ def err_bounds_type_annotation_lost_checking : Error<
     "argument has unknown bounds, bounds expected because the "
     "%ordinal0 parameter has bounds">;
 
+  def err_expected_bounds_for_return : Error<
+    "return value has unknown bounds, bounds expected because the "
+    "function %0 has bounds">;
+
   def err_initializer_expected_with_bounds : Error<
     "automatic variable %0 with bounds must have initializer">;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11623,6 +11623,21 @@ def err_bounds_type_annotation_lost_checking : Error<
   def error_static_cast_bounds_invalid : Error<
     "cast source bounds are too narrow for %0">;
 
+  def error_return_bounds_invalid : Error<
+    "return value bounds do not imply declared return bounds for %0">;
+
+  def error_return_bounds_unprovable: Error<
+    "it is not possible to prove that return value bounds "
+    "imply declared return bounds for %0">;
+
+  def warn_return_bounds_invalid: Warning<
+    "cannot prove return value bounds imply declared return bounds for %0">,
+    InGroup<CheckBoundsDeclsUnchecked>;
+
+  def warn_checked_scope_return_bounds_invalid : Warning<
+    "cannot prove return value bounds imply declared return bounds for %0">,
+    InGroup<CheckBoundsDeclsChecked>;
+
   def note_declared_return_bounds : Note<
     "(expanded) declared return bounds are '%0'">;
 

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -306,6 +306,13 @@ bool ExprUtil::ReadsMemoryViaPointer(Expr *E, bool IncludeAllMemberExprs) {
   }
 }
 
+bool ExprUtil::IsReturnValueExpr(Expr *E) {
+  BoundsValueExpr *BVE = dyn_cast_or_null<BoundsValueExpr>(E);
+  if (!BVE)
+    return false;
+  return BVE->getKind() == BoundsValueExpr::Kind::Return;
+}
+
 namespace {
   class FindLValueHelper : public RecursiveASTVisitor<FindLValueHelper> {
     private:

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -958,6 +958,7 @@ namespace {
     enum class ProofStmtKind : unsigned {
       BoundsDeclaration,
       StaticBoundsCast,
+      ReturnStmt,
       MemoryAccess,
       MemberArrowBase
     };

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4009,14 +4009,13 @@ namespace {
         return ResultBounds;
 
       // Check the return value if it exists.
-      Check(RetValue, CSS, State);
+      BoundsExpr *RetValueBounds = Check(RetValue, CSS, State);
 
-      if (!ReturnBounds)
-        return ResultBounds;
+      // Check that the return expression bounds imply the return bounds.
+      ValidateReturnBounds(RS, RetValue, RetValueBounds, State.EquivExprs,
+                           CSS);
 
-      // TODO: Actually check that the return expression bounds imply the 
-      // return bounds.
-      // TODO: Also check that any parameters used in the return bounds are
+      // TODO: Check that any parameters used in the return bounds are
       // unmodified.
       return ResultBounds;
     }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -1379,6 +1379,11 @@ namespace {
             ExprUtil::ReadsMemoryViaPointer(E2, true))
           return false;
 
+        // If E1 or E2 is a _Return_value expression, we skip since we cannot
+        // determine the set of variables that occur in these expressions.
+        if (ExprUtil::IsReturnValueExpr(E1) || ExprUtil::IsReturnValueExpr(E2))
+          return false;
+
         bool HasFreeVariables = false;
         EqualExprTy Vars1 = CollectVariableSet(S, E1);
         EqualExprTy Vars2 = CollectVariableSet(S, E2);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4587,6 +4587,32 @@ namespace {
       return Loc;
     }
 
+    // DiagnoseUnknownReturnBounds emits an error message at the return
+    // statement RS and return expression RetExpr whose inferred bounds are
+    // unknown, where the enclosing function has declared bounds ReturnBounds.
+    void DiagnoseUnknownReturnBounds(ReturnStmt *RS, Expr *RetExpr) {
+      SourceLocation Loc = RetExpr->getBeginLoc();
+      S.Diag(Loc, diag::err_expected_bounds_for_return)
+        << FunctionDeclaration << RS->getSourceRange();
+
+      SourceLocation DeclaredLoc = FunctionDeclaration->getLocation();
+      S.Diag(DeclaredLoc, diag::note_declared_return_bounds)
+        << ReturnBounds << ReturnBounds->getSourceRange();
+    }
+
+    // DiagnoseUnknownReturnBounds emits an error message at the return
+    // statement RS and return expression RetExpr whose inferred bounds are
+    // unknown, where the enclosing function has declared bounds ReturnBounds.
+    void DiagnoseUnknownReturnBounds(ReturnStmt *RS, Expr *RetExpr) {
+      SourceLocation Loc = RetExpr->getBeginLoc();
+      S.Diag(Loc, diag::err_expected_bounds_for_return)
+        << FunctionDeclaration << RS->getSourceRange();
+
+      SourceLocation DeclaredLoc = FunctionDeclaration->getLocation();
+      S.Diag(DeclaredLoc, diag::note_declared_return_bounds)
+        << ReturnBounds << ReturnBounds->getSourceRange();
+    }
+
     // Methods to update the checking state.
 
     // UpdateAfterAssignment updates the checking state after the lvalue

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -652,8 +652,20 @@ namespace {
     uint64_t PointerWidth;
     Stmt *Body;
     CFG *Cfg;
-    BoundsExpr *ReturnBounds; // return bounds expression for enclosing
-                              // function, if any.
+
+    // Declaration for enclosing function. Having this here allows us to emit
+    // the name of the function in any diagnostic message when checking return
+    // bounds.
+    FunctionDecl *FunctionDeclaration;
+    // Return value expression for enclosing function, if any. Having this
+    // here allows us to avoid reconstructing a return value for each
+    // return statement.
+    BoundsValueExpr *ReturnVal;
+    // Expanded declared return bounds expression for enclosing function, if
+    // any. Having this here allows us to avoid re-expanding the return bounds
+    // for each return statement.
+    BoundsExpr *ReturnBounds;
+
     ASTContext &Context;
     std::pair<ComparisonSet, ComparisonSet> &Facts;
 
@@ -2569,14 +2581,16 @@ namespace {
 
 
   public:
-    CheckBoundsDeclarations(Sema &SemaRef, PrepassInfo &Info, Stmt *Body, CFG *Cfg, BoundsExpr *ReturnBounds, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
+    CheckBoundsDeclarations(Sema &SemaRef, PrepassInfo &Info, Stmt *Body, CFG *Cfg, FunctionDecl *FD, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
       DumpBounds(SemaRef.getLangOpts().DumpInferredBounds),
       DumpState(SemaRef.getLangOpts().DumpCheckingState),
       DumpSynthesizedMembers(SemaRef.getLangOpts().DumpSynthesizedMembers),
       PointerWidth(SemaRef.Context.getTargetInfo().getPointerWidth(0)),
       Body(Body),
       Cfg(Cfg),
-      ReturnBounds(ReturnBounds),
+      FunctionDeclaration(FD),
+      ReturnVal(nullptr),
+      ReturnBounds(nullptr),
       Context(SemaRef.Context),
       Facts(Facts),
       BoundsWideningAnalyzer(BoundsWideningAnalysis(SemaRef, Cfg,
@@ -2585,7 +2599,16 @@ namespace {
                                                     Info.CheckedScopeMap)),
       AbstractSetMgr(AbstractSetManager(SemaRef, Info.VarUses)),
       BoundsSiblingFields(Info.BoundsSiblingFields),
-      IncludeNullTerminator(false) {}
+      IncludeNullTerminator(false) {
+        if (FD) {
+          ReturnVal =
+            new (S.Context) BoundsValueExpr(SourceLocation(),
+                                            FD->getReturnType(),
+                                            BoundsValueExpr::Kind::Return);
+          ReturnBounds =
+            BoundsUtil::ExpandToRange(S, ReturnVal, FD->getBoundsExpr());
+        }
+      }
 
     CheckBoundsDeclarations(Sema &SemaRef, PrepassInfo &Info, std::pair<ComparisonSet, ComparisonSet> &Facts) : S(SemaRef),
       DumpBounds(SemaRef.getLangOpts().DumpInferredBounds),
@@ -2594,6 +2617,8 @@ namespace {
       PointerWidth(SemaRef.Context.getTargetInfo().getPointerWidth(0)),
       Body(nullptr),
       Cfg(nullptr),
+      FunctionDeclaration(nullptr),
+      ReturnVal(nullptr),
       ReturnBounds(nullptr),
       Context(SemaRef.Context),
       Facts(Facts),
@@ -6134,7 +6159,7 @@ void Sema::CheckFunctionBodyBoundsDecls(FunctionDecl *FD, Stmt *Body) {
   BO.AddLifetime = true;
   BO.AddNullStmt = true;
   std::unique_ptr<CFG> Cfg = CFG::buildCFG(nullptr, Body, &getASTContext(), BO);
-  CheckBoundsDeclarations Checker(*this, Info, Body, Cfg.get(), FD->getBoundsExpr(), EmptyFacts);
+  CheckBoundsDeclarations Checker(*this, Info, Body, Cfg.get(), FD, EmptyFacts);
   if (Cfg != nullptr) {
     AvailableFactsAnalysis Collector(*this, Cfg.get());
     Collector.Analyze();

--- a/clang/test/3C/functionDeclEnd.c
+++ b/clang/test/3C/functionDeclEnd.c
@@ -4,6 +4,16 @@
 // RUN: 3c -base-dir=%S -addcr -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/functionDeclEnd.c -- | diff %t.checked/functionDeclEnd.c -
+// XFAIL: *
+
+// TODO: checkedc-clang issue 1147. This test fails due to the compiler
+// checking that the inferred bounds for the return value of a function
+// imply the declared bounds for the function. The following functions in
+// this test file return expressions with unknown bounds, which do not imply
+// the function's declared bounds:
+// 1. test3
+// 2. test7
+// 3. test8
 
 // Tests for issue 392. When rewriting function prototypes sometimes code
 // falling between the start of the definition and the end of the prototype

--- a/clang/test/3C/itype_nt_arr_cast.c
+++ b/clang/test/3C/itype_nt_arr_cast.c
@@ -4,6 +4,14 @@
 // RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/itype_nt_arr_cast.c -- | diff %t.checked/itype_nt_arr_cast.c -
+// XFAIL: *
+
+// TODO: checkedc-clang issue 1147. This test fails due to the compiler
+// checking that the inferred bounds for the return value of a function
+// imply the declared bounds for the function. The following functions in
+// this test file return expressions with unknown bounds, which do not imply
+// the function's declared bounds:
+// 1. fn1
 
 char *fn1() {
 //CHECK_ALL: char *fn1(void) : itype(_Nt_array_ptr<char>) {

--- a/clang/test/CheckedC/dump-dataflow-facts.c
+++ b/clang/test/CheckedC/dump-dataflow-facts.c
@@ -187,7 +187,7 @@ _Nt_array_ptr<int> fn_5(int a) {
     return 0;
 
   _Nt_array_ptr<int> p : byte_count(d) = g(a);
-  return p;
+  return 0;
 
 // CHECK-LABEL: fn_5
 // CHECK-NEXT: Block #4: {
@@ -216,7 +216,7 @@ _Nt_array_ptr<int> fn_6(int a) {
   int d;
   if (d <= a) {
     _Nt_array_ptr<int> p : byte_count(d) = g(a);
-    return p;
+    return 0;
   }
   return 0;
 

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -298,20 +298,20 @@ _Array_ptr<struct S> f37_i(unsigned num) : count(num) {
   _Array_ptr<struct S> p : count(0) = q; // expected-warning {{cannot prove declared bounds for 'p' are valid after initialization}} \
                                          // expected-note {{(expanded) declared bounds are 'bounds(p, p + 0)'}} \
                                          // expected-note {{(expanded) inferred bounds are 'bounds(q, q + num)'}}
-  return p;
+  return q;
 }
 
 _Array_ptr<int> f37(unsigned num) : count(num) {
   _Array_ptr<int> q : count(num) = 0;
   _Array_ptr<int> p : count(0) = q;
-  return p;
+  return q;
 }
 
 
 _Nt_array_ptr<int> f37_n(unsigned num) : count(num) {
   _Nt_array_ptr<int> q : count(num) = 0;
   _Nt_array_ptr<int> p : count(0) = q;
-  return p;
+  return q;
 }
 
 //
@@ -605,7 +605,7 @@ void a_f_15(void) {
 static _Array_ptr<char> v23 : count(32768);
 static _Array_ptr<void> a_f_16(int size) : byte_count(size) {
   v23 = simulate_calloc<char>(32768, sizeof(char));
-  return v23;
+  return 0;
 }
 
 //

--- a/clang/test/CheckedC/static-checking/return-bounds.c
+++ b/clang/test/CheckedC/static-checking/return-bounds.c
@@ -1,0 +1,123 @@
+// Tests for checking that the inferred bounds of a return value imply the
+// declared return bounds for a function.  Because the static checker is
+// mostly unimplemented, we only issue warnings when return bounds cannot
+// be proved to hold.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
+
+//
+// Test null bounds, bounds(unknown), and bounds(any)
+//
+
+_Array_ptr<int> f1(void) : count(1) {
+  return 0;
+}
+
+_Array_ptr<char> f2(_Array_ptr<char> p : bounds(unknown)) {
+  return p;
+}
+
+_Array_ptr<int> f3(_Array_ptr<int> p : bounds(unknown)) : bounds(unknown) {
+  return p;
+}
+
+_Array_ptr<char> f4(_Array_ptr<char> p : bounds(unknown)) : count(1) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 1)'}}
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'f4' has bounds}}
+}
+
+//
+// Test no warnings or errors
+//
+
+_Array_ptr<char> f5(_Array_ptr<char> p : count(2)) : bounds(p, p + 2) {
+  _Array_ptr<char> q : count(2) = p;
+  return q;
+}
+
+_Nt_array_ptr<char> f6(void) : count(3) {
+  return "abcd";
+}
+
+//
+// Test bounds warnings
+//
+
+_Nt_array_ptr<char> f7(_Nt_array_ptr<char> p, int test) : count(0) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 0)'}}
+  if (test)
+    return p;
+  return p + 1; // expected-warning {{cannot prove return value bounds imply declared return bounds for 'f7'}} \
+                // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + 0)'}}
+}
+
+_Array_ptr<int> f8(int i, int j) : count(i) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + i)'}}
+  i = j + 1;
+  _Array_ptr<int> p : count(j) = 0;
+  return p; // expected-warning {{cannot prove return value bounds imply declared return bounds for 'f8'}} \
+            // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + j)'}}
+}
+
+_Array_ptr<const char> f9(_Array_ptr<const char> p : bounds(p, (p + i) + 1), int i) : bounds(p, (p + i) + 1) { // expected-note {{(expanded) declared return bounds are 'bounds(p, (p + i) + 1)'}}
+  _Array_ptr<const char> q : bounds(p, p + (i - 1)) = 0;
+  return q; // expected-warning {{cannot prove return value bounds imply declared return bounds for 'f9'}} \
+            // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + (i - 1))'}}
+}
+
+//
+// Test bounds errors
+//
+
+_Array_ptr<long> f10(_Array_ptr<long> p : count(1)) : bounds(_Return_value, _Return_value + 2) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 2)'}}
+  return p; // expected-error {{return value bounds do not imply declared return bounds for 'f10'}} \
+            // expected-note {{declared return bounds are wider than the return value bounds}} \
+            // expected-note {{declared return upper bound is above return value upper bound}} \
+            // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + 1)'}}
+}
+
+_Array_ptr<int> f11(_Array_ptr<int> p : count(2)) : bounds(p - 1, p + 2) { // expected-note {{(expanded) declared return bounds are 'bounds(p - 1, p + 2)'}}
+  return p; // expected-error {{return value bounds do not imply declared return bounds for 'f11'}} \
+            // expected-note {{declared return bounds are wider than the return value bounds}} \
+            // expected-note {{declared return lower bound is below return value lower bound}} \
+            // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + 2)'}}
+}
+
+_Nt_array_ptr<int> f12(_Nt_array_ptr<int> p, // expected-note 2 {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 3)'}}
+                       _Nt_array_ptr<int> q : bounds(q + 1, q + 2),
+                       int test) : count(3) {
+  if (test)
+    return p; // expected-error {{return value bounds do not imply declared return bounds for 'f12'}} \
+              // expected-note {{source bounds are an empty range}} \
+              // expected-note {{declared return upper bound is above return value upper bound}} \
+              // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + 0)'}}
+  else
+    return q; // expected-error {{return value bounds do not imply declared return bounds for 'f12'}} \
+              // expected-note {{declared return bounds are wider than the return value bounds}} \
+              // expected-note {{declared return lower bound is below return value lower bound}} \
+              // expected-note {{declared return upper bound is above return value upper bound}} \
+              // expected-note {{(expanded) inferred return value bounds are 'bounds(q + 1, q + 2)'}}
+}
+
+//
+// Test free variable bounds errors
+//
+
+_Array_ptr<char> f13(_Array_ptr<char> p : count(i), int i) : count(2) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 2)'}}
+  return p; // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'f13'}} \
+            // expected-note {{the inferred upper bounds use the variable 'i' and there is no relational information involving 'i' and any of the expressions used by the declared upper bounds}} \
+            // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + i)'}}
+}
+
+_Array_ptr<int> f14(_Array_ptr<int> p : count(3), // expected-note {{(expanded) declared return bounds are 'bounds(q, q + 3)'}}
+                    _Array_ptr<int> q : bounds(p, p + 3)) : bounds(q, q + 3) {
+  return q; // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'f14'}} \
+            // expected-note {{the declared bounds use the variable 'q' and there is no relational information involving 'q' and any of the expressions used by the inferred bounds}} \
+            // expected-note {{the inferred bounds use the variable 'p' and there is no relational information involving 'p' and any of the expressions used by the declared bounds}} \
+            // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + 3)'}}
+}
+
+_Nt_array_ptr<char> f15(int i) : count(i);
+
+_Nt_array_ptr<char> f15(int i) : count(i) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + i)'}}
+  return "abc"; // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'f15'}} \
+                // expected-note {{the declared upper bounds use the variable 'i' and there is no relational information involving 'i' and any of the expressions used by the inferred upper bounds}} \
+                // expected-note {{(expanded) inferred return value bounds are 'bounds(value of "abc", value of "abc" + 3)'}}
+}

--- a/clang/test/CheckedC/static-checking/return-bounds.c
+++ b/clang/test/CheckedC/static-checking/return-bounds.c
@@ -146,3 +146,19 @@ int *f20(int *p : count(7)) : bounds(p, p + 7) _Checked {
 int *f21(_Array_ptr<int> p : count(8)) : count(8) _Unchecked {
   return p;
 }
+
+//
+// Test bounds casts
+//
+
+_Array_ptr<char> f22(_Array_ptr<char> p : count(i), int i) : count(3) {
+  return _Dynamic_bounds_cast<_Array_ptr<char>>(p, count(3));
+}
+
+_Array_ptr<int> f23(_Array_ptr<int> p : count(4), int i) : count(i) {
+  return _Assume_bounds_cast<_Array_ptr<int>>(p, count(i));
+}
+
+_Array_ptr<int> f24(_Array_ptr<int> p : count(i), int i) : count(2) {
+  return _Dynamic_bounds_cast<_Array_ptr<int>>(p + 1, count(2));
+}

--- a/clang/test/CheckedC/static-checking/return-bounds.c
+++ b/clang/test/CheckedC/static-checking/return-bounds.c
@@ -162,3 +162,23 @@ _Array_ptr<int> f23(_Array_ptr<int> p : count(4), int i) : count(i) {
 _Array_ptr<int> f24(_Array_ptr<int> p : count(i), int i) : count(2) {
   return _Dynamic_bounds_cast<_Array_ptr<int>>(p + 1, count(2));
 }
+
+//
+// Test function calls
+//
+
+extern _Array_ptr<int> g1(void) : count(2);
+extern int *g2(int size) : count(size);
+extern _Nt_array_ptr<char> g3(_Nt_array_ptr<char> p) : bounds(p, p);
+
+_Array_ptr<int> f25(void) : count(2) {
+  return g1();
+}
+
+_Array_ptr<int> f26(int len) : count(len + 1) {
+  return g2(len + 1);
+}
+
+_Nt_array_ptr<char> f27(_Nt_array_ptr<char> p) : bounds(p, p) {
+  return g3(p);
+}

--- a/clang/test/CheckedC/static-checking/return-bounds.c
+++ b/clang/test/CheckedC/static-checking/return-bounds.c
@@ -121,3 +121,28 @@ _Nt_array_ptr<char> f15(int i) : count(i) { // expected-note {{(expanded) declar
                 // expected-note {{the declared upper bounds use the variable 'i' and there is no relational information involving 'i' and any of the expressions used by the inferred upper bounds}} \
                 // expected-note {{(expanded) inferred return value bounds are 'bounds(value of "abc", value of "abc" + 3)'}}
 }
+
+//
+// Test bounds-safe interfaces
+//
+
+int *f16(int *p) : byte_count(4) _Unchecked { // expected-note {{(expanded) declared return bounds are 'bounds((_Array_ptr<char>)_Return_value, (_Array_ptr<char>)_Return_value + 4)'}}
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'f16' has bounds}}
+}
+
+int *f17(int *p : bounds(unknown)) : count(5) _Checked { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 5)'}}
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'f17' has bounds}}
+}
+
+int *f19(int *p : count(6)) : count(6) _Unchecked { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + 6)'}}
+  return p + 1; // expected-warning {{cannot prove return value bounds imply declared return bounds for 'f19'}} \
+                // expected-note {{(expanded) inferred return value bounds are 'bounds(p, p + 6)'}}
+}
+
+int *f20(int *p : count(7)) : bounds(p, p + 7) _Checked {
+  return p + 1;
+}
+
+int *f21(_Array_ptr<int> p : count(8)) : count(8) _Unchecked {
+  return p;
+}


### PR DESCRIPTION
This PR checks that the inferred bounds of a return value expression imply the declared return bounds (if any) for the enclosing function.

This PR does not check modifications to variables or other lvalue expressions that are used in return bounds. For example:

```
_Array_ptr<int> f(int size) : count(size) {
  size = 3; // modify the size variable used in the declared return bounds
  return 0;
}
```
At the assignment `size = 3`, the bounds checker will not emit any diagnostic messages even though the modified variable `size` is used in the declared return bounds. This can be done in a separate PR.