### PR TITLE
Don't record temporary equality between expression such as x and x + 1 in TargetSrcEquality

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3858,7 +3858,8 @@ namespace {
           ExprCreatorUtil::CreateImplicitCast(S, TargetDeclRef, Kind, TargetTy);
 
         // Record equality between the target and initializer.
-        RecordEqualityWithTarget(TargetDeclRef, TargetExpr, Init, State);
+        RecordEqualityWithTarget(TargetDeclRef, TargetExpr, Init,
+                                 /*AllowTempEquality=*/true, State);
       }
 
       if (D->isInvalidDecl())
@@ -4537,9 +4538,15 @@ namespace {
                                                              OriginalValue,
                                                              CSS, State);
       UpdateEquivExprsAfterAssignment(LValue, OriginalValue, CSS, State);
-      UpdateSameValueAfterAssignment(LValue, OriginalValue,
-                                     OriginalValueUsesLValue, CSS, State);
-      RecordEqualityWithTarget(LValue, Target, Src, State);
+      // We can only record equality between Target and Src if Src does
+      // not use the value of LValue. If UpdateSameValueAfterAssignment
+      // did not modify the contents of State.SameValue, then no expressions
+      // equivalent to Src use the value of LValue, so we can record equality
+      // between Target and Src.
+      bool AllowTempEquality =
+        UpdateSameValueAfterAssignment(LValue, OriginalValue,
+                                       OriginalValueUsesLValue, CSS, State);
+      RecordEqualityWithTarget(LValue, Target, Src, AllowTempEquality, State);
 
       StateUpdated = true;
       return ResultBounds;
@@ -4687,7 +4694,11 @@ namespace {
     // that modifies the expression LValue.
     //
     // OriginalValue is the value of LValue before the assignment.
-    void UpdateSameValueAfterAssignment(Expr *LValue, Expr *OriginalValue,
+    //
+    // UpdateSameValue returns true if the contents of SameValue were
+    // not modified, i.e. if no expressions in SameValue used the value
+    // of LValue.
+    bool UpdateSameValueAfterAssignment(Expr *LValue, Expr *OriginalValue,
                                         bool OriginalValueUsesLValue,
                                         CheckedScopeSpecifier CSS,
                                         CheckingState &State) {
@@ -4710,15 +4721,27 @@ namespace {
         if (AdjustedE && !EqualExprsContainsExpr(State.SameValue, AdjustedE))
           State.SameValue.push_back(AdjustedE);
       }
+      return State.SameValue.size() == PrevSameValue.size();
     }
 
     // RecordEqualityWithTarget updates the checking state to record equality
     // implied by an assignment or initializer of the form LValue = Src,
     // where Target is an rvalue expression that is the value of LValue.
     //
+    // AllowTempEquality is true if it is permissible to record temporary
+    // equality between Target and Src in State.TargetSrcEquality if necessary.
+    // The purpose of TargetSrcEquality is to record equality between target
+    // and source expressions only for checking bounds after the current
+    // statement (unlike State.EquivExprs, this equality does not persist
+    // across statements). However, not all target/source pairs should be added
+    // to TargetSrcEquality. For example, in an assignment x = x + 1, SameValue
+    // will be empty since x + 1 uses the value of x. However, x => x + 1
+    // should not be added to TargetSrcEquality.
+    //
     // State.SameValue is assumed to contain expressions that produce the same
-    // value as Source.
+    // value as Src.
     void RecordEqualityWithTarget(Expr *LValue, Expr *Target, Expr *Src,
+                                  bool AllowTempEquality,
                                   CheckingState &State) {
       if (!LValue)
         return;
@@ -4726,9 +4749,10 @@ namespace {
 
       // Certain kinds of expressions (e.g. member expressions) are not allowed
       // to be included in EquivExprs. For these expressions, we record
-      // temporary equality between Target and Src in TargetSrcEquality instead
-      // of in EquivExprs. If Src is allowed in EquivExprs, SameValue will
-      // contain at least one expression that produces the same value as Src.
+      // temporary equality (if permitted by AllowTempEquality) between Target
+      // and Src in TargetSrcEquality instead of in EquivExprs. If Src is
+      // allowed in EquivExprs, SameValue will contain at least one expression
+      // that produces the same value as Src.
       bool TargetAllowedInEquivExprs = !isa<MemberExpr>(LValue);
       bool SrcAllowedInEquivExprs = State.SameValue.size() > 0;
 
@@ -4766,7 +4790,8 @@ namespace {
       // This temporary equality information will be used to validate the
       // bounds context after checking the current top-level CFG statement,
       // but does not persist across checking CFG statements.
-      if (Src && (!TargetAllowedInEquivExprs || !SrcAllowedInEquivExprs)) {
+      if (AllowTempEquality && Src &&
+          (!TargetAllowedInEquivExprs || !SrcAllowedInEquivExprs)) {
         CHKCBindTemporaryExpr *Temp = GetTempBinding(Src);
         if (Temp)
           State.TargetSrcEquality[Target] = CreateTemporaryUse(Temp);


### PR DESCRIPTION
This PR fixes a bug with the way equivalent expressions were being recorded in `RecordEqualityWithTarget`.

In an assignment such as `x++`, `x += 1`, `x = x + 1`, etc., `SameValue` is empty after calling `UpdateSameValueAfterAssignment` (since the RHS `x + 1` of the assignment uses the value of the LHS `x`). This meant that `SrcAllowedInEquivExprs` was `false` in `RecordEqualityWithTarget`, so the mapping `x => x + 1` was added to `TargetSrcEquality`. The information in `TargetSrcEquality` is added to `EquivExprs` in `ValidateBoundsContext`, so `EquivExprs` would contain a set that contained both `x` and `x + 1` only while checking bounds after the current top-level statement.

This PR adds an `AllowTempEquality` argument to `RecordEqualityWithTarget` that controls whether the mapping `Target => Src` is permitted to be added to `TargetSrcEquality`. `UpdateSameValueAfterAssignment` now returns `true` if `State.SameValue` was unchanged by the assignment (if the RHS of the assignment uses the value of the LHS, then at least one expression will be removed from `State.SameValue` if `State.SameValue` was initially nonempty). If `State.SameValue` was unchanged by the assignment, then temporary equality is allowed to be recorded between `Target` and `Src`.