### PR TITLE
Member expression bounds checking in multiple assignments

### DIFF
--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -4836,8 +4836,9 @@ namespace {
                                             CheckingState &State) {
       // If LValue is a member expression, get the set of AbstractSets whose
       // target bounds depend on LValue. The observed bounds of each of these
-      // AbstractSets are recorded in ObservedBounds if they are not already
-      // present in ObservedBounds.
+      // AbstractSets are recorded in ObservedBounds. If they are not already
+      // present in ObservedBounds, their observed bounds are initialized to
+      // their target bounds.
       MemberExpr *M = dyn_cast<MemberExpr>(LValue);
       if (M) {
         AbstractSetSetTy AbstractSets;

--- a/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
@@ -8,14 +8,14 @@
 
 struct S {
   int len;
-  array_ptr<int> p : count(len); // expected-note 4 {{(expanded) declared bounds are 'bounds(s->p, s->p + s->len)'}}
+  array_ptr<int> p : count(len); // expected-note 5 {{(expanded) declared bounds are 'bounds(s->p, s->p + s->len)'}}
   int i;
   array_ptr<int> q : count(i); // expected-note 2 {{(expanded) declared bounds are 'bounds(s[3].q, s[3].q + s[3].i)'}} \
                                // expected-note {{(expanded) declared bounds are 'bounds(s[4].q, s[4].q + s[4].i)'}}
   array_ptr<int> r : count(i); // expected-note 2 {{(expanded) declared bounds are 'bounds(s[3].r, s[3].r + s[3].i)'}}
   array_ptr<int> f : count(3); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}}
   array_ptr<int> g : bounds(f, f + 3); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}}
-  array_ptr<int> a : count(2);
+  array_ptr<int> a : count(2); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->a, s->a + 2)'}}
   array_ptr<int> b : count(2);
 };
 
@@ -357,6 +357,115 @@ void updated_source_bounds3(struct S *s) {
   // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
+  // CHECK-NEXT: }
+}
+
+void multiple_assignments1(struct S *s, _Array_ptr<int> arr : count(3)) {
+  // Observed bounds context after statement: { s->p => bounds(arr, arr + 3), arr => bounds(arr, arr + 3) }
+  s->p = arr, s->len = 3;
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: MemberExpr {{.*}} ->p
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: }
+
+  // Observed bounds context after assignment: { s->p => bounds(unknown), arr => bounds(arr, arr + 3) }
+  s[0].len = 0; // expected-error {{inferred bounds for 's->p' are unknown after assignment}} \
+                // expected-note {{lost the value of the expression 's[0].len' which is used in the (expanded) inferred bounds 'bounds(s->p, s->p + s->len)' of 's->p'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} '='
+  // CHECK: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: MemberExpr {{.*}} ->p
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: }
+}
+
+void multiple_assignments2(struct S *s) {
+  // Observed bounds context after statement: { s->a => bounds(s->a - 1, (s->a - 1) + 2) }
+  s->a = s->b, s->a++; // expected-warning {{cannot prove declared bounds for 's->a' are valid after increment}} \
+                       // expected-note {{(expanded) inferred bounds are 'bounds(s->a - 1, s->a - 1 + 2)'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: MemberExpr {{.*}} ->a
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       MemberExpr {{.*}} ->a
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         MemberExpr {{.*}} ->a
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: }
+
+  // Observed bounds context after statement: { s->a => bounds(unknown), s->b = bounds(any) }
+  s->a = s->b, s->b = 0; // expected-error {{inferred bounds for 's->a' are unknown after assignment}} \
+                         // expected-note {{lost the value of the expression 's->b' which is used in the (expanded) inferred bounds 'bounds(s->b, s->b + 2)' of 's->a'}}
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: MemberExpr {{.*}} ->a
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: MemberExpr {{.*}} ->b
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 }
 


### PR DESCRIPTION
This PR fixes an issue with bounds checking member expressions across multiple assignments.

Consider an example:

```
struct S {
  int len;
  _Array_ptr<int> p : count(len);
};

void f(struct S *s, _Array_ptr<int> arr : count(3)) {
  s->p = arr, s->len = 3;
}
```

After the assignment `s->p = arr`, the observed bounds of `s->p` are `bounds(arr, arr + 3)`. At the assignment `s->len = 3`, we synthesize the member expression `s->p` whose target bounds `bounds(s->p, s->p + s->len)` use the value of `s->len`. However, since `s->p` already has observed bounds recorded in `State.ObservedBounds`, we do not update the observed bounds of `s->p` to its target bounds. Therefore, the assignment to `s->len` does not modify the observed bounds of `s->p`. At the end of this statement, the observed bounds of `s->p` are `bounds(arr, arr + 3)` and we have equality between `s->p` and `arr` and between `s->len` and `3`. The observed bounds `bounds(arr, arr + 3)` imply the target bounds `bounds(s->p, s->p + s->len)`. No errors or warnings are emitted.