### PR TITLE
Fix 3 bad source code merges.

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5144,6 +5144,7 @@ recurse:
     mangleType(USN->getTypeSourceInfo()->getType());
 
     Out << "E";
+    break;
   }
   case Expr::PackExprClass:
     llvm_unreachable("Don't know how to mangle pack expressions");

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -247,6 +247,7 @@ TypeEvaluationKind CodeGenFunction::getEvaluationKind(QualType type) {
     case Type::Enum:
     case Type::ObjCObjectPointer:
     case Type::Pipe:
+    case Type::BitInt:
     case Type::TypeVariable:
       return TEK_Scalar;
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14914,15 +14914,6 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
   if (getLangOpts().CheckedC && !getLangOpts()._3C)
     CheckTopLevelBoundsDecls(var);
 
-  // All the following checks are C++ only.
-  if (!getLangOpts().CPlusPlus) {
-    // If this variable must be emitted, add it as an initializer for the
-    // current module.
-    if (Context.DeclMustBeEmitted(var) && !ModuleScopes.empty())
-      Context.addModuleInitializer(ModuleScopes.back().Module, var);
-    return;
-  }
-
   QualType type = var->getType();
 
   if (var->hasAttr<BlocksAttr>())


### PR DESCRIPTION
Fix some incorrect merges that were causing test failures:
- In 2 cases, statements were accidentally deleted.  Restore them.
- In SemaDecl.cpp, we kept some old code that should have been deleted. This caused processing of section pragmas and section information on declarations to be skipped on non-C++ files.

These were identified by looking at diffs with the original clang source code or debugging the handling failing test cases in the compiler.

This fixes 20 failing tests.  With this change, the test results from check-clang are:
```
Testing Time: 6139.36s
  Skipped          :    30
  Unsupported      :   237
  Passed           : 33385
  Expectedly Failed:    39
  Failed           :    48
```
