### PR TITLE
Update bounds checking notes

### DIFF
--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -186,6 +186,8 @@ BoundsExpr *BoundsUtil::ExpandToRange(Sema &S, VarDecl *D, BoundsExpr *B) {
 BoundsExpr *BoundsUtil::ReplaceLValueInBounds(Sema &S, BoundsExpr *Bounds,
                                               Expr *LValue, Expr *OriginalValue,
                                               CheckedScopeSpecifier CSS) {
+  if (Bounds->isUnknown() || Bounds->isAny())
+    return Bounds;
   Expr *Replaced = ReplaceLValue(S, Bounds, LValue, OriginalValue, CSS);
   if (!Replaced)
     return CreateBoundsUnknown(S);

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -1138,7 +1138,6 @@ void multiple_assign1(
   // Observed bounds context after assignments: { a => bounds(unknown), b => bounds(unknown) }
   len = 0, a = b; // expected-error {{inferred bounds for 'a' are unknown after assignment}} \
                   // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(a, a + len)' of 'a'}} \
-                  // expected-note {{assigned expression 'b' with unknown bounds to 'a'}} \
                   // expected-error {{inferred bounds for 'b' are unknown after assignment}} \
                   // expected-note {{lost the value of the expression 'len' which is used in the (expanded) inferred bounds 'bounds(b, b + len)' of 'b'}}
   // CHECK: Statement S:

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -816,3 +816,24 @@ void f96(_Nt_array_ptr<char> p : bounds(p, (p + (len + 4)) + 4), int len) {
                                                               // expected-note {{(expanded) declared bounds are 'bounds(v, (v + (1 + len)) + 2)'}} \
                                                               // expected-note {{(expanded) inferred bounds are 'bounds(p, (p + (len + 4)) + 4)'}}
 }
+
+//
+// Test diagnostic behavior for bounds checking across multiple assignments.
+//
+
+void f97(_Array_ptr<int> p : count(i), // expected-note 4 {{(expanded) declared bounds are 'bounds(p, p + i)'}}
+         unsigned int i, 
+         _Array_ptr<int> unknwn1,
+         _Array_ptr<int> unknwn2) {
+  p = unknwn1, p = p; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
+                      // expected-note {{assigned expression 'unknwn1' with unknown bounds to 'p'}}
+
+  p = unknwn1, p++; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
+                    // expected-note {{assigned expression 'unknwn1' with unknown bounds to 'p'}}
+
+  p = unknwn1, p = unknwn2; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
+                            // expected-note {{assigned expression 'unknwn1' with unknown bounds to 'p'}}
+
+  p++, i = 0, p = unknwn1; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
+                           // expected-note {{lost the value of the expression 'i' which is used in the (expanded) inferred bounds 'bounds(p - 1, p - 1 + i)' of 'p'}}
+}

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -837,3 +837,11 @@ void f97(_Array_ptr<int> p : count(i), // expected-note 4 {{(expanded) declared 
   p++, i = 0, p = unknwn1; // expected-error {{inferred bounds for 'p' are unknown after assignment}} \
                            // expected-note {{lost the value of the expression 'i' which is used in the (expanded) inferred bounds 'bounds(p - 1, p - 1 + i)' of 'p'}}
 }
+
+void f98(_Array_ptr<int> p : count(i), unsigned int i) { // expected-note 2 {{(expanded) declared bounds are 'bounds(p, p + i)'}}
+  i++, p += 2; // expected-warning {{cannot prove declared bounds for 'p' are valid after assignment}} \
+               // expected-note {{(expanded) inferred bounds are 'bounds(p - 2, p - 2 + i)'}}
+
+  p += 2, i++; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
+               // expected-note {{(expanded) inferred bounds are 'bounds(p - 2, p - 2 + i - 1U)'}}
+}


### PR DESCRIPTION
This PR makes a minor modification to the notes emitted during bounds checking:

Only one note is emitted per statement per lvalue expression for an expression with unknown bounds being assigned to an lvalue expression.
For example:
```
void f(_Array_ptr<int> p : count(1), _Array_ptr<int> q : bounds(unknown) {
  p = q, p++;
}
```
Both assignments `p = q` and `p++` assign expressions (`q` and `p + 1` respectively) with unknown bounds to `p`. A note will only be emitted for the first assignment. This helps avoid confusion in the note messages - it may be unclear to the user why the expression `p++` would result in the note "assigned expression p + 1 with unknown bounds to p".
