### PR TITLE
Get rvalue bounds for the value of lvalue expressions from the CheckingState

### DIFF
--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -472,6 +472,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) const {
      // of Lexicographic. These expressions are compared by their addresses.
      // This comparison will be deterministic for one compiler run, but is
      // not guaranteed to be deterministic across compiler runs.
+     case Expr::ExtVectorElementExprClass:
      case Expr::InitListExprClass:
      case Expr::ImplicitValueInitExprClass: return CompareAddress(E1, E2);
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
@@ -464,6 +464,33 @@ void multiple_assignments2(struct S *s) {
   // CHECK-NEXT: }
 }
 
+void multiple_assignments3(struct S *s, int i) {
+  // Observed bounds context after statement: { s->a = bounds(s->f, s->f + 3) }
+  // The access s->a[2] is within s->a's observed bounds of bounds(s->f, s->f + 3)
+  s->a = s->f, i = s->a[2];
+  // CHECK: Statement S:
+  // CHECK-NEXT: BinaryOperator {{.*}} ','
+  // CHECK: Observed bounds context after checking S:
+  // CHECK-NEXT: {
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: MemberExpr {{.*}} ->a
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     MemberExpr {{.*}} ->f
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       MemberExpr {{.*}} ->f
+  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:           DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: }
+}
+
 struct C {
   int len;
   array_ptr<int> r : count(len); // expected-note {{(expanded) declared bounds are 'bounds(a.b.c.r, a.b.c.r + a.b.c.len)'}}

--- a/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context-members.c
@@ -15,7 +15,7 @@ struct S {
   array_ptr<int> r : count(i); // expected-note 2 {{(expanded) declared bounds are 'bounds(s[3].r, s[3].r + s[3].i)'}}
   array_ptr<int> f : count(3); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}}
   array_ptr<int> g : bounds(f, f + 3); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->f, s->f + 3)'}}
-  array_ptr<int> a : count(2); // expected-note 2 {{(expanded) declared bounds are 'bounds(s->a, s->a + 2)'}}
+  array_ptr<int> a : count(2); // expected-note {{(expanded) declared bounds are 'bounds(s->a, s->a + 2)'}}
   array_ptr<int> b : count(2);
 };
 
@@ -418,9 +418,8 @@ void multiple_assignments1(struct S *s, _Array_ptr<int> arr : count(3)) {
 }
 
 void multiple_assignments2(struct S *s) {
-  // Observed bounds context after statement: { s->a => bounds(s->a - 1, (s->a - 1) + 2) }
-  s->a = s->b, s->a++; // expected-warning {{cannot prove declared bounds for 's->a' are valid after increment}} \
-                       // expected-note {{(expanded) inferred bounds are 'bounds(s->a - 1, s->a - 1 + 2)'}}
+  // Observed bounds context after statement: { s->a => bounds(s->b, s->b + 2) }
+  s->a = s->b, s->a++;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} ','
   // CHECK: Observed bounds context after checking S:
@@ -431,19 +430,15 @@ void multiple_assignments2(struct S *s) {
   // CHECK-NEXT:     DeclRefExpr {{.*}} 's'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   BinaryOperator {{.*}} '-'
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     MemberExpr {{.*}} ->b
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 's'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       MemberExpr {{.*}} ->a
+  // CHECK-NEXT:       MemberExpr {{.*}} ->b
   // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:           DeclRefExpr {{.*}} 's'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         MemberExpr {{.*}} ->a
-  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:             DeclRefExpr {{.*}} 's'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: }
 

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -2733,10 +2733,10 @@ void conditional3(nt_array_ptr<char> p : count(i),
     if (*(q + j)) {
       // Bounds written in condition: { q => bounds(q - 2, q - 2 + j) }
       // Bounds written in "true" arm: { q => bounds(any) }
-      // Bounds written in "false" arm: { q => bounds(q + 1 - 2, q + 1 - 2 + j) }
+      // Bounds written in "false" arm: { q => bounds(q + 1 - 2, q + 1 - 2 + j + 1) }
       // Observed bounds context: {  p => bounds(p, p + i), q => bounds(q, q + j + 1) }
       (q += 2) ? (q = 0) : q--; // expected-warning {{cannot prove declared bounds for 'q' are valid after decrement}} \
-                                // expected-note {{(expanded) inferred bounds are 'bounds(q + 1 - 2, q + 1 - 2 + j)'}}
+                                // expected-note {{(expanded) inferred bounds are 'bounds(q + 1 - 2, q + 1 - 2 + j + 1)'}}
       // CHECK: Statement S:
       // CHECK:      ConditionalOperator
       // CHECK-NEXT:   ParenExpr

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -840,7 +840,7 @@ void f97(_Array_ptr<int> p : count(i), // expected-note 4 {{(expanded) declared 
 
 void f98(_Array_ptr<int> p : count(i), unsigned int i) { // expected-note 2 {{(expanded) declared bounds are 'bounds(p, p + i)'}}
   i++, p += 2; // expected-warning {{cannot prove declared bounds for 'p' are valid after assignment}} \
-               // expected-note {{(expanded) inferred bounds are 'bounds(p - 2, p - 2 + i)'}}
+               // expected-note {{(expanded) inferred bounds are 'bounds(p - 2, p - 2 + i - 1U)'}}
 
   p += 2, i++; // expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} \
                // expected-note {{(expanded) inferred bounds are 'bounds(p - 2, p - 2 + i - 1U)'}}

--- a/clang/test/CheckedC/static-checking/pointer-dereference-bounds.c
+++ b/clang/test/CheckedC/static-checking/pointer-dereference-bounds.c
@@ -53,17 +53,22 @@ void f1(_Array_ptr<_Nt_array_ptr<char>> ptr_to_buf : count(10),
 // to have an inverse actually have no inverse in the current implementation.
 // TODO: investigate using semantic expression comparison in invertibility.
 void f2(_Array_ptr<_Nt_array_ptr<char>> p : count(10)) {
-  p[0] = *p + 1; // expected-error {{inferred bounds for 'p[0]' are unknown after assignment}} \
-                 // expected-note {{(expanded) declared bounds are 'bounds(p[0], p[0] + 0)'}} \
-                 // expected-note {{lost the value of the expression 'p[0]' which is used in the (expanded) inferred bounds 'bounds(*p, *p + 0)' of 'p[0]'}}
+  // The representative expression for the AbstractSet containing p[0], *p,
+  // *(p + 0), and p[2 - 2] is *p.
+  // The representative expression for the AbstractSet containing *(p + 2 + 3)
+  // and 5[p] is 5[p].
 
-  *(p + 0) = p[2 - 2] + 1; // expected-error {{inferred bounds for 'p[0]' are unknown after assignment}} \
-                           // expected-note {{(expanded) declared bounds are 'bounds(p[0], p[0] + 0)'}} \
-                           // expected-note {{lost the value of the expression '*(p + 0)' which is used in the (expanded) inferred bounds 'bounds(p[2 - 2], p[2 - 2] + 0)' of 'p[0]'}}
+  p[0] = *p + 1; // expected-error {{inferred bounds for '*p' are unknown after assignment}} \
+                 // expected-note {{(expanded) declared bounds are 'bounds(*p, *p + 0)'}} \
+                 // expected-note {{lost the value of the expression 'p[0]' which is used in the (expanded) inferred bounds 'bounds(*p, *p + 0)' of '*p'}}
 
-  *(p + 2 + 3) = 5[p] - 2; // expected-error {{inferred bounds for '*(p + 2 + 3)' are unknown after assignment}} \
-                           // expected-note {{(expanded) declared bounds are 'bounds(*(p + 2 + 3), *(p + 2 + 3) + 0)'}} \
-                           // expected-note {{lost the value of the expression '*(p + 2 + 3)' which is used in the (expanded) inferred bounds 'bounds(5[p], 5[p] + 0)' of '*(p + 2 + 3)'}}
+  *(p + 0) = p[2 - 2] + 1; // expected-error {{inferred bounds for '*p' are unknown after assignment}} \
+                           // expected-note {{(expanded) declared bounds are 'bounds(*p, *p + 0)'}} \
+                           // expected-note {{lost the value of the expression '*(p + 0)' which is used in the (expanded) inferred bounds 'bounds(p[2 - 2], p[2 - 2] + 0)' of '*p'}}
+
+  *(p + 2 + 3) = 5[p] - 2; // expected-error {{inferred bounds for '5[p]' are unknown after assignment}} \
+                           // expected-note {{(expanded) declared bounds are 'bounds(5[p], 5[p] + 0)'}} \
+                           // expected-note {{lost the value of the expression '*(p + 2 + 3)' which is used in the (expanded) inferred bounds 'bounds(5[p], 5[p] + 0)' of '5[p]'}}
 }
 
 void f3(_Array_ptr<_Nt_array_ptr<int> *> p : itype(_Array_ptr<_Array_ptr<_Nt_array_ptr<int>>>) count(10),


### PR DESCRIPTION
This PR modifies the way that rvalue bounds are determined for the value of a member expression, pointer deference, or array subscript to be consistent with the way that rvalue bounds are determined for the value of a variable. The rvalue bounds for the value of a variable, member expression, pointer dereference, or array subscript expression `e` are determined by looking at the `ObservedBounds` map in the checking state. If the `AbstractSet` containing `e` is present in `ObservedBounds`, then those are the bounds for the value of `e`. Otherwise, the bounds for the value of `e` default to the lvalue target bounds of `e` (or the lvalue bounds of `e` if `e` is the subexpression of an `ArrayToPointerDecay` cast.

One consequence of this change is that the order of expressions used to get or create an `AbstractSet` may differ, which may affect the representative expression for the `AbstractSet`. For example, consider the assignment `*p = p[0] + 1`. The rvalue bounds of `p[0]` are determined before modifying the observed bounds of `*p`. This means that `p[0]` is the first expression that is used to create the `AbstractSet` that contains `*p` and `p[0]`, so `p[0]` is the representative expression for this `AbstractSet`.

This PR also includes a minor fix in CanonBounds where `ExtVectorElementExprs` are compared by address. This prevents an `llvm_unreachable` that would otherwise occur when creating an `AbstractSet` for a member expression that contains an `ExtVectorElementExpr`.