### PR TITLE
Bounds checking bounds-safe interfaces in unchecked scopes

### DIFF
--- a/clang/test/CheckedC/inferred-bounds/member-reference.c
+++ b/clang/test/CheckedC/inferred-bounds/member-reference.c
@@ -348,7 +348,7 @@ int global_arr2 _Checked[5];
 void f12(struct Interop_S1 a1) {
   // TODO: need bundled block.
   a1.p = global_arr2;
-  a1.len = 5; // expected-error {{inferred bounds for 'a1.p' are unknown after assignment}}
+  a1.len = 5;
 }
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' '='

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -840,7 +840,7 @@ _Unchecked void f97(int *p : count(i), // expected-note 8 {{(expanded) declared 
 
   // The type of the RHS expression p + r is int *, so a checked pointer is not
   // assigned to p here.
-  p -= (_Array_ptr<int>)q; // expected-warning {{incompatible integer to pointer conversion assigning to 'int *' from 'long long'}}
+  p -= (_Array_ptr<int>)q; // expected-warning {{incompatible integer to pointer conversion assigning to 'int *'}}
 
   // For statements where a checked pointer is assigned to p, validate the
   // bounds of p.

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -838,8 +838,8 @@ _Unchecked void f97(int *p : count(i), // expected-note 8 {{(expanded) declared 
   p = get_unchecked(r);
   p += i;
 
-  // The type of the RHS expression p + r is int *, so a checked pointer is not
-  // assigned to p here.
+  // The type of the RHS expression p - (_Array_ptr<int>)q is int *, so a
+  // checked pointer is not assigned to p here.
   p -= (_Array_ptr<int>)q; // expected-warning {{incompatible integer to pointer conversion assigning to 'int *'}}
 
   // For statements where a checked pointer is assigned to p, validate the

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -872,4 +872,17 @@ _Unchecked void f97(int *p : count(i), // expected-note 8 {{(expanded) declared 
     ++p; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
          // expected-note {{(expanded) inferred bounds are 'bounds(p - 1, p - 1 + i)'}}
   }
+
+  // Non-pointer-typed values with declared bounds do not have their bounds
+  // validated in unchecked scopes.
+  short int t1 : byte_count(2) = (short int)arr; // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+  t1 = (short int)r; // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+
+  // Non-pointer-typed values with declared bounds have their bounds
+  // validated in checked scopes.
+  _Checked {
+    short int t2 : byte_count(2) = (short int)r; // expected-error {{inferred bounds for 't2' are unknown after initialization}} \
+                                                 // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)t2, (_Array_ptr<char>)t2 + 2)'}} \
+                                                 // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+  }
 }

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -825,7 +825,7 @@ void f96(_Nt_array_ptr<char> p : bounds(p, (p + (len + 4)) + 4), int len) {
 _Unchecked extern int *get_unchecked(_Array_ptr<int> a);
 extern _Array_ptr<int> get_checked(unsigned int i) : count(i);
 
-_Unchecked void f97(int *p : count(i), // expected-note 7 {{(expanded) declared bounds are 'bounds(p, p + i)'}}
+_Unchecked void f97(int *p : count(i), // expected-note 8 {{(expanded) declared bounds are 'bounds(p, p + i)'}}
                     int *q : bounds(unknown),
                     _Array_ptr<int> r,
                     unsigned int i) {
@@ -858,6 +858,11 @@ _Unchecked void f97(int *p : count(i), // expected-note 7 {{(expanded) declared 
 
   p = (_Array_ptr<int>)p, --p; // expected-warning {{cannot prove declared bounds for 'p' are valid after decrement}} \
                                // expected-note {{'bounds((int *)p + 1, (int *)p + 1 + i)'}}
+
+  int arr _Checked[3] : count(3) = {0, 1, 2};
+  p = arr; // expected-error {{it is not possible to prove that the inferred bounds of 'p' imply the declared bounds of 'p' after assignment}} \
+           // expected-note {{the declared upper bounds use the variable 'i' and there is no relational information involving 'i' and any of the expressions used by the inferred upper bounds}} \
+           // expected-note {{(expanded) inferred bounds are 'bounds(arr, arr + 3)'}}
   
   // In a checked scope, always validate the bounds of p.
   _Checked {

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -760,9 +760,9 @@ void f91(_Array_ptr<int> p : count(1)) _Unchecked { // expected-note {{(expanded
        // expected-note {{(expanded) inferred bounds are 'bounds(p - 1, p - 1 + 1)'}}
 }
 
-void f92(int *p : count(1)) _Unchecked { // expected-note {{(expanded) declared bounds are 'bounds(p, p + 1)'}}
- ++p; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
-      // expected-note {{(expanded) inferred bounds are 'bounds(p - 1, p - 1 + 1)'}}
+_Unchecked void f92(_Array_ptr<int> p : bounds(q, q + 1), int *q) { // expected-note {{(expanded) declared bounds are 'bounds(q, q + 1)'}}
+ ++q; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
+      // expected-note {{(expanded) inferred bounds are 'bounds(q - 1, q - 1 + 1)'}}
 }
 
 //

--- a/clang/test/CheckedC/static-checking/free-variables.c
+++ b/clang/test/CheckedC/static-checking/free-variables.c
@@ -133,10 +133,13 @@ void f3(struct S1 a3) {
 void f4(void) {
   int a checked[5];
   // Check that parentheses are correctly ignored.
-  short int t1 : byte_count(5 * sizeof(int)) = ((((short int)(a)))); // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
-                                                                     // expected-warning {{cannot prove declared bounds for 't1' are valid after initialization}} \
-                                                                     // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)t1, (_Array_ptr<char>)t1 + 5 * sizeof(int))'}} \
-                                                                     // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 5)'}}
+  _Checked {
+    short int t1 : byte_count(5 * sizeof(int)) = ((((short int)(a)))); // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
+                                                                       // expected-warning {{cannot prove declared bounds for 't1' are valid after initialization}} \
+                                                                       // expected-note {{(expanded) declared bounds are 'bounds((_Array_ptr<char>)t1, (_Array_ptr<char>)t1 + 5 * sizeof(int))'}} \
+                                                                       // expected-note {{(expanded) inferred bounds are 'bounds(a, a + 5)'}}
+  }
+
   array_ptr<int> t2 : byte_count(5 * sizeof(int)) = (((a)));
   array_ptr<int> t3 : byte_count(5 * sizeof(int)) = (((array_ptr<int>)(((a)))));
 


### PR DESCRIPTION
Fixes #1158 

This PR updates the bounds checking behavior for lvalue expressions with bounds-safe interfaces in unchecked scopes.

If:
1. A statement `S` is in an unchecked scope, and:
2. An lvalue expression `e` has unchecked pointer type (its bounds were declared using a bounds-safe interface), and:
3. `S` does not contain an assignment `e = e1` where `e1` is a checked pointer, then:

The bounds of `e` are **not** validated after checking `S`.