### PR TITLE
Separate out windows and non-windows-specific tests for variadic functions

### DIFF
--- a/clang/test/CheckedC/checked-scope/variadic-functions-non-win.c
+++ b/clang/test/CheckedC/checked-scope/variadic-functions-non-win.c
@@ -1,0 +1,32 @@
+// UNSUPPORTED: system-windows
+
+// Test calls to variadic functions in checked scopes.
+// Some -Wformat error messages are different between linux and windows
+// systems. This file contains non-windows-specific tests. The windows tests
+// are in variadic-functions-win.c and the common tests are in
+// variadic-functions.c.
+
+// RUN: %clang_cc1 -fcheckedc-extension -verify \
+// RUN: -verify-ignore-unexpected=note %s
+
+int printf(const char *format : itype(_Nt_array_ptr<const char>), ...);
+int MyPrintf(const char *format : itype(_Nt_array_ptr<const char>), ...)
+  __attribute__((format(printf, 1, 2)));
+
+int scanf(const char *format : itype(_Nt_array_ptr<const char>), ...);
+int MyScanf(const char *format : itype(_Nt_array_ptr<const char>), ...)
+  __attribute__((format(scanf, 1, 2)));
+
+void f1 (_Nt_array_ptr<char> p) {
+_Checked {
+  printf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
+  MyPrintf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
+  scanf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
+  MyScanf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
+
+  printf("%Li", (long long) 42); // expected-error {{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}}
+  MyPrintf("%Li", (long long) 42); // expected-error {{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}}
+  scanf("%Li", (long long) 42); // expected-error {{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}} expected-error {{format specifies type 'long long *' but the argument has type 'long long'}}
+  MyScanf("%Li", (long long) 42); // expected-error {{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}} expected-error {{format specifies type 'long long *' but the argument has type 'long long'}}
+}
+}

--- a/clang/test/CheckedC/checked-scope/variadic-functions-win.c
+++ b/clang/test/CheckedC/checked-scope/variadic-functions-win.c
@@ -1,0 +1,32 @@
+// UNSUPPORTED: !windows
+
+// Test calls to variadic functions in checked scopes.
+// Some -Wformat error messages are different between linux and windows
+// systems. This file contains windows-specific tests. The non-windows tests
+// are in variadic-functions-non-win.c and the common tests are in
+// variadic-functions.c.
+
+// RUN: %clang_cc1 -fcheckedc-extension -verify \
+// RUN: -verify-ignore-unexpected=note %s
+
+int printf(const char *format : itype(_Nt_array_ptr<const char>), ...);
+int MyPrintf(const char *format : itype(_Nt_array_ptr<const char>), ...)
+  __attribute__((format(printf, 1, 2)));
+
+int scanf(const char *format : itype(_Nt_array_ptr<const char>), ...);
+int MyScanf(const char *format : itype(_Nt_array_ptr<const char>), ...)
+  __attribute__((format(scanf, 1, 2)));
+
+void f1 (_Nt_array_ptr<char> p) {
+_Checked {
+  printf("%Z", p);
+  MyPrintf("%Z", p);
+  scanf("%Z", p); // expected-error {{'Z' conversion specifier is not supported by ISO C}}
+  MyScanf("%Z", p); // expected-error {{'Z' conversion specifier is not supported by ISO C}}
+
+  printf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
+  MyPrintf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
+  scanf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
+  MyScanf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
+}
+}

--- a/clang/test/CheckedC/checked-scope/variadic-functions-win.c
+++ b/clang/test/CheckedC/checked-scope/variadic-functions-win.c
@@ -19,14 +19,14 @@ int MyScanf(const char *format : itype(_Nt_array_ptr<const char>), ...)
 
 void f1 (_Nt_array_ptr<char> p) {
 _Checked {
-  printf("%Z", p);
-  MyPrintf("%Z", p);
-  scanf("%Z", p); // expected-error {{'Z' conversion specifier is not supported by ISO C}}
-  MyScanf("%Z", p); // expected-error {{'Z' conversion specifier is not supported by ISO C}}
+  printf("%Z", p); // expected-error {{'Z' conversion specifier is not supported by ISO C}}
+  MyPrintf("%Z", p); // expected-error {{'Z' conversion specifier is not supported by ISO C}}
+  scanf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
+  MyScanf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
 
   printf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
   MyPrintf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
-  scanf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
-  MyScanf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}}
+  scanf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}} expected-error {{format specifies type 'long long *' but the argument has type 'long long'}}
+  MyScanf("%Li", (long long) 42); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'i' conversion specifier}} expected-error {{format specifies type 'long long *' but the argument has type 'long long'}}
 }
 }

--- a/clang/test/CheckedC/checked-scope/variadic-functions.c
+++ b/clang/test/CheckedC/checked-scope/variadic-functions.c
@@ -1,4 +1,9 @@
 // Test calls to variadic functions in checked scopes.
+// Some -Wformat error messages are different between linux and windows
+// systems. This file contains tests that have the same error messages on both
+// linux and windows. The windows-specific tests are in
+// variadic-functions-win.c and the non-windows tests are in
+// variadic-functions-non-win.c.
 
 // RUN: %clang_cc1 -fcheckedc-extension -verify \
 // RUN: -verify-ignore-unexpected=note %s
@@ -120,11 +125,6 @@ _Checked {
   scanf("%d", 1, 2); // expected-error {{format specifies type 'int *' but the argument has type 'int'}} expected-error {{data argument not used by format string}}
   MyScanf("%d", 1, 2); // expected-error {{format specifies type 'int *' but the argument has type 'int'}} expected-error {{data argument not used by format string}}
 
-  printf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
-  MyPrintf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
-  scanf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
-  MyScanf("%Z", p); // expected-error {{invalid conversion specifier 'Z'}}
-
   printf("\%", p); // expected-error {{incomplete format specifier}}
   MyPrintf("\%", p); // expected-error {{incomplete format specifier}}
   scanf("\%", p); // expected-error {{incomplete format specifier}}
@@ -169,11 +169,6 @@ _Checked {
   MyPrintf("%Lc", 'a'); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'c' conversion specifier}}
   scanf("%Lc", 'a'); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'c' conversion specifier}}
   MyScanf("%Lc", 'a'); // expected-error {{length modifier 'L' results in undefined behavior or no effect with 'c' conversion specifier}}
-
-  printf("%Li", (long long) 42); // expected-error{{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}}
-  MyPrintf("%Li", (long long) 42); // expected-error{{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}}
-  scanf("%Li", (long long) 42); // expected-error{{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}} expected-error {{format specifies type 'long long *' but the argument has type 'long long'}}
-  MyScanf("%Li", (long long) 42); // expected-error{{using length modifier 'L' with conversion specifier 'i' is not supported by ISO C}} expected-error {{format specifies type 'long long *' but the argument has type 'long long'}}
 
   printf("%P", p); // expected-error {{invalid conversion specifier 'P'}}
   MyPrintf("%P", p); // expected-error {{invalid conversion specifier 'P'}}


### PR DESCRIPTION
Some -Wformat error messages are different between linux and windows systems.
We separate out the common tests in variadic-functions.c. The windows-specific
tests are in variadic-functions-win.c and the non-windows tests are in
variadic-functions-non-win.c.
