### PR TITLE
Verify if an expr contains errors before checking invertibility 

### DIFF
--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -469,7 +469,7 @@ void ExprUtil::EnsureEqualBitWidths(llvm::APSInt &A, llvm::APSInt &B) {
 }
 
 bool InverseUtil::IsInvertible(Sema &S, Expr *LValue, Expr *E) {
-  if (!E)
+  if (!E || E->containsErrors())
     return false;
 
   E = E->IgnoreParens();


### PR DESCRIPTION
The community has introduced a new annotation called "contains-errors" on AST
nodes that contain semantic errors. As a result, after the upgrade of Checked C
sources to LLVM 12 we need to check if an expr contains errors before operating
on the expr. One such place is in InverseUtil::IsInvertible where we need to
check if the input modifying expr contains errors.