### PR TITLE
Check that variables and member expressions used in return bounds are unmodified

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11619,6 +11619,12 @@ def err_bounds_type_annotation_lost_checking : Error<
   def error_static_cast_bounds_invalid : Error<
     "cast source bounds are too narrow for %0">;
 
+  def error_modified_return_bounds : Error<
+    "modified expression '%0' used in the declared return bounds for %1">;
+
+  def note_declared_return_bounds : Note<
+    "(expanded) declared return bounds are '%0'">;
+
   def error_out_of_bounds_access : Error<
     "out-of-bounds %select{||memory access|base value}0">;
 

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4553,7 +4553,7 @@ namespace {
 
       // Account for uses of LValue in the declared return bounds (if any)
       // for the enclosing function.
-      UpdateReturnBoundsAfterAssignment(LValue, E, CSS);
+      CheckIfLValueIsUsedInReturnBounds(LValue, E, CSS);
 
       // Get the original value (if any) of LValue before the assignment,
       // and determine whether the original value uses the value of LValue.
@@ -4581,8 +4581,8 @@ namespace {
       return ResultBounds;
     }
 
-    // UpdateReturnBoundsAfterAssignment computes the observed bounds for the
-    // return value of the enclosing function (if any) by replacing all
+    // CheckIfLValueIsUsedInReturnBounds computes the observed bounds for
+    // the return value of the enclosing function (if any) by replacing all
     // uses of LValue within the declared return bounds with null. If the
     // declared return bounds use the value of LValue, the observed return
     // bounds will be bounds(unknown) and an error will be emitted.
@@ -4595,7 +4595,7 @@ namespace {
     // TODO: track an observed return bounds expression as a global property
     // of the function body so that invertibility of lvalue expressions can
     // be taken into account.
-    void UpdateReturnBoundsAfterAssignment(Expr *LValue, Expr *E,
+    void CheckIfLValueIsUsedInReturnBounds(Expr *LValue, Expr *E,
                                            CheckedScopeSpecifier CSS) {
       if (!ReturnBounds || ReturnBounds->isUnknown() || ReturnBounds->isAny())
         return;

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4551,6 +4551,10 @@ namespace {
         return SrcBounds;
       }
 
+      // Account for uses of LValue in the declared return bounds (if any)
+      // for the enclosing function.
+      UpdateReturnBoundsAfterAssignment(LValue, E, Src, CSS);
+
       // Get the original value (if any) of LValue before the assignment,
       // and determine whether the original value uses the value of LValue.
       // OriginalValue is named OV in the Checked C spec.
@@ -4575,6 +4579,47 @@ namespace {
 
       StateUpdated = true;
       return ResultBounds;
+    }
+
+    // UpdateReturnBoundsAfterAssignment computes the observed bounds for the
+    // return value of the enclosing function (if any) by replacing all
+    // uses of LValue within the declared return bounds with null. If the
+    // declared return bounds use the value of LValue, the observed return
+    // bounds will be bounds(unknown) and an error will be emitted.
+    //
+    // The current implementation does not use invertibility of lvalue
+    // expressions. This simplifies the implementation so that the updated
+    // return bounds can be computed locally at each assignment statement,
+    // rather than keeping track of a return bounds expression across the
+    // entire function body.
+    // TODO: track an observed return bounds expression as a global property
+    // of the function body so that invertibility of lvalue expressions can
+    // be taken into account.
+    void UpdateReturnBoundsAfterAssignment(Expr *LValue, Expr *E, Expr *Src,
+                                           CheckedScopeSpecifier CSS) {
+      if (!ReturnBounds || ReturnBounds->isUnknown() || ReturnBounds->isAny())
+        return;
+
+      // In unchecked scopes, if the enclosing function has its bounds declared
+      // via a bounds-safe interface, we do not check that expressions used in
+      // the declared function bounds are not modified.
+      if (CSS == CheckedScopeSpecifier::CSS_Unchecked) {
+        if (FunctionDeclaration->hasBoundsSafeInterface(Context))
+          return;
+      }
+
+      BoundsExpr *UpdatedReturnBounds =
+        BoundsUtil::ReplaceLValueInBounds(S, ReturnBounds, LValue,
+                                          nullptr, CSS);
+      if (!UpdatedReturnBounds->isUnknown())
+        return;
+
+      S.Diag(LValue->getBeginLoc(), diag::error_modified_return_bounds)
+          << LValue << FunctionDeclaration << E->getSourceRange();
+
+      SourceLocation DeclaredLoc = FunctionDeclaration->getLocation();
+      S.Diag(DeclaredLoc, diag::note_declared_return_bounds)
+        << ReturnBounds << ReturnBounds->getSourceRange();
     }
 
     // UpdateBoundsAfterAssignment updates the observed bounds context after

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4553,7 +4553,7 @@ namespace {
 
       // Account for uses of LValue in the declared return bounds (if any)
       // for the enclosing function.
-      UpdateReturnBoundsAfterAssignment(LValue, E, Src, CSS);
+      UpdateReturnBoundsAfterAssignment(LValue, E, CSS);
 
       // Get the original value (if any) of LValue before the assignment,
       // and determine whether the original value uses the value of LValue.
@@ -4595,7 +4595,7 @@ namespace {
     // TODO: track an observed return bounds expression as a global property
     // of the function body so that invertibility of lvalue expressions can
     // be taken into account.
-    void UpdateReturnBoundsAfterAssignment(Expr *LValue, Expr *E, Expr *Src,
+    void UpdateReturnBoundsAfterAssignment(Expr *LValue, Expr *E,
                                            CheckedScopeSpecifier CSS) {
       if (!ReturnBounds || ReturnBounds->isUnknown() || ReturnBounds->isAny())
         return;

--- a/clang/test/CheckedC/static-checking/return-bounds-parameters.c
+++ b/clang/test/CheckedC/static-checking/return-bounds-parameters.c
@@ -1,0 +1,101 @@
+// Tests for checking that parameter expressions used in declared return
+// bounds are unmodified in checked scopes (or if the function's return
+// type is a checked pointer).
+//
+// RUN: %clang_cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
+
+//
+// Test variable parameters used in return bounds.
+//
+
+_Array_ptr<int> f1(_Array_ptr<int> p : count(1), unsigned int i) : bounds(p, p + i) { // expected-note 2 {{(expanded) declared return bounds are 'bounds(p, p + i)'}}
+  p = 0; // expected-error {{modified expression 'p' used in the declared return bounds for 'f1'}}
+  i++; // expected-error {{modified expression 'i' used in the declared return bounds for 'f1'}}
+  return 0;
+}
+
+_Nt_array_ptr<char> f2(unsigned int len) : count(len) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + len)'}}
+  len = len * 2; // expected-error {{modified expression 'len' used in the declared return bounds for 'f2'}}
+  return "abcd";
+}
+
+_Array_ptr<int> f3(_Array_ptr<int> arr : count(1), unsigned int idx) : byte_count(arr[idx]) { // expected-note 2 {{(expanded) declared return bounds are 'bounds((_Array_ptr<char>)_Return_value, (_Array_ptr<char>)_Return_value + arr[idx])'}}
+  arr = 0; // expected-error {{modified expression 'arr' used in the declared return bounds for 'f3'}}
+  idx--; // expected-error {{modified expression 'idx' used in the declared return bounds for 'f3'}}
+
+  // We currently do not check that array subscript expressions used in return
+  // bounds are not modified.
+  arr[idx] = 1;
+  return 0;
+}
+
+_Array_ptr<char> f4(_Ptr<int> num) : count(*num + 1) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + *num + 1)'}}
+  num = 0; // expected-error {{modified expression 'num' used in the declared return bounds for 'f4'}}
+
+  // We currently do not check that pointer dereference expressions used in
+  // return bounds are not modified.
+  *num = 1;
+  return 0;
+}
+
+_Array_ptr<int> f5(unsigned int a, unsigned int b) : count(a + b) { // expected-note 2 {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + a + b)'}}
+  a++, b--; // expected-error {{modified expression 'a' used in the declared return bounds for 'f5'}} \
+            // expected-error {{modified expression 'b' used in the declared return bounds for 'f5'}}
+  return 0;
+}
+
+//
+// Test member expressions used in return bounds.
+//
+
+struct S1 {
+  _Array_ptr<int> f : count(2);
+  int len;
+};
+
+_Array_ptr<char> f6(struct S1 *s) : count(s->len) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + s->len)'}}
+  s->len *= 2; // expected-error {{modified expression 's->len' used in the declared return bounds for 'f6'}}
+  return 0;
+}
+
+_Array_ptr<int> f7(struct S1 s) : bounds(s.f, s.f + s.len) { // expected-note 2 {{(expanded) declared return bounds are 'bounds(s.f, s.f + s.len)'}}
+  s.f = 0; // expected-error {{modified expression 's.f' used in the declared return bounds for 'f7'}}
+  s.len++; // expected-error {{modified expression 's.len' used in the declared return bounds for 'f7'}}
+  return 0;
+}
+
+//
+// Test funtions with bounds-safe interfaces in checked scopes
+//
+
+struct S2 {
+  int *f : count(2);
+  int len;
+};
+
+int *f8(struct S2 s, int i) : bounds(s.f, s.f + i) _Checked { // expected-note 2 {{(expanded) declared return bounds are 'bounds(s.f, s.f + i)'}}
+  s.f = 0; // expected-error {{modified expression 's.f' used in the declared return bounds for 'f8'}}
+  i += 1; // expected-error {{modified expression 'i' used in the declared return bounds for 'f8'}}
+  return 0;
+}
+
+char *f9(_Array_ptr<char> p) : bounds(p, p + 1) _Checked { // expected-note {{(expanded) declared return bounds are 'bounds(p, p + 1)'}}
+  p++; // expected-error {{modified expression 'p' used in the declared return bounds for 'f9'}}
+  return 0;
+}
+
+//
+// Test functions with bounds-safe interfaces in unchecked scopes
+//
+
+int *f10(_Array_ptr<int> p, _Array_ptr<int> q, unsigned int i) : bounds(p, p + i) _Unchecked {
+  p = q;
+  i = 0;
+  return 0;
+}
+
+char *f11(struct S2 *s) : count(s->len + 1) _Unchecked {
+  s->len += 2;
+  return 0;
+}
+


### PR DESCRIPTION
After each assignment expression to a variable or member expression `e`, this PR checks that `e` is not used in the declared return bounds (if any) for the enclosing function.

In unchecked scopes, if the enclosing function has a bounds-safe interface, this checking is not performed (regardless of the type of `e` or the type of the RHS expression that was assigned to `e`).