### PR TITLE
Bounds checking for pointer dereferences and array subscripts

### DIFF
--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -145,6 +145,10 @@ public:
   // pointer). Returns false if E is nullptr.
   static bool ReadsMemoryViaPointer(Expr *E, bool IncludeAllMemberExprs = false);
 
+  // IsDereferenceOrSubscript returns true if the expression e is a pointer
+  // dereference *e1 or an array subscript expression e1[e2].
+  static bool IsDereferenceOrSubscript(Expr *E);
+
   // FindLValue returns true if the given lvalue expression occurs in E.
   static bool FindLValue(Sema &S, Expr *LValue, Expr *E);
 

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -306,6 +306,18 @@ bool ExprUtil::ReadsMemoryViaPointer(Expr *E, bool IncludeAllMemberExprs) {
   }
 }
 
+bool ExprUtil::IsDereferenceOrSubscript(Expr *E) {
+  if (!E)
+    return false;
+  E = E->IgnoreParens();
+  if (isa<ArraySubscriptExpr>(E))
+    return true;
+  UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
+  if (!UO)
+    return false;
+  return UO->getOpcode() == UnaryOperatorKind::UO_Deref;
+}
+
 namespace {
   class FindLValueHelper : public RecursiveASTVisitor<FindLValueHelper> {
     private:

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -458,6 +458,22 @@ namespace {
         return true;
       }
 
+      bool VisitUnaryOperator(UnaryOperator *E) {
+        if (!ExprUtil::IsDereferenceOrSubscript(LValue))
+          return true;
+        if (Lex.CompareExprSemantically(E, LValue))
+          ++Count;
+        return true;
+      }
+
+      bool VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
+        if (!ExprUtil::IsDereferenceOrSubscript(LValue))
+          return true;
+        if (Lex.CompareExprSemantically(E, LValue))
+          ++Count;
+        return true;
+      }
+
       // Do not traverse the child of a BoundsValueExpr.
       // If a BoundsValueExpr uses the expression LValue (or a variable whose
       // declaration matches V), this should not count toward the total

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -353,6 +353,22 @@ namespace {
         return true;
       }
 
+      bool VisitUnaryOperator(UnaryOperator *E) {
+        if (!ExprUtil::IsDereferenceOrSubscript(LValue))
+          return true;
+        if (Lex.CompareExprSemantically(E, LValue))
+          Found = true;
+        return true;
+      }
+
+      bool VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
+        if (!ExprUtil::IsDereferenceOrSubscript(LValue))
+          return true;
+        if (Lex.CompareExprSemantically(E, LValue))
+          Found = true;
+        return true;
+      }
+
       // Do not traverse the child of a BoundsValueExpr.
       // Expressions within a BoundsValueExpr should not be considered
       // when looking for LValue.

--- a/clang/lib/AST/PreorderAST.cpp
+++ b/clang/lib/AST/PreorderAST.cpp
@@ -168,14 +168,14 @@ void PreorderAST::CreateUnaryOperator(UnaryOperator *E, Node *Parent) {
 }
 
 void PreorderAST::CreateArraySubscript(ArraySubscriptExpr *E, Node *Parent) {
-  // e1[e2] has the same canonical form as *(e1 + e2).
+  // e1[e2] has the same canonical form as *(e1 + e2 + 0).
   auto *DerefExpr = BinaryOperator::Create(Ctx, E->getBase(), E->getIdx(),
                                            BinaryOperatorKind::BO_Add, E->getType(),
                                            E->getValueKind(), E->getObjectKind(),
                                            E->getExprLoc(), FPOptionsOverride());
   auto *N = new UnaryOperatorNode(UnaryOperatorKind::UO_Deref, Parent);
   AttachNode(N, Parent);
-  Create(DerefExpr, N);
+  AddZero(DerefExpr, N);
 }
 
 void PreorderAST::CreateMember(MemberExpr *E, Node *Parent) {

--- a/clang/lib/Sema/BoundsUtils.cpp
+++ b/clang/lib/Sema/BoundsUtils.cpp
@@ -242,6 +242,30 @@ namespace {
           return E;
       }
 
+      ExprResult TransformUnaryOperator(UnaryOperator *E) {
+        if (!ExprUtil::IsDereferenceOrSubscript(LValue))
+          return E;
+        if (Lex.CompareExprSemantically(LValue, E)) {
+          if (OriginalValue)
+            return OriginalValue;
+          else
+            return ExprError();
+        } else
+          return E;
+      }
+
+      ExprResult TransformArraySubscriptExpr(ArraySubscriptExpr *E) {
+        if (!ExprUtil::IsDereferenceOrSubscript(LValue))
+          return E;
+        if (Lex.CompareExprSemantically(LValue, E)) {
+          if (OriginalValue)
+            return OriginalValue;
+          else
+            return ExprError();
+        } else
+          return E;
+      }
+
       // Overriding TransformImplicitCastExpr is necessary since TreeTransform
       // does not preserve implicit casts.
       ExprResult TransformImplicitCastExpr(ImplicitCastExpr *E) {

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -3300,8 +3300,9 @@ namespace {
 
         // Update the checking state and result bounds to reflect the
         // assignment to `e1`.
-        ResultBounds = UpdateAfterAssignment(LHS, E, Target, Src, ResultBounds,
-                                             CSS, State, StateUpdated);
+        ResultBounds = UpdateAfterAssignment(LHS, LHSTargetBounds, E, Target,
+                                             Src, ResultBounds, CSS, State,
+                                             StateUpdated);
 
         // SameValue is empty for assignments to a non-variable. This
         // conservative approach avoids recording false equality facts for
@@ -3759,9 +3760,9 @@ namespace {
                                        SubExprBounds, State);
         }
         bool StateUpdated = false;
-        IncDecResultBounds = UpdateAfterAssignment(SubExpr, E, Target, RHS,
-                                                   RHSBounds, CSS,
-                                                   State, StateUpdated);
+        IncDecResultBounds = UpdateAfterAssignment(SubExpr, SubExprTargetBounds,
+                                                   E, Target, RHS, RHSBounds,
+                                                   CSS, State, StateUpdated);
 
         // Update the set SameValue of expressions that produce the same
         // value as `e`.
@@ -4506,10 +4507,14 @@ namespace {
     // LValue = Src.
     // UpdateAfterAssignment also returns updated bounds for Src.
     //
+    // TargetBounds are the bounds for the target of LValue.
+    //
     // Target is an rvalue expression that is the value of LValue.
     //
     // SrcBounds are the original bounds for the source of the assignment.
-    BoundsExpr *UpdateAfterAssignment(Expr *LValue, Expr *E, Expr *Target,
+    BoundsExpr *UpdateAfterAssignment(Expr *LValue,
+                                      BoundsExpr *TargetBounds,
+                                      Expr *E, Expr *Target,
                                       Expr *Src, BoundsExpr *SrcBounds,
                                       CheckedScopeSpecifier CSS,
                                       CheckingState &State,

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4755,7 +4755,7 @@ namespace {
       // We only update the checking state after assignments to a variable,
       // member expression, pointer dereference, or array subscript.
       if (!isa<DeclRefExpr>(LValue) && !isa<MemberExpr>(LValue) &&
-          !isa<UnaryOperator>(LValue) && !isa<ArraySubscriptExpr>(LValue)) {
+          !ExprUtil::IsDereferenceOrSubscript(LValue)) {
         StateUpdated = false;
         return SrcBounds;
       }

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4401,12 +4401,12 @@ namespace {
       if (Result == ProofResult::True)
         return;
 
-      // If v currently has widened bounds and the widened bounds of v are not
+      // If A currently has widened bounds and the widened bounds of A are not
       // killed by the statement St, then the proof failure was caused by not
-      // being able to prove the widened bounds of v imply the declared bounds
-      // of v. Diagnostics should not be emitted in this case. Otherwise,
-      // statements that make no changes to v or any variables used in the
-      // bounds of v would cause diagnostics to be emitted.
+      // being able to prove the widened bounds of A imply the declared bounds
+      // of A. Diagnostics should not be emitted in this case. Otherwise,
+      // statements that make no changes to A or any expressions used in the
+      // bounds of A would cause diagnostics to be emitted.
       // For example, the widened bounds (p, (p + 0) + 1) do not provably imply
       // the declared bounds (p, p + 0) due to the left-associativity of the
       // observed upper bound (p + 0) + 1.

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -1858,21 +1858,49 @@ void inc_dec_bounds4(array_ptr<int> a : bounds(a, a)) { // expected-note {{(expa
   // CHECK-NEXT: }
 }
 
-// Increment/decrement operators on non-variables or variables without declared bounds
-// do not result in bounds checking-related warnings or errors
+// Increment/decrement operators on dereference expressions or array subscripts
+// of type _Nt_array_ptr<T> are bounds checked
+// Increment/decrement operators on variables without declared bounds are not
+// bounds checked
 void inc_dec_bounds5(nt_array_ptr<int> *p, array_ptr<int> a) {
-  // Observed bounds context after increment:  { }
-  ++*p;
+  // Observed bounds context after increment:  { *p => bounds(*p - 1, (*p - 1) + 0) }
+  ++*p; // expected-warning {{cannot prove declared bounds for '*p' are valid after increment}} \
+        // expected-note {{(expanded) declared bounds are 'bounds(*p, *p + 0)'}} \
+        // expected-note {{(expanded) inferred bounds are 'bounds(*p - 1, *p - 1 + 0)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} prefix '++'
   // CHECK-NEXT:   UnaryOperator {{.*}} '*'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT: Observed bounds context after checking S:
-  // CHECK-NEXT: { }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT:   UnaryOperator {{.*}} '_Nt_array_ptr<int>' {{.*}} '*'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} '_Nt_array_ptr<int> *' <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int> *'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}}  <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}}  <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: }
 
-  // Observed bounds context after increment:  { }
-  p[0]++;
+  // Observed bounds context after increment:  { *p => bounds(p[0] - 1, (p[0] - 1) + 0) }
+  // Note: *p is the representative expression of the AbstractSet containing *p and p[0]
+  p[0]++; // expected-warning {{cannot prove declared bounds for '*p' are valid after increment}} \
+          // expected-note {{(expanded) declared bounds are 'bounds(*p, *p + 0)'}} \
+          // expected-note {{(expanded) inferred bounds are 'bounds(p[0] - 1, p[0] - 1 + 0)'}}
   // CHECK: Statement S:
   // CHECK-NEXT: UnaryOperator {{.*}} postfix '++'
   // CHECK-NEXT:   ArraySubscriptExpr {{.*}} '_Nt_array_ptr<int>'
@@ -1880,7 +1908,30 @@ void inc_dec_bounds5(nt_array_ptr<int> *p, array_ptr<int> a) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
-  // CHECK-NEXT: { }
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT:   UnaryOperator {{.*}} '_Nt_array_ptr<int>' {{.*}} '*'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} '_Nt_array_ptr<int> *' <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int> *'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       ArraySubscriptExpr {{.*}} '_Nt_array_ptr<int>'
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}}  <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:         IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         ArraySubscriptExpr {{.*}} '_Nt_array_ptr<int>'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}}  <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:           IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: }
 
   // Observed bounds context after increment:  { }
   a--;

--- a/clang/test/CheckedC/static-checking/pointer-dereference-bounds.c
+++ b/clang/test/CheckedC/static-checking/pointer-dereference-bounds.c
@@ -187,3 +187,21 @@ void f6(_Ptr<struct S1> s) {
   *(s->arr + s->len[1 + 0] + 0) = 0; // expected-error {{inferred bounds for 's->f' are unknown after assignment}} \
                                      // expected-note {{lost the value of the expression '*(s->arr + s->len[1 + 0] + 0)'}}
 }
+
+//
+// Test pointer dereferences with bounds-safe interface types.
+//
+
+void f7(_Array_ptr<char *> p : count(10) itype(_Array_ptr<_Nt_array_ptr<char>>),
+        _Nt_array_ptr<char> buf : bounds(unknown)) _Unchecked {
+  // In an unchecked scope, *p has type char * and has target bounds of bounds(unknown).
+  *p = buf;
+
+  _Checked {
+    // In a checked scope, *p has type _Nt_array_ptr<char> and has target bounds
+    // of bounds(*p, *p + 0).
+    *p = buf; // expected-error {{inferred bounds for '*p' are unknown after assignment}} \
+              // expected-note {{(expanded) declared bounds are 'bounds(*p, *p + 0)'}} \
+              // expected-note {{assigned expression 'buf' with unknown bounds to '*p'}}
+  }
+}

--- a/clang/test/CheckedC/static-checking/pointer-dereference-bounds.c
+++ b/clang/test/CheckedC/static-checking/pointer-dereference-bounds.c
@@ -1,0 +1,66 @@
+// Tests for checking:
+// 1. Inferred bounds of pointer dereferences and array subscript expressions.
+// 2. Bounds that use the value of a pointer dereference or array subscript.
+//
+// Because the static checker is mostly unimplemented, we only issue warnings
+// when bounds declarations cannot be provided to hold.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -Wcheck-bounds-decls -verify %s
+
+//
+// Test checking the bounds of pointer dereferences and array subscripts
+// of type _Nt_array_ptr<T>.
+//
+
+extern _Nt_array_ptr<char> g1(_Nt_array_ptr<char> p);
+
+void f1(_Array_ptr<_Nt_array_ptr<char>> ptr_to_buf : count(10),
+        _Nt_array_ptr<char> buf : bounds(unknown)) {
+  *ptr_to_buf = "abc";
+  ptr_to_buf[0] = "xyz";
+
+  *(ptr_to_buf + 5) = g1(*ptr_to_buf);
+  5[ptr_to_buf] = g1(ptr_to_buf[1]);
+  ptr_to_buf[7 - 2] = g1(*(ptr_to_buf + 2));
+
+  // The representative expression for all these lvalues is *ptr_to_buf.
+  *ptr_to_buf = buf; // expected-error {{inferred bounds for '*ptr_to_buf' are unknown after assignment}} \
+                     // expected-note {{(expanded) declared bounds are 'bounds(*ptr_to_buf, *ptr_to_buf + 0)'}} \
+                     // expected-note {{assigned expression 'buf' with unknown bounds to '*ptr_to_buf'}}
+  0[ptr_to_buf] = buf; // expected-error {{inferred bounds for '*ptr_to_buf' are unknown after assignment}} \
+                       // expected-note {{(expanded) declared bounds are 'bounds(*ptr_to_buf, *ptr_to_buf + 0)'}} \
+                       // expected-note {{assigned expression 'buf' with unknown bounds to '*ptr_to_buf'}}
+  *(ptr_to_buf + 2 - 1 - 1) = buf; // expected-error {{inferred bounds for '*ptr_to_buf' are unknown after assignment}} \
+                                   // expected-note {{(expanded) declared bounds are 'bounds(*ptr_to_buf, *ptr_to_buf + 0)'}} \
+                                   // expected-note {{assigned expression 'buf' with unknown bounds to '*ptr_to_buf'}}
+
+  // The representative expression for all these lvalues is ptr_to_buf[4],
+  // so the target bounds for each lvalue are created using ptr_to_buf[4].
+  ptr_to_buf[4]++; // expected-warning {{cannot prove declared bounds for 'ptr_to_buf[4]' are valid after increment}} \
+                   // expected-note {{(expanded) declared bounds are 'bounds(ptr_to_buf[4], ptr_to_buf[4] + 0)'}} \
+                   // expected-note {{(expanded) inferred bounds are 'bounds(ptr_to_buf[4] - 1, ptr_to_buf[4] - 1 + 0)'}}
+  ptr_to_buf[2 * 2] = ptr_to_buf[2 * 2] + 1; // expected-warning {{cannot prove declared bounds for 'ptr_to_buf[4]' are valid after assignment}} \
+                       // expected-note {{(expanded) declared bounds are 'bounds(ptr_to_buf[4], ptr_to_buf[4] + 0)'}} \
+                       // expected-note {{(expanded) inferred bounds are 'bounds(ptr_to_buf[2 * 2] - 1, ptr_to_buf[2 * 2] - 1 + 0)'}}
+  *(1 + 3 + ptr_to_buf) += 1; // expected-warning {{cannot prove declared bounds for 'ptr_to_buf[4]' are valid after assignment}} \
+                              // expected-note {{(expanded) declared bounds are 'bounds(ptr_to_buf[4], ptr_to_buf[4] + 0)'}} \
+                              // expected-note {{(expanded) inferred bounds are 'bounds(*(1 + 3 + ptr_to_buf) - 1, *(1 + 3 + ptr_to_buf) - 1 + 0)'}}
+}
+
+// This test function demonstrates the fact that invertibility does not
+// use semantic expression comparison, so expressions that might be expected
+// to have an inverse actually have no inverse in the current implementation.
+// TODO: investigate using semantic expression comparison in invertibility.
+void f2(_Array_ptr<_Nt_array_ptr<char>> p : count(10)) {
+  p[0] = *p + 1; // expected-error {{inferred bounds for 'p[0]' are unknown after assignment}} \
+                 // expected-note {{(expanded) declared bounds are 'bounds(p[0], p[0] + 0)'}} \
+                 // expected-note {{lost the value of the expression 'p[0]' which is used in the (expanded) inferred bounds 'bounds(*p, *p + 0)' of 'p[0]'}}
+
+  *(p + 0) = p[2 - 2] + 1; // expected-error {{inferred bounds for 'p[0]' are unknown after assignment}} \
+                           // expected-note {{(expanded) declared bounds are 'bounds(p[0], p[0] + 0)'}} \
+                           // expected-note {{lost the value of the expression '*(p + 0)' which is used in the (expanded) inferred bounds 'bounds(p[2 - 2], p[2 - 2] + 0)' of 'p[0]'}}
+
+  *(p + 2 + 3) = 5[p] - 2; // expected-error {{inferred bounds for '*(p + 2 + 3)' are unknown after assignment}} \
+                           // expected-note {{(expanded) declared bounds are 'bounds(*(p + 2 + 3), *(p + 2 + 3) + 0)'}} \
+                           // expected-note {{lost the value of the expression '*(p + 2 + 3)' which is used in the (expanded) inferred bounds 'bounds(5[p], 5[p] + 0)' of '*(p + 2 + 3)'}}
+}

--- a/clang/test/CheckedC/static-checking/return-bounds-parameters.c
+++ b/clang/test/CheckedC/static-checking/return-bounds-parameters.c
@@ -19,28 +19,31 @@ _Nt_array_ptr<char> f2(unsigned int len) : count(len) { // expected-note {{(expa
   return 0;
 }
 
-_Array_ptr<int> f3(_Array_ptr<int> arr : count(1), unsigned int idx) : byte_count(arr[idx]) { // expected-note 2 {{(expanded) declared return bounds are 'bounds((_Array_ptr<char>)_Return_value, (_Array_ptr<char>)_Return_value + arr[idx])'}}
-  arr = 0; // expected-error {{modified expression 'arr' used in the declared return bounds for 'f3'}}
-  idx--; // expected-error {{modified expression 'idx' used in the declared return bounds for 'f3'}}
-
-  // We currently do not check that array subscript expressions used in return
-  // bounds are not modified.
-  arr[idx] = 1;
+_Array_ptr<int> f3(unsigned int a, unsigned int b) : count(a + b) { // expected-note 2 {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + a + b)'}}
+  a++, b--; // expected-error {{modified expression 'a' used in the declared return bounds for 'f3'}} \
+            // expected-error {{modified expression 'b' used in the declared return bounds for 'f3'}}
   return 0;
 }
 
-_Array_ptr<char> f4(_Ptr<int> num) : count(*num + 1) { // expected-note {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + *num + 1)'}}
-  num = 0; // expected-error {{modified expression 'num' used in the declared return bounds for 'f4'}}
+//
+// Test variable parameters, pointer dereferences, and array subscripts
+// used in return bounds.
+//
 
-  // We currently do not check that pointer dereference expressions used in
-  // return bounds are not modified.
-  *num = 1;
+_Array_ptr<int> f4(_Array_ptr<int> arr : count(1), unsigned int idx) : byte_count(arr[idx]) { // expected-note 5 {{(expanded) declared return bounds are 'bounds((_Array_ptr<char>)_Return_value, (_Array_ptr<char>)_Return_value + arr[idx])'}}
+  arr = 0; // expected-error {{modified expression 'arr' used in the declared return bounds for 'f4'}}
+  idx--; // expected-error {{modified expression 'idx' used in the declared return bounds for 'f4'}}
+
+  arr[idx] = 1; // expected-error {{modified expression 'arr[idx]' used in the declared return bounds for 'f4'}}
+  *(arr + idx) = 2; // expected-error {{'*(arr + idx)' used in the declared return bounds for 'f4'}}
+  *(idx + arr + 1 - 1) = 3; // expected-error {{'*(idx + arr + 1 - 1)' used in the declared return bounds for 'f4'}}
   return 0;
 }
 
-_Array_ptr<int> f5(unsigned int a, unsigned int b) : count(a + b) { // expected-note 2 {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + a + b)'}}
-  a++, b--; // expected-error {{modified expression 'a' used in the declared return bounds for 'f5'}} \
-            // expected-error {{modified expression 'b' used in the declared return bounds for 'f5'}}
+_Array_ptr<char> f5(_Ptr<int> num) : count(*num + 1) { // expected-note 2 {{(expanded) declared return bounds are 'bounds(_Return_value, _Return_value + *num + 1)'}}
+  num = 0; // expected-error {{modified expression 'num' used in the declared return bounds for 'f5'}}
+
+  *num = 1; // expected-error {{modified expression '*num' used in the declared return bounds for 'f5'}}
   return 0;
 }
 


### PR DESCRIPTION
This PR updates bounds validation to handle the following cases:
1. Validate the bounds of a pointer dereference `*p` or array subscript `p[i]`.
2. Account for uses of pointer dereferences and array subscripts in observed bounds

The behavior for synthesizing member expressions whose bounds depend on a member expression that is being modified via an assignment has been extended: we now synthesize member expressions whose bounds depend on an lvalue expression that uses a member expression to update memory via an assignment. For example:

```
struct S {
  _Array_ptr<int> f : count(*ptr_to_len);
  _Array_ptr<int> ptr_to_len : count(10);
};

void f(struct S *s) {
  *s->ptr_to_len = 0;
}
```

The lvalue expression `*s->ptr_to_len` uses the member expression `s->ptr_to_len` to write to memory. We synthesize the member expression `s->f` whose declared bounds `bounds(s->f, s->f + *s->ptr_to_len)` depend on `*s->ptr_to_len`.

There is also a minor fix included in this PR that the pointer bounds checking depends on: in PreorderAST, the canonical form of `e1[e2]` is now `*(e1 + e2 + 0)` rather than `*(e1 + e2)`. This enables bounds validation to treat expressions such as `p[i]` and `*(p + i)` as equivalent, since PreorderAST canonicalizes `*(p + i)` to `*(p + i + 0)`.