### PR TITLE
Treat address-of array subscripts the same way as address-of dereferences

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14203,6 +14203,11 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
 
   if (getLangOpts().C99) {
     // Implement C99-only parts of addressof rules.
+    // This logic should be near the end of this method (as opposed to the
+    // C99-only rules for addressof dereferences above) so that the necessary
+    // checks can be made for addressof array subscript expressions (taking
+    // the address of a register variable, taking the address of a vector
+    // element, etc.).
     if (ArraySubscriptExpr *arrSubscript = dyn_cast<ArraySubscriptExpr>(op)) {
       // Per C99 6.5.3.2, the address of an array subscript always returns
       // a valid result (assuming the array subscript expression is valid).

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14049,6 +14049,8 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
         // (assuming the deref expression is valid).
         return uOp->getSubExpr()->getType();
     }
+    // Technically, there should be a check for array subscript
+    // expressions here, but the result of one is always an lvalue anyway.
   }
   ValueDecl *dcl = getPrimaryDecl(op);
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14049,8 +14049,11 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
         // (assuming the deref expression is valid).
         return uOp->getSubExpr()->getType();
     }
-    // Technically, there should be a check for array subscript
-    // expressions here, but the result of one is always an lvalue anyway.
+    if (ArraySubscriptExpr *arrSub = dyn_cast<ArraySubscriptExpr>(op)) {
+      // Per C99 6.5.3.2, the address of an array subscript always returns
+      // a valid result (assuming the array subscript expression is valid).
+      return arrSub->getBase()->getType();
+    }
   }
   ValueDecl *dcl = getPrimaryDecl(op);
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14049,11 +14049,6 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
         // (assuming the deref expression is valid).
         return uOp->getSubExpr()->getType();
     }
-    if (ArraySubscriptExpr *arrSub = dyn_cast<ArraySubscriptExpr>(op)) {
-      // Per C99 6.5.3.2, the address of an array subscript always returns
-      // a valid result (assuming the array subscript expression is valid).
-      return arrSub->getBase()->getType();
-    }
   }
   ValueDecl *dcl = getPrimaryDecl(op);
 
@@ -14203,6 +14198,15 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
     return Context.getObjCObjectPointerType(op->getType());
 
   CheckAddressOfPackedMember(op);
+
+  if (getLangOpts().C99) {
+    // Implement C99-only parts of addressof rules.
+    if (ArraySubscriptExpr *arrSubscript = dyn_cast<ArraySubscriptExpr>(op)) {
+      // Per C99 6.5.3.2, the address of an array subscript always returns
+      // a valid result (assuming the array subscript expression is valid).
+      return arrSubscript->getBase()->getType();
+    }
+  }
 
   // Checked scopes change the types of the address-of(&) operator.
   // In a checked scope, the operator produces an array_ptr<T> except for

--- a/clang/test/CheckedC/inferred-bounds/basic.c
+++ b/clang/test/CheckedC/inferred-bounds/basic.c
@@ -431,8 +431,7 @@ void f42(void) {
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} r '_Array_ptr<int>' cinit
 // CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' prefix '&'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' prefix '&'
 // CHECK:     `-ArraySubscriptExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
@@ -521,8 +520,7 @@ void f43(void) {
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '='
 // CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'r' '_Array_ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' prefix '&'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' prefix '&'
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK:       | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1027,27 +1027,25 @@ void original_value11(array_ptr<int> p, array_ptr<int> q) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Original value of p in (_Array_ptr<int>&p[2]): (int *)p - 2
-  // Updated EquivExprs: { { (int *)p - 2 + 1, q } }
+  // Original value of p in &p[2]: p - 2
+  // Updated EquivExprs: { { p - 2 + 1, q } }
   p = &p[2];
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
-  // CHECK-NEXT:     UnaryOperator {{.*}} 'int *' prefix '&'
-  // CHECK-NEXT:       ArraySubscriptExpr {{.*}} 'int'
-  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:         IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
+  // CHECK-NEXT:     ArraySubscriptExpr {{.*}} 'int'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'int *' <BitCast>
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'q'
@@ -1127,28 +1125,26 @@ void original_value13(array_ptr<int> p, array_ptr<int> q) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Original value of p in (_Array_ptr<int>)&0[&*p]: (int *)p - 0
-  // Updated EquivExprs: { { (int *)p - 0 + 1, q } }
+  // Original value of p in &0[&*p]: p - 0
+  // Updated EquivExprs: { { p - 0 + 1, q } }
   p = &0[&*p];
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
-  // CHECK-NEXT:     UnaryOperator {{.*}} 'int *' prefix '&'
-  // CHECK-NEXT:       ArraySubscriptExpr {{.*}} 'int'
-  // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-  // CHECK-NEXT:         UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
-  // CHECK-NEXT:           UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:             ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:               DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
+  // CHECK-NEXT:     ArraySubscriptExpr {{.*}} 'int'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:       UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
+  // CHECK-NEXT:         UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'p'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'int *' <BitCast>
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>

--- a/clang/test/CheckedC/inferred-bounds/ptr-cast.c
+++ b/clang/test/CheckedC/inferred-bounds/ptr-cast.c
@@ -71,7 +71,7 @@ void f2(_Array_ptr<int> p : count(5)) {
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 5
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' prefix '&'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' prefix '&'
 // CHECK:   `-ArraySubscriptExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue
 // CHECK:     |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK:     | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'


### PR DESCRIPTION
Fixes #1148

This PR modifies the type checker so that, if an expression `e` has type `T`, then `&e[idx]` and `&idx[e]` also have type `T`. This is similar to the current behavior where, if `e` has type `T`, then `&*e` also has type `T`.

From the C spec section 6.5.3.2:

> Similarly, if the operand is the result of a [] operator, neither the & operator nor the unary * that is implied by the [] is evaluated and the result is as if the & operator were removed and the [] operator were changed to a + operator.

This is similar to the rules for `&*e`:

> If the operand is the result of a unary * operator, neither that operator nor the & operator is evaluated and the result is as if both were omitted, except that the constraints on the operators still apply and the result is not an lvalue.